### PR TITLE
Complete CLI operand regeneration

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -164,6 +164,9 @@ jobs:
         if: steps.should-run.outputs.run == 'true'
         run: |
           mkdir -p "$RUNNER_TEMP/cli-tools/bin" "$RUNNER_TEMP/generator-work"
+          if [ "${{ matrix.tool }}" = "dotnet" ]; then
+            cp "$GITHUB_WORKSPACE/global.json" "$RUNNER_TEMP/generator-work/global.json"
+          fi
           echo "CLI_TOOLS_ROOT=$RUNNER_TEMP/cli-tools" >> "$GITHUB_ENV"
           echo "$RUNNER_TEMP/cli-tools/bin" >> "$GITHUB_PATH"
 
@@ -749,8 +752,13 @@ jobs:
         shell: pwsh
         run: |
           $cliToolsRoot = Join-Path $env:RUNNER_TEMP 'cli-tools'
+          $generatorWork = Join-Path $env:RUNNER_TEMP 'generator-work'
           New-Item -ItemType Directory -Force (Join-Path $cliToolsRoot 'bin') | Out-Null
-          New-Item -ItemType Directory -Force (Join-Path $env:RUNNER_TEMP 'generator-work') | Out-Null
+          New-Item -ItemType Directory -Force $generatorWork | Out-Null
+          if ('${{ matrix.tool }}' -eq 'dotnet') {
+            Copy-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'global.json') `
+              -Destination (Join-Path $generatorWork 'global.json')
+          }
           "CLI_TOOLS_ROOT=$cliToolsRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           (Join-Path $cliToolsRoot 'bin') | Out-File -FilePath $env:GITHUB_PATH -Append
 

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -814,8 +814,12 @@ jobs:
       - name: Install WinGet
         if: steps.should-run.outputs.run == 'true' && matrix.tool == 'winget'
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # WinGet is pre-installed on windows-latest (Windows Server 2022)
+          Install-Module Microsoft.WinGet.Client -Repository PSGallery -Scope CurrentUser -Force
+          Import-Module Microsoft.WinGet.Client -Force
+          Repair-WinGetPackageManager -Latest -Force
           winget --version
 
       - name: Pin resolved executable for scraper

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1369,6 +1369,61 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Composes_Integer_To_Optional_Value_Forwarding()
+    {
+        var command = Command("ToolRunOptions", "ToolOptions", ["run"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--color",
+                    PropertyName = "ColorOption",
+                    CSharpType = "CliOptionValue?",
+                    ValueArity = CliOptionValueArity.Optional,
+                },
+            ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "LegacyColor",
+                    CSharpType = "int?",
+                    ForwardToPropertyName = "Color",
+                    ForwardingKind = CliCompatibilityForwardingKind.NullableInt32ToString,
+                    ObsoleteMessage = "Use ColorOption instead.",
+                },
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "Color",
+                    CSharpType = "string?",
+                    ForwardToPropertyName = "ColorOption",
+                    ForwardingKind = CliCompatibilityForwardingKind.NullableStringToCliOptionValue,
+                    ObsoleteMessage = "Use ColorOption instead.",
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(command, []);
+        ExternalToolDefinitionLoader.ValidateCompatibilityMetadata(preserved, []);
+        var legacyColor = preserved.CompatibilityProperties.Single(property =>
+            property.PropertyName.Equals("LegacyColor", StringComparison.Ordinal));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(legacyColor.ForwardToPropertyName).IsEqualTo("ColorOption");
+            await Assert.That(legacyColor.ForwardingKind)
+                .IsEqualTo(CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue);
+        }
+
+        await AssertCompatibilityForwardingRoundTrips(
+            preserved,
+            "LegacyColor",
+            "ColorOption",
+            CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue);
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Composes_Forwarding_When_Target_Is_Renamed()
     {
         var command = Command("ToolRunOptions", "ToolOptions", ["run"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4759,6 +4759,49 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Restores_Removed_Nested_Root_Facade()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolPinInstalled_formulaOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"pin\", \"installed_formula\")] "
+                + "public record ToolPinInstalled_formulaOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "Tool.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class Tool { "
+                + "public Task PinInstalled_formulaAsync(ToolPinInstalled_formulaOptions? options = null) "
+                + "=> Task.CompletedTask; }");
+            var current = Command("ToolPinOptions", "ToolOptions", ["pin"]);
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(current), root);
+            var restored = preserved.Commands.Single(command =>
+                command.ClassName == "ToolPinInstalled_formulaOptions");
+            var generated = (await new ServiceImplementationGenerator().GenerateAsync(preserved))
+                .Single(file => file.RelativePath.EndsWith("Tool.Generated.cs", StringComparison.Ordinal))
+                .Content;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsNull();
+                await Assert.That(restored.PreserveRootNamedFacade).IsTrue();
+                await Assert.That(generated).Contains("PinInstalled_formulaAsync(");
+                await Assert.That(generated)
+                    .Contains("ToolPinInstalled_formulaOptions? options = null");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Keeps_Literal_Execute_When_It_Gains_Children()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
@@ -4961,7 +5004,7 @@ public class GeneratorHardeningTests
                 Kind: CliCompatibilityForwardingKind.ScalarToCollection),
         };
 
-        foreach (var testCase in cases)
+        foreach (var (TargetName, TargetType, AliasName, AliasType, Kind) in cases)
         {
             var command = Command("ToolPushOptions", "ToolOptions", ["push"]) with
             {
@@ -4970,31 +5013,31 @@ public class GeneratorHardeningTests
                     new CliOptionDefinition
                     {
                         SwitchName = "--output",
-                        PropertyName = testCase.AliasName,
-                        CSharpType = testCase.TargetType,
-                        AcceptsMultipleValues = testCase.Kind == CliCompatibilityForwardingKind.ScalarToCollection,
+                        PropertyName = AliasName,
+                        CSharpType = TargetType,
+                        AcceptsMultipleValues = Kind == CliCompatibilityForwardingKind.ScalarToCollection,
                     },
                 ],
             };
             var preserved = GeneratedApiCompatibilityPreserver.Preserve(
                 command,
                 [
-                    BaselineProperty(testCase.TargetName, testCase.TargetType, switchName: "--output"),
+                    BaselineProperty(TargetName, TargetType, switchName: "--output"),
                     BaselineProperty(
-                        testCase.AliasName,
-                        testCase.AliasType,
+                        AliasName,
+                        AliasType,
                         isCompatibility: true,
-                        forwardToPropertyName: testCase.TargetName,
-                        forwardingKind: testCase.Kind),
+                        forwardToPropertyName: TargetName,
+                        forwardingKind: Kind),
                 ]);
             var alias = preserved.CompatibilityProperties.Single(property =>
-                property.PropertyName == testCase.AliasName);
+                property.PropertyName == AliasName);
 
             using (Assert.Multiple())
             {
-                await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo(testCase.TargetName);
-                await Assert.That(alias.ForwardToPropertyName).IsEqualTo(testCase.TargetName);
-                await Assert.That(alias.ForwardingKind).IsEqualTo(testCase.Kind);
+                await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo(TargetName);
+                await Assert.That(alias.ForwardToPropertyName).IsEqualTo(TargetName);
+                await Assert.That(alias.ForwardingKind).IsEqualTo(Kind);
             }
         }
     }
@@ -5494,7 +5537,7 @@ public class GeneratorHardeningTests
     [Test]
     public async Task Case_Variant_Enum_Names_Fail_The_Duplicate_Path_Check()
     {
-        CliEnumDefinition EnumDef(string name) => new()
+        static CliEnumDefinition EnumDef(string name) => new()
         {
             EnumName = name,
             Values = [new CliEnumValue { MemberName = "Json", CliValue = "json" }],

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1305,6 +1305,7 @@ public class GeneratorHardeningTests
 
         await AssertCompatibilityForwardingRoundTrips(
             preserved,
+            "LegacyCount",
             "Count",
             CliCompatibilityForwardingKind.NullableInt32ToRequiredString);
     }
@@ -1362,6 +1363,7 @@ public class GeneratorHardeningTests
 
         await AssertCompatibilityForwardingRoundTrips(
             preserved,
+            "LegacyCount",
             "CountValues",
             CliCompatibilityForwardingKind.NullableInt32ToStringCollection);
     }
@@ -1412,12 +1414,14 @@ public class GeneratorHardeningTests
 
         await AssertCompatibilityForwardingRoundTrips(
             preserved,
+            "LegacyCount",
             "CountValues",
             CliCompatibilityForwardingKind.NullableInt32ToStringCollection);
     }
 
     private static async Task AssertCompatibilityForwardingRoundTrips(
         CliCommandDefinition generatedCommand,
+        string compatibilityPropertyName,
         string expectedTarget,
         CliCompatibilityForwardingKind expectedKind)
     {
@@ -1434,7 +1438,7 @@ public class GeneratorHardeningTests
             var current = generatedCommand with { CompatibilityProperties = [] };
             var roundTripped = GeneratedApiCompatibilityPreserver.Preserve(Tool(current), root);
             var alias = roundTripped.Commands.Single().CompatibilityProperties.Single(property =>
-                property.PropertyName.Equals("LegacyCount", StringComparison.Ordinal));
+                property.PropertyName.Equals(compatibilityPropertyName, StringComparison.Ordinal));
 
             using (Assert.Multiple())
             {
@@ -4657,6 +4661,99 @@ public class GeneratorHardeningTests
             await Assert.That(preserved.CompatibilityProperties.Single().ForwardToPropertyName)
                 .IsNull();
         }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Allows_Explicit_Rendering_Phase_Migration()
+    {
+        var command = Command("ToolRunOptions", "ToolOptions", ["run"]) with
+        {
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Input",
+                    CSharpType = "string?",
+                    PositionIndex = 0,
+                    Phase = CommandLinePhase.Passthrough,
+                    AllowRenderingPhaseMigrationFromBaseline = true,
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty(
+                "Input",
+                "string?",
+                argumentPosition: 0,
+                phase: CommandLinePhase.EarlyOperand)]);
+
+        await Assert.That(preserved.PositionalArguments.Single().Phase)
+            .IsEqualTo(CommandLinePhase.Passthrough);
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Preserves_Optional_Value_Property_Types()
+    {
+        var command = Command("ToolBranchOptions", "ToolOptions", ["branch"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--color",
+                    PropertyName = "Color",
+                    CSharpType = "string?",
+                    ValueArity = CliOptionValueArity.Optional,
+                },
+                new CliOptionDefinition
+                {
+                    SwitchName = "--abbrev",
+                    PropertyName = "Abbrev",
+                    CSharpType = "int?",
+                    ValueArity = CliOptionValueArity.Optional,
+                },
+                new CliOptionDefinition
+                {
+                    SwitchName = "--depth",
+                    PropertyName = "Depth",
+                    CSharpType = "int?",
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [
+                BaselineProperty("Color", "string?", switchName: "--color[=<when>]"),
+                BaselineProperty("Abbrev", "int?", switchName: "--abbrev[=<n>]"),
+                BaselineProperty("Depth", "int?", switchName: "--depth=<n>"),
+            ]);
+        var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(preserved)))
+            .Single().Content;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.Options.Select(option => option.PropertyName))
+                .IsEquivalentTo(["ColorOption", "AbbrevOption", "Depth"]);
+            await Assert.That(generated).Contains("public CliOptionValue? ColorOption");
+            await Assert.That(generated).Contains("public string? Color");
+            await Assert.That(generated).Contains("get => ColorOption?.Value;");
+            await Assert.That(generated).Contains("public int? Abbrev");
+            await Assert.That(generated).Contains("int.TryParse(AbbrevOption?.Value");
+        }
+
+        await AssertCompatibilityForwardingRoundTrips(
+            preserved,
+            "Color",
+            "ColorOption",
+            CliCompatibilityForwardingKind.NullableStringToCliOptionValue);
+        await AssertCompatibilityForwardingRoundTrips(
+            preserved,
+            "Abbrev",
+            "AbbrevOption",
+            CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1478,6 +1478,42 @@ public class GeneratorHardeningTests
             CliCompatibilityForwardingKind.NullableInt32ToStringCollection);
     }
 
+    [Test]
+    public async Task ApiCompatibilityPreserver_Forwards_Renamed_Boolean_To_String()
+    {
+        var command = Command("AzAksCreateOptions", "AzOptions", ["aks", "create"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--apiserver-subnet-id",
+                    PropertyName = "ApiServerSubnetId",
+                    CSharpType = "string?",
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty("ApiserverSubnetId", "bool?", switchName: "--apiserver-subnet-id")]);
+        ExternalToolDefinitionLoader.ValidateCompatibilityMetadata(preserved, []);
+        var alias = preserved.CompatibilityProperties.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(alias.ForwardToPropertyName).IsEqualTo("ApiServerSubnetId");
+            await Assert.That(alias.ForwardingKind)
+                .IsEqualTo(CliCompatibilityForwardingKind.NullableBooleanToString);
+        }
+
+        await AssertCompatibilityForwardingRoundTrips(
+            preserved,
+            "ApiserverSubnetId",
+            "ApiServerSubnetId",
+            CliCompatibilityForwardingKind.NullableBooleanToString);
+    }
+
     private static async Task AssertCompatibilityForwardingRoundTrips(
         CliCommandDefinition generatedCommand,
         string compatibilityPropertyName,
@@ -4719,6 +4755,51 @@ public class GeneratorHardeningTests
                 .IsEqualTo("CommandOptions");
             await Assert.That(preserved.CompatibilityProperties.Single().ForwardToPropertyName)
                 .IsNull();
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Keeps_Literal_Execute_When_It_Gains_Children()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolRemoteExecuteOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"remote\", \"execute\")] "
+                + "public record ToolRemoteExecuteOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolRemote.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolRemote { "
+                + "public Task ExecuteAsync(ToolRemoteExecuteOptions? options = null) => Task.CompletedTask; }");
+            var execute = Command(
+                "ToolRemoteExecuteOptions",
+                "ToolOptions",
+                ["remote", "execute"],
+                subDomainGroup: "Remote");
+            var nested = Command(
+                "ToolRemoteExecuteNestedOptions",
+                "ToolOptions",
+                ["remote", "execute", "nested"],
+                subDomainGroup: "Remote");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(execute, nested), root);
+            var literalExecute = preserved.Commands.Single(command =>
+                command.ClassName == "ToolRemoteExecuteOptions");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(literalExecute.PreserveNamedFacade).IsTrue();
+                await Assert.That(literalExecute.PreserveExecuteFacade).IsFalse();
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4943,6 +4943,63 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Restores_NonOptional_Forwarded_Alias_Targets()
+    {
+        var cases = new[]
+        {
+            (
+                TargetName: "Output",
+                TargetType: "string?",
+                AliasName: "LegacyOutput",
+                AliasType: "string?",
+                Kind: CliCompatibilityForwardingKind.Direct),
+            (
+                TargetName: "Outputs",
+                TargetType: "IEnumerable<string>?",
+                AliasName: "Output",
+                AliasType: "string?",
+                Kind: CliCompatibilityForwardingKind.ScalarToCollection),
+        };
+
+        foreach (var testCase in cases)
+        {
+            var command = Command("ToolPushOptions", "ToolOptions", ["push"]) with
+            {
+                Options =
+                [
+                    new CliOptionDefinition
+                    {
+                        SwitchName = "--output",
+                        PropertyName = testCase.AliasName,
+                        CSharpType = testCase.TargetType,
+                        AcceptsMultipleValues = testCase.Kind == CliCompatibilityForwardingKind.ScalarToCollection,
+                    },
+                ],
+            };
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                command,
+                [
+                    BaselineProperty(testCase.TargetName, testCase.TargetType, switchName: "--output"),
+                    BaselineProperty(
+                        testCase.AliasName,
+                        testCase.AliasType,
+                        isCompatibility: true,
+                        forwardToPropertyName: testCase.TargetName,
+                        forwardingKind: testCase.Kind),
+                ]);
+            var alias = preserved.CompatibilityProperties.Single(property =>
+                property.PropertyName == testCase.AliasName);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo(testCase.TargetName);
+                await Assert.That(alias.ForwardToPropertyName).IsEqualTo(testCase.TargetName);
+                await Assert.That(alias.ForwardingKind).IsEqualTo(testCase.Kind);
+            }
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Defaults_Historical_Positional_Phase_Before_Matching()
     {
         var command = Command("ToolRunOptions", "ToolOptions", ["run"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -143,7 +143,9 @@ public class GeneratorHardeningTests
         string? forwardToPropertyName = null,
         bool useInitAccessor = false,
         CommandLinePhase? phase = null,
-        bool omitPhase = false) =>
+        bool omitPhase = false,
+        CliCompatibilityForwardingKind forwardingKind = CliCompatibilityForwardingKind.Direct,
+        CliOptionValueArity valueArity = CliOptionValueArity.Required) =>
         new(
             propertyName,
             cSharpType,
@@ -154,6 +156,8 @@ public class GeneratorHardeningTests
             forwardToPropertyName,
             null,
             useInitAccessor,
+            ForwardingKind: forwardingKind,
+            ValueArity: valueArity,
             Phase: phase ?? (argumentPosition is not null && !omitPhase
                 ? CommandLinePhase.EarlyOperand
                 : null));
@@ -4809,6 +4813,52 @@ public class GeneratorHardeningTests
             "Abbrev",
             "AbbrevOption",
             CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue);
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Restores_Optional_Value_Target_On_Second_Run()
+    {
+        var command = Command("ToolBranchOptions", "ToolOptions", ["branch"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--color",
+                    PropertyName = "Color",
+                    CSharpType = "string?",
+                    ValueArity = CliOptionValueArity.Optional,
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [
+                BaselineProperty(
+                    "ColorOption",
+                    "CliOptionValue?",
+                    switchName: "--color",
+                    valueArity: CliOptionValueArity.Optional),
+                BaselineProperty(
+                    "Color",
+                    "string?",
+                    isCompatibility: true,
+                    forwardToPropertyName: "ColorOption",
+                    forwardingKind: CliCompatibilityForwardingKind.NullableStringToCliOptionValue),
+            ]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo("ColorOption");
+            await Assert.That(preserved.CompatibilityProperties.Single().PropertyName).IsEqualTo("Color");
+        }
+
+        await AssertCompatibilityForwardingRoundTrips(
+            preserved,
+            "Color",
+            "ColorOption",
+            CliCompatibilityForwardingKind.NullableStringToCliOptionValue);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
@@ -154,6 +154,38 @@ public class ArgoCdCliScraperTests
     }
 
     [Test]
+    public async Task App_Unset_Drops_Parameters_Usage_Literal()
+    {
+        var scraper = new TestArgoCdCliScraper();
+        var parsedArguments = scraper.ParseArguments(
+            ["argocd", "app", "unset"],
+            "Usage:\n  argocd app unset APPNAME parameters [flags]");
+
+        var arguments = scraper.ApplyFix(["app", "unset"], parsedArguments);
+
+        await Assert.That(arguments).HasSingleItem();
+        using (Assert.Multiple())
+        {
+            await Assert.That(arguments[0].PropertyName).IsEqualTo("ApplicationName");
+            await Assert.That(arguments[0].CSharpType).IsEqualTo("string");
+            await Assert.That(arguments[0].IsRequired).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Command_Groups_Drop_Command_Placeholders()
+    {
+        var scraper = new TestArgoCdCliScraper();
+        var parsedArguments = scraper.ParseArguments(
+            ["argocd", "app"],
+            "Usage:\n  argocd app [flags] [command]");
+
+        var arguments = scraper.ApplyFix(["app"], parsedArguments);
+
+        await Assert.That(arguments).IsEmpty();
+    }
+
+    [Test]
     public async Task Repo_Rm_Uses_Required_Repository_Collection()
     {
         var scraper = new TestArgoCdCliScraper();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -146,10 +146,32 @@ public class CliScraperTraversalTests
                   docker buildx [OPTIONS] COMMAND
                 """,
             ["buildx --help"] = """
-                Usage: docker buildx [OPTIONS]
+                Usage: docker buildx [OPTIONS] COMMAND
 
                 Flags:
                   --builder string   Override the builder
+
+                Commands:
+                  build   Start a build
+                  dap     Start a debugger
+                """,
+            ["buildx build --help"] = """
+                Usage: docker buildx build [OPTIONS] PATH
+
+                Flags:
+                  --pull   Always attempt to pull
+                """,
+            ["buildx dap --help"] = """
+                Usage: docker buildx dap [OPTIONS] COMMAND
+
+                Commands:
+                  build   Debug a build
+                """,
+            ["buildx dap build --help"] = """
+                Usage: docker buildx dap build [OPTIONS] COMMAND [ARG...]
+
+                Flags:
+                  --debug   Enable debug logging
                 """,
         });
         var scraper = new DockerCliScraper(
@@ -162,9 +184,35 @@ public class CliScraperTraversalTests
 
         await Assert.That(commands.Select(command => command.FullCommand))
             .Contains("docker buildx");
+        await Assert.That(commands.Single(command => command.FullCommand == "docker buildx")
+            .PositionalArguments).IsEmpty();
+        await Assert.That(commands.Single(command => command.FullCommand == "docker buildx dap")
+            .PositionalArguments).IsEmpty();
+        await Assert.That(commands.Single(command => command.FullCommand == "docker buildx dap build")
+            .PositionalArguments.Select(argument => argument.PropertyName))
+            .Contains("Command");
         await Assert.That(alias.Alias).IsEqualTo("builder");
         await Assert.That(alias.CanonicalCommand).IsEqualTo("buildx");
         await Assert.That(executor.Arguments).DoesNotContain("builder build --help");
+    }
+
+    [Test]
+    public async Task CobraTraversal_Parses_Command_Headings_With_Lowercase_Connectors()
+    {
+        const string helpText = """
+            Configuration and Management Commands:
+              addons    Manage addons
+              config    Manage configuration
+
+            Networking and Connectivity Commands:
+              service   Connect to a service
+              tunnel    Connect to load balancers
+            """;
+        var scraper = new TestCobraScraper(new StubExecutor(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+
+        await Assert.That(scraper.GetSubcommands(helpText))
+            .IsEquivalentTo(["addons", "config", "service", "tunnel"]);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -148,6 +148,17 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_External_Ipv6_Prefix_Length_Is_Known_Scalar()
+    {
+        var scraper = CreateGcloudScraper();
+
+        await Assert.That(scraper.IsKnownScalar(
+                ["compute", "instances", "create"],
+                "--external-ipv6-prefix-length"))
+            .IsTrue();
+    }
+
+    [Test]
     public async Task Gcloud_Prioritizes_Enum_Types_Over_Key_Value_Hints()
     {
         const string helpText = """
@@ -345,6 +356,9 @@ public partial class NestedArgumentGroupParsingTests
     {
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
             ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+
+        public bool IsKnownScalar(IReadOnlyList<string> commandParts, string switchName) =>
+            ShouldTreatOptionAsScalar(commandParts, switchName);
     }
 
     private sealed class TestArgumentGroupScraper : CliScraperBase

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -35,6 +35,28 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    public async Task DotNet_NuGet_Add_Source_Preserves_Public_Operand_Name()
+    {
+        const string helpText = "Usage: NuGet.CommandLine.XPlat add source <PackageSourcePath> [options]";
+        var command = await new TestDotNetCliScraper().Parse(
+            ["dotnet", "nuget", "add", "source"],
+            helpText);
+
+        await AssertArgument(command, "Packagesourcepath", isRequired: true, isVariadic: false);
+    }
+
+    [Test]
+    public async Task DotNet_NuGet_Push_Preserves_Public_Scalar_Operand()
+    {
+        const string helpText = "Usage: NuGet.CommandLine.XPlat push <package-paths>... [options]";
+        var command = await new TestDotNetCliScraper().Parse(
+            ["dotnet", "nuget", "push"],
+            helpText);
+
+        await AssertArgument(command, "Path", isRequired: true, isVariadic: false);
+    }
+
+    [Test]
     public async Task Go_Fix_Preserves_Packages_But_Not_Option_Value()
     {
         const string helpText = "usage: go fix [build flags] [-fixtool prog] [fix flags] [packages]";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -43,6 +43,25 @@ public class PositionalOperandAdapterTests
         await AssertArgument(command, "Packages", isRequired: false, isVariadic: true);
         await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
             .IsEquivalentTo(["Packages"]);
+        await Assert.That(command.PositionalArguments.Single().Phase)
+            .IsEqualTo(CommandLinePhase.Passthrough);
+    }
+
+    [Test]
+    public async Task Go_Mod_Preserves_Generic_Arguments_As_Separate_Tokens()
+    {
+        var command = await new TestGoCliScraper().Parse(
+            ["go", "mod"],
+            "usage: go mod <command> [arguments]");
+
+        var arguments = command!.PositionalArguments.Single(argument =>
+            argument.PropertyName == "Arguments");
+        using (Assert.Multiple())
+        {
+            await Assert.That(arguments.IsVariadic).IsTrue();
+            await Assert.That(arguments.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(arguments.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+        }
     }
 
     [Test]
@@ -91,6 +110,22 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    public async Task Pip_Install_Treats_Package_Index_Syntax_As_Option_Label()
+    {
+        var command = await new TestPipCliScraper().Parse(
+            ["pip", "install"],
+            "Usage: pip install [options] <requirement specifier> [package-index-options] ...");
+
+        var requirement = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(requirement.PropertyName).IsEqualTo("RequirementSpecifier");
+            await Assert.That(requirement.IsVariadic).IsTrue();
+            await Assert.That(requirement.CSharpType).IsEqualTo("IEnumerable<string>");
+        }
+    }
+
+    [Test]
     [Arguments("cache", "Usage: pip cache list [<pattern>]\n  pip cache purge")]
     [Arguments("config", "Usage: pip config [<file-option>] list\n  pip config get command.option")]
     [Arguments("index", "Usage: pip index versions <package>")]
@@ -111,6 +146,8 @@ public class PositionalOperandAdapterTests
             "Usage: pnpm add <name>");
 
         await AssertArgument(command, "Name", isRequired: true, isVariadic: false);
+        await Assert.That(command!.PositionalArguments.Single().Phase)
+            .IsEqualTo(CommandLinePhase.Passthrough);
     }
 
     [Test]
@@ -176,6 +213,23 @@ public class PositionalOperandAdapterTests
         await Assert.That(command!.PositionalArguments.Single().PropertyName).IsEqualTo("Template");
         await Assert.That(command.PositionalArguments.Single().Phase)
             .IsEqualTo(CommandLinePhase.Passthrough);
+    }
+
+    [Test]
+    public async Task Packer_Plugins_Preserves_Trailing_Arguments_As_Separate_Tokens()
+    {
+        var command = await new TestPackerCliScraper().Parse(
+            ["packer", "plugins"],
+            "Usage: packer plugins <subcommand> [options] [args]");
+
+        var arguments = command!.PositionalArguments.Single(argument =>
+            argument.PropertyName == "Args");
+        using (Assert.Multiple())
+        {
+            await Assert.That(arguments.IsVariadic).IsTrue();
+            await Assert.That(arguments.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(arguments.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+        }
     }
 
     private static async Task AssertArgument(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
@@ -222,6 +222,28 @@ public class SnykCliScraperTests
     }
 
     [Test]
+    public async Task Iac_Describe_From_Glob_Remains_Scalar()
+    {
+        const string helpText = """
+            Describe infrastructure as code.
+
+            Options
+              --from=<PATH>
+                Specify multiple Terraform state files to be read. Glob patterns are supported.
+            """;
+
+        var command = await new TestSnykCliScraper().Parse(["snyk", "iac", "describe"], helpText);
+        var option = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("--from");
+            await Assert.That(option.CSharpType).IsEqualTo("string?");
+            await Assert.That(option.AcceptsMultipleValues).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task Root_Test_Models_Optional_Target()
     {
         var command = await new TestSnykCliScraper().Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -77,6 +77,38 @@ public class YarnCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Parses_Current_Plain_Clipanion_Sections()
+    {
+        const string helpText = """
+            Run a package in a temporary environment
+
+            Usage
+
+            $ yarn dlx <command> ...
+
+            Options
+
+              -p,--package #0    The package(s) to install before running the command
+              -q,--quiet         Only report critical errors instead of printing the full install logs
+
+            Details
+
+            This command installs a package in a temporary environment.
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(["yarn", "dlx"], helpText);
+        var package = command!.Options.Single(option => option.PropertyName == "Package");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.Options.Select(option => option.PropertyName))
+                .IsEquivalentTo(["Package", "Quiet"]);
+            await Assert.That(package.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(package.AcceptsMultipleValues).IsTrue();
+        }
+    }
+
     private sealed class TestYarnCliScraper : YarnCliScraper
     {
         public TestYarnCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -194,6 +194,86 @@ public class ZeroOutputScraperTests
     }
 
     [Test]
+    public async Task Gh_Command_Groups_Drop_Command_Placeholders()
+    {
+        const string helpText = """
+            Work with GitHub issues.
+
+            USAGE
+              gh issue <command> [flags]
+
+            FLAGS
+              -R, --repo string   Select another repository
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "issue"], helpText);
+
+        await Assert.That(command!.PositionalArguments).IsEmpty();
+    }
+
+    [Test]
+    public async Task Gh_Codespace_Ssh_Keeps_Optional_Forwarded_Operands()
+    {
+        const string helpText = """
+            SSH into a codespace.
+
+            USAGE
+              gh codespace ssh [<flags>...] [-- <ssh-flags>...] [<command>]
+
+            FLAGS
+              -c, --codespace string   Name of the codespace
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "codespace", "ssh"], helpText);
+        var arguments = command!.PositionalArguments.ToDictionary(argument => argument.PropertyName);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(arguments.Keys).IsEquivalentTo(["Flags", "SshFlags", "Command"]);
+            await Assert.That(arguments["SshFlags"].CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(arguments["SshFlags"].IsRequired).IsFalse();
+            await Assert.That(arguments["Command"].CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
+    public async Task Gh_Issue_Edit_Models_Number_Or_Url_Targets_As_A_Collection()
+    {
+        const string helpText = """
+            Edit issues.
+
+            USAGE
+              gh issue edit {<numbers> | <urls>} [flags]
+
+            FLAGS
+              -t, --title string   Set the new title
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "issue", "edit"], helpText);
+        var argument = command!.PositionalArguments.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.PropertyName).IsEqualTo("NumbersOrUrls");
+            await Assert.That(argument.CSharpType).IsEqualTo("IEnumerable<string>");
+            await Assert.That(argument.IsRequired).IsTrue();
+            await Assert.That(argument.IsVariadic).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Gh_Pr_Alternatives_Use_Accurate_Property_Name()
+    {
+        var command = await new TestGhCliScraper().Parse(
+            ["gh", "pr", "view"],
+            "USAGE\n  gh pr view [<number> | <url> | <branch>] [flags]\n\nFLAGS\n  --web   Open in browser");
+
+        var argument = command!.PositionalArguments.Single();
+        await Assert.That(argument.PropertyName).IsEqualTo("NumberOrUrlOrBranch");
+        await Assert.That(argument.CSharpType).IsEqualTo("string?");
+    }
+
+    [Test]
     public async Task Yarn_Extracts_Classic_Bulleted_Command_List()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
@@ -626,6 +626,12 @@ public static class ExternalToolDefinitionLoader
             CliCompatibilityForwardingKind.NullableInt32ToStringCollection =>
                 propertyType.IsEquivalentTo(SyntaxFactory.ParseTypeName("int?"))
                 && targetType.IsEquivalentTo(SyntaxFactory.ParseTypeName("IEnumerable<string>?")),
+            CliCompatibilityForwardingKind.NullableStringToCliOptionValue =>
+                propertyType.IsEquivalentTo(SyntaxFactory.ParseTypeName("string?"))
+                && targetType.IsEquivalentTo(SyntaxFactory.ParseTypeName("CliOptionValue?")),
+            CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue =>
+                propertyType.IsEquivalentTo(SyntaxFactory.ParseTypeName("int?"))
+                && targetType.IsEquivalentTo(SyntaxFactory.ParseTypeName("CliOptionValue?")),
             _ => false,
         };
         if (!typesAreCompatible)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
@@ -617,6 +617,9 @@ public static class ExternalToolDefinitionLoader
             CliCompatibilityForwardingKind.NullableInt32ToString =>
                 propertyType.IsEquivalentTo(SyntaxFactory.ParseTypeName("int?"))
                 && targetType.IsEquivalentTo(SyntaxFactory.ParseTypeName("string?")),
+            CliCompatibilityForwardingKind.NullableBooleanToString =>
+                propertyType.IsEquivalentTo(SyntaxFactory.ParseTypeName("bool?"))
+                && targetType.IsEquivalentTo(SyntaxFactory.ParseTypeName("string?")),
             CliCompatibilityForwardingKind.NullableStringToRequiredString =>
                 propertyType.IsEquivalentTo(SyntaxFactory.ParseTypeName("string?"))
                 && targetType.IsEquivalentTo(SyntaxFactory.ParseTypeName("string")),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1321,10 +1321,23 @@ internal static class GeneratedApiCompatibilityPreserver
                 options,
                 property => property.PropertyName.Equals(alias.PropertyName, StringComparison.Ordinal));
             var targetBaseline = FindForwardingTargetBaseline(baselineProperties, alias);
-            if (aliasMember is null
-                || targetBaseline is null
-                || HasSameCliIdentity(GetLocalMember(aliasMember.Value, positionalArguments, options), targetBaseline))
+            if (aliasMember is null || targetBaseline is null)
             {
+                continue;
+            }
+
+            if (HasSameCliIdentity(
+                    GetLocalMember(aliasMember.Value, positionalArguments, options),
+                    targetBaseline))
+            {
+                RestoreForwardedOptionalValueAlias(
+                    alias,
+                    aliasMember.Value,
+                    targetBaseline,
+                    positionalArguments,
+                    options,
+                    compatibilityProperties,
+                    propertyNames);
                 continue;
             }
 
@@ -1351,6 +1364,34 @@ internal static class GeneratedApiCompatibilityPreserver
             compatibilityProperties.Add(ToCompatibilityProperty(alias));
             propertyNames.Add(alias.PropertyName);
         }
+    }
+
+    private static void RestoreForwardedOptionalValueAlias(
+        GeneratedApiProperty alias,
+        LocalMemberLocation aliasMember,
+        GeneratedApiProperty targetBaseline,
+        CliPositionalArgument[] positionalArguments,
+        CliOptionDefinition[] options,
+        ICollection<CliCompatibilityProperty> compatibilityProperties,
+        HashSet<string> propertyNames)
+    {
+        if (alias.ForwardingKind is not (
+                CliCompatibilityForwardingKind.NullableStringToCliOptionValue
+                or CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue)
+            || propertyNames.Contains(targetBaseline.PropertyName))
+        {
+            return;
+        }
+
+        propertyNames.Remove(alias.PropertyName);
+        RenameLocalMember(
+            aliasMember,
+            targetBaseline.PropertyName,
+            positionalArguments,
+            options);
+        compatibilityProperties.Add(ToCompatibilityProperty(alias));
+        propertyNames.Add(targetBaseline.PropertyName);
+        propertyNames.Add(alias.PropertyName);
     }
 
     private static GeneratedApiProperty? FindForwardingTargetBaseline(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -60,16 +60,18 @@ internal static class GeneratedApiCompatibilityPreserver
             tool.NamespacePrefix,
             baseline);
         var executeFacadeOptionTypes = facadeMethods
-            .Where(static method => method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal))
+            .Where(method => IsParentExecuteFacade(
+                GetFacadeImplementationType(compatibleTool, method),
+                method))
             .Select(static method => method.OptionsType)
             .ToHashSet(StringComparer.Ordinal);
         var namedFacadeOptionTypes = facadeMethods
-            .Where(static method => !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal))
+            .Where(method => IsNamedFacadeMethod(compatibleTool, method))
             .Select(static method => method.OptionsType)
             .ToHashSet(StringComparer.Ordinal);
         var rootNamedFacadeOptionTypes = facadeMethods
             .Where(method => IsRootFacadeMethod(compatibleTool, method)
-                             && !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal))
+                             && IsNamedFacadeMethod(compatibleTool, method))
             .Select(static method => method.OptionsType)
             .ToHashSet(StringComparer.Ordinal);
         var optionalFacadeOptionTypes = facadeMethods
@@ -240,13 +242,13 @@ internal static class GeneratedApiCompatibilityPreserver
                 commandParts,
                 groupIdentifier,
                 facadeMethods),
-            PreserveExecuteFacade = facadeMethods.Any(static method =>
-                method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
-            PreserveNamedFacade = facadeMethods.Any(static method =>
-                !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
+            PreserveExecuteFacade = facadeMethods.Any(method => IsParentExecuteFacade(
+                GetFacadeImplementationType(tool, method),
+                method)),
+            PreserveNamedFacade = facadeMethods.Any(method => IsNamedFacadeMethod(tool, method)),
             PreserveRootNamedFacade = facadeMethods.Any(method =>
                 IsRootFacadeMethod(tool, method)
-                && !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
+                && IsNamedFacadeMethod(tool, method)),
             PreserveOptionalOptionsParameter = facadeMethods.Any(static method => method.IsOptionsOptional),
         };
     }
@@ -529,6 +531,12 @@ internal static class GeneratedApiCompatibilityPreserver
         return facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
                && implementationType.Equals(optionsImplementationType, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsNamedFacadeMethod(
+        CliToolDefinition tool,
+        GeneratedFacadeMethod method) =>
+        !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
+        || !IsParentExecuteFacade(GetFacadeImplementationType(tool, method), method);
 
     private static CliOptionDefinition[] RestoreRemovedOptions(
         IEnumerable<GeneratedApiProperty> properties) =>
@@ -2170,6 +2178,12 @@ internal static class GeneratedApiCompatibilityPreserver
             return CliCompatibilityForwardingKind.Direct;
         }
 
+        if (baseline.CSharpType.Equals("bool?", StringComparison.Ordinal)
+            && replacement.CSharpType.Equals("string?", StringComparison.Ordinal))
+        {
+            return CliCompatibilityForwardingKind.NullableBooleanToString;
+        }
+
         if (!baseline.CSharpType.Equals("string?", StringComparison.Ordinal))
         {
             return null;
@@ -3477,6 +3491,11 @@ internal static class GeneratedApiCompatibilityPreserver
             return forwarding;
         }
 
+        if (TryGetNullableBooleanForwarding(expression, out forwarding))
+        {
+            return forwarding;
+        }
+
         return (null, CliCompatibilityForwardingKind.Direct);
     }
 
@@ -3491,6 +3510,10 @@ internal static class GeneratedApiCompatibilityPreserver
                 {
                     Expression: MemberAccessExpressionSyntax
                     {
+                        Expression: PredefinedTypeSyntax
+                        {
+                            Keyword.RawKind: (int) SyntaxKind.IntKeyword,
+                        },
                         Name.Identifier.ValueText: "TryParse",
                     },
                     ArgumentList.Arguments: { Count: > 0 } arguments,
@@ -3537,6 +3560,37 @@ internal static class GeneratedApiCompatibilityPreserver
             forwarding = (
                 optionValueTarget.Identifier.ValueText,
                 CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue);
+            return true;
+        }
+
+        forwarding = default;
+        return false;
+    }
+
+    private static bool TryGetNullableBooleanForwarding(
+        ExpressionSyntax? expression,
+        out (string? TargetPropertyName, CliCompatibilityForwardingKind Kind) forwarding)
+    {
+        if (expression is ConditionalExpressionSyntax
+            {
+                Condition: InvocationExpressionSyntax
+                {
+                    Expression: MemberAccessExpressionSyntax
+                    {
+                        Expression: PredefinedTypeSyntax
+                        {
+                            Keyword.RawKind: (int) SyntaxKind.BoolKeyword,
+                        },
+                        Name.Identifier.ValueText: "TryParse",
+                    },
+                    ArgumentList.Arguments: { Count: > 0 } arguments,
+                },
+            }
+            && arguments[0].Expression is IdentifierNameSyntax stringValue)
+        {
+            forwarding = (
+                stringValue.Identifier.ValueText,
+                CliCompatibilityForwardingKind.NullableBooleanToString);
             return true;
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1336,23 +1336,24 @@ internal static class GeneratedApiCompatibilityPreserver
 
             if (HasSameCliIdentity(
                     GetLocalMember(aliasMember.Value, positionalArguments, options),
-                    targetBaseline))
-            {
-                RestoreForwardedOptionalValueAlias(
+                    targetBaseline)
+                && TryRestoreForwardedAliasTarget(
                     alias,
                     aliasMember.Value,
                     targetBaseline,
                     positionalArguments,
                     options,
                     compatibilityProperties,
-                    propertyNames);
+                    propertyNames))
+            {
                 continue;
             }
 
             var targetMember = FindLocalMember(
                 positionalArguments,
                 options,
-                property => HasSameCliIdentity(property, targetBaseline));
+                property => !property.PropertyName.Equals(alias.PropertyName, StringComparison.Ordinal)
+                            && HasSameCliIdentity(property, targetBaseline));
             if (targetMember is null)
             {
                 continue;
@@ -1374,7 +1375,7 @@ internal static class GeneratedApiCompatibilityPreserver
         }
     }
 
-    private static void RestoreForwardedOptionalValueAlias(
+    private static bool TryRestoreForwardedAliasTarget(
         GeneratedApiProperty alias,
         LocalMemberLocation aliasMember,
         GeneratedApiProperty targetBaseline,
@@ -1383,12 +1384,13 @@ internal static class GeneratedApiCompatibilityPreserver
         ICollection<CliCompatibilityProperty> compatibilityProperties,
         HashSet<string> propertyNames)
     {
-        if (alias.ForwardingKind is not (
-                CliCompatibilityForwardingKind.NullableStringToCliOptionValue
-                or CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue)
-            || propertyNames.Contains(targetBaseline.PropertyName))
+        if (propertyNames.Contains(targetBaseline.PropertyName)
+            || (alias.ForwardingKind == CliCompatibilityForwardingKind.Direct
+                && alias.PropertyName.Equals(
+                    targetBaseline.PropertyName,
+                    StringComparison.OrdinalIgnoreCase)))
         {
-            return;
+            return false;
         }
 
         propertyNames.Remove(alias.PropertyName);
@@ -1400,6 +1402,7 @@ internal static class GeneratedApiCompatibilityPreserver
         compatibilityProperties.Add(ToCompatibilityProperty(alias));
         propertyNames.Add(targetBaseline.PropertyName);
         propertyNames.Add(alias.PropertyName);
+        return true;
     }
 
     private static GeneratedApiProperty? FindForwardingTargetBaseline(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -2787,15 +2787,18 @@ internal static class GeneratedApiCompatibilityPreserver
 
         if (left.SwitchName is not null || right.SwitchName is not null)
         {
-            return left.SwitchName is not null
-                   && right.SwitchName is not null
-                   && NormalizeCliSwitchIdentity(left.SwitchName).Equals(
-                       NormalizeCliSwitchIdentity(right.SwitchName),
-                       StringComparison.Ordinal);
+            return HasSameOptionIdentity(left.SwitchName, right.SwitchName);
         }
 
         return true;
     }
+
+    private static bool HasSameOptionIdentity(string? left, string? right) =>
+        left is not null
+        && right is not null
+        && NormalizeCliSwitchIdentity(left).Equals(
+            NormalizeCliSwitchIdentity(right),
+            StringComparison.Ordinal);
 
     private static bool HasCompatibleCliIdentity(
         GeneratedApiProperty current,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1140,6 +1140,14 @@ internal static class GeneratedApiCompatibilityPreserver
             compatibilityProperties,
             renamedProperties,
             violations);
+        preservedTypeChanges.UnionWith(PreserveOptionalValueArityChanges(
+            command,
+            baselineProperties,
+            positionalArguments,
+            options,
+            compatibilityProperties,
+            renamedProperties,
+            violations));
         RestoreBaselinePropertyShapes(
             baselineProperties,
             preservedTypeChanges,
@@ -1479,6 +1487,86 @@ internal static class GeneratedApiCompatibilityPreserver
         }
 
         return preserved;
+    }
+
+    private static HashSet<string> PreserveOptionalValueArityChanges(
+        CliCommandDefinition command,
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
+        CliOptionDefinition[] options,
+        ICollection<CliCompatibilityProperty> compatibilityProperties,
+        IDictionary<string, string> renamedProperties,
+        ICollection<string> violations)
+    {
+        var preserved = new HashSet<string>(StringComparer.Ordinal);
+        var propertyNames = options.Select(static option => option.PropertyName)
+            .Concat(positionalArguments.Select(static argument => argument.PropertyName))
+            .Concat(compatibilityProperties.Select(static property => property.PropertyName))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var baseline in baselineProperties.Where(static property =>
+                     !property.IsRequired
+                     && property.CSharpType is "string?" or "int?"
+                     && property.SwitchName?.Contains('[', StringComparison.Ordinal) == true))
+        {
+            var optionIndex = Array.FindIndex(options, option =>
+                option.PropertyName.Equals(baseline.PropertyName, StringComparison.Ordinal)
+                && option.ValueArity == CliOptionValueArity.Optional
+                && NormalizeCliSwitchIdentity(baseline.SwitchName!)
+                    .Equals(option.SwitchName, StringComparison.Ordinal));
+            if (optionIndex < 0)
+            {
+                continue;
+            }
+
+            var replacementName = GetUniqueReplacementName(
+                $"{baseline.PropertyName}Option",
+                propertyNames);
+            propertyNames.Add(replacementName);
+            options[optionIndex] = options[optionIndex] with { PropertyName = replacementName };
+            PreserveCompatibilityProperty(
+                command,
+                new CliCompatibilityProperty
+                {
+                    PropertyName = baseline.PropertyName,
+                    CSharpType = baseline.CSharpType,
+                    ForwardToPropertyName = replacementName,
+                    ForwardingKind = baseline.CSharpType.Equals("int?", StringComparison.Ordinal)
+                        ? CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue
+                        : CliCompatibilityForwardingKind.NullableStringToCliOptionValue,
+                    ObsoleteMessage = $"Use {replacementName} instead.",
+                },
+                compatibilityProperties,
+                violations);
+            renamedProperties[baseline.PropertyName] = replacementName;
+            preserved.Add(baseline.PropertyName);
+        }
+
+        return preserved;
+    }
+
+    private static string NormalizeCliSwitchIdentity(string switchName)
+    {
+        var optionalValueStart = switchName.IndexOf('[', StringComparison.Ordinal);
+        if (optionalValueStart >= 0)
+        {
+            return switchName[..optionalValueStart];
+        }
+
+        var placeholderStart = switchName.IndexOf('<', StringComparison.Ordinal);
+        if (placeholderStart < 0)
+        {
+            return switchName;
+        }
+
+        var switchEnd = placeholderStart;
+        while (switchEnd > 0 && (switchName[switchEnd - 1] == '='
+                                 || char.IsWhiteSpace(switchName[switchEnd - 1])))
+        {
+            switchEnd--;
+        }
+
+        return switchName[..switchEnd];
     }
 
     private static void RestoreBaselinePropertyShapes(
@@ -2047,6 +2135,7 @@ internal static class GeneratedApiCompatibilityPreserver
         {
             "string" => CliCompatibilityForwardingKind.NullableStringToRequiredString,
             "IEnumerable<string>?" => CliCompatibilityForwardingKind.ScalarToCollection,
+            "CliOptionValue?" => CliCompatibilityForwardingKind.NullableStringToCliOptionValue,
             _ => null,
         };
     }
@@ -2128,12 +2217,27 @@ internal static class GeneratedApiCompatibilityPreserver
             return;
         }
 
-        if (!HasCompatibleCliIdentity(current, baseline))
+        if (!HasCompatibleCliIdentity(current, baseline)
+            && !AllowsRenderingPhaseMigration(command, current, baseline))
         {
             violations.Add(
                 $"{command.ClassName}.{baseline.PropertyName} changed CLI switch or argument position");
         }
     }
+
+    private static bool AllowsRenderingPhaseMigration(
+        CliCommandDefinition command,
+        GeneratedApiProperty current,
+        GeneratedApiProperty baseline) =>
+        current.ArgumentPosition is not null
+        && baseline.ArgumentPosition is not null
+        && current.ArgumentPosition == baseline.ArgumentPosition
+        && (!baseline.PrependOptionTerminator || current.PrependOptionTerminator)
+        && (!baseline.PrependOptionTerminatorIfValueStartsWithDash
+            || current.PrependOptionTerminatorIfValueStartsWithDash)
+        && command.PositionalArguments.Any(argument =>
+            argument.AllowRenderingPhaseMigrationFromBaseline
+            && argument.PropertyName.Equals(current.PropertyName, StringComparison.Ordinal));
 
     private static bool ValidateMatchingPropertyShape(
         CliCommandDefinition command,
@@ -2683,7 +2787,11 @@ internal static class GeneratedApiCompatibilityPreserver
 
         if (left.SwitchName is not null || right.SwitchName is not null)
         {
-            return left.SwitchName?.Equals(right.SwitchName, StringComparison.Ordinal) == true;
+            return left.SwitchName is not null
+                   && right.SwitchName is not null
+                   && NormalizeCliSwitchIdentity(left.SwitchName).Equals(
+                       NormalizeCliSwitchIdentity(right.SwitchName),
+                       StringComparison.Ordinal);
         }
 
         return true;
@@ -3305,6 +3413,18 @@ internal static class GeneratedApiCompatibilityPreserver
                 CliCompatibilityForwardingKind.ScalarToCollection);
         }
 
+        if (expression is ConditionalAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax optionValue,
+                WhenNotNull: MemberBindingExpressionSyntax optionValueMember,
+            }
+            && optionValueMember.Name.Identifier.ValueText.Equals("Value", StringComparison.Ordinal))
+        {
+            return (
+                optionValue.Identifier.ValueText,
+                CliCompatibilityForwardingKind.NullableStringToCliOptionValue);
+        }
+
         if (TryGetNullableInt32Forwarding(expression, setterExpression, out var forwarding))
         {
             return forwarding;
@@ -3357,6 +3477,19 @@ internal static class GeneratedApiCompatibilityPreserver
             forwarding = (
                 collectionTarget.Identifier.ValueText,
                 CliCompatibilityForwardingKind.NullableInt32ToStringCollection);
+            return true;
+        }
+
+        if (arguments[0].Expression is ConditionalAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax optionValueTarget,
+                WhenNotNull: MemberBindingExpressionSyntax optionValueMember,
+            }
+            && optionValueMember.Name.Identifier.ValueText.Equals("Value", StringComparison.Ordinal))
+        {
+            forwarding = (
+                optionValueTarget.Identifier.ValueText,
+                CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue);
             return true;
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -46,10 +46,9 @@ internal static class GeneratedApiCompatibilityPreserver
         MergeCurrentAliasEnumValues(tool, enumBaseline);
         tool = tool with
         {
-            CompatibilityEnums = tool.CompatibilityEnums
+            CompatibilityEnums = [.. tool.CompatibilityEnums
                 .Concat(enumBaseline.Values)
-                .DistinctBy(static definition => definition.EnumName)
-                .ToArray(),
+                .DistinctBy(static definition => definition.EnumName)],
         };
         var compatibleTool = baseline.TryGetValue($"{tool.NamespacePrefix}Options", out var globalBaseline)
             ? PreserveGlobalOptions(tool, globalBaseline.Properties)
@@ -97,7 +96,7 @@ internal static class GeneratedApiCompatibilityPreserver
         var commandGlobalCompatibilityProperties = compatibleTool.GlobalCompatibilityProperties;
         var preservedTool = compatibleTool with
         {
-            Commands = commands
+            Commands = [.. commands
                 .Select(command => baseline.TryGetValue(command.ClassName, out var commandBaseline)
                     ? Preserve(
                         command,
@@ -123,8 +122,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 .Select(command => optionalFacadeOptionTypes.Contains(command.ClassName)
                     ? command with { PreserveOptionalOptionsParameter = true }
                     : command)
-                .Select(command => PreserveFacadeMethodCasing(command, facadeMethods))
-                .ToArray(),
+                .Select(command => PreserveFacadeMethodCasing(command, facadeMethods))],
         };
         RejectRemovedFacadeMethods(preservedTool, facadeMethods);
         return preservedTool;
@@ -142,7 +140,7 @@ internal static class GeneratedApiCompatibilityPreserver
             .GroupBy(static method => method.OptionsType, StringComparer.Ordinal)
             .ToDictionary(
                 static group => group.Key,
-                static group => (IReadOnlyList<GeneratedFacadeMethod>) group.ToArray(),
+                static group => (IReadOnlyList<GeneratedFacadeMethod>) [.. group],
                 StringComparer.Ordinal);
         foreach (var commandBaseline in baseline.Values
                      .Where(command => command.CommandParts is { Length: > 0 }
@@ -220,7 +218,12 @@ internal static class GeneratedApiCompatibilityPreserver
     {
         var commandParts = baseline.CommandParts!;
         var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, baseline, facadeMethods);
-        var subDomainGroup = commandParts.Length > 1
+        var preserveRootNamedFacade = facadeMethods.Any(method =>
+            IsRootFacadeMethod(tool, method)
+            && IsNamedFacadeMethod(tool, method));
+        var currentRootMethodName = GeneratorUtils.EnsureAsyncSuffix(
+            GeneratorUtils.GenerateMethodNameFromCommandParts(commandParts));
+        var subDomainGroup = commandParts.Length > 1 && !preserveRootNamedFacade
             ? GetRestoredSubDomainGroup(tool, commandParts[0], groupIdentifier)
             : null;
 
@@ -235,8 +238,19 @@ internal static class GeneratedApiCompatibilityPreserver
             PositionalArguments = RestoreRemovedPositionalArguments(baseline.Properties),
             CompatibilityProperties = RestoreRemovedCompatibilityProperties(baseline.Properties),
             CompatibilityConstructors = baseline.Constructors,
+            CompatibilityMethods = [.. facadeMethods
+                .Where(method => IsRootFacadeMethod(tool, method)
+                                 && IsNamedFacadeMethod(tool, method))
+                .Select(method => new CliCompatibilityMethod
+                {
+                    MethodName = method.MethodName,
+                    ObsoleteMessage = $"Use {currentRootMethodName} instead.",
+                })
+                .DistinctBy(static method => method.MethodName, StringComparer.Ordinal)],
             SubDomainGroup = subDomainGroup,
-            CommandGroupIdentifierOverride = commandParts.Length > 1 ? groupIdentifier : null,
+            CommandGroupIdentifierOverride = commandParts.Length > 1 && !preserveRootNamedFacade
+                ? groupIdentifier
+                : null,
             CommandPartIdentifierOverrides = GetRestoredCommandPartIdentifierOverrides(
                 tool,
                 commandParts,
@@ -246,9 +260,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 GetFacadeImplementationType(tool, method),
                 method)),
             PreserveNamedFacade = facadeMethods.Any(method => IsNamedFacadeMethod(tool, method)),
-            PreserveRootNamedFacade = facadeMethods.Any(method =>
-                IsRootFacadeMethod(tool, method)
-                && IsNamedFacadeMethod(tool, method)),
+            PreserveRootNamedFacade = preserveRootNamedFacade,
             PreserveOptionalOptionsParameter = facadeMethods.Any(static method => method.IsOptionsOptional),
         };
     }
@@ -317,9 +329,7 @@ internal static class GeneratedApiCompatibilityPreserver
         {
             var recoveredIdentifiers = SplitRecoveredIdentifiers(
                 baseline.ClassName[tool.NamespacePrefix.Length..^"Options".Length],
-                baseline.CommandParts!
-                    .Select(GeneratorUtils.ToPascalCase)
-                    .ToArray());
+                [.. baseline.CommandParts!.Select(GeneratorUtils.ToPascalCase)]);
             if (recoveredIdentifiers is not null)
             {
                 return recoveredIdentifiers[0];
@@ -377,7 +387,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 continue;
             }
 
-            recoveredOverrides ??= new Dictionary<int, string>();
+            recoveredOverrides ??= [];
             foreach (var (partIndex, identifier) in candidate)
             {
                 if (recoveredOverrides.TryGetValue(partIndex, out var recoveredIdentifier)
@@ -390,7 +400,7 @@ internal static class GeneratedApiCompatibilityPreserver
             }
         }
 
-        return recoveredOverrides ?? new Dictionary<int, string>();
+        return recoveredOverrides ?? [];
     }
 
     private static Dictionary<int, string>? GetRecoveredCommandPartIdentifierOverrides(
@@ -540,7 +550,7 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static CliOptionDefinition[] RestoreRemovedOptions(
         IEnumerable<GeneratedApiProperty> properties) =>
-        properties
+        [.. properties
             .Where(static property => !property.IsCompatibility && property.SwitchName is not null)
             .Select(static property => new CliOptionDefinition
             {
@@ -558,12 +568,11 @@ internal static class GeneratedApiCompatibilityPreserver
                 IsSecret = property.IsSecret,
                 SecretValueKeys = property.SecretValueKeys ?? [],
                 ValidationConstraints = property.ValidationConstraints,
-            })
-            .ToArray();
+            })];
 
     private static CliPositionalArgument[] RestoreRemovedPositionalArguments(
         IEnumerable<GeneratedApiProperty> properties) =>
-        properties
+        [.. properties
             .Where(static property => !property.IsCompatibility && property.ArgumentPosition is not null)
             .Select(static property => new CliPositionalArgument
             {
@@ -576,12 +585,11 @@ internal static class GeneratedApiCompatibilityPreserver
                 PrependOptionTerminatorIfValueStartsWithDash =
                     property.PrependOptionTerminatorIfValueStartsWithDash,
                 IsSecret = property.IsSecret,
-            })
-            .ToArray();
+            })];
 
     private static CliCompatibilityProperty[] RestoreRemovedCompatibilityProperties(
         IEnumerable<GeneratedApiProperty> properties) =>
-        properties
+        [.. properties
             .Where(static property => property.IsCompatibility)
             .Select(static property => new CliCompatibilityProperty
             {
@@ -592,8 +600,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 ForwardingKind = property.ForwardingKind,
                 ObsoleteMessage = property.ObsoleteMessage
                     ?? $"{property.PropertyName} is retained for compatibility.",
-            })
-            .ToArray();
+            })];
 
     private static CliCommandDefinition PreserveIdentifierCasing(
         CliToolDefinition tool,
@@ -721,18 +728,16 @@ internal static class GeneratedApiCompatibilityPreserver
 
         return preserved with
         {
-            Enums = preserved.Enums.Select(Rename).ToArray(),
-            Options = preserved.Options.Select(option => RenameOptionEnum(
+            Enums = [.. preserved.Enums.Select(Rename)],
+            Options = [.. preserved.Options.Select(option => RenameOptionEnum(
                     option,
                     enumRenames,
-                    option.EnumDefinition is null ? null : Rename(option.EnumDefinition)))
-                .ToArray(),
-            CompatibilityProperties = preserved.CompatibilityProperties
+                    option.EnumDefinition is null ? null : Rename(option.EnumDefinition)))],
+            CompatibilityProperties = [.. preserved.CompatibilityProperties
                 .Select(property => property with
                 {
                     CSharpType = RenameEnumType(property.CSharpType, enumRenames),
-                })
-                .ToArray(),
+                })],
         };
     }
 
@@ -833,10 +838,9 @@ internal static class GeneratedApiCompatibilityPreserver
 
         return command with
         {
-            CompatibilityMethods = command.CompatibilityMethods
+            CompatibilityMethods = [.. command.CompatibilityMethods
                 .Concat(compatibilityMethods)
-                .DistinctBy(static method => method.MethodName, StringComparer.Ordinal)
-                .ToArray(),
+                .DistinctBy(static method => method.MethodName, StringComparer.Ordinal)],
         };
     }
 
@@ -980,13 +984,8 @@ internal static class GeneratedApiCompatibilityPreserver
         }
 
         var canonicalProperty = canonicalProperties.FirstOrDefault(property =>
-            property.PropertyName.Equals(baselineProperty.PropertyName, StringComparison.Ordinal));
-        if (canonicalProperty is null)
-        {
-            throw new InvalidOperationException(
+            property.PropertyName.Equals(baselineProperty.PropertyName, StringComparison.Ordinal)) ?? throw new InvalidOperationException(
                 $"Cannot retain alias property {baselineProperty.PropertyName} because the canonical property is missing.");
-        }
-
         EnsureAliasPropertyCanForward(baselineProperty, canonicalProperty, enumBaseline);
         var supplied = compatibilityProperties.FirstOrDefault(existing =>
             existing.PropertyName.Equals(baselineProperty.PropertyName, StringComparison.Ordinal));
@@ -1200,9 +1199,8 @@ internal static class GeneratedApiCompatibilityPreserver
         RetargetCompatibilityProperties(compatibilityProperties, renamedProperties);
         ResolveCompatibilityForwardingTargets(
             compatibilityProperties,
-            GetCurrentProperties(positionalArguments, options)
-                .Concat((globalOptions ?? []).Select(ToGeneratedProperty))
-                .ToArray(),
+            [.. GetCurrentProperties(positionalArguments, options)
+, .. (globalOptions ?? []).Select(ToGeneratedProperty)],
             globalCompatibilityProperties ?? []);
 
         if (violations.Count > 0)
@@ -1775,7 +1773,7 @@ internal static class GeneratedApiCompatibilityPreserver
             livePropertyNames.Add(baseline.PropertyName);
         }
 
-        return restored.ToArray();
+        return [.. restored];
     }
 
     private static bool OccupiesSamePositionalSlot(
@@ -2563,9 +2561,7 @@ internal static class GeneratedApiCompatibilityPreserver
         PreserveCompatibilityConstructors(
             baselineProperties,
             baselineConstructors,
-            GetCurrentProperties(positionalArguments, options)
-                .Where(static property => property.IsRequired)
-                .ToArray(),
+            [.. GetCurrentProperties(positionalArguments, options).Where(static property => property.IsRequired)],
             compatibilityConstructors,
             allowNewRequiredMembers: true);
 
@@ -2643,12 +2639,11 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<GeneratedApiProperty> currentRequired) =>
         constructor with
         {
-            PrimaryConstructorArguments = currentRequired
+            PrimaryConstructorArguments = [.. currentRequired
                 .Select(current => GetPreservedPrimaryConstructorArgument(
                     constructor,
                     baselineRequired,
-                    current))
-                .ToArray(),
+                    current))],
         };
 
     private static string GetPreservedPrimaryConstructorArgument(
@@ -2684,12 +2679,11 @@ internal static class GeneratedApiCompatibilityPreserver
 
         constructor = constructor with
         {
-            PrimaryConstructorArguments = constructor.PrimaryConstructorArguments
+            PrimaryConstructorArguments = [.. constructor.PrimaryConstructorArguments
                 .Select((argument, index) => argument.Equals("default!", StringComparison.Ordinal)
                                              && index < currentRequired.Count
                     ? GetTypedDefault(currentRequired[index].CSharpType)
-                    : argument)
-                .ToArray(),
+                    : argument)],
         };
 
         var existing = constructors.FirstOrDefault(candidate => HasSameConstructorSignature(
@@ -2805,9 +2799,8 @@ internal static class GeneratedApiCompatibilityPreserver
     private static GeneratedApiProperty[] GetCurrentProperties(
         IEnumerable<CliPositionalArgument> positionalArguments,
         IEnumerable<CliOptionDefinition> options) =>
-        options.Select(ToGeneratedProperty)
-            .Concat(positionalArguments.Select(ToGeneratedProperty))
-            .ToArray();
+        [.. options.Select(ToGeneratedProperty)
+, .. positionalArguments.Select(ToGeneratedProperty)];
 
     private static GeneratedApiProperty ToGeneratedProperty(CliPositionalArgument argument) =>
         new(
@@ -3040,10 +3033,9 @@ internal static class GeneratedApiCompatibilityPreserver
 
             enumBaseline[pair.Key] = pair.Value with
             {
-                Values = pair.Value.Values
+                Values = [.. pair.Value.Values
                     .Concat(currentValues)
-                    .DistinctBy(static value => value.CliValue, StringComparer.Ordinal)
-                    .ToArray(),
+                    .DistinctBy(static value => value.CliValue, StringComparer.Ordinal)],
             };
         }
     }
@@ -3059,13 +3051,12 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static CliCompatibilityConstructor[] ReadCompatibilityConstructors(
         RecordDeclarationSyntax declaration) =>
-        declaration.Members
+        [.. declaration.Members
             .OfType<ConstructorDeclarationSyntax>()
             .Where(constructor => constructor.Modifiers.Any(SyntaxKind.PublicKeyword))
             .Where(constructor => constructor.Initializer?.IsKind(
                 SyntaxKind.ThisConstructorInitializer) == true)
-            .Select(constructor => ReadCompatibilityConstructor(declaration, constructor))
-            .ToArray();
+            .Select(constructor => ReadCompatibilityConstructor(declaration, constructor))];
 
     private static CliCompatibilityConstructor ReadCompatibilityConstructor(
         RecordDeclarationSyntax declaration,
@@ -3079,9 +3070,7 @@ internal static class GeneratedApiCompatibilityPreserver
         return new CliCompatibilityConstructor
         {
             Parameters = parameters,
-            PrimaryConstructorArguments = constructor.Initializer!.ArgumentList.Arguments
-                .Select(argument => argument.Expression.ToString())
-                .ToArray(),
+            PrimaryConstructorArguments = [.. constructor.Initializer!.ArgumentList.Arguments.Select(argument => argument.Expression.ToString())],
             PreserveDeconstruct = HasMatchingDeconstruct(declaration, parameters),
         };
     }
@@ -3162,9 +3151,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 SearchOption.TopDirectoryOnly)
             .Where(IsGeneratedBaselineFile)
             .Select(File.ReadAllText);
-        return ReadFacadeMethods(sources, targetNamespace)
-            .Where(method => IsFacadeOwnedByTool(method, namespacePrefix, baseline))
-            .ToArray();
+        return [.. ReadFacadeMethods(sources, targetNamespace).Where(method => IsFacadeOwnedByTool(method, namespacePrefix, baseline))];
     }
 
     private static bool IsFacadeOwnedByTool(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -2074,6 +2074,9 @@ internal static class GeneratedApiCompatibilityPreserver
             (CliCompatibilityForwardingKind.NullableInt32ToString,
                 CliCompatibilityForwardingKind.ScalarToCollection) =>
                 CliCompatibilityForwardingKind.NullableInt32ToStringCollection,
+            (CliCompatibilityForwardingKind.NullableInt32ToString,
+                CliCompatibilityForwardingKind.NullableStringToCliOptionValue) =>
+                CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue,
             _ => throw new InvalidOperationException(
                 $"Compatibility property '{property.PropertyName}' has unsupported composed forwarding "
                 + $"conversions {first} and {second}."),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -78,6 +78,14 @@ public static partial class GeneratorUtils
                 sb.AppendLine($"        get => int.TryParse({property.ForwardToPropertyName}?.FirstOrDefault(), global::System.Globalization.NumberStyles.Integer, global::System.Globalization.CultureInfo.InvariantCulture, out var value) ? value : null;");
                 sb.AppendLine($"        {setter} => {property.ForwardToPropertyName} = value is null ? null : [value.Value.ToString(global::System.Globalization.CultureInfo.InvariantCulture)];");
                 break;
+            case CliCompatibilityForwardingKind.NullableStringToCliOptionValue:
+                sb.AppendLine($"        get => {property.ForwardToPropertyName}?.Value;");
+                sb.AppendLine($"        {setter} => {property.ForwardToPropertyName} = value;");
+                break;
+            case CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue:
+                sb.AppendLine($"        get => int.TryParse({property.ForwardToPropertyName}?.Value, global::System.Globalization.NumberStyles.Integer, global::System.Globalization.CultureInfo.InvariantCulture, out var value) ? value : null;");
+                sb.AppendLine($"        {setter} => {property.ForwardToPropertyName} = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);");
+                break;
             default:
                 throw new ArgumentOutOfRangeException(
                     nameof(property.ForwardingKind),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -66,6 +66,10 @@ public static partial class GeneratorUtils
                 sb.AppendLine($"        get => int.TryParse({property.ForwardToPropertyName}, global::System.Globalization.NumberStyles.Integer, global::System.Globalization.CultureInfo.InvariantCulture, out var value) ? value : null;");
                 sb.AppendLine($"        {setter} => {property.ForwardToPropertyName} = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);");
                 break;
+            case CliCompatibilityForwardingKind.NullableBooleanToString:
+                sb.AppendLine($"        get => bool.TryParse({property.ForwardToPropertyName}, out var value) ? value : null;");
+                sb.AppendLine($"        {setter} => {property.ForwardToPropertyName} = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);");
+                break;
             case CliCompatibilityForwardingKind.NullableStringToRequiredString:
                 sb.AppendLine($"        get => {property.ForwardToPropertyName};");
                 sb.AppendLine($"        {setter} => {property.ForwardToPropertyName} = value ?? string.Empty;");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -256,6 +256,7 @@ public enum CliCompatibilityForwardingKind
     Direct,
     ScalarToCollection,
     NullableInt32ToString,
+    NullableBooleanToString,
     NullableStringToRequiredString,
     NullableInt32ToRequiredString,
     NullableInt32ToStringCollection,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -259,6 +259,8 @@ public enum CliCompatibilityForwardingKind
     NullableStringToRequiredString,
     NullableInt32ToRequiredString,
     NullableInt32ToStringCollection,
+    NullableStringToCliOptionValue,
+    NullableInt32ToCliOptionValue,
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
@@ -107,6 +107,12 @@ public record CliPositionalArgument
     public bool PrependOptionTerminatorIfValueStartsWithDash { get; init; }
 
     /// <summary>
+    /// Allows an intentional rendering-phase migration for an existing generated operand.
+    /// The compatibility guard still requires the same property name, type, and position.
+    /// </summary>
+    public bool AllowRenderingPhaseMigrationFromBaseline { get; init; }
+
+    /// <summary>
     /// Whether this positional argument contains a secret value that should be obfuscated in logs.
     /// </summary>
     public bool IsSecret { get; init; }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
@@ -56,6 +56,9 @@ public partial class ArgoCdCliScraper : CobraCliScraper
         string[] commandParts,
         IReadOnlyList<CliPositionalArgument> positionalArguments)
     {
+        positionalArguments = positionalArguments
+            .Where(argument => !UsageSynopsisParser.IsCommandGroupPlaceholder(argument))
+            .ToArray();
         var commandSpecificArguments = GetCommandSpecificArguments(commandParts, positionalArguments);
         if (commandSpecificArguments is not null)
         {
@@ -91,6 +94,11 @@ public partial class ArgoCdCliScraper : CobraCliScraper
             .ToList();
     }
 
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
+
     private static IReadOnlyList<CliPositionalArgument>? GetCommandSpecificArguments(
         string[] commandParts,
         IReadOnlyList<CliPositionalArgument> positionalArguments) => commandParts switch
@@ -106,6 +114,13 @@ public partial class ArgoCdCliScraper : CobraCliScraper
                 })
                 .ToList(),
             ["app", "delete"] or ["app", "sync"] or ["app", "wait"] => [ApplicationNamesArgument()],
+            ["app", "unset"] =>
+            [
+                RequiredArgument(
+                    "ApplicationName",
+                    "string",
+                    "Application name."),
+            ],
             ["repo", "rm"] =>
             [
                 RequiredArgument(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -475,6 +475,7 @@ public abstract partial class CliScraperBase : ICliScraper
         usage = NormalizeUsageSynopsis(command, usage);
         command = command with
         {
+            HasOperandTakingUsage = usage.HasOperandTokens,
             UsagePositionalArguments = usage.PositionalArguments,
         };
         command.ValidateOperandCoverage(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -120,6 +120,14 @@ public abstract partial class CliScraperBase : ICliScraper
     protected virtual IReadOnlySet<string> AdditionalSkipSubcommands => new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Returns whether tool-specific syntax proves an option is scalar despite repeatability prose
+    /// elsewhere in the same help block.
+    /// </summary>
+    protected virtual bool ShouldTreatOptionAsScalar(
+        IReadOnlyList<string> commandParts,
+        string switchName) => false;
+
+    /// <summary>
     /// Global options that are documented but absent from the installed CLI's help output.
     /// </summary>
     protected virtual IReadOnlyList<CliOptionDefinition> SupplementalGlobalOptions => [];
@@ -1000,7 +1008,7 @@ public abstract partial class CliScraperBase : ICliScraper
         Func<string, CliArgumentDefinition?> parseArgument) =>
         CliArgumentGroupParser.Parse(section, parseArgument);
 
-    private static void ValidateOptionShapes(CliCommandDefinition command, string helpText)
+    private void ValidateOptionShapes(CliCommandDefinition command, string helpText)
     {
         foreach (var option in command.Options)
         {
@@ -1016,6 +1024,7 @@ public abstract partial class CliScraperBase : ICliScraper
             if (!option.IsFlag
                 && !isBoolean
                 && HelpDeclaresRepeatableOption(helpText, option.SwitchName, description)
+                && !ShouldTreatOptionAsScalar(command.CommandParts, option.SwitchName)
                 && !option.AcceptsMultipleValues)
             {
                 throw new InvalidOperationException(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -1003,7 +1003,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// "Utility Commands:", etc. Uses a flexible pattern to match any word prefix.
     /// </summary>
     [GeneratedRegex(
-        @"^(?:[A-Z][\w-]*(?:[ \t]+[A-Z][\w-]*)*[ \t]+)?(?:Commands|COMMANDS):?[ \t]*$",
+        @"^(?:[A-Z][\w-]*(?:[ \t]+[A-Za-z][\w-]*)*[ \t]+)?(?:Commands|COMMANDS):?[ \t]*$",
         RegexOptions.Multiline)]
     private static partial Regex CommandsSectionPattern();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
@@ -33,6 +33,31 @@ public class DockerCliScraper : CobraCliScraper
         DockerCliCompatibility.DetectCommandGroupAlias(commandPath, helpText);
 
     /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        IsBuildxCommandGroup(command.CommandParts)
+            ? UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage)
+            : usage;
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        IsBuildxCommandGroup(commandParts)
+            ? positionalArguments
+                .Where(argument => !UsageSynopsisParser.IsCommandGroupPlaceholder(argument))
+                .ToArray()
+            : positionalArguments;
+
+    private static bool IsBuildxCommandGroup(IReadOnlyList<string> commandParts) =>
+        commandParts is ["buildx"]
+        or ["buildx", "dap"]
+        or ["buildx", "history"]
+        or ["buildx", "imagetools"]
+        or ["buildx", "policy"];
+
+    /// <inheritdoc />
     protected override string NormalizeOptionSwitchName(
         string[] commandParts,
         string switchName) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -480,7 +480,41 @@ public partial class DotNetCliScraper : CliScraperBase
             ];
         }
 
+        // Keep the established public API names until a major release can model the newer
+        // NuGet operand spellings and push cardinality without compatibility warnings.
+        if (commandKey.Equals("nuget add source", StringComparison.OrdinalIgnoreCase))
+        {
+            return RenameSingleArgument(args, "Packagesourcepath", isVariadic: false);
+        }
+
+        if (commandKey.Equals("nuget push", StringComparison.OrdinalIgnoreCase))
+        {
+            return RenameSingleArgument(args, "Path", isVariadic: false);
+        }
+
         return args;
+    }
+
+    private static List<CliPositionalArgument> RenameSingleArgument(
+        List<CliPositionalArgument> args,
+        string propertyName,
+        bool isVariadic)
+    {
+        if (args.Count != 1)
+        {
+            return args;
+        }
+
+        var argument = args[0];
+        return
+        [
+            argument with
+            {
+                PropertyName = propertyName,
+                CSharpType = isVariadic ? "IEnumerable<string>?" : "string?",
+                IsVariadic = isVariadic,
+            },
+        ];
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -153,6 +153,11 @@ public partial class GcloudCliScraper : CliScraperBase
                base.IsSkippableSubcommand(subcommand);
     }
 
+    protected override bool ShouldTreatOptionAsScalar(
+        IReadOnlyList<string> commandParts,
+        string switchName) =>
+        switchName.Equals("--external-ipv6-prefix-length", StringComparison.OrdinalIgnoreCase);
+
     #endregion
 
     #region Gcloud-Specific Parsing Helpers

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -64,4 +65,86 @@ public partial class GhCliScraper : CobraCliScraper
         string helpText) =>
         RepeatableOptions.Contains(switchName)
         || base.IsRepeatableOption(commandParts, switchName, typeHint, description, helpText);
+
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        positionalArguments
+            .Where(argument => ShouldKeepOperand(commandParts, argument))
+            .Select(argument => NormalizeOperand(commandParts, argument))
+            .ToArray();
+
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage)
+    {
+        var positionalArguments = usage.PositionalArguments
+            .Where(argument => ShouldKeepOperand(command.CommandParts, argument))
+            .Select(argument => NormalizeOperand(command.CommandParts, argument))
+            .ToArray();
+        return usage with
+        {
+            HasOperandTokens = positionalArguments.Length > 0 || usage.UnparsedOperandTokens.Count > 0,
+            PositionalArguments = positionalArguments,
+        };
+    }
+
+    private static bool ShouldKeepOperand(
+        IReadOnlyList<string> commandParts,
+        CliPositionalArgument argument) =>
+        !UsageSynopsisParser.IsCommandGroupPlaceholder(argument)
+        || commandParts is ["codespace", "ssh"];
+
+    private static CliPositionalArgument NormalizeOperand(
+        IReadOnlyList<string> commandParts,
+        CliPositionalArgument argument)
+    {
+        if (argument.Phase == CommandLinePhase.Passthrough
+            && argument.PropertyName is "SshFlags" or "Gitflags")
+        {
+            return argument with
+            {
+                CSharpType = "IEnumerable<string>?",
+                IsRequired = false,
+                IsVariadic = true,
+            };
+        }
+
+        var command = string.Join(' ', commandParts);
+        if (command.Equals("issue edit", StringComparison.Ordinal)
+            && argument.PropertyName.Equals("Numbers", StringComparison.Ordinal))
+        {
+            return argument with
+            {
+                PropertyName = "NumbersOrUrls",
+                CSharpType = "IEnumerable<string>",
+                IsVariadic = true,
+            };
+        }
+
+        var propertyName = (command, argument.PropertyName) switch
+        {
+            ("agent-task view", "SessionId") => "SessionIdOrPrNumberOrPrUrlOrPrBranch",
+            ("attestation download" or "attestation verify", "FilePath") => "FilePathOrImageUri",
+            ("browse", "Number") => "NumberOrPathOrCommitSha",
+            ("cache delete", "CacheId") => "CacheIdOrCacheKey",
+            ("discussion comment" or "discussion view", "Number") =>
+                "NumberOrDiscussionUrlOrCommentIdOrCommentUrl",
+            ("discussion edit", "Number") => "NumberOrDiscussionUrl",
+            ("gist create", "FilenameArgument") => "FilenameOrPattern",
+            ("gist delete" or "gist edit" or "gist rename" or "gist view", "Id") => "IdOrUrl",
+            ("release create", "Filename") => "FilenameOrPattern",
+            ("workflow disable" or "workflow enable" or "workflow run", "WorkflowId") =>
+                "WorkflowIdOrWorkflowName",
+            ("workflow view", "WorkflowId") => "WorkflowIdOrWorkflowNameOrFilename",
+            _ when command.StartsWith("issue ", StringComparison.Ordinal)
+                   && argument.PropertyName.Equals("Number", StringComparison.Ordinal) => "NumberOrUrl",
+            _ when command is "pr lock" or "pr unlock"
+                   && argument.PropertyName.Equals("Number", StringComparison.Ordinal) => "NumberOrUrl",
+            _ when command.StartsWith("pr ", StringComparison.Ordinal)
+                   && argument.PropertyName.Equals("Number", StringComparison.Ordinal) => "NumberOrUrlOrBranch",
+            _ => argument.PropertyName,
+        };
+        return argument with { PropertyName = propertyName };
+    }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
@@ -26,6 +26,29 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public partial class GhCliScraper : CobraCliScraper
 {
+    private static readonly IReadOnlyDictionary<(string Command, string Operand), string> OperandNames =
+        new Dictionary<(string Command, string Operand), string>
+        {
+            [("agent-task view", "SessionId")] = "SessionIdOrPrNumberOrPrUrlOrPrBranch",
+            [("attestation download", "FilePath")] = "FilePathOrImageUri",
+            [("attestation verify", "FilePath")] = "FilePathOrImageUri",
+            [("browse", "Number")] = "NumberOrPathOrCommitSha",
+            [("cache delete", "CacheId")] = "CacheIdOrCacheKey",
+            [("discussion comment", "Number")] = "NumberOrDiscussionUrlOrCommentIdOrCommentUrl",
+            [("discussion view", "Number")] = "NumberOrDiscussionUrlOrCommentIdOrCommentUrl",
+            [("discussion edit", "Number")] = "NumberOrDiscussionUrl",
+            [("gist create", "FilenameArgument")] = "FilenameOrPattern",
+            [("gist delete", "Id")] = "IdOrUrl",
+            [("gist edit", "Id")] = "IdOrUrl",
+            [("gist rename", "Id")] = "IdOrUrl",
+            [("gist view", "Id")] = "IdOrUrl",
+            [("release create", "Filename")] = "FilenameOrPattern",
+            [("workflow disable", "WorkflowId")] = "WorkflowIdOrWorkflowName",
+            [("workflow enable", "WorkflowId")] = "WorkflowIdOrWorkflowName",
+            [("workflow run", "WorkflowId")] = "WorkflowIdOrWorkflowName",
+            [("workflow view", "WorkflowId")] = "WorkflowIdOrWorkflowNameOrFilename",
+        };
+
     private static readonly HashSet<string> RepeatableOptions = new(StringComparer.OrdinalIgnoreCase)
     {
         "--field",
@@ -122,29 +145,28 @@ public partial class GhCliScraper : CobraCliScraper
             };
         }
 
-        var propertyName = (command, argument.PropertyName) switch
-        {
-            ("agent-task view", "SessionId") => "SessionIdOrPrNumberOrPrUrlOrPrBranch",
-            ("attestation download" or "attestation verify", "FilePath") => "FilePathOrImageUri",
-            ("browse", "Number") => "NumberOrPathOrCommitSha",
-            ("cache delete", "CacheId") => "CacheIdOrCacheKey",
-            ("discussion comment" or "discussion view", "Number") =>
-                "NumberOrDiscussionUrlOrCommentIdOrCommentUrl",
-            ("discussion edit", "Number") => "NumberOrDiscussionUrl",
-            ("gist create", "FilenameArgument") => "FilenameOrPattern",
-            ("gist delete" or "gist edit" or "gist rename" or "gist view", "Id") => "IdOrUrl",
-            ("release create", "Filename") => "FilenameOrPattern",
-            ("workflow disable" or "workflow enable" or "workflow run", "WorkflowId") =>
-                "WorkflowIdOrWorkflowName",
-            ("workflow view", "WorkflowId") => "WorkflowIdOrWorkflowNameOrFilename",
-            _ when command.StartsWith("issue ", StringComparison.Ordinal)
-                   && argument.PropertyName.Equals("Number", StringComparison.Ordinal) => "NumberOrUrl",
-            _ when command is "pr lock" or "pr unlock"
-                   && argument.PropertyName.Equals("Number", StringComparison.Ordinal) => "NumberOrUrl",
-            _ when command.StartsWith("pr ", StringComparison.Ordinal)
-                   && argument.PropertyName.Equals("Number", StringComparison.Ordinal) => "NumberOrUrlOrBranch",
-            _ => argument.PropertyName,
-        };
+        var propertyName = GetOperandName(command, argument.PropertyName);
         return argument with { PropertyName = propertyName };
+    }
+
+    private static string GetOperandName(string command, string operand)
+    {
+        if (OperandNames.TryGetValue((command, operand), out var propertyName))
+        {
+            return propertyName;
+        }
+
+        if (!operand.Equals("Number", StringComparison.Ordinal))
+        {
+            return operand;
+        }
+
+        if (command.StartsWith("issue ", StringComparison.Ordinal)
+            || command is "pr lock" or "pr unlock")
+        {
+            return "NumberOrUrl";
+        }
+
+        return command.StartsWith("pr ", StringComparison.Ordinal) ? "NumberOrUrlOrBranch" : operand;
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -205,7 +206,11 @@ public partial class GoCliScraper : CliScraperBase
     private static IReadOnlyList<CliPositionalArgument> NormalizePositionalArguments(
         IReadOnlyList<string> commandParts,
         IReadOnlyList<CliPositionalArgument> arguments) =>
-        arguments.Select(argument => NormalizePositionalArgument(commandParts, argument)).ToArray();
+        arguments.Select(argument => NormalizePositionalArgument(commandParts, argument) with
+        {
+            Phase = CommandLinePhase.Passthrough,
+        })
+            .ToArray();
 
     private static CliPositionalArgument NormalizePositionalArgument(
         IReadOnlyList<string> commandParts,
@@ -229,7 +234,8 @@ public partial class GoCliScraper : CliScraperBase
             };
         }
 
-        if (argument.PropertyName is not ("Packages" or "Modules" or "Moddirs" or "Targets"))
+        if (argument.PropertyName is not (
+            "Arguments" or "CliArguments" or "Packages" or "Modules" or "Moddirs" or "Targets"))
         {
             return argument;
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
@@ -100,7 +100,7 @@ public partial class PackerCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
-        usage = NormalizeInspectUsage(commandParts, usage);
+        usage = NormalizeUsage(commandParts, usage);
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
@@ -127,23 +127,46 @@ public partial class PackerCliScraper : CliScraperBase
         return Task.FromResult<CliCommandDefinition?>(command);
     }
 
-    private static UsageSynopsisParseResult NormalizeInspectUsage(
+    private static UsageSynopsisParseResult NormalizeUsage(
         IReadOnlyList<string> commandParts,
-        UsageSynopsisParseResult usage) =>
-        commandParts is ["inspect"]
-            ? usage with
+        UsageSynopsisParseResult usage)
+    {
+        if (commandParts is ["inspect"])
+        {
+            return usage with
             {
                 PositionalArguments = usage.PositionalArguments
                     .Select(argument => argument with { Phase = CommandLinePhase.Passthrough })
                     .ToArray(),
-            }
-            : usage;
+            };
+        }
+
+        if (commandParts is not ["plugins"])
+        {
+            return usage;
+        }
+
+        return usage with
+        {
+            PositionalArguments = usage.PositionalArguments
+                .Select(argument => argument.PropertyName is "Args" or "Arguments" or "CliArguments"
+                    ? argument with
+                    {
+                        CSharpType = argument.IsRequired
+                            ? "IEnumerable<string>"
+                            : "IEnumerable<string>?",
+                        IsVariadic = true,
+                    }
+                    : argument)
+                .ToArray(),
+        };
+    }
 
     /// <inheritdoc />
     protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
         CliCommandDefinition command,
         UsageSynopsisParseResult usage) =>
-        NormalizeInspectUsage(command.CommandParts, usage);
+        NormalizeUsage(command.CommandParts, usage);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -173,8 +173,9 @@ public partial class PipCliScraper : CliScraperBase
 
     private static UsageSynopsisParseResult NormalizeParentGroupUsage(
         IReadOnlyList<string> commandParts,
-        UsageSynopsisParseResult usage) =>
-        commandParts is ["cache" or "config" or "index"]
+        UsageSynopsisParseResult usage)
+    {
+        var normalized = commandParts is ["cache" or "config" or "index"]
             ? usage with
             {
                 HasOperandTokens = false,
@@ -182,6 +183,33 @@ public partial class PipCliScraper : CliScraperBase
                 UnparsedOperandTokens = [],
             }
             : usage;
+        var hasPackageIndexLabel = normalized.PositionalArguments.Any(argument =>
+            argument.PropertyName.Equals("PackageIndexOptions", StringComparison.Ordinal));
+        if (!hasPackageIndexLabel)
+        {
+            return normalized;
+        }
+
+        return normalized with
+        {
+            PositionalArguments = normalized.PositionalArguments
+                .Where(argument => !argument.PropertyName.Equals(
+                    "PackageIndexOptions",
+                    StringComparison.Ordinal))
+                .Select(argument => argument.PropertyName.Equals(
+                    "RequirementSpecifier",
+                    StringComparison.Ordinal)
+                    ? argument with
+                    {
+                        CSharpType = argument.IsRequired
+                            ? "IEnumerable<string>"
+                            : "IEnumerable<string>?",
+                        IsVariadic = true,
+                    }
+                    : argument)
+                .ToArray(),
+        };
+    }
 
     /// <inheritdoc />
     protected override UsageSynopsisParseResult NormalizeUsageSynopsis(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -199,8 +200,9 @@ public partial class PnpmCliScraper : CliScraperBase
 
     private static UsageSynopsisParseResult NormalizeParentGroupUsage(
         IReadOnlyList<string> commandParts,
-        UsageSynopsisParseResult usage) =>
-        commandParts is ["stage"]
+        UsageSynopsisParseResult usage)
+    {
+        var normalized = commandParts is ["stage"]
             ? usage with
             {
                 HasOperandTokens = false,
@@ -208,6 +210,13 @@ public partial class PnpmCliScraper : CliScraperBase
                 UnparsedOperandTokens = [],
             }
             : usage;
+        return normalized with
+        {
+            PositionalArguments = normalized.PositionalArguments
+                .Select(argument => argument with { Phase = CommandLinePhase.Passthrough })
+                .ToArray(),
+        };
+    }
 
     /// <inheritdoc />
     protected override UsageSynopsisParseResult NormalizeUsageSynopsis(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -326,75 +326,85 @@ public partial class SnykCliScraper : CliScraperBase
             var optionHeading = proseIndex >= 0 ? line[..proseIndex] : line;
             foreach (Match match in SnykOptionPattern().Matches(optionHeading))
             {
-                var longForm = match.Groups["long"].Value.Trim();
-                var valueHint = match.Groups["value"].Value.Trim().Trim('<', '>', '[', ']');
-
-                if (!seenOptions.Add(longForm))
+                if (CreateOption(match, commandParts, description, seenOptions) is { } option)
                 {
-                    continue;
+                    options.Add(option);
                 }
-
-                var propertyName = NormalizePropertyName(longForm);
-                if (propertyName is null)
-                {
-                    continue;
-                }
-
-                var isNumeric = NumericOptions.Contains(longForm);
-                var isFlag = string.IsNullOrEmpty(valueHint)
-                    && !isNumeric
-                    && !ValueOptionsWithoutHelpPlaceholders.Contains(longForm);
-                var isBoolean = IsBooleanValueHint(valueHint);
-                var acceptsMultipleValues = !IsKnownScalarValueOption(commandParts, longForm)
-                                            && IsRepeatableValueOption(
-                                                description ?? string.Empty,
-                                                isFlag,
-                                                isBoolean);
-                var csharpType = isFlag || isBoolean ? "bool?" : isNumeric ? "int?" : "string?";
-
-                CliEnumDefinition? enumDef = null;
-                if (!isBoolean && !string.IsNullOrEmpty(valueHint) && valueHint.Contains('|'))
-                {
-                    var values = valueHint.Split('|', StringSplitOptions.RemoveEmptyEntries)
-                        .Select(v => v.Trim())
-                        .ToArray();
-                    if (values.Length >= 2)
-                    {
-                        enumDef = new CliEnumDefinition
-                        {
-                            EnumName = $"Snyk{propertyName}",
-                            Values = values.Select(v => new CliEnumValue
-                            {
-                                MemberName = GeneratorUtils.ToEnumMemberName(v),
-                                CliValue = v
-                            }).ToList(),
-                            Description = $"Allowed values for --{longForm.TrimStart('-')}"
-                        };
-                        csharpType = $"{enumDef.EnumName}?";
-                    }
-                }
-
-                csharpType = AsCSharpType(csharpType, acceptsMultipleValues);
-
-                options.Add(new CliOptionDefinition
-                {
-                    SwitchName = longForm,
-                    ShortForm = null,
-                    PropertyName = propertyName,
-                    CSharpType = csharpType,
-                    Description = description,
-                    IsFlag = isFlag,
-                    IsRequired = description?.Contains("Required.", StringComparison.OrdinalIgnoreCase) == true,
-                    AcceptsMultipleValues = acceptsMultipleValues,
-                    IsKeyValue = false,
-                    IsNumeric = isNumeric,
-                    ValueSeparator = isFlag ? " " : "=",
-                    EnumDefinition = enumDef,
-                    IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
-                        || longForm.Equals("--fetch-tfstate-headers", StringComparison.OrdinalIgnoreCase)
-                });
             }
         }
+    }
+
+    private CliOptionDefinition? CreateOption(
+        Match match,
+        IReadOnlyList<string> commandParts,
+        string? description,
+        HashSet<string> seenOptions)
+    {
+        var longForm = match.Groups["long"].Value.Trim();
+        var valueHint = match.Groups["value"].Value.Trim().Trim('<', '>', '[', ']');
+        if (!seenOptions.Add(longForm) || NormalizePropertyName(longForm) is not { } propertyName)
+        {
+            return null;
+        }
+
+        var isNumeric = NumericOptions.Contains(longForm);
+        var isFlag = string.IsNullOrEmpty(valueHint)
+            && !isNumeric
+            && !ValueOptionsWithoutHelpPlaceholders.Contains(longForm);
+        var isBoolean = IsBooleanValueHint(valueHint);
+        var acceptsMultipleValues = !IsKnownScalarValueOption(commandParts, longForm)
+                                    && IsRepeatableValueOption(
+                                        description ?? string.Empty,
+                                        isFlag,
+                                        isBoolean);
+        var enumDefinition = CreateEnumDefinition(propertyName, longForm, valueHint, isBoolean);
+        var scalarType = enumDefinition is not null
+            ? $"{enumDefinition.EnumName}?"
+            : isFlag || isBoolean ? "bool?" : isNumeric ? "int?" : "string?";
+
+        return new CliOptionDefinition
+        {
+            SwitchName = longForm,
+            ShortForm = null,
+            PropertyName = propertyName,
+            CSharpType = AsCSharpType(scalarType, acceptsMultipleValues),
+            Description = description,
+            IsFlag = isFlag,
+            IsRequired = description?.Contains("Required.", StringComparison.OrdinalIgnoreCase) == true,
+            AcceptsMultipleValues = acceptsMultipleValues,
+            IsKeyValue = false,
+            IsNumeric = isNumeric,
+            ValueSeparator = isFlag ? " " : "=",
+            EnumDefinition = enumDefinition,
+            IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
+                || longForm.Equals("--fetch-tfstate-headers", StringComparison.OrdinalIgnoreCase),
+        };
+    }
+
+    private static CliEnumDefinition? CreateEnumDefinition(
+        string propertyName,
+        string longForm,
+        string valueHint,
+        bool isBoolean)
+    {
+        if (isBoolean || string.IsNullOrEmpty(valueHint) || !valueHint.Contains('|'))
+        {
+            return null;
+        }
+
+        var values = valueHint.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return values.Length < 2
+            ? null
+            : new CliEnumDefinition
+            {
+                EnumName = $"Snyk{propertyName}",
+                Values = values.Select(value => new CliEnumValue
+                {
+                    MemberName = GeneratorUtils.ToEnumMemberName(value),
+                    CliValue = value,
+                }).ToList(),
+                Description = $"Allowed values for --{longForm.TrimStart('-')}",
+            };
     }
 
     private static bool IsKnownScalarValueOption(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -165,7 +165,7 @@ public partial class SnykCliScraper : CliScraperBase
         usage = NormalizeCommandGroupUsage(commandParts, usage);
 
         var description = ExtractDescription(helpText);
-        var options = ParseOptions(helpText);
+        var options = ParseOptions(helpText, commandParts);
         AddDocumentedOptions(commandParts, options);
         var positionalArguments = CliPositionalArgument.MergeDuplicates(
             GetPositionalArguments(commandParts)
@@ -263,7 +263,9 @@ public partial class SnykCliScraper : CliScraperBase
     ///         --json
     ///         --sarif
     /// </summary>
-    private List<CliOptionDefinition> ParseOptions(string helpText)
+    private List<CliOptionDefinition> ParseOptions(
+        string helpText,
+        string[] commandParts)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -271,7 +273,7 @@ public partial class SnykCliScraper : CliScraperBase
         var optionsMatch = OptionsSectionPattern().Match(helpText);
         if (!optionsMatch.Success)
         {
-            ParseOptionLines(helpText.Split('\n'), options, seenOptions);
+            ParseOptionLines(helpText.Split('\n'), commandParts, options, seenOptions);
         }
         else
         {
@@ -279,7 +281,7 @@ public partial class SnykCliScraper : CliScraperBase
             var nextSection = NextSectionPattern().Match(helpText, sectionStart);
             var sectionEnd = nextSection.Success ? nextSection.Index : helpText.Length;
             var section = helpText.Substring(sectionStart, sectionEnd - sectionStart);
-            ParseOptionLines(section.Split('\n'), options, seenOptions);
+            ParseOptionLines(section.Split('\n'), commandParts, options, seenOptions);
         }
 
         if (DebugOptionPattern().IsMatch(helpText) && seenOptions.Add("-d"))
@@ -300,6 +302,7 @@ public partial class SnykCliScraper : CliScraperBase
 
     private void ParseOptionLines(
         string[] lines,
+        string[] commandParts,
         List<CliOptionDefinition> options,
         HashSet<string> seenOptions)
     {
@@ -342,10 +345,11 @@ public partial class SnykCliScraper : CliScraperBase
                     && !isNumeric
                     && !ValueOptionsWithoutHelpPlaceholders.Contains(longForm);
                 var isBoolean = IsBooleanValueHint(valueHint);
-                var acceptsMultipleValues = IsRepeatableValueOption(
-                    description ?? string.Empty,
-                    isFlag,
-                    isBoolean);
+                var acceptsMultipleValues = !IsKnownScalarValueOption(commandParts, longForm)
+                                            && IsRepeatableValueOption(
+                                                description ?? string.Empty,
+                                                isFlag,
+                                                isBoolean);
                 var csharpType = isFlag || isBoolean ? "bool?" : isNumeric ? "int?" : "string?";
 
                 CliEnumDefinition? enumDef = null;
@@ -392,6 +396,12 @@ public partial class SnykCliScraper : CliScraperBase
             }
         }
     }
+
+    private static bool IsKnownScalarValueOption(
+        IReadOnlyList<string> commandParts,
+        string switchName) =>
+        commandParts is ["iac", "describe"]
+        && switchName.Equals("--from", StringComparison.OrdinalIgnoreCase);
 
     private static void AddDocumentedOptions(
         string[] commandParts,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -342,25 +342,27 @@ public partial class SnykCliScraper : CliScraperBase
     {
         var longForm = match.Groups["long"].Value.Trim();
         var valueHint = match.Groups["value"].Value.Trim().Trim('<', '>', '[', ']');
-        if (!seenOptions.Add(longForm) || NormalizePropertyName(longForm) is not { } propertyName)
+        if (!seenOptions.Add(longForm))
+        {
+            return null;
+        }
+
+        if (NormalizePropertyName(longForm) is not { } propertyName)
         {
             return null;
         }
 
         var isNumeric = NumericOptions.Contains(longForm);
-        var isFlag = string.IsNullOrEmpty(valueHint)
-            && !isNumeric
-            && !ValueOptionsWithoutHelpPlaceholders.Contains(longForm);
+        var isFlag = IsFlagOption(longForm, valueHint, isNumeric);
         var isBoolean = IsBooleanValueHint(valueHint);
-        var acceptsMultipleValues = !IsKnownScalarValueOption(commandParts, longForm)
-                                    && IsRepeatableValueOption(
-                                        description ?? string.Empty,
-                                        isFlag,
-                                        isBoolean);
+        var acceptsMultipleValues = AcceptsMultipleValues(
+            commandParts,
+            longForm,
+            description,
+            isFlag,
+            isBoolean);
         var enumDefinition = CreateEnumDefinition(propertyName, longForm, valueHint, isBoolean);
-        var scalarType = enumDefinition is not null
-            ? $"{enumDefinition.EnumName}?"
-            : isFlag || isBoolean ? "bool?" : isNumeric ? "int?" : "string?";
+        var scalarType = GetScalarType(enumDefinition, isFlag, isBoolean, isNumeric);
 
         return new CliOptionDefinition
         {
@@ -380,6 +382,34 @@ public partial class SnykCliScraper : CliScraperBase
                 || longForm.Equals("--fetch-tfstate-headers", StringComparison.OrdinalIgnoreCase),
         };
     }
+
+    private static bool IsFlagOption(string longForm, string valueHint, bool isNumeric) =>
+        string.IsNullOrEmpty(valueHint)
+        && !isNumeric
+        && !ValueOptionsWithoutHelpPlaceholders.Contains(longForm);
+
+    private static bool AcceptsMultipleValues(
+        IReadOnlyList<string> commandParts,
+        string longForm,
+        string? description,
+        bool isFlag,
+        bool isBoolean) =>
+        !IsKnownScalarValueOption(commandParts, longForm)
+        && IsRepeatableValueOption(description ?? string.Empty, isFlag, isBoolean);
+
+    private static string GetScalarType(
+        CliEnumDefinition? enumDefinition,
+        bool isFlag,
+        bool isBoolean,
+        bool isNumeric) =>
+        enumDefinition is not null
+            ? $"{enumDefinition.EnumName}?"
+            : (isFlag || isBoolean, isNumeric) switch
+            {
+                (true, _) => "bool?",
+                (_, true) => "int?",
+                _ => "string?",
+            };
 
     private static CliEnumDefinition? CreateEnumDefinition(
         string propertyName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -132,7 +132,7 @@ public static class UsageSynopsisParser
         UsageSynopsisParseResult result)
     {
         var positionalArguments = result.PositionalArguments
-            .Where(argument => !CommandGroupPlaceholderNames.Contains(argument.PropertyName))
+            .Where(argument => !IsCommandGroupPlaceholder(argument))
             .ToList();
 
         return result with
@@ -141,6 +141,9 @@ public static class UsageSynopsisParser
             PositionalArguments = positionalArguments,
         };
     }
+
+    internal static bool IsCommandGroupPlaceholder(CliPositionalArgument argument) =>
+        CommandGroupPlaceholderNames.Contains(argument.PropertyName);
 
     private static UsageSynopsisParseResult ParseSynopsis(
         string synopsis,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -548,7 +548,9 @@ public partial class YarnCliScraper : CliScraperBase
             // Determine if this is a flag (boolean) or takes a value
             var isFlag = !match.Groups["value"].Success
                          && IsBooleanOption(longForm, description);
-            var csharpType = isFlag ? "bool?" : "string?";
+            var acceptsMultipleValues = commandParts is ["dlx"]
+                                        && longForm.Equals("--package", StringComparison.OrdinalIgnoreCase);
+            var csharpType = AsCSharpType(isFlag ? "bool?" : "string?", acceptsMultipleValues);
 
             options.Add(new CliOptionDefinition
             {
@@ -559,7 +561,7 @@ public partial class YarnCliScraper : CliScraperBase
                 Description = description,
                 IsFlag = isFlag,
                 IsRequired = false,
-                AcceptsMultipleValues = false,
+                AcceptsMultipleValues = acceptsMultipleValues,
                 IsKeyValue = false,
                 IsNumeric = false,
                 ValueSeparator = isFlag ? " " : " ",
@@ -712,26 +714,28 @@ public partial class YarnCliScraper : CliScraperBase
     /// <summary>
     /// Matches Clipanion-style "━━━ Details ━━━" section header.
     /// </summary>
-    [GeneratedRegex(@"━+\s+Details\s+━+\s*\n", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(?:━+\s+)?Details(?:\s+━+)?\s*\r?\n", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex ClipanionDetailsSectionPattern();
 
     /// <summary>
     /// Matches Clipanion-style "━━━ Options ━━━" section header.
     /// </summary>
-    [GeneratedRegex(@"━+\s+Options\s+━+\s*\n", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(?:━+\s+)?Options(?:\s+━+)?\s*\r?\n", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex ClipanionOptionsSectionPattern();
 
     /// <summary>
     /// Matches Clipanion-style "━━━ Usage ━━━" section header.
     /// </summary>
-    [GeneratedRegex(@"━+\s+Usage\s+━+\s*\n", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(?:━+\s+)?Usage(?:\s+━+)?\s*\r?\n", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex ClipanionUsageSectionPattern();
 
     /// <summary>
     /// Matches any Clipanion section header (used to find section boundaries).
     /// Format: ━━━ Section Name ━━━━━━━━━━━━
     /// </summary>
-    [GeneratedRegex(@"━+\s+[^━]+?\s+━+", RegexOptions.Multiline)]
+    [GeneratedRegex(
+        @"(?:━+\s+[^━\r\n]+?\s+━+)|(?:^(?:Usage|Options|Details|Examples)\s*$)",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex ClipanionSectionPattern();
 
     // ===== Yarn Classic patterns (v1) =====

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YqCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YqCliScraper.cs
@@ -73,6 +73,7 @@ public partial class YqCliScraper : CobraCliScraper
                 {
                     Phase = CommandLinePhase.Passthrough,
                     PrependOptionTerminatorIfValueStartsWithDash = true,
+                    AllowRenderingPhaseMigrationFromBaseline = true,
                 })
                 .ToArray()
             : positionalArguments;


### PR DESCRIPTION
## Summary
- recover Cobra command sections containing lowercase connector words
- ignore Docker buildx command-group placeholders while retaining leaf command operands
- preserve optional-valued APIs and chained compatibility aliases across repeated generation
- explicitly migrate Yq operand rendering phases
- correct pnpm, Go, pip, Packer, Argo CD, Snyk, Yarn, GitHub CLI, Azure, and Gcloud normalization
- run DotNet generation under the repository Microsoft.Testing.Platform configuration while retaining public NuGet operand names
- install the latest official WinGet client before Windows regeneration
- retain removed nested root facade methods, including historical Homebrew placeholder APIs
- simplify Snyk and GitHub CLI normalization to satisfy quality gates

## Validation
- prior OptionsGenerator suite: 1130/1130
- latest root-facade regression and adjacent compatibility tests: 3/3
- latest full suite attempt exceeded the mandated 2 GB agent limit (2,269 MB); CI will validate
- current Yq regeneration: passed
- current Minikube v1.38.1 regeneration: 46 commands, passed
- local Git regeneration: API validation passed; stopped at expected older-Git coverage guard
- Docker full local generation exceeded the mandated 2 GB agent limit; CI will validate
- targeted formatting: passed
- WinGet branch regeneration: passed: https://github.com/thomhurst/ModularPipelines/actions/runs/32857753447

Refs #3996
