### PR TITLE
Fix remaining CLI regeneration blockers

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -632,6 +632,16 @@ jobs:
             Write-Host "No meaningful changes detected for ${{ matrix.tool }}"
           }
 
+      - name: Increase swap space for Gcloud build
+        if: steps.should-run.outputs.run == 'true' && matrix.tool == 'gcloud' && steps.changes.outputs.has_changes == 'true'
+        run: |
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo fallocate -l 10G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+
       - name: Build solution to verify changes
         if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true'
         run: |

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -99,7 +99,7 @@ jobs:
                 prefix: .namespacePrefix,
                 outputDirectory: .outputDirectory,
                 generateCommandFacade: .generateCommandFacade,
-                timeoutMinutes: (if .toolName == "aws" then 150 else 60 end)
+                timeoutMinutes: (if .toolName == "aws" then 150 elif .toolName == "gcloud" then 90 else 60 end)
               }]}' \
               "$RUNNER_TEMP/tool-catalog.json"
           }
@@ -634,7 +634,14 @@ jobs:
 
       - name: Build solution to verify changes
         if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true'
-        run: dotnet build "src/${{ steps.package.outputs.package }}/${{ steps.package.outputs.package }}.slnx" -c Release
+        run: |
+          BUILD_ARGS=()
+          # Gcloud generates enough source for parallel MSBuild nodes to exhaust the hosted runner.
+          if [[ "${{ matrix.tool }}" == "gcloud" ]]; then
+            BUILD_ARGS+=(/m:1 -p:UseSharedCompilation=false)
+          fi
+          dotnet build "src/${{ steps.package.outputs.package }}/${{ steps.package.outputs.package }}.slnx" \
+            -c Release "${BUILD_ARGS[@]}"
 
       - name: Validate generated API compatibility
         id: api-compat

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -13,6 +13,7 @@ namespace ModularPipelines.SourceGenerator;
 [Generator]
 public sealed class CommandOptionsGenerator : IIncrementalGenerator
 {
+    private const int RuntimeRegistrationChunkSize = 32;
     private const int RuntimeMetadataSchemaVersion = 2;
     private const int CommandMetadataSchemaVersion = 3;
     private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
@@ -184,12 +185,13 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             unambiguousCandidates,
             optionsTypes,
             input.Configuration.RequiresGeneratedMetadata);
-        sourceContext.AddSource(
-            "ModularPipelines.RuntimeMetadata.g.cs",
-            Generate(
-                items,
-                input.Configuration.CoveredExternalAssemblyIdentities,
-                input.Configuration.RequiresGeneratedMetadata));
+        foreach (var (hintName, source) in Generate(
+                     items,
+                     input.Configuration.CoveredExternalAssemblyIdentities,
+                     input.Configuration.RequiresGeneratedMetadata))
+        {
+            sourceContext.AddSource(hintName, source);
+        }
     }
 
     internal static bool IsTypeCandidate(SyntaxNode node)
@@ -1062,7 +1064,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         return false;
     }
 
-    private static string Generate(
+    private static List<(string HintName, string Source)> Generate(
         ImmutableArray<TypeMetadata> items,
         ImmutableArray<string> coveredExternalAssemblyIdentities,
         bool requiresGeneratedMetadata)
@@ -1073,6 +1075,29 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             .OrderBy(item => item.MetadataName, StringComparer.Ordinal)
             .ThenBy(item => item.AssemblyIdentity, StringComparer.Ordinal)
             .ToList();
+
+        if (uniqueItems.Count(RequiresCommandRegistrationChunking) <= RuntimeRegistrationChunkSize)
+        {
+            return
+            [
+                ("ModularPipelines.RuntimeMetadata.g.cs", GenerateSingleSource(
+                    uniqueItems,
+                    coveredExternalAssemblyIdentities,
+                    requiresGeneratedMetadata)),
+            ];
+        }
+
+        return GenerateChunkedSources(
+            uniqueItems,
+            coveredExternalAssemblyIdentities,
+            requiresGeneratedMetadata);
+    }
+
+    private static string GenerateSingleSource(
+        IReadOnlyList<TypeMetadata> uniqueItems,
+        ImmutableArray<string> coveredExternalAssemblyIdentities,
+        bool requiresGeneratedMetadata)
+    {
         var sb = new StringBuilder();
 
         AppendGeneratedFilePreamble(sb, uniqueItems);
@@ -1084,6 +1109,52 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         return sb.ToString();
     }
 
+    private static List<(string HintName, string Source)> GenerateChunkedSources(
+        IReadOnlyList<TypeMetadata> uniqueItems,
+        ImmutableArray<string> coveredExternalAssemblyIdentities,
+        bool requiresGeneratedMetadata)
+    {
+        var registrationItems = uniqueItems
+            .Where(RequiresRuntimeRegistrationChunk)
+            .ToArray();
+        var chunks = new List<IReadOnlyList<TypeMetadata>>();
+        for (var offset = 0; offset < registrationItems.Length; offset += RuntimeRegistrationChunkSize)
+        {
+            chunks.Add(
+            [
+                .. registrationItems
+                    .Skip(offset)
+                    .Take(RuntimeRegistrationChunkSize),
+            ]);
+        }
+
+        var sources = new List<(string HintName, string Source)>(chunks.Count + 1);
+        var registrationSource = new StringBuilder();
+        AppendGeneratedFilePreamble(registrationSource, uniqueItems);
+        AppendChunkedRuntimeMetadataRegistration(
+            registrationSource,
+            uniqueItems,
+            coveredExternalAssemblyIdentities,
+            requiresGeneratedMetadata,
+            chunks.Count);
+        sources.Add(("ModularPipelines.RuntimeMetadata.g.cs", registrationSource.ToString()));
+
+        for (var index = 0; index < chunks.Count; index++)
+        {
+            var chunkSource = new StringBuilder();
+            AppendGeneratedFilePreamble(
+                chunkSource,
+                chunks[index],
+                includeIncompleteMetadataAttributes: false);
+            AppendRuntimeMetadataChunk(chunkSource, chunks[index], index);
+            sources.Add((
+                $"ModularPipelines.RuntimeMetadata.Chunk{index:D4}.g.cs",
+                chunkSource.ToString()));
+        }
+
+        return sources;
+    }
+
     private static string GetRegistrationIdentity(TypeMetadata item) =>
         item.UseExternalTypeNameForEmptySecretCoverage
         || item.RequiresSecretReflectionFallback
@@ -1092,14 +1163,18 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
 
     private static void AppendGeneratedFilePreamble(
         StringBuilder sb,
-        IReadOnlyList<TypeMetadata> uniqueItems)
+        IReadOnlyList<TypeMetadata> uniqueItems,
+        bool includeIncompleteMetadataAttributes = true)
     {
         sb.AppendLine("// <auto-generated/>");
         sb.AppendLine("#nullable enable");
-        foreach (var item in uniqueItems.Where(HasIncompleteSecretMetadata))
+        if (includeIncompleteMetadataAttributes)
         {
-            sb.AppendLine(
-                $"[assembly: global::{IncompleteRuntimeMetadataAttributeFullName}({Literal(item.MetadataName)})]");
+            foreach (var item in uniqueItems.Where(HasIncompleteSecretMetadata))
+            {
+                sb.AppendLine(
+                    $"[assembly: global::{IncompleteRuntimeMetadataAttributeFullName}({Literal(item.MetadataName)})]");
+            }
         }
 
         var suppressedDiagnostics = uniqueItems
@@ -1149,6 +1224,76 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             sb,
             "RegisterCoveredExternalAssemblyIdentities",
             coveredExternalAssemblyIdentities);
+        AppendCoverageRegistrations(sb, uniqueItems);
+        AppendRuntimeTypeRegistrations(sb, uniqueItems);
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+    }
+
+    private static void AppendChunkedRuntimeMetadataRegistration(
+        StringBuilder sb,
+        IReadOnlyList<TypeMetadata> uniqueItems,
+        ImmutableArray<string> coveredExternalAssemblyIdentities,
+        bool requiresGeneratedMetadata,
+        int chunkCount)
+    {
+        sb.AppendLine("namespace ModularPipelines.Generated;");
+        sb.AppendLine();
+        sb.AppendLine("internal static partial class RuntimeMetadataRegistration");
+        sb.AppendLine("{");
+        sb.AppendLine($"    public const int SchemaVersion = {RuntimeMetadataSchemaVersion};");
+        sb.AppendLine($"    public const int CommandSchemaVersion = {CommandMetadataSchemaVersion};");
+        sb.AppendLine();
+        sb.AppendLine("    [global::System.Runtime.CompilerServices.ModuleInitializer]");
+        sb.AppendLine("    [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]");
+        sb.AppendLine("    internal static void Register()");
+        sb.AppendLine("    {");
+        sb.AppendLine("        var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();");
+        var requiresGeneratedMetadataLiteral = requiresGeneratedMetadata ? "true" : "false";
+        AppendAssemblyRegistration(
+            sb,
+            "global::ModularPipelines.Helpers.Internal.GeneratedCommandMetadata",
+            requiresGeneratedMetadataLiteral);
+        AppendAssemblyRegistration(
+            sb,
+            "global::ModularPipelines.Engine.GeneratedSecretMetadata",
+            requiresGeneratedMetadataLiteral);
+        AppendStringRegistration(
+            sb,
+            "RegisterCoveredExternalAssemblyIdentities",
+            coveredExternalAssemblyIdentities);
+        AppendCoverageRegistrations(sb, uniqueItems);
+        for (var index = 0; index < chunkCount; index++)
+        {
+            sb.AppendLine($"        RegisterChunk{index:D4}(assembly);");
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+    }
+
+    private static void AppendRuntimeMetadataChunk(
+        StringBuilder sb,
+        IReadOnlyList<TypeMetadata> items,
+        int index)
+    {
+        sb.AppendLine("namespace ModularPipelines.Generated;");
+        sb.AppendLine();
+        sb.AppendLine("internal static partial class RuntimeMetadataRegistration");
+        sb.AppendLine("{");
+        AppendCommandMetadataDependencies(sb, items);
+        sb.AppendLine($"    private static void RegisterChunk{index:D4}(global::System.Reflection.Assembly assembly)");
+        sb.AppendLine("    {");
+        AppendRuntimeTypeRegistrations(sb, items);
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+    }
+
+    private static void AppendCoverageRegistrations(
+        StringBuilder sb,
+        IReadOnlyList<TypeMetadata> uniqueItems)
+    {
         AppendExternalTypeNameRegistrations(
             sb,
             "RegisterCoveredExternalTypeNames",
@@ -1176,10 +1321,6 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             sb,
             "RegisterIncompleteTypeNames",
             uniqueItems.Where(HasIncompleteSecretMetadata));
-        AppendRuntimeTypeRegistrations(sb, uniqueItems);
-
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
     }
 
     private static void AppendCommandMetadataDependencies(
@@ -1217,6 +1358,16 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             }
         }
     }
+
+    private static bool RequiresRuntimeRegistrationChunk(TypeMetadata item) =>
+        CanPreserveCommandOptionProperties(item)
+        || CanRegisterCompleteCommandMetadata(item)
+        || (item.SecretMetadata.IsComplete && !item.RequiresSecretReflectionFallback);
+
+    private static bool RequiresCommandRegistrationChunking(TypeMetadata item) =>
+        !item.IsExternal
+        && item.IsCommandOptions
+        && (CanPreserveCommandOptionProperties(item) || CanRegisterCompleteCommandMetadata(item));
 
     private static void AppendAssemblyRegistration(
         StringBuilder sb,

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -172,6 +172,48 @@ public class IncompleteMetadataDiagnosticTests
         """;
 
     [Test]
+    public async Task Large_Metadata_Registration_Is_Chunked()
+    {
+        var source = string.Join(
+            Environment.NewLine,
+            Enumerable.Range(0, 33).Select(index => $$"""
+                public sealed class Options{{index}}
+                    : ModularPipelines.Options.CommandLineToolOptions
+                {
+                    [ModularPipelines.Attributes.CliOption("--value")]
+                    public string Value { get; set; } = "";
+                }
+                """));
+
+        var result = GeneratorTestHarness.Run(
+            new CommandOptionsGenerator(),
+            CommandInfrastructure,
+            source);
+        var generatedDiagnostics = result.GeneratedTrees
+            .SelectMany(static tree => tree.GetDiagnostics())
+            .ToArray();
+        var generatedSources = result.GeneratedTrees
+            .Select(static tree => tree.ToString())
+            .ToArray();
+        var registrationSource = generatedSources.Single(static generatedSource =>
+            generatedSource.Contains("internal static void Register()", StringComparison.Ordinal));
+        var chunkSources = generatedSources.Where(static generatedSource =>
+            generatedSource.Contains("private static void RegisterChunk", StringComparison.Ordinal)).ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedDiagnostics).IsEmpty();
+            await Assert.That(generatedSources).Count().IsEqualTo(3);
+            await Assert.That(chunkSources).Count().IsEqualTo(2);
+            await Assert.That(registrationSource).Contains("RegisterChunk0000(assembly);");
+            await Assert.That(registrationSource).Contains("RegisterChunk0001(assembly);");
+            await Assert.That(string.Join(Environment.NewLine, chunkSources))
+                .Contains("typeof(global::Options32)");
+        }
+    }
+
+    [Test]
     public async Task Generated_Legacy_Optional_Value_Metadata_Is_Unsupported()
     {
         var result = GeneratorTestHarness.Run(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/EnumDefinitionStabilizerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/EnumDefinitionStabilizerTests.cs
@@ -173,6 +173,52 @@ public class EnumDefinitionStabilizerTests
     }
 
     [Test]
+    public async Task Stabilize_Retains_Case_Variant_Cli_Values()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-enum-tests", Guid.NewGuid().ToString("N"));
+        var enumDirectory = Path.Combine(outputRoot, "src", "Fake", "Enums");
+        Directory.CreateDirectory(enumDirectory);
+        File.WriteAllText(
+            Path.Combine(enumDirectory, "FakeVisibility.Generated.cs"),
+            "public enum FakeVisibility { "
+            + "[EnumValue(\"ALLOW\")] Allow = 4, "
+            + "[EnumValue(\"DENY\")] Deny = 5 }");
+
+        try
+        {
+            var stabilized = EnumDefinitionStabilizer.Stabilize(
+                Tool(Value("allow"), Value("deny")),
+                outputRoot);
+            var values = stabilized.AllEnums.Single().Values;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(values.Select(value => value.MemberName))
+                    .IsEquivalentTo(["Allow", "Deny", "AllowLowercase", "DenyLowercase"]);
+                await Assert.That(values.Select(value => value.CliValue))
+                    .IsEquivalentTo(["ALLOW", "DENY", "allow", "deny"]);
+                await Assert.That(values.Select(value => value.NumericValue!.Value))
+                    .IsEquivalentTo([4, 5, 6, 7]);
+            }
+
+            var generated = (await new EnumGenerator().GenerateAsync(stabilized)).Single().Content;
+            await File.WriteAllTextAsync(
+                Path.Combine(enumDirectory, "FakeVisibility.Generated.cs"),
+                generated);
+            var restabilized = EnumDefinitionStabilizer.Stabilize(
+                Tool(Value("allow"), Value("deny")),
+                outputRoot);
+
+            await Assert.That(restabilized.AllEnums.Single().Values)
+                .IsEquivalentTo(values);
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task Stabilize_Rejects_Suspicious_Prose_Values()
     {
         var tool = Tool(Value("them"), Value("accepts"));

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -61,6 +61,28 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task OptionsClassGenerator_Imports_Preserved_KeyValue_Types()
+    {
+        var command = Command(
+            "ToolRunOptions",
+            "ToolOptions",
+            options:
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--labels",
+                    PropertyName = "Labels",
+                    CSharpType = "IReadOnlyList<KeyValue>?",
+                },
+            ]);
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
+
+        await Assert.That(generated).Contains("using ModularPipelines.Models;");
+        await Assert.That(generated).Contains("public IReadOnlyList<KeyValue>? Labels { get; set; }");
+    }
+
+    [Test]
     public async Task OptionsClassGenerator_Validates_Explicit_Optional_Values()
     {
         var command = Command(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -72,14 +72,25 @@ public class GeneratorHardeningTests
                 {
                     SwitchName = "--labels",
                     PropertyName = "Labels",
-                    CSharpType = "IReadOnlyList<KeyValue>?",
+                    CSharpType = "string?",
                 },
-            ]);
+            ]) with
+        {
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "LegacyLabels",
+                    CSharpType = "IReadOnlyList<KeyValue>?",
+                    ObsoleteMessage = "Use Labels instead.",
+                },
+            ],
+        };
 
         var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
 
         await Assert.That(generated).Contains("using ModularPipelines.Models;");
-        await Assert.That(generated).Contains("public IReadOnlyList<KeyValue>? Labels { get; set; }");
+        await Assert.That(generated).Contains("public IReadOnlyList<KeyValue>? LegacyLabels { get; set; }");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -3200,6 +3200,50 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Retains_Literal_Execute_Overload_Beside_Parent()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupNestedExecuteOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"nested\", \"execute\")] "
+                + "public record ToolGroupNestedExecuteOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupNested.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupNested { "
+                + "public Task ExecuteAsync(ToolGroupNestedExecuteOptions? options = null) => Task.CompletedTask; }");
+
+            var parent = Command(
+                "ToolGroupNestedOptions",
+                "ToolOptions",
+                ["group", "nested"],
+                subDomainGroup: "group");
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(parent), root);
+            var generated = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => Path.GetFileName(file.RelativePath).Equals(
+                    "ToolGroupNested.Generated.cs",
+                    StringComparison.Ordinal))
+                .Content;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(generated).Contains("ExecuteCommandAsync(");
+                await Assert.That(generated).Contains("ToolGroupNestedExecuteOptions? options = null");
+                await Assert.That(generated).Contains("ToolGroupNestedOptions? options = null");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Distinguishes_Execute_When_Parent_Name_Ends_In_Execute()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4120,8 +4120,9 @@ public class GeneratorHardeningTests
 
             await Assert.That(constructor.Parameters.Select(static parameter => parameter.PropertyName))
                 .IsEquivalentTo(["Source"]);
-            await Assert.That(constructor.PrimaryConstructorArguments)
-                .IsEquivalentTo(["Source", "default(string)!"]);
+            await Assert.That(constructor.PrimaryConstructorArguments.Count).IsEqualTo(2);
+            await Assert.That(constructor.PrimaryConstructorArguments[0]).IsEqualTo("Source");
+            await Assert.That(constructor.PrimaryConstructorArguments[1]).IsEqualTo("default(string)!");
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -3235,6 +3235,8 @@ public class GeneratorHardeningTests
                 await Assert.That(generated).Contains("ExecuteCommandAsync(");
                 await Assert.That(generated).Contains("ToolGroupNestedExecuteOptions? options = null");
                 await Assert.That(generated).Contains("ToolGroupNestedOptions? options = null");
+                await Assert.That(generated)
+                    .Contains("[Obsolete(\"Use the current command facade instead.\")]");
             }
         }
         finally

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4074,7 +4074,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task ApiCompatibilityPreserver_Rejects_Alias_Constructors_For_New_Required_Members()
+    public async Task ApiCompatibilityPreserver_Preserves_Alias_Constructors_For_New_Required_Members()
     {
         var root = Path.Combine(Path.GetTempPath(), $"options-api-{Guid.NewGuid():N}");
         var optionsDirectory = Path.Combine(root, "src", "ModularPipelines.Tool", "Options");
@@ -4113,10 +4113,15 @@ public class GeneratorHardeningTests
                 ],
             };
 
-            var exception = Assert.Throws<InvalidOperationException>(() =>
-                GeneratedApiCompatibilityPreserver.Preserve(tool, root));
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+            var constructor = preserved.Commands.Single()
+                .AliasCompatibilityConstructors["ToolBuilderBakeOptions"]
+                .Single();
 
-            await Assert.That(exception.Message).Contains("newly required member(s) Destination have no baseline value");
+            await Assert.That(constructor.Parameters.Select(static parameter => parameter.PropertyName))
+                .IsEquivalentTo(["Source"]);
+            await Assert.That(constructor.PrimaryConstructorArguments)
+                .IsEquivalentTo(["Source", "default(string)!"]);
         }
         finally
         {
@@ -4125,7 +4130,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task ApiCompatibilityPreserver_Rejects_Parameterless_Alias_Constructor_For_New_Required_Members()
+    public async Task ApiCompatibilityPreserver_Preserves_Parameterless_Alias_Constructor_For_New_Required_Members()
     {
         var root = Path.Combine(Path.GetTempPath(), $"options-api-{Guid.NewGuid():N}");
         var optionsDirectory = Path.Combine(root, "src", "ModularPipelines.Tool", "Options");
@@ -4159,10 +4164,14 @@ public class GeneratorHardeningTests
                 ],
             };
 
-            var exception = Assert.Throws<InvalidOperationException>(() =>
-                GeneratedApiCompatibilityPreserver.Preserve(tool, root));
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+            var constructor = preserved.Commands.Single()
+                .AliasCompatibilityConstructors["ToolBuilderBakeOptions"]
+                .Single();
 
-            await Assert.That(exception.Message).Contains("newly required member(s) Source have no baseline value");
+            await Assert.That(constructor.Parameters).IsEmpty();
+            await Assert.That(constructor.PrimaryConstructorArguments)
+                .IsEquivalentTo(["default(string)!"]);
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -3246,6 +3246,58 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Retains_Live_Literal_Execute_Overload_Beside_Parent()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupNestedExecuteOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"nested\", \"execute\")] "
+                + "public record ToolGroupNestedExecuteOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupNested.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupNested { "
+                + "public Task ExecuteAsync(ToolGroupNestedExecuteOptions? options = null) => Task.CompletedTask; }");
+
+            var parent = Command(
+                "ToolGroupNestedOptions",
+                "ToolOptions",
+                ["group", "nested"],
+                subDomainGroup: "group");
+            var literalExecute = Command(
+                "ToolGroupNestedExecuteOptions",
+                "ToolOptions",
+                ["group", "nested", "execute"],
+                subDomainGroup: "group");
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(parent, literalExecute),
+                root);
+            var generated = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => Path.GetFileName(file.RelativePath).Equals(
+                    "ToolGroupNested.Generated.cs",
+                    StringComparison.Ordinal))
+                .Content;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(generated).Contains("ExecuteCommandAsync(");
+                await Assert.That(generated).Contains("ToolGroupNestedExecuteOptions? options = null");
+                await Assert.That(generated).Contains("ToolGroupNestedOptions? options = null");
+                await Assert.That(generated).Contains("Use ExecuteCommandAsync instead.");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Distinguishes_Execute_When_Parent_Name_Ends_In_Execute()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliOptionDefinitionTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliOptionDefinitionTests.cs
@@ -207,6 +207,19 @@ public class CliOptionDefinitionTests
     }
 
     [Test]
+    public async Task RequiresModelsNamespace_When_CSharpType_Uses_KeyValue_Without_Metadata()
+    {
+        var option = new CliOptionDefinition
+        {
+            SwitchName = "--labels",
+            PropertyName = "Labels",
+            CSharpType = "IReadOnlyList<KeyValue>?",
+        };
+
+        await Assert.That(option.RequiresModelsNamespace).IsTrue();
+    }
+
+    [Test]
     public async Task PropertyType_Preserves_Grouped_Optional_Collection_Shape()
     {
         var option = new CliOptionDefinition

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -257,6 +258,30 @@ public class AzCliScraperTests
         {
             await Assert.That(option.IsFlag).IsTrue();
             await Assert.That(option.CSharpType).IsEqualTo("bool?");
+        }
+    }
+
+    [Test]
+    public async Task Identity_Value_Is_Optional_When_Valueless_Form_Is_Documented()
+    {
+        const string helpText = """
+            Command
+                az appconfig identity assign : Update managed identities.
+
+            Optional Arguments
+                --identities : Accept system-assigned or user-assigned managed identities separated by spaces. If this argument is provided without any value, system-assigned managed identity is used.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "appconfig", "identity", "assign"],
+            helpText);
+        var identities = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(identities.IsFlag).IsFalse();
+            await Assert.That(identities.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(identities.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -237,6 +237,29 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Accept_Term_Remains_A_Presence_Only_Flag()
+    {
+        const string helpText = """
+            Command
+                az vm create : Create a virtual machine.
+
+            Optional Arguments
+                --accept-term : Accept the license agreement and privacy statement.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "vm", "create"],
+            helpText);
+        var option = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsTrue();
+            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -282,6 +282,7 @@ public class AzCliScraperTests
             await Assert.That(identities.IsFlag).IsFalse();
             await Assert.That(identities.CSharpType).IsEqualTo("IEnumerable<string>?");
             await Assert.That(identities.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(identities.GroupValues).IsTrue();
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -193,6 +193,50 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Current_Description_Only_Values_Are_Not_Flags()
+    {
+        const string helpText = """
+            Command
+                az service update : Update a service.
+
+            Optional Arguments
+                --default-identity       : Accept system or user assigned identity separated.
+                --install-script         : Install script configurations. Provide key-value pairs.
+                --credentials-secret-uri : Key Vault secret URI for credentials.
+                --source                 : Source URI or path for the storage mount.
+                --id                     : The deployment stack what-if result resource ID.
+                --maintenance-batch      : The batch of the custom-managed maintenance window. Accepted values: Default, Batch1, Batch2.
+                --related                : Related resource or alert to add to the issue.
+                --force                  : Force the operation without confirmation.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "service", "update"],
+            helpText);
+
+        using (Assert.Multiple())
+        {
+            foreach (var propertyName in new[]
+                     {
+                         "DefaultIdentity",
+                         "InstallScript",
+                         "CredentialsSecretUri",
+                         "Source",
+                         "Id",
+                         "MaintenanceBatch",
+                         "Related",
+                     })
+            {
+                await Assert.That(command!.Options.Single(option =>
+                    option.PropertyName == propertyName).IsFlag).IsFalse();
+            }
+
+            await Assert.That(command!.Options.Single(option => option.PropertyName == "Force").IsFlag)
+                .IsTrue();
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -77,6 +77,30 @@ public class BrewCliScraperTests
     }
 
     [Test]
+    public async Task Descriptive_List_And_Writable_Words_Remain_Flags()
+    {
+        const string helpText = """
+            Usage: brew list [options]
+
+                  --formula        List only formulae.
+                  --writable       List only writable kegs.
+                  --formulae=LIST  Use a comma-separated list of formulae.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "list"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Single(option => option.SwitchName == "--formula").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--writable").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--formulae").IsFlag)
+                .IsFalse();
+        }
+    }
+
+    [Test]
     public async Task Models_Command_Operands_As_A_Required_Collection()
     {
         const string helpText = "Usage: brew command command [...]";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -100,6 +100,27 @@ public class BrewCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Models_Generate_Zap_Cask_Operand_After_Name_Flag()
+    {
+        const string helpText = """
+            Usage: brew generate-zap [--name] cask_or_name
+
+                  --name   Treat the operand as a cask name.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(
+            ["brew", "generate-zap"],
+            helpText);
+
+        var operand = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(operand.PropertyName).IsEqualTo("CaskOrName");
+            await Assert.That(operand.IsRequired).IsTrue();
+        }
+    }
+
     private sealed class TestBrewCliScraper : BrewCliScraper
     {
         public TestBrewCliScraper(ICliCommandExecutor? executor = null)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -140,6 +140,25 @@ public class BrewCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Models_Unlink_Installed_Formulae_As_A_Required_Collection()
+    {
+        const string helpText = "Usage: brew unlink [--dry-run] installed_formula [...]";
+
+        var command = await new TestBrewCliScraper().Parse(
+            ["brew", "unlink"],
+            helpText);
+        var operand = command!.PositionalArguments.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(operand.PropertyName).IsEqualTo("InstalledFormula");
+            await Assert.That(operand.CSharpType).IsEqualTo("IEnumerable<string>");
+            await Assert.That(operand.IsRequired).IsTrue();
+            await Assert.That(operand.IsVariadic).IsTrue();
+        }
+    }
+
     private sealed class TestBrewCliScraper : BrewCliScraper
     {
         public TestBrewCliScraper(ICliCommandExecutor? executor = null)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -55,6 +55,51 @@ public class BrewCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Models_Exec_Command_And_Value_Options()
+    {
+        const string helpText = """
+            Usage: brew exec [options] command [args...]
+
+                  --formulae=LIST   Populate the environment with a comma-separated list of formulae.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "exec"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
+                .IsEquivalentTo(["Command", "Arguments"]);
+            await Assert.That(command.PositionalArguments[0].IsRequired).IsTrue();
+            await Assert.That(command.PositionalArguments[1].IsVariadic).IsTrue();
+            await Assert.That(command.Options.Single().IsFlag).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Models_Sandbox_Command_After_Writable_Path_Option()
+    {
+        const string helpText = """
+            Usage: brew sandbox-exec [options] -- command [args...]
+
+                  --writable-path=PATH   Add a writable path to the sandbox.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(
+            ["brew", "sandbox-exec"],
+            helpText);
+
+        var operand = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(operand.PropertyName).IsEqualTo("Command");
+            await Assert.That(operand.IsRequired).IsTrue();
+            await Assert.That(operand.IsVariadic).IsTrue();
+            await Assert.That(operand.PrependOptionTerminator).IsTrue();
+            await Assert.That(command.Options.Single().IsFlag).IsFalse();
+        }
+    }
+
     private sealed class TestBrewCliScraper : BrewCliScraper
     {
         public TestBrewCliScraper(ICliCommandExecutor? executor = null)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -77,6 +77,25 @@ public class BrewCliScraperTests
     }
 
     [Test]
+    public async Task Models_Command_Operands_As_A_Required_Collection()
+    {
+        const string helpText = "Usage: brew command command [...]";
+
+        var command = await new TestBrewCliScraper().Parse(
+            ["brew", "command"],
+            helpText);
+        var operand = command!.PositionalArguments.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(operand.PropertyName).IsEqualTo("Cmd");
+            await Assert.That(operand.CSharpType).IsEqualTo("IEnumerable<string>");
+            await Assert.That(operand.IsRequired).IsTrue();
+            await Assert.That(operand.IsVariadic).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Models_Sandbox_Command_After_Writable_Path_Option()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -818,6 +818,45 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task PnpmTraversal_Does_Not_Recurse_Into_Repeated_Parent_Help()
+    {
+        const string stageHelp = """
+            Usage: pnpm stage publish [<tarball>|<dir>] [options]
+                   pnpm stage download <stage-id>
+
+            Subcommands:
+                  download    Download a staged package
+                  publish     Stage a package for publishing
+
+            Options:
+                  --json      Show information in JSON format
+            """;
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage: pnpm [command] [flags]
+
+                Other:
+                      stage    Stage packages for publishing
+
+                Options:
+                  -r, --recursive    Run recursively
+                """,
+            ["stage --help"] = stageHelp,
+            ["stage download --help"] = stageHelp,
+            ["stage publish --help"] = stageHelp,
+        });
+        var scraper = new TestPnpmCliScraper(executor);
+
+        var commands = await ScrapeAsync(scraper);
+
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["pnpm stage", "pnpm stage download", "pnpm stage publish"]);
+        await Assert.That(executor.Arguments)
+            .IsEquivalentTo(["--help", "stage --help", "stage download --help", "stage publish --help"]);
+    }
+
+    [Test]
     public async Task Shared_Skip_Filter_Preserves_Uppercase_Subcommands()
     {
         var scraper = new OptionShapeScraper(new StubExecutor(
@@ -910,6 +949,12 @@ public class CliScraperTraversalTests
             IReadOnlyList<CliPositionalArgument> positionalArguments) =>
             ApplyPositionalArgumentFixes(command.Split(' '), positionalArguments);
     }
+
+    private sealed class TestPnpmCliScraper(ICliCommandExecutor executor)
+        : PnpmCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<PnpmCliScraper>.Instance);
 
     private sealed class ComposeProviderExecutor : ICliCommandExecutor
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -177,6 +177,33 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_Repeatable_Key_Value_Option_Keeps_Key_Value_Type()
+    {
+        const string helpText = """
+            NAME
+                gcloud example update - update an example
+
+            SYNOPSIS
+                gcloud example update
+
+            FLAGS
+                 --metadata=KEY=VALUE
+                    This flag can be repeated to add metadata entries.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "example", "update"],
+            helpText);
+        var metadata = command!.Options.Single(option => option.SwitchName == "--metadata");
+
+        await Assert.That(metadata.AcceptsMultipleValues).IsTrue();
+        await Assert.That(metadata.CSharpType).IsEqualTo("IReadOnlyList<KeyValue>?");
+    }
+
+    [Test]
     public async Task Gcloud_External_Ipv6_Prefix_Length_Is_Known_Scalar()
     {
         var scraper = CreateGcloudScraper();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -148,6 +148,35 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_Uses_Whole_Option_Block_For_Repeatability()
+    {
+        const string helpText = """
+            NAME
+                gcloud compute instances create - create an instance
+
+            SYNOPSIS
+                gcloud compute instances create
+
+            FLAGS
+                 --ipv6-public-ptr-domain=DOMAIN
+                    Domain for the public PTR record.
+                 This flag can be repeated to configure multiple domains.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "compute", "instances", "create"],
+            helpText);
+        var option = command!.Options.Single(candidate =>
+            candidate.SwitchName == "--ipv6-public-ptr-domain");
+
+        await Assert.That(option.AcceptsMultipleValues).IsTrue();
+        await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
+    }
+
+    [Test]
     public async Task Gcloud_External_Ipv6_Prefix_Length_Is_Known_Scalar()
     {
         var scraper = CreateGcloudScraper();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -101,6 +102,39 @@ public class DotNetCliScraperTests
             .IsEquivalentTo(["Nologo", "Debug"]);
     }
 
+    [Test]
+    public async Task Preserves_Current_Option_And_Operand_Arity()
+    {
+        const string helpText = """
+            Usage: dotnet tool run <COMMAND_NAME> [<toolArguments>...]
+
+            Arguments:
+              <COMMAND_NAME>       The command to run.
+              <toolArguments>      Arguments passed to the tool.
+
+            Options:
+              --project [<PROJECT>]  The project file to operate on.
+              --exact-match          Require an exact package match. [default: False]
+            """;
+
+        var command = await new TestDotNetCliScraper().Parse(
+            ["dotnet", "tool", "run"],
+            helpText);
+
+        var project = command!.Options.Single(option => option.PropertyName == "Project");
+        var exactMatch = command.Options.Single(option => option.PropertyName == "ExactMatch");
+        var toolArguments = command.PositionalArguments.Single(argument =>
+            argument.PropertyName == "ToolArguments");
+        using (Assert.Multiple())
+        {
+            await Assert.That(project.IsFlag).IsFalse();
+            await Assert.That(project.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(exactMatch.IsFlag).IsTrue();
+            await Assert.That(toolArguments.IsVariadic).IsTrue();
+            await Assert.That(toolArguments.CSharpType).IsEqualTo("IEnumerable<string>?");
+        }
+    }
+
     private static CliOptionDefinition Flag(string switchName, string propertyName) => new()
     {
         SwitchName = switchName,
@@ -121,6 +155,13 @@ public class DotNetCliScraperTests
         }
 
         public IReadOnlyList<string> Extract(string helpText) => [.. ExtractSubcommands(helpText)];
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
     }
 
     private sealed class StaticHtmlHandler(string html) : HttpMessageHandler

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
@@ -63,6 +63,32 @@ public class KubectlCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Kuberc_Set_Option_Values_Do_Not_Keep_Operand_Usage()
+    {
+        const string helpText = """
+            Usage:
+              kubectl kuberc set --section (defaults|aliases) --command COMMAND [options]
+
+            Options:
+                  --section string   Section to update.
+                  --command string   Command to update.
+            """;
+        var commandPath = new[] { "kubectl", "kuberc", "set" };
+        var scraper = new TestKubectlCliScraper();
+        var command = await scraper.Parse(commandPath, helpText);
+        var usage = scraper.Normalize(
+            command!,
+            UsageSynopsisParser.Parse(helpText, commandPath));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.PositionalArguments).IsEmpty();
+            await Assert.That(usage.PositionalArguments).IsEmpty();
+            await Assert.That(usage.HasOperandTokens).IsFalse();
+        }
+    }
+
     private sealed class TestKubectlCliScraper()
         : KubectlCliScraper(
             new RecordingExecutor(),
@@ -75,6 +101,11 @@ public class KubectlCliScraperTests
                 helpText,
                 UsageSynopsisParser.Parse(helpText, commandPath),
                 CancellationToken.None);
+
+        public UsageSynopsisParseResult Normalize(
+            CliCommandDefinition command,
+            UsageSynopsisParseResult usage) =>
+            NormalizeUsageSynopsis(command, usage);
     }
 
     private sealed class RecordingExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -22,6 +23,58 @@ public class KubectlCliScraperTests
         await Assert.That(version).IsEqualTo("Client Version: v1.35.0");
         await Assert.That(executor.AvailabilityArguments).IsEquivalentTo(["version --client"]);
         await Assert.That(executor.Arguments).IsEquivalentTo(["version --client"]);
+    }
+
+    [Test]
+    [Arguments("diff", "Usage:\n  kubectl diff -f FILENAME", "-f, --filename stringArray   Files to diff.")]
+    [Arguments("attach", "Usage:\n  kubectl attach POD -c CONTAINER", "-c, --container string   Container name.")]
+    public async Task Option_Values_Are_Not_Emitted_As_Positionals(
+        string commandName,
+        string usage,
+        string option)
+    {
+        var helpText = $"{usage}\n\nOptions:\n  {option}";
+        var command = await new TestKubectlCliScraper().Parse(
+            ["kubectl", commandName],
+            helpText);
+
+        await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
+            .DoesNotContain("Filename")
+            .And.DoesNotContain("Container");
+    }
+
+    [Test]
+    public async Task Port_Forward_Numbered_Repeat_Is_One_Collection()
+    {
+        const string helpText = """
+            Usage:
+              kubectl port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]
+            """;
+        var command = await new TestKubectlCliScraper().Parse(
+            ["kubectl", "port-forward"],
+            helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
+                .IsEquivalentTo(["TypeOrName", "LocalPortRemotePort"]);
+            await Assert.That(command.PositionalArguments.Single(argument =>
+                argument.PropertyName == "LocalPortRemotePort").IsVariadic).IsTrue();
+        }
+    }
+
+    private sealed class TestKubectlCliScraper()
+        : KubectlCliScraper(
+            new RecordingExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<KubectlCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
     }
 
     private sealed class RecordingExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MinikubeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MinikubeCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -44,6 +45,33 @@ public class MinikubeCliScraperTests
         var version = await scraper.GetVersionAsync();
 
         await Assert.That(version).IsNull();
+    }
+
+    [Test]
+    [Arguments("addons")]
+    [Arguments("config")]
+    public async Task Command_Groups_Do_Not_Model_Subcommand_Placeholders(string group)
+    {
+        var helpText = $"Usage:\n  minikube {group} SUBCOMMAND [flags]";
+        var command = await new TestMinikubeCliScraper().Parse(
+            ["minikube", group],
+            helpText);
+
+        await Assert.That(command!.PositionalArguments).IsEmpty();
+    }
+
+    private sealed class TestMinikubeCliScraper()
+        : MinikubeCliScraper(
+            new RecordingExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<MinikubeCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
     }
 
     private sealed class RecordingExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MinikubeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MinikubeCliScraperTests.cs
@@ -53,11 +53,21 @@ public class MinikubeCliScraperTests
     public async Task Command_Groups_Do_Not_Model_Subcommand_Placeholders(string group)
     {
         var helpText = $"Usage:\n  minikube {group} SUBCOMMAND [flags]";
-        var command = await new TestMinikubeCliScraper().Parse(
-            ["minikube", group],
+        var scraper = new TestMinikubeCliScraper();
+        var commandPath = new[] { "minikube", group };
+        var command = await scraper.Parse(
+            commandPath,
             helpText);
+        var usage = scraper.Normalize(
+            command!,
+            UsageSynopsisParser.Parse(helpText, commandPath));
 
-        await Assert.That(command!.PositionalArguments).IsEmpty();
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.PositionalArguments).IsEmpty();
+            await Assert.That(usage.PositionalArguments).IsEmpty();
+            await Assert.That(usage.HasOperandTokens).IsFalse();
+        }
     }
 
     private sealed class TestMinikubeCliScraper()
@@ -72,6 +82,11 @@ public class MinikubeCliScraperTests
                 helpText,
                 UsageSynopsisParser.Parse(helpText, commandPath),
                 CancellationToken.None);
+
+        public UsageSynopsisParseResult Normalize(
+            CliCommandDefinition command,
+            UsageSynopsisParseResult usage) =>
+            NormalizeUsageSynopsis(command, usage);
     }
 
     private sealed class RecordingExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -172,6 +172,23 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    public async Task Go_Usage_Parses_Inline_Option_Values()
+    {
+        const string helpText = "usage: go tool compile -o=FILE [packages]";
+        var command = await new TestGoCliScraper().Parse(
+            ["go", "tool", "compile"],
+            helpText);
+        var output = command!.Options.Single(option => option.SwitchName == "-o");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output.IsFlag).IsFalse();
+            await Assert.That(output.CSharpType).IsEqualTo("string?");
+            await Assert.That(output.ValueSeparator).IsEqualTo("=");
+        }
+    }
+
+    [Test]
     public async Task Pip_Require_Hashes_Is_A_Presence_Only_Flag()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -184,6 +184,24 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    public async Task Pnpm_Audit_Extracts_Child_Without_Modeling_It_As_An_Operand()
+    {
+        const string helpText = """
+            Usage: pnpm audit [options]
+                   pnpm audit signatures [options]
+
+            Commands:
+                  signatures    Verify registry signatures
+            """;
+        var scraper = new TestPnpmCliScraper();
+
+        var command = await scraper.Parse(["pnpm", "audit"], helpText);
+
+        await Assert.That(scraper.Extract(helpText)).IsEquivalentTo(["signatures"]);
+        await Assert.That(command!.PositionalArguments).IsEmpty();
+    }
+
+    [Test]
     public async Task Pnpm_Unlink_Ignores_Parenthetical_Explanation()
     {
         const string helpText = "Usage: pnpm unlink (in package dir)\n"
@@ -330,6 +348,9 @@ public class PositionalOperandAdapterTests
             PositionalOperandAdapterTests.Cache,
             NullLogger<PnpmCliScraper>.Instance)
     {
+        public IReadOnlyList<string> Extract(string helpText) =>
+            ExtractSubcommands(helpText).ToArray();
+
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
             ParseCommandAsync(
                 commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -148,6 +148,52 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    public async Task Go_Clean_Extracts_Options_Without_A_Flags_Table()
+    {
+        const string helpText = """
+            usage: go clean [-i] [-r] [-cache] [-o output] [packages]
+
+            The -i flag removes installed archives.
+            The -r flag applies clean recursively.
+            The -cache flag removes the entire build cache.
+            """;
+
+        var command = await new TestGoCliScraper().Parse(["go", "clean"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["-i", "-r", "-cache", "-o"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "-o").IsFlag)
+                .IsFalse();
+            await Assert.That(command.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Packages");
+        }
+    }
+
+    [Test]
+    public async Task Pip_Require_Hashes_Is_A_Presence_Only_Flag()
+    {
+        const string helpText = """
+            Usage:
+              pip install [options] <requirement specifier> ...
+
+            Install Options:
+              --require-hashes      Require a hash to check each requirement against, for repeatable installs.
+            """;
+
+        var command = await new TestPipCliScraper().Parse(["pip", "install"], helpText);
+        var requireHashes = command!.Options.Single(option => option.PropertyName == "RequireHashes");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(requireHashes.IsFlag).IsTrue();
+            await Assert.That(requireHashes.CSharpType).IsEqualTo("bool?");
+            await Assert.That(requireHashes.AcceptsMultipleValues).IsFalse();
+        }
+    }
+
+    [Test]
     [Arguments("cache", "Usage: pip cache list [<pattern>]\n  pip cache purge")]
     [Arguments("config", "Usage: pip config [<file-option>] list\n  pip config get command.option")]
     [Arguments("index", "Usage: pip index versions <package>")]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -172,6 +172,22 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    public async Task Go_Clean_Does_Not_Treat_Prose_Examples_As_Options()
+    {
+        const string helpText = """
+            usage: go clean [-i] [packages]
+
+            The -i flag removes installed archives.
+            DIR.test(.exe) from go test -c
+            """;
+
+        var command = await new TestGoCliScraper().Parse(["go", "clean"], helpText);
+
+        await Assert.That(command!.Options.Select(option => option.SwitchName))
+            .IsEquivalentTo(["-i"]);
+    }
+
+    [Test]
     public async Task Go_Usage_Parses_Inline_Option_Values()
     {
         const string helpText = "usage: go tool compile -o=FILE [packages]";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
@@ -232,7 +232,8 @@ public class SnykCliScraperTests
                 Specify multiple Terraform state files to be read. Glob patterns are supported.
             """;
 
-        var command = await new TestSnykCliScraper().Parse(["snyk", "iac", "describe"], helpText);
+        var scraper = new TestSnykCliScraper();
+        var command = await scraper.Parse(["snyk", "iac", "describe"], helpText);
         var option = command!.Options.Single();
 
         using (Assert.Multiple())
@@ -240,6 +241,8 @@ public class SnykCliScraperTests
             await Assert.That(option.SwitchName).IsEqualTo("--from");
             await Assert.That(option.CSharpType).IsEqualTo("string?");
             await Assert.That(option.AcceptsMultipleValues).IsFalse();
+            await Assert.That(scraper.IsKnownScalar(["iac", "describe"], "--from"))
+                .IsTrue();
         }
     }
 
@@ -439,6 +442,9 @@ public class SnykCliScraperTests
         public bool DeclaresCommandGroup(string helpText) => HelpDeclaresCommandGroup(helpText);
 
         public bool CanGenerate(string helpText) => HasOptions(helpText);
+
+        public bool IsKnownScalar(IReadOnlyList<string> commandParts, string switchName) =>
+            ShouldTreatOptionAsScalar(commandParts, switchName);
 
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
             => ParseCommandAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -678,6 +678,22 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Associates_Standalone_Option_Value_With_Its_Switch()
+    {
+        var usage = UsageSynopsisParser.Parse(
+            "Usage: kubectl diff -f FILENAME",
+            ["kubectl", "diff"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(usage.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Filename");
+            await Assert.That(usage.PositionalArguments.Single().AssociatedOptionSwitch)
+                .IsEqualTo("-f");
+        }
+    }
+
+    [Test]
     public async Task Model_Rejects_Standalone_Operand_Sharing_Named_Option_Property()
     {
         var usage = UsageSynopsisParser.Parse(
@@ -731,6 +747,7 @@ public class UsageSynopsisParserTests
                     SwitchName = "--output",
                     PropertyName = "Output",
                     CSharpType = "bool?",
+                    IsFlag = true,
                 },
             ],
         };
@@ -742,7 +759,8 @@ public class UsageSynopsisParserTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(usage.PositionalArguments.Single().AssociatedOptionSwitch).IsNull();
+            await Assert.That(usage.PositionalArguments.Single().AssociatedOptionSwitch)
+                .IsEqualTo("--output");
             await Assert.That(Validate)
                 .Throws<InvalidOperationException>()
                 .And.HasMessageContaining("no CliPositionalArgument");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
@@ -26,6 +26,25 @@ public class WinGetCliScraperTests
     }
 
     [Test]
+    public async Task Command_Group_Does_Not_Model_Child_Command_Placeholder()
+    {
+        const string helpText = """
+            Manage package sources.
+
+            usage: winget source [<command>] [<options>]
+
+            The following sub-commands are available:
+              add     Add a new source
+              list    List current sources
+            """;
+
+        var command = await new TestWinGetCliScraper().Parse(["winget", "source"], helpText);
+
+        await Assert.That(command!.PositionalArguments).IsEmpty();
+        await Assert.That(command.UsagePositionalArguments).IsEmpty();
+    }
+
+    [Test]
     public async Task Models_Repeatable_Sort_As_A_Collection()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -106,6 +107,42 @@ public class YarnCliScraperTests
                 .IsEquivalentTo(["Package", "Quiet"]);
             await Assert.That(package.CSharpType).IsEqualTo("IEnumerable<string>?");
             await Assert.That(package.AcceptsMultipleValues).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Preserves_Clipanion_Option_Arity()
+    {
+        const string helpText = """
+            Usage
+
+            $ yarn workspaces foreach [--immutable] [--include #0] [--since] [-v,--verbose]
+
+            Options
+
+              --immutable       Abort if the lockfile would be modified
+              --include #0      An array of glob pattern idents or paths
+              --since           Only include workspaces changed since the configured base refs
+              -v,--verbose      Increase verbosity up to 2 times
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(
+            ["yarn", "workspaces", "foreach"],
+            helpText);
+
+        var immutable = command!.Options.Single(option => option.PropertyName == "Immutable");
+        var include = command.Options.Single(option => option.PropertyName == "Include");
+        var since = command.Options.Single(option => option.PropertyName == "Since");
+        var verbose = command.Options.Single(option => option.PropertyName == "Verbose");
+        using (Assert.Multiple())
+        {
+            await Assert.That(immutable.IsFlag).IsTrue();
+            await Assert.That(include.AcceptsMultipleValues).IsTrue();
+            await Assert.That(include.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(since.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(verbose.IsFlag).IsTrue();
+            await Assert.That(verbose.CSharpType).IsEqualTo("int?");
+            await Assert.That(verbose.ValidationConstraints!.MaxValue).IsEqualTo(2);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -140,9 +140,36 @@ public class YarnCliScraperTests
             await Assert.That(include.AcceptsMultipleValues).IsTrue();
             await Assert.That(include.CSharpType).IsEqualTo("IEnumerable<string>?");
             await Assert.That(since.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(since.ValueSeparator).IsEqualTo("=");
             await Assert.That(verbose.IsFlag).IsTrue();
             await Assert.That(verbose.CSharpType).IsEqualTo("int?");
             await Assert.That(verbose.ValidationConstraints!.MaxValue).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task Version_Apply_Prerelease_Accepts_An_Optional_Identifier()
+    {
+        const string helpText = """
+            Usage
+
+            $ yarn version apply [--prerelease]
+
+            Options
+
+              --prerelease      Apply the prerelease identifier
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(
+            ["yarn", "version", "apply"],
+            helpText);
+        var prerelease = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(prerelease.IsFlag).IsFalse();
+            await Assert.That(prerelease.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(prerelease.ValueSeparator).IsEqualTo("=");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -173,6 +173,57 @@ public class YarnCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Init_Install_Accepts_An_Optional_Bundle()
+    {
+        const string helpText = """
+            Usage
+
+            $ yarn init [-i,--install]
+
+            Options
+
+              -i,--install      Initialize with a specific bundle
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(["yarn", "init"], helpText);
+        var install = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(install.IsFlag).IsFalse();
+            await Assert.That(install.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(install.ValueSeparator).IsEqualTo("=");
+        }
+    }
+
+    [Test]
+    public async Task Run_Inspect_Options_Accept_Optional_Values()
+    {
+        const string helpText = """
+            Usage
+
+            $ yarn run [--inspect] [--inspect-brk]
+
+            Options
+
+              --inspect         Forward to the Node process
+              --inspect-brk     Forward to the Node process and break
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(["yarn", "run"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.IsFlag))
+                .IsEquivalentTo([false, false]);
+            await Assert.That(command.Options.Select(option => option.ValueArity))
+                .IsEquivalentTo([CliOptionValueArity.Optional, CliOptionValueArity.Optional]);
+            await Assert.That(command.Options.Select(option => option.ValueSeparator))
+                .IsEquivalentTo(["=", "="]);
+        }
+    }
+
     private sealed class TestYarnCliScraper : YarnCliScraper
     {
         public TestYarnCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -62,6 +62,31 @@ public class ZeroOutputScraperTests
     }
 
     [Test]
+    [Arguments("create")]
+    [Arguments("edit")]
+    public async Task Gh_Release_Latest_Preserves_Explicit_False(string commandName)
+    {
+        const string helpText = """
+            USAGE
+              gh release COMMAND [flags]
+
+            FLAGS
+                  --latest   Mark this release as Latest (default: automatic based on date)
+            """;
+
+        var command = await new TestGhCliScraper().Parse(
+            ["gh", "release", commandName],
+            helpText.Replace("COMMAND", commandName, StringComparison.Ordinal));
+        var latest = command!.Options.Single(option => option.PropertyName == "Latest");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(latest.IsFlag).IsFalse();
+            await Assert.That(latest.CSharpType).IsEqualTo("bool?");
+        }
+    }
+
+    [Test]
     public async Task Gh_Parses_Inline_Usage_And_Indented_Flags_Sections()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumDefinitionStabilizer.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumDefinitionStabilizer.cs
@@ -106,7 +106,8 @@ internal static partial class EnumDefinitionStabilizer
             var reusedMember = definition.Values.FirstOrDefault(value => value.MemberName.Equals(
                 existingValue.MemberName,
                 StringComparison.Ordinal));
-            if (reusedMember is not null)
+            if (reusedMember is not null
+                && !reusedMember.CliValue.Equals(existingValue.CliValue, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException(
                     $"Enum '{definition.EnumName}' member '{existingValue.MemberName}' changed CLI value from "
@@ -145,18 +146,44 @@ internal static partial class EnumDefinitionStabilizer
         for (var index = 0; index < newValues.Count; index++)
         {
             var incomingValue = newValues[index];
+            var memberName = GetCompatibleMemberName(incomingValue, stabilizedValues);
             while (usedNumericValues.Contains(nextNumericValue))
             {
                 nextNumericValue = checked(nextNumericValue + 1);
             }
 
-            stabilizedValues.Add(incomingValue with { NumericValue = nextNumericValue });
+            stabilizedValues.Add(incomingValue with
+            {
+                MemberName = memberName,
+                NumericValue = nextNumericValue,
+            });
             usedNumericValues.Add(nextNumericValue);
             if (index < newValues.Count - 1)
             {
                 nextNumericValue = checked(nextNumericValue + 1);
             }
         }
+    }
+
+    private static string GetCompatibleMemberName(
+        CliEnumValue incomingValue,
+        IReadOnlyCollection<CliEnumValue> stabilizedValues)
+    {
+        var existingMember = stabilizedValues.FirstOrDefault(value => value.MemberName.Equals(
+            incomingValue.MemberName,
+            StringComparison.Ordinal));
+        if (existingMember is null
+            || !existingMember.CliValue.Equals(incomingValue.CliValue, StringComparison.OrdinalIgnoreCase))
+        {
+            return incomingValue.MemberName;
+        }
+
+        var suffix = incomingValue.CliValue == incomingValue.CliValue.ToLowerInvariant()
+            ? "Lowercase"
+            : incomingValue.CliValue == incomingValue.CliValue.ToUpperInvariant()
+                ? "Uppercase"
+                : "CaseVariant";
+        return $"{incomingValue.MemberName}{suffix}";
     }
 
     private static void ValidateValues(CliEnumDefinition definition)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -239,12 +239,15 @@ internal static class GeneratedApiCompatibilityPreserver
             CompatibilityProperties = RestoreRemovedCompatibilityProperties(baseline.Properties),
             CompatibilityConstructors = baseline.Constructors,
             CompatibilityMethods = [.. facadeMethods
-                .Where(method => IsRootFacadeMethod(tool, method)
-                                 && IsNamedFacadeMethod(tool, method))
+                .Where(method => IsNamedFacadeMethod(tool, method))
                 .Select(method => new CliCompatibilityMethod
                 {
                     MethodName = method.MethodName,
-                    ObsoleteMessage = $"Use {currentRootMethodName} instead.",
+                    ObsoleteMessage = method.MethodName.Equals(
+                        currentRootMethodName,
+                        StringComparison.Ordinal)
+                        ? "Use the current command facade instead."
+                        : $"Use {currentRootMethodName} instead.",
                 })
                 .DistinctBy(static method => method.MethodName, StringComparer.Ordinal)],
             SubDomainGroup = subDomainGroup,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -121,8 +121,16 @@ internal static class GeneratedApiCompatibilityPreserver
                     : command)
                 .Select(command => optionalFacadeOptionTypes.Contains(command.ClassName)
                     ? command with { PreserveOptionalOptionsParameter = true }
-                    : command)
-                .Select(command => PreserveFacadeMethodCasing(command, facadeMethods))],
+                    : command)],
+        };
+        var currentFacadeMethods = GenerateFacadeMethods(preservedTool);
+        preservedTool = preservedTool with
+        {
+            Commands = [.. preservedTool.Commands.Select(command =>
+                PreserveFacadeMethodCompatibility(
+                    command,
+                    facadeMethods,
+                    currentFacadeMethods))],
         };
         RejectRemovedFacadeMethods(preservedTool, facadeMethods);
         return preservedTool;
@@ -821,20 +829,27 @@ internal static class GeneratedApiCompatibilityPreserver
         };
     }
 
-    private static CliCommandDefinition PreserveFacadeMethodCasing(
+    private static CliCommandDefinition PreserveFacadeMethodCompatibility(
         CliCommandDefinition command,
-        IReadOnlyList<GeneratedFacadeMethod> baselineFacadeMethods)
+        IReadOnlyList<GeneratedFacadeMethod> baselineFacadeMethods,
+        IReadOnlyList<GeneratedFacadeMethod> currentFacadeMethods)
     {
-        var currentMethodName = GeneratorUtils.EnsureAsyncSuffix(
-            GeneratorUtils.GenerateMethodNameFromLastCommandPart(command));
+        var currentMethods = currentFacadeMethods
+            .Where(method => method.OptionsType.Equals(command.ClassName, StringComparison.Ordinal))
+            .ToArray();
         var compatibilityMethods = baselineFacadeMethods
             .Where(method => method.OptionsType.Equals(command.ClassName, StringComparison.Ordinal)
-                             && method.MethodName.Equals(currentMethodName, StringComparison.OrdinalIgnoreCase)
-                             && !method.MethodName.Equals(currentMethodName, StringComparison.Ordinal))
-            .Select(method => new CliCompatibilityMethod
+                             && !currentFacadeMethods.Contains(method))
+            .Select(method => (Baseline: method, Replacements: currentMethods
+                .Where(current => current.DeclaringType.Equals(method.DeclaringType, StringComparison.Ordinal))
+                .Select(static current => current.MethodName)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray()))
+            .Where(static match => match.Replacements.Length == 1)
+            .Select(match => new CliCompatibilityMethod
             {
-                MethodName = method.MethodName,
-                ObsoleteMessage = $"Use {currentMethodName} instead.",
+                MethodName = match.Baseline.MethodName,
+                ObsoleteMessage = $"Use {match.Replacements[0]} instead.",
             });
 
         return command with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -921,8 +921,7 @@ internal static class GeneratedApiCompatibilityPreserver
             aliasBaseline.Properties,
             aliasBaseline.Constructors,
             currentRequired,
-            compatibilityConstructors,
-            allowNewRequiredMembers: false);
+            compatibilityConstructors);
         SetCompatibilityEntries(constructorsByAlias, aliasClassName, compatibilityConstructors);
     }
 
@@ -2562,15 +2561,13 @@ internal static class GeneratedApiCompatibilityPreserver
             baselineProperties,
             baselineConstructors,
             [.. GetCurrentProperties(positionalArguments, options).Where(static property => property.IsRequired)],
-            compatibilityConstructors,
-            allowNewRequiredMembers: true);
+            compatibilityConstructors);
 
     private static void PreserveCompatibilityConstructors(
         IReadOnlyList<GeneratedApiProperty> baselineProperties,
         IReadOnlyList<CliCompatibilityConstructor> baselineConstructors,
         IReadOnlyList<GeneratedApiProperty> currentRequired,
-        List<CliCompatibilityConstructor> compatibilityConstructors,
-        bool allowNewRequiredMembers)
+        List<CliCompatibilityConstructor> compatibilityConstructors)
     {
         if (currentRequired.Count == 0)
         {
@@ -2581,19 +2578,6 @@ internal static class GeneratedApiCompatibilityPreserver
         var baselineRequired = baselineProperties
             .Where(static property => property.IsRequired && !property.IsCompatibility)
             .ToArray();
-        var addedRequired = currentRequired
-            .Where(current => !baselineRequired.Any(baseline =>
-                baseline.PropertyName.Equals(current.PropertyName, StringComparison.Ordinal)
-                && baseline.CSharpType.Equals(current.CSharpType, StringComparison.Ordinal)))
-            .Select(static property => property.PropertyName)
-            .ToArray();
-        if (addedRequired.Length > 0 && !allowNewRequiredMembers)
-        {
-            throw new InvalidOperationException(
-                "Cannot retain generated constructors because newly required member(s) "
-                + $"{string.Join(", ", addedRequired)} have no baseline value.");
-        }
-
         foreach (var constructor in baselineConstructors)
         {
             AddCompatibilityConstructor(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -243,9 +243,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 .Select(method => new CliCompatibilityMethod
                 {
                     MethodName = method.MethodName,
-                    ObsoleteMessage = method.MethodName.Equals(
-                        currentRootMethodName,
-                        StringComparison.Ordinal)
+                    ObsoleteMessage = !IsRootFacadeMethod(tool, method)
                         ? "Use the current command facade instead."
                         : $"Use {currentRootMethodName} instead.",
                 })

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -72,7 +72,12 @@ public class OptionsClassGenerator : ICodeGenerator
         sb.AppendLine("using System.CodeDom.Compiler;");
         sb.AppendLine("using System.Diagnostics.CodeAnalysis;");
         if (requiredParameters.Any(static parameter =>
-                parameter.Option?.ValueArity == CliOptionValueArity.Optional))
+                parameter.Option?.RequiresModelsNamespace == true)
+            || compatibilityProperties.Any(static property =>
+                CliOptionDefinition.TypeRequiresModelsNamespace(property.AliasCSharpType))
+            || compatibilityConstructors
+                .SelectMany(static constructor => constructor.Parameters)
+                .Any(static parameter => CliOptionDefinition.TypeRequiresModelsNamespace(parameter.CSharpType)))
         {
             sb.AppendLine("using ModularPipelines.Models;");
         }
@@ -386,7 +391,12 @@ public class OptionsClassGenerator : ICodeGenerator
         // Include the existing Options namespace where the base class lives
         sb.AppendLine($"using {tool.TargetNamespace}.Options;");
 
-        if (command.Options.Any(o => o.RequiresModelsNamespace))
+        if (command.Options.Any(static option => option.RequiresModelsNamespace)
+            || command.CompatibilityProperties.Any(static property =>
+                CliOptionDefinition.TypeRequiresModelsNamespace(property.CSharpType))
+            || command.CompatibilityConstructors
+                .SelectMany(static constructor => constructor.Parameters)
+                .Any(static parameter => CliOptionDefinition.TypeRequiresModelsNamespace(parameter.CSharpType)))
         {
             sb.AppendLine("using ModularPipelines.Models;");
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -204,7 +204,8 @@ public record CliCommandDefinition
         IReadOnlyList<CliPositionalArgument>? usagePositionalArguments) =>
         usagePositionalArguments is { Count: > 0 }
         && usagePositionalArguments.All(argument => Options.Any(option =>
-            option.PropertyName.Equals(argument.PropertyName, StringComparison.OrdinalIgnoreCase)
+            !option.IsFlag
+            && option.PropertyName.Equals(argument.PropertyName, StringComparison.OrdinalIgnoreCase)
             && argument.AssociatedOptionSwitch is not null
             && (option.SwitchName.Equals(argument.AssociatedOptionSwitch, StringComparison.OrdinalIgnoreCase)
                 || option.ShortForm?.Equals(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -214,9 +214,13 @@ public record CliOptionDefinition
     /// </summary>
     public bool RequiresModelsNamespace
         => IsKeyValue
-           || CSharpType.Contains("KeyValue", StringComparison.Ordinal)
            || ValueArity == CliOptionValueArity.Optional
-           || CSharpType.Contains("CliValuePair", StringComparison.Ordinal);
+           || TypeRequiresModelsNamespace(CSharpType);
+
+    internal static bool TypeRequiresModelsNamespace(string cSharpType) =>
+        cSharpType.Contains("KeyValue", StringComparison.Ordinal)
+        || cSharpType.Contains("CliValuePair", StringComparison.Ordinal)
+        || cSharpType.Contains("CliOptionValue", StringComparison.Ordinal);
 
     /// <summary>
     /// Whether the value is numeric.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -214,6 +214,7 @@ public record CliOptionDefinition
     /// </summary>
     public bool RequiresModelsNamespace
         => IsKeyValue
+           || CSharpType.Contains("KeyValue", StringComparison.Ordinal)
            || ValueArity == CliOptionValueArity.Optional
            || CSharpType.Contains("CliValuePair", StringComparison.Ordinal);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -318,6 +318,7 @@ public partial class AzCliScraper : CliScraperBase
                     IsFlag = isFlag,
                     IsRequired = isRequired,
                     AcceptsMultipleValues = csharpType.StartsWith("IEnumerable"),
+                    GroupValues = HelpDeclaresSpaceSeparatedList(description),
                     IsKeyValue = false,
                     IsNumeric = csharpType == "int?",
                     ValueSeparator = " ",
@@ -423,8 +424,8 @@ public partial class AzCliScraper : CliScraperBase
         description.Contains("list of false");
 
     private static bool HelpDeclaresSpaceSeparatedList(string description) =>
-        description.Contains("space-separated")
-        || description.Contains("separated by spaces");
+        description.Contains("space-separated", StringComparison.OrdinalIgnoreCase)
+        || description.Contains("separated by spaces", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Checks if an option is a global option that should be on the base class.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -307,9 +307,6 @@ public partial class AzCliScraper : CliScraperBase
                 var isRequired = sectionName.Equals("Required Arguments", StringComparison.OrdinalIgnoreCase);
 
                 var csharpType = DetermineType(valueHint, description, isFlag, explicitBooleanValue);
-                var valueArity = !isFlag && HelpDeclaresOptionalValue(description)
-                    ? CliOptionValueArity.Optional
-                    : CliOptionValueArity.Required;
 
                 options.Add(new CliOptionDefinition
                 {
@@ -324,7 +321,7 @@ public partial class AzCliScraper : CliScraperBase
                     IsKeyValue = false,
                     IsNumeric = csharpType == "int?",
                     ValueSeparator = " ",
-                    ValueArity = valueArity,
+                    ValueArity = GetValueArity(isFlag, description),
                     EnumDefinition = null,
                     IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
                 });
@@ -368,6 +365,11 @@ public partial class AzCliScraper : CliScraperBase
 
     private static bool HelpDeclaresOptionalValue(string description) =>
         description.Contains("provided without any value", StringComparison.OrdinalIgnoreCase);
+
+    private static CliOptionValueArity GetValueArity(bool isFlag, string description) =>
+        !isFlag && HelpDeclaresOptionalValue(description)
+            ? CliOptionValueArity.Optional
+            : CliOptionValueArity.Required;
 
     /// <summary>
     /// Determines the C# type based on value hint and description.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -297,7 +297,11 @@ public partial class AzCliScraper : CliScraperBase
 
                 // Determine type based on value hint
                 var explicitBooleanValue = HelpDeclaresExplicitBooleanValue(description);
-                var isFlag = IsPresenceOnlyFlag(valueHint, description, explicitBooleanValue);
+                var isFlag = IsPresenceOnlyFlag(
+                    longFlag,
+                    valueHint,
+                    description,
+                    explicitBooleanValue);
 
                 var isRequired = sectionName.Equals("Required Arguments", StringComparison.OrdinalIgnoreCase);
 
@@ -329,10 +333,17 @@ public partial class AzCliScraper : CliScraperBase
     /// Determines whether an option is rendered without a value.
     /// </summary>
     private static bool IsPresenceOnlyFlag(
+        string switchName,
         string valueHint,
         string description,
         bool explicitBooleanValue)
     {
+        if (switchName.Equals("accept-term", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrEmpty(valueHint))
+        {
+            return true;
+        }
+
         if (explicitBooleanValue || HelpDeclaresOptionValue(description))
         {
             return false;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers;
@@ -306,6 +307,9 @@ public partial class AzCliScraper : CliScraperBase
                 var isRequired = sectionName.Equals("Required Arguments", StringComparison.OrdinalIgnoreCase);
 
                 var csharpType = DetermineType(valueHint, description, isFlag, explicitBooleanValue);
+                var valueArity = !isFlag && HelpDeclaresOptionalValue(description)
+                    ? CliOptionValueArity.Optional
+                    : CliOptionValueArity.Required;
 
                 options.Add(new CliOptionDefinition
                 {
@@ -320,6 +324,7 @@ public partial class AzCliScraper : CliScraperBase
                     IsKeyValue = false,
                     IsNumeric = csharpType == "int?",
                     ValueSeparator = " ",
+                    ValueArity = valueArity,
                     EnumDefinition = null,
                     IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
                 });
@@ -360,6 +365,9 @@ public partial class AzCliScraper : CliScraperBase
         || description.Contains("may be supplied", StringComparison.OrdinalIgnoreCase)
         || description.Contains("space-separated", StringComparison.OrdinalIgnoreCase)
         || description.Contains("key=value", StringComparison.OrdinalIgnoreCase);
+
+    private static bool HelpDeclaresOptionalValue(string description) =>
+        description.Contains("provided without any value", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Determines the C# type based on value hint and description.
@@ -413,7 +421,8 @@ public partial class AzCliScraper : CliScraperBase
         description.Contains("list of false");
 
     private static bool HelpDeclaresSpaceSeparatedList(string description) =>
-        description.Contains("space-separated");
+        description.Contains("space-separated")
+        || description.Contains("separated by spaces");
 
     /// <summary>
     /// Checks if an option is a global option that should be on the base class.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -345,6 +345,7 @@ public partial class AzCliScraper : CliScraperBase
 
     private static bool HelpDeclaresOptionValue(string description) =>
         AzValueDescriptionPattern().IsMatch(description)
+        || AzEmbeddedValueDescriptionPattern().IsMatch(description)
         || description.Contains("may be supplied", StringComparison.OrdinalIgnoreCase)
         || description.Contains("space-separated", StringComparison.OrdinalIgnoreCase)
         || description.Contains("key=value", StringComparison.OrdinalIgnoreCase);
@@ -509,8 +510,11 @@ public partial class AzCliScraper : CliScraperBase
     [GeneratedRegex(@"^\s+--(?<long>[\w-]+)(?:\s+-(?<short>\w))?(?:\s+(?<value>[A-Z_]+))?\s*:\s*(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex AzOptionPattern();
 
-    [GeneratedRegex(@"^(?:(?:a|an|the)\s+)?(?:path|uri|url|name|id|identifier|description|query|string|value|template|resource|parameters?|managed identity|subnet|virtual network)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(?:(?:a|an|the)\s+)?(?:path|uri|url|name|id|identifier|description|query|string|value|template|resource|parameters?|managed identity|subnet|virtual network|default identity|install script|registry adapter|storage mount|key vault|source|related resource|batch|accepts?)\b", RegexOptions.IgnoreCase)]
     private static partial Regex AzValueDescriptionPattern();
+
+    [GeneratedRegex(@"\b(?:resource ID|secret URI|URI or path|key-value pairs|accepted values?)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex AzEmbeddedValueDescriptionPattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -333,6 +333,14 @@ public partial class BrewCliScraper : CliScraperBase
             [
                 RequiredArgument("CaskOrName", 0),
             ],
+            ["unlink"] =>
+            [
+                RequiredArgument("InstalledFormula", 0) with
+                {
+                    CSharpType = "IEnumerable<string>",
+                    IsVariadic = true,
+                },
+            ],
             _ => arguments,
         };
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -469,7 +469,7 @@ public partial class BrewCliScraper : CliScraperBase
             // Determine if it's a flag or takes a value
             // Homebrew options are mostly flags unless they mention a value in description
             var isFlag = !hasInlineValue &&
-                         !descriptionPart.Contains("=") &&
+                         !descriptionPart.Contains('=') &&
                          !DescriptionSuggestsValue().IsMatch(descriptionPart);
 
             var csharpType = isFlag ? "bool?" : "string?";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -325,6 +325,10 @@ public partial class BrewCliScraper : CliScraperBase
                     PrependOptionTerminator = true,
                 },
             ],
+            ["generate-zap"] =>
+            [
+                RequiredArgument("CaskOrName", 0),
+            ],
             _ => arguments,
         };
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -309,7 +309,11 @@ public partial class BrewCliScraper : CliScraperBase
         {
             ["command"] =>
             [
-                RequiredArgument("Cmd", 0),
+                RequiredArgument("Cmd", 0) with
+                {
+                    CSharpType = "IEnumerable<string>",
+                    IsVariadic = true,
+                },
             ],
             ["exec"] =>
             [

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -558,7 +558,7 @@ public partial class BrewCliScraper : CliScraperBase
     /// <summary>
     /// Matches descriptions that suggest the option takes a value.
     /// </summary>
-    [GeneratedRegex(@"\b(?:set|specify|use|path|file|directory|number|name|value|list|comma-separated|writable)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?:set|specify|use|path|file|directory|number|name|value)\b", RegexOptions.IgnoreCase)]
     private static partial Regex DescriptionSuggestsValue();
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -245,9 +246,11 @@ public partial class BrewCliScraper : CliScraperBase
 
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
-        var positionalArguments = DisambiguatePositionalArguments(
-            usage.PositionalArguments,
-            options);
+        var positionalArguments = NormalizePositionalArguments(
+            commandParts,
+            DisambiguatePositionalArguments(
+                GetPositionalArguments(usage, options),
+                options));
 
         // Extract enums from options
         var enums = options
@@ -298,6 +301,52 @@ public partial class BrewCliScraper : CliScraperBase
             })
             .ToArray();
     }
+
+    private static IReadOnlyList<CliPositionalArgument> NormalizePositionalArguments(
+        IReadOnlyList<string> commandParts,
+        IReadOnlyList<CliPositionalArgument> arguments) =>
+        commandParts switch
+        {
+            ["command"] =>
+            [
+                RequiredArgument("Cmd", 0),
+            ],
+            ["exec"] =>
+            [
+                RequiredArgument("Command", 0),
+                VariadicArgument("Arguments", 1),
+            ],
+            ["sandbox-exec"] =>
+            [
+                RequiredArgument("Command", 0) with
+                {
+                    CSharpType = "IEnumerable<string>",
+                    IsVariadic = true,
+                    PrependOptionTerminator = true,
+                },
+            ],
+            _ => arguments,
+        };
+
+    private static CliPositionalArgument RequiredArgument(string propertyName, int position) => new()
+    {
+        PropertyName = propertyName,
+        CSharpType = "string",
+        Description = $"The {propertyName.ToLowerInvariant()} operand.",
+        Phase = CommandLinePhase.Passthrough,
+        PositionIndex = position,
+        IsRequired = true,
+    };
+
+    private static CliPositionalArgument VariadicArgument(string propertyName, int position) => new()
+    {
+        PropertyName = propertyName,
+        CSharpType = "IEnumerable<string>?",
+        Description = $"The {propertyName.ToLowerInvariant()} operands.",
+        Phase = CommandLinePhase.Passthrough,
+        PositionIndex = position,
+        IsVariadic = true,
+    };
 
     /// <summary>
     /// Extracts description from help text.
@@ -392,6 +441,9 @@ public partial class BrewCliScraper : CliScraperBase
                 continue;
             }
 
+            var hasInlineValue = longForm.Contains('=');
+            longForm = longForm.Split('=', 2)[0];
+
             // Skip duplicates
             if (seenOptions.Contains(longForm))
             {
@@ -408,8 +460,8 @@ public partial class BrewCliScraper : CliScraperBase
 
             // Determine if it's a flag or takes a value
             // Homebrew options are mostly flags unless they mention a value in description
-            var isFlag = !descriptionPart.Contains("=") &&
-                         !longForm.Contains("=") &&
+            var isFlag = !hasInlineValue &&
+                         !descriptionPart.Contains("=") &&
                          !DescriptionSuggestsValue().IsMatch(descriptionPart);
 
             var csharpType = isFlag ? "bool?" : "string?";
@@ -484,13 +536,13 @@ public partial class BrewCliScraper : CliScraperBase
     ///   -d, --debug                  Display any debugging information.
     ///       --formula, --formulae    Treat all named arguments as formulae.
     /// </summary>
-    [GeneratedRegex(@"^\s{2,}(?<flags>(?:-\w,\s*)?(?:--[\w\[\]-]+(?:,\s*--[\w-]+)*))(?:\s{2,}|\s*$)(?<description>.*)$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s{2,}(?<flags>(?:-\w,\s*)?(?:--[\w\[\]-]+(?:=[^\s,]+)?(?:,\s*--[\w-]+(?:=[^\s,]+)?)*))(?:\s{2,}|\s*$)(?<description>.*)$", RegexOptions.Multiline)]
     private static partial Regex BrewOptionPattern();
 
     /// <summary>
     /// Matches descriptions that suggest the option takes a value.
     /// </summary>
-    [GeneratedRegex(@"\b(?:set|specify|use|path|file|directory|number|name|value)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?:set|specify|use|path|file|directory|number|name|value|list|comma-separated|writable)\b", RegexOptions.IgnoreCase)]
     private static partial Regex DescriptionSuggestsValue();
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -772,6 +772,25 @@ public abstract partial class CliScraperBase : ICliScraper
             .ToArray();
 
     /// <summary>
+    /// Returns true positional operands, retaining operands that follow presence-only flags.
+    /// </summary>
+    protected static IReadOnlyList<CliPositionalArgument> GetPositionalArguments(
+        UsageSynopsisParseResult usage,
+        IReadOnlyList<CliOptionDefinition> options) =>
+        usage.PositionalArguments
+            .Where(argument => argument.AssociatedOptionSwitch is null
+                               || !options.Any(option =>
+                                   !option.IsFlag
+                                   && (option.SwitchName.Equals(
+                                           argument.AssociatedOptionSwitch,
+                                           StringComparison.OrdinalIgnoreCase)
+                                       || option.ShortForm?.Equals(
+                                           argument.AssociatedOptionSwitch,
+                                           StringComparison.OrdinalIgnoreCase) == true)))
+            .Select(argument => argument with { AssociatedOptionSwitch = null })
+            .ToArray();
+
+    /// <summary>
     /// Checks if help text indicates the command has options/flags.
     /// Override if the CLI has a different pattern for leaf commands.
     /// </summary>
@@ -1098,7 +1117,8 @@ public abstract partial class CliScraperBase : ICliScraper
         + @"|(?:accepts?|specify|supply|provide|use|pass|set|give|supports?|takes?|contains?)\s+"
         + @"(?:multiple\s+times|more\s+than\s+once|"
         + RepeatableItemCountPattern
-        + @"|multiple\s+[\w-]+))\b";
+        + @"|multiple\s+[\w-]+)"
+        + @"|(?:an?\s+)?array\s+of\s+[\w-]+)\b";
 
     [GeneratedRegex(RepeatableValueRegex, RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace)]
     private static partial Regex RepeatableValuePattern();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1082,7 +1082,7 @@ public abstract partial class CliScraperBase : ICliScraper
     /// Pattern to match option lines (e.g., "-f, --flag" or "--option").
     /// </summary>
     [GeneratedRegex(
-        @"^[ \t]*(?:-\w(?:[ \t]+[^,\s]+)?[ \t]*,[ \t]*)?--[\w-]+(?:[ \t]|,|$)",
+        @"^[ \t]*(?:-\w(?:[ \t]+[^,\s]+)?[ \t]*,[ \t]*)?--[\w-]+(?:[ \t]|,|=|$)",
         RegexOptions.Multiline)]
     protected static partial Regex OptionLinePattern();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -206,7 +206,9 @@ public abstract partial class CobraCliScraper : CliScraperBase
         var options = ApplyOptionFixes(commandParts, ParseOptions(helpText, commandParts));
 
         // Parse positional arguments from usage/synopsis text
-        var positionalArgs = ApplyPositionalArgumentFixes(commandParts, usage.PositionalArguments);
+        var positionalArgs = ApplyPositionalArgumentFixes(
+            commandParts,
+            GetPositionalArguments(usage, options));
 
         // Extract enums from options
         var enums = options

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -154,9 +154,14 @@ public partial class DotNetCliScraper : CliScraperBase
 
         // Parse positional arguments
         var positionalArgs = ParsePositionalArguments(helpText);
+        var usagePositionalArgs = GetPositionalArguments(usage, options);
         if (positionalArgs.Count == 0)
         {
-            positionalArgs.AddRange(GetPositionalArguments(usage));
+            positionalArgs.AddRange(usagePositionalArgs);
+        }
+        else
+        {
+            positionalArgs = ApplyUsageCardinality(positionalArgs, usagePositionalArgs);
         }
 
         // Apply command-specific positional argument fixes
@@ -268,7 +273,10 @@ public partial class DotNetCliScraper : CliScraperBase
 
             var shortFlag = match.Groups["short"].Value.Trim();
             var longFlag = match.Groups["long"].Value.Trim();
-            var valueHint = match.Groups["value"].Value.Trim();
+            var hasOptionalValue = match.Groups["optionalValue"].Success;
+            var valueHint = (hasOptionalValue
+                ? match.Groups["optionalValue"]
+                : match.Groups["value"]).Value.Trim();
             var description = match.Groups["desc"].Value.Trim();
 
             // Need at least one flag
@@ -305,7 +313,15 @@ public partial class DotNetCliScraper : CliScraperBase
 
             // Determine type based on value hint
             // Some nuget options don't have value hints but still take values (e.g., -n|--name)
-            var isFlag = string.IsNullOrEmpty(valueHint) && !IsLikelyValueOption(primaryFlag, description);
+            var declaresBooleanDefault = description.Contains(
+                                             "[default: False]",
+                                             StringComparison.OrdinalIgnoreCase)
+                                         || description.Contains(
+                                             "[default: True]",
+                                             StringComparison.OrdinalIgnoreCase);
+            var isFlag = string.IsNullOrEmpty(valueHint)
+                         && (declaresBooleanDefault
+                             || !IsLikelyValueOption(primaryFlag, description));
             var isRequired = false;
             var acceptsMultiple = description.Contains("multiple", StringComparison.OrdinalIgnoreCase) ||
                                   description.Contains("can be specified more than once", StringComparison.OrdinalIgnoreCase);
@@ -325,6 +341,9 @@ public partial class DotNetCliScraper : CliScraperBase
                 IsKeyValue = primaryFlag.Contains("property", StringComparison.OrdinalIgnoreCase),
                 IsNumeric = csharpType == "int?",
                 ValueSeparator = " ",
+                ValueArity = hasOptionalValue
+                    ? CliOptionValueArity.Optional
+                    : CliOptionValueArity.Required,
                 EnumDefinition = null,
                 IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
             });
@@ -494,6 +513,24 @@ public partial class DotNetCliScraper : CliScraperBase
 
         return args;
     }
+
+    private static List<CliPositionalArgument> ApplyUsageCardinality(
+        List<CliPositionalArgument> arguments,
+        IReadOnlyList<CliPositionalArgument> usageArguments) =>
+        arguments.Select(argument =>
+        {
+            var usageArgument = usageArguments.FirstOrDefault(candidate =>
+                candidate.PropertyName.Equals(
+                    argument.PropertyName,
+                    StringComparison.OrdinalIgnoreCase));
+            return usageArgument is { IsVariadic: true }
+                ? argument with
+                {
+                    CSharpType = "IEnumerable<string>?",
+                    IsVariadic = true,
+                }
+                : argument;
+        }).ToList();
 
     private static List<CliPositionalArgument> RenameSingleArgument(
         List<CliPositionalArgument> args,
@@ -737,7 +774,7 @@ public partial class DotNetCliScraper : CliScraperBase
     /// -s|--source <source>                 Description    (pipe separator, nuget style)
     /// -ss|--symbol-source <source>         Description    (multi-char short, pipe separator)
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:-(?<short>\w+)[,|]\s*)?--(?<long>[\w-]+)(?:\s+<(?<value>[^>]+)>)?\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s+(?:-(?<short>\w+)[,|]\s*)?--(?<long>[\w-]+)(?:\s+(?:<(?<value>[^>]+)>|\[<(?<optionalValue>[^>]+)>\]))?\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex DotNetOptionPattern();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -238,26 +238,34 @@ public partial class GcloudCliScraper : CliScraperBase
                 continue;
             }
 
-            if (!option.IsFlag
-                && option.CSharpType is not ("bool" or "bool?")
-                && !option.AcceptsMultipleValues
-                && !ShouldTreatOptionAsScalar(commandParts, option.SwitchName)
-                && HelpDeclaresRepeatableOption(
-                    helpText,
-                    option.SwitchName,
-                    option.Description ?? string.Empty))
-            {
-                option = option with
-                {
-                    AcceptsMultipleValues = true,
-                    CSharpType = AsCSharpType(option.CSharpType, acceptsMultipleValues: true),
-                };
-            }
-
-            options.Add(option);
+            options.Add(NormalizeRepeatability(option, helpText, commandParts));
         }
 
         return (options, [argumentGroup]);
+    }
+
+    private CliOptionDefinition NormalizeRepeatability(
+        CliOptionDefinition option,
+        string helpText,
+        IReadOnlyList<string> commandParts)
+    {
+        if (option.IsFlag
+            || option.CSharpType is "bool" or "bool?"
+            || option.AcceptsMultipleValues
+            || ShouldTreatOptionAsScalar(commandParts, option.SwitchName)
+            || !HelpDeclaresRepeatableOption(
+                helpText,
+                option.SwitchName,
+                option.Description ?? string.Empty))
+        {
+            return option;
+        }
+
+        return option with
+        {
+            AcceptsMultipleValues = true,
+            CSharpType = AsCSharpType(option.CSharpType, acceptsMultipleValues: true),
+        };
     }
 
     private static CliOptionDefinition? CreateOption(CliArgumentDefinition argument)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -99,7 +99,7 @@ public partial class GcloudCliScraper : CliScraperBase
 
         var subDomain = commandParts.Length > 1 ? ToPascalCase(commandParts[0]) : null;
         var description = ExtractDescription(helpText);
-        var parsedOptions = ParseOptions(helpText);
+        var parsedOptions = ParseOptions(helpText, commandParts);
         var options = parsedOptions.Options;
         var positionalArgs = ParsePositionalArguments(helpText);
 
@@ -207,8 +207,9 @@ public partial class GcloudCliScraper : CliScraperBase
         return null;
     }
 
-    private static (List<CliOptionDefinition> Options, IReadOnlyList<CliArgumentGroup> ArgumentGroups) ParseOptions(
-        string helpText)
+    private (List<CliOptionDefinition> Options, IReadOnlyList<CliArgumentGroup> ArgumentGroups) ParseOptions(
+        string helpText,
+        IReadOnlyList<string> commandParts)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -235,6 +236,22 @@ public partial class GcloudCliScraper : CliScraperBase
             if (option is null || !seenOptions.Add(option.SwitchName))
             {
                 continue;
+            }
+
+            if (!option.IsFlag
+                && option.CSharpType is not ("bool" or "bool?")
+                && !option.AcceptsMultipleValues
+                && !ShouldTreatOptionAsScalar(commandParts, option.SwitchName)
+                && HelpDeclaresRepeatableOption(
+                    helpText,
+                    option.SwitchName,
+                    option.Description ?? string.Empty))
+            {
+                option = option with
+                {
+                    AcceptsMultipleValues = true,
+                    CSharpType = AsCSharpType(option.CSharpType, acceptsMultipleValues: true),
+                };
             }
 
             options.Add(option);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -264,7 +264,9 @@ public partial class GcloudCliScraper : CliScraperBase
         return option with
         {
             AcceptsMultipleValues = true,
-            CSharpType = AsCSharpType(option.CSharpType, acceptsMultipleValues: true),
+            CSharpType = option.IsKeyValue
+                ? option.CSharpType
+                : AsCSharpType(option.CSharpType, acceptsMultipleValues: true),
         };
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
@@ -89,6 +89,14 @@ public partial class GhCliScraper : CobraCliScraper
         RepeatableOptions.Contains(switchName)
         || base.IsRepeatableOption(commandParts, switchName, typeHint, description, helpText);
 
+    protected override bool IsBooleanValueOption(
+        string[] commandParts,
+        string switchName,
+        string description) =>
+        (commandParts is ["release", "create"] or ["release", "edit"]
+         && switchName.Equals("--latest", StringComparison.OrdinalIgnoreCase))
+        || base.IsBooleanValueOption(commandParts, switchName, description);
+
     protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
         string[] commandParts,
         IReadOnlyList<CliPositionalArgument> positionalArguments) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -398,6 +398,7 @@ public partial class GoCliScraper : CliScraperBase
 
             var valueHint = match.Groups["value"].Value;
             var isFlag = string.IsNullOrEmpty(valueHint);
+            var valueSeparator = match.Groups["separator"].Value == "=" ? "=" : " ";
             options.Add(new CliOptionDefinition
             {
                 SwitchName = flagName,
@@ -405,7 +406,7 @@ public partial class GoCliScraper : CliScraperBase
                 CSharpType = isFlag ? "bool?" : "string?",
                 Description = $"The {flagName} option.",
                 IsFlag = isFlag,
-                ValueSeparator = " ",
+                ValueSeparator = valueSeparator,
                 IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag),
             });
         }
@@ -509,7 +510,7 @@ public partial class GoCliScraper : CliScraperBase
     /// Matches options declared directly in Go usage and prose, including commands whose
     /// help does not expose a dedicated flags table.
     /// </summary>
-    [GeneratedRegex(@"(?<![\w-])(?<flag>-[a-z][\w-]*)(?:\s+(?<value>(?!(?:flag|flags|option|options)\b)[A-Za-z][\w-]*))?", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"(?<![\w-])(?<flag>-[a-z][\w-]*)(?:(?<separator>=|[ \t]+)(?<value>(?!(?:flag|flags|option|options)\b)[A-Za-z][\w-]*))?", RegexOptions.IgnoreCase)]
     private static partial Regex GoUsageOptionPattern();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -179,7 +179,7 @@ public partial class GoCliScraper : CliScraperBase
             .ToList();
         var positionalArguments = NormalizePositionalArguments(
             commandParts,
-            GetPositionalArguments(usage));
+            GetPositionalArguments(usage, options));
 
         var className = GenerateClassName(commandPath);
 
@@ -310,16 +310,15 @@ public partial class GoCliScraper : CliScraperBase
 
         // Find flags sections
         var flagsSectionMatch = FlagsSectionPattern().Match(helpText);
-        if (!flagsSectionMatch.Success)
-        {
-            return options;
-        }
-
-        var sectionStart = flagsSectionMatch.Index + flagsSectionMatch.Length;
+        var sectionStart = flagsSectionMatch.Success
+            ? flagsSectionMatch.Index + flagsSectionMatch.Length
+            : 0;
         var sectionEnd = helpText.Length;
 
-        var nextSection = NextSectionPattern().Match(helpText, sectionStart);
-        if (nextSection.Success)
+        var nextSection = flagsSectionMatch.Success
+            ? NextSectionPattern().Match(helpText, sectionStart)
+            : Match.Empty;
+        if (flagsSectionMatch.Success && nextSection.Success)
         {
             sectionEnd = nextSection.Index;
         }
@@ -345,20 +344,17 @@ public partial class GoCliScraper : CliScraperBase
                 continue;
             }
 
-            // Convert single-dash flags to double-dash for consistency
-            var longForm = flagName.StartsWith("--") ? flagName : $"--{flagName.TrimStart('-')}";
+            var optionKey = flagName.TrimStart('-');
 
-            if (seenOptions.Contains(longForm))
+            if (!seenOptions.Add(optionKey))
             {
                 continue;
             }
 
-            seenOptions.Add(longForm);
-
             // Accumulate multi-line descriptions
             i = AccumulateMultiLineDescription(lines, i, ref description);
 
-            var propertyName = NormalizePropertyName(longForm);
+            var propertyName = NormalizePropertyName(optionKey);
             if (propertyName is null)
             {
                 continue;
@@ -369,7 +365,7 @@ public partial class GoCliScraper : CliScraperBase
 
             options.Add(new CliOptionDefinition
             {
-                SwitchName = flagName.TrimStart('-'),
+                SwitchName = flagName,
                 ShortForm = null,
                 PropertyName = propertyName,
                 CSharpType = csharpType,
@@ -382,6 +378,35 @@ public partial class GoCliScraper : CliScraperBase
                 ValueSeparator = isFlag ? " " : " ",
                 EnumDefinition = null,
                 IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
+            });
+        }
+
+        foreach (Match match in GoUsageOptionPattern().Matches(helpText))
+        {
+            var flagName = match.Groups["flag"].Value;
+            var optionKey = flagName.TrimStart('-');
+            if (!seenOptions.Add(optionKey))
+            {
+                continue;
+            }
+
+            var propertyName = NormalizePropertyName(optionKey);
+            if (propertyName is null)
+            {
+                continue;
+            }
+
+            var valueHint = match.Groups["value"].Value;
+            var isFlag = string.IsNullOrEmpty(valueHint);
+            options.Add(new CliOptionDefinition
+            {
+                SwitchName = flagName,
+                PropertyName = propertyName,
+                CSharpType = isFlag ? "bool?" : "string?",
+                Description = $"The {flagName} option.",
+                IsFlag = isFlag,
+                ValueSeparator = " ",
+                IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag),
             });
         }
 
@@ -479,6 +504,13 @@ public partial class GoCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^\s+(?<flag>-[\w-]+)(?:\s+(?<value>\w+))?\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex GoOptionPattern();
+
+    /// <summary>
+    /// Matches options declared directly in Go usage and prose, including commands whose
+    /// help does not expose a dedicated flags table.
+    /// </summary>
+    [GeneratedRegex(@"(?<![\w-])(?<flag>-[a-z][\w-]*)(?:\s+(?<value>(?!(?:flag|flags|option|options)\b)[A-Za-z][\w-]*))?", RegexOptions.IgnoreCase)]
+    private static partial Regex GoUsageOptionPattern();
 
     /// <summary>
     /// Matches flag lines.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -172,7 +172,7 @@ public partial class GoCliScraper : CliScraperBase
         }
 
         var description = ExtractDescription(helpText);
-        var options = ParseOptions(helpText);
+        var options = ParseOptions(helpText, usage.Synopsis);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
@@ -303,12 +303,12 @@ public partial class GoCliScraper : CliScraperBase
     /// Format: -flag    description
     ///         -flag value    description
     /// </summary>
-    private static List<CliOptionDefinition> ParseOptions(string helpText)
+    private static List<CliOptionDefinition> ParseOptions(string helpText, string? usageSynopsis)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         AddDocumentedOptions(GetOptionSectionLines(helpText), options, seenOptions);
-        AddUsageOptions(helpText, options, seenOptions);
+        AddUsageOptions(usageSynopsis ?? string.Empty, options, seenOptions);
         return options;
     }
 
@@ -521,7 +521,7 @@ public partial class GoCliScraper : CliScraperBase
     private static partial Regex GoOptionPattern();
 
     /// <summary>
-    /// Matches options declared directly in Go usage and prose, including commands whose
+    /// Matches options declared directly in a Go usage synopsis, including commands whose
     /// help does not expose a dedicated flags table.
     /// </summary>
     [GeneratedRegex(@"(?<![\w-])(?<flag>-[a-z][\w-]*)(?:(?<separator>=|[ \t]+)(?<value>(?!(?:flag|flags|option|options)\b)[A-Za-z][\w-]*))?", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -172,7 +172,7 @@ public partial class GoCliScraper : CliScraperBase
         }
 
         var description = ExtractDescription(helpText);
-        var options = ParseOptions(helpText, commandParts);
+        var options = ParseOptions(helpText);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
@@ -303,12 +303,17 @@ public partial class GoCliScraper : CliScraperBase
     /// Format: -flag    description
     ///         -flag value    description
     /// </summary>
-    private List<CliOptionDefinition> ParseOptions(string helpText, string[] commandParts)
+    private static List<CliOptionDefinition> ParseOptions(string helpText)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddDocumentedOptions(GetOptionSectionLines(helpText), options, seenOptions);
+        AddUsageOptions(helpText, options, seenOptions);
+        return options;
+    }
 
-        // Find flags sections
+    private static string[] GetOptionSectionLines(string helpText)
+    {
         var flagsSectionMatch = FlagsSectionPattern().Match(helpText);
         var sectionStart = flagsSectionMatch.Success
             ? flagsSectionMatch.Index + flagsSectionMatch.Length
@@ -323,9 +328,14 @@ public partial class GoCliScraper : CliScraperBase
             sectionEnd = nextSection.Index;
         }
 
-        var section = helpText.Substring(sectionStart, sectionEnd - sectionStart);
-        var lines = section.Split('\n');
+        return helpText.Substring(sectionStart, sectionEnd - sectionStart).Split('\n');
+    }
 
+    private static void AddDocumentedOptions(
+        string[] lines,
+        ICollection<CliOptionDefinition> options,
+        ISet<string> seenOptions)
+    {
         for (var i = 0; i < lines.Length; i++)
         {
             var line = lines[i];
@@ -380,7 +390,13 @@ public partial class GoCliScraper : CliScraperBase
                 IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
             });
         }
+    }
 
+    private static void AddUsageOptions(
+        string helpText,
+        ICollection<CliOptionDefinition> options,
+        ISet<string> seenOptions)
+    {
         foreach (Match match in GoUsageOptionPattern().Matches(helpText))
         {
             var flagName = match.Groups["flag"].Value;
@@ -410,8 +426,6 @@ public partial class GoCliScraper : CliScraperBase
                 IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag),
             });
         }
-
-        return options;
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
@@ -22,6 +22,19 @@ public class KubectlCliScraper : CobraCliScraper
     {
     }
 
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage)
+    {
+        var positionalArguments = GetPositionalArguments(usage, command.Options);
+        return usage with
+        {
+            HasOperandTokens = positionalArguments.Count > 0
+                               || usage.UnparsedOperandTokens.Count > 0,
+            PositionalArguments = positionalArguments,
+        };
+    }
+
     /// <summary>
     /// kubectl has some additional skip patterns for plugin and completion commands.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -33,5 +34,53 @@ public class KubectlCliScraper : CobraCliScraper
 
         var lowerName = subcommand.ToLowerInvariant();
         return lowerName is "plugin" or "kustomize" or "api-versions" or "api-resources";
+    }
+
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        commandParts switch
+        {
+            ["annotate"] => CollapseNumberedRepeat(
+                positionalArguments,
+                "Key_1Val_1",
+                "KeyNValN",
+                "Annotations"),
+            ["port-forward"] => CollapseNumberedRepeat(
+                positionalArguments,
+                "LocalPortRemotePort",
+                "LocalPortNRemotePortN",
+                "LocalPortRemotePort"),
+            ["taint"] => CollapseNumberedRepeat(
+                positionalArguments,
+                "Key_1Val_1TaintEffect_1",
+                "KeyNValNTaintEffectN",
+                "Taints"),
+            _ => positionalArguments,
+        };
+
+    private static IReadOnlyList<CliPositionalArgument> CollapseNumberedRepeat(
+        IReadOnlyList<CliPositionalArgument> arguments,
+        string firstPropertyName,
+        string repeatedPropertyName,
+        string generatedPropertyName)
+    {
+        var normalized = arguments
+            .Where(argument => !argument.PropertyName.Equals(
+                repeatedPropertyName,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(argument => argument.PropertyName.Equals(
+                firstPropertyName,
+                StringComparison.OrdinalIgnoreCase)
+                ? argument with
+                {
+                    PropertyName = generatedPropertyName,
+                    CSharpType = argument.IsRequired
+                        ? "IEnumerable<string>"
+                        : "IEnumerable<string>?",
+                    IsVariadic = true,
+                }
+                : argument);
+        return CliPositionalArgument.MergeDuplicates(normalized);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
@@ -83,4 +83,11 @@ public partial class MinikubeCliScraper : CobraCliScraper
                 .Where(argument => !UsageSynopsisParser.IsCommandGroupPlaceholder(argument))
                 .ToArray()
             : positionalArguments;
+
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        command.CommandParts is ["addons"] or ["config"]
+            ? UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage)
+            : usage;
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -73,4 +74,13 @@ public partial class MinikubeCliScraper : CobraCliScraper
     {
         "--help", "-h", "--version", "help", "completion", "version", "update-check"
     };
+
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        commandParts is ["addons"] or ["config"]
+            ? positionalArguments
+                .Where(argument => !UsageSynopsisParser.IsCommandGroupPlaceholder(argument))
+                .ToArray()
+            : positionalArguments;
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -368,6 +368,7 @@ public partial class PipCliScraper : CliScraperBase
             cleanName == "upgrade" ||
             cleanName == "force-reinstall" ||
             cleanName == "ignore-installed" ||
+            cleanName == "require-hashes" ||
             cleanName == "pre" ||
             cleanName == "user" ||
             cleanName == "editable")

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -56,36 +56,26 @@ public partial class PnpmCliScraper : CliScraperBase
 
     /// <summary>
     /// Extracts subcommand names from pnpm help text.
-    /// pnpm has a FLAT command structure - commands like "add", "install", "run" do NOT have subcommands.
-    /// Only extract subcommands from the root help text (pnpm --help).
+    /// Most pnpm commands are flat, but newer releases also expose nested commands
+    /// through an explicit Commands section (for example, audit signatures).
     /// </summary>
     protected override IEnumerable<string> ExtractSubcommands(string helpText)
     {
-        // pnpm has a flat command structure - no nested subcommands.
-        // Only parse subcommands from the root help (which shows "Usage: pnpm [command]")
-        // Subcommand help (e.g., "pnpm add --help") shows "pnpm add <pkg>" not "Usage: pnpm [command]"
-        if (!helpText.Contains("Usage: pnpm [command]") && !helpText.Contains("pnpm [command]"))
-        {
-            // This is a subcommand's help text, not the root - no further subcommands
-            return [];
-        }
-
         var subcommands = new List<string>();
         var seenCommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // pnpm root help uses sections with headers followed by command lines:
-        // Manage your dependencies:
-        //       add                  Installs a package...
-        //       install              Installs all dependencies...
-        var commandLineMatches = CommandLinePattern().Matches(helpText);
-        foreach (Match match in commandLineMatches)
+        var isRootHelp = helpText.Contains("Usage: pnpm [command]", StringComparison.OrdinalIgnoreCase)
+                         || helpText.Contains("pnpm [command]", StringComparison.OrdinalIgnoreCase);
+        if (isRootHelp)
         {
-            var commandName = match.Groups["command"].Value.Trim();
-            if (!string.IsNullOrEmpty(commandName) &&
-                IsValidCommand(commandName) &&
-                seenCommands.Add(commandName))
+            // pnpm root help uses sections with headers followed by command lines:
+            // Manage your dependencies:
+            //       add                  Installs a package...
+            //       install              Installs all dependencies...
+            var commandLineMatches = CommandLinePattern().Matches(helpText);
+            foreach (Match match in commandLineMatches)
             {
-                subcommands.Add(commandName);
+                AddSubcommand(match.Groups["command"].Value);
             }
         }
 
@@ -110,18 +100,23 @@ public partial class PnpmCliScraper : CliScraperBase
                 var match = SubcommandLinePattern().Match(line);
                 if (match.Success)
                 {
-                    var commandName = match.Groups["name"].Value.Trim();
-                    if (!string.IsNullOrEmpty(commandName) &&
-                        IsValidCommand(commandName) &&
-                        seenCommands.Add(commandName))
-                    {
-                        subcommands.Add(commandName);
-                    }
+                    AddSubcommand(match.Groups["name"].Value);
                 }
             }
         }
 
         return subcommands;
+
+        void AddSubcommand(string candidate)
+        {
+            var commandName = candidate.Trim();
+            if (!string.IsNullOrEmpty(commandName)
+                && IsValidCommand(commandName)
+                && seenCommands.Add(commandName))
+            {
+                subcommands.Add(commandName);
+            }
+        }
     }
 
     /// <summary>
@@ -202,7 +197,7 @@ public partial class PnpmCliScraper : CliScraperBase
         IReadOnlyList<string> commandParts,
         UsageSynopsisParseResult usage)
     {
-        var normalized = commandParts is ["stage"]
+        var normalized = commandParts is ["stage"] or ["audit"]
             ? usage with
             {
                 HasOperandTokens = false,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -119,6 +119,23 @@ public partial class PnpmCliScraper : CliScraperBase
         }
     }
 
+    /// <inheritdoc />
+    protected override IEnumerable<string> ExtractSubcommands(
+        string[] commandPath,
+        string helpText)
+    {
+        var subcommands = ExtractSubcommands(helpText).ToList();
+
+        // pnpm returns the parent command-group help for leaf commands. For example,
+        // `pnpm stage download --help` repeats the stage subcommand catalog. Once the
+        // requested leaf appears in that catalog, rediscovering it would recursively
+        // combine every sibling command with every other sibling command.
+        var repeatsParentCatalog = commandPath.Length > 1
+                                   && subcommands.Contains(commandPath[^1], StringComparer.OrdinalIgnoreCase);
+
+        return repeatsParentCatalog ? [] : subcommands;
+    }
+
     /// <summary>
     /// Checks if a string looks like a valid command name.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -443,6 +443,12 @@ public partial class SnykCliScraper : CliScraperBase
         commandParts is ["iac", "describe"]
         && switchName.Equals("--from", StringComparison.OrdinalIgnoreCase);
 
+    /// <inheritdoc />
+    protected override bool ShouldTreatOptionAsScalar(
+        IReadOnlyList<string> commandParts,
+        string switchName) =>
+        IsKnownScalarValueOption(commandParts, switchName);
+
     private static void AddDocumentedOptions(
         string[] commandParts,
         List<CliOptionDefinition> options)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -187,6 +187,7 @@ public static class UsageSynopsisParser
         var arguments = new List<CliPositionalArgument>();
         var unparsedTokens = new List<string>();
         var prependOptionTerminatorToNextOperand = false;
+        string? associatedOptionSwitch = null;
 
         foreach (var token in TrimTrailingUsageExplanation(CollapseAlternatives(operandTokens)))
         {
@@ -201,6 +202,12 @@ public static class UsageSynopsisParser
             var groupedBehindOptionTerminator =
                 TryUnwrapOptionTerminatedOperand(token, out var unwrappedOperand);
             var operandToken = groupedBehindOptionTerminator ? unwrappedOperand : token;
+            if (TryGetOptionSwitch(operandToken, out var optionSwitch))
+            {
+                associatedOptionSwitch = optionSwitch;
+                continue;
+            }
+
             if (TryApplyStandaloneRepeat(operandToken, arguments))
             {
                 continue;
@@ -226,7 +233,13 @@ public static class UsageSynopsisParser
             if (argument is null)
             {
                 unparsedTokens.Add(operandToken);
+                associatedOptionSwitch = null;
                 continue;
+            }
+
+            if (associatedOptionSwitch is not null)
+            {
+                argument = argument with { AssociatedOptionSwitch = associatedOptionSwitch };
             }
 
             if (groupedBehindOptionTerminator || prependOptionTerminatorToNextOperand)
@@ -236,6 +249,7 @@ public static class UsageSynopsisParser
 
             arguments.Add(argument);
             prependOptionTerminatorToNextOperand = false;
+            associatedOptionSwitch = null;
         }
 
         return new ParsedOperands(arguments, unparsedTokens);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -207,9 +207,9 @@ public partial class WinGetCliScraper : CliScraperBase
             .Select(o => o.EnumDefinition!)
             .ToList();
         var usageArguments = AssociateNamedOptionOperands(options, usage.PositionalArguments);
-        var positionalArguments = usageArguments
-            .Where(argument => argument.AssociatedOptionSwitch is null)
-            .ToArray();
+        var positionalArguments = GetPositionalArguments(
+            usage with { PositionalArguments = usageArguments },
+            options);
 
         var className = GenerateClassName(commandPath);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -186,6 +186,8 @@ public partial class WinGetCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
+        usage = NormalizeCommandGroupUsage(commandParts, usage);
+
         // Parse description from help text (first non-empty line before usage)
         var description = ExtractDescription(helpText);
 
@@ -234,13 +236,27 @@ public partial class WinGetCliScraper : CliScraperBase
     /// <inheritdoc />
     protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
         CliCommandDefinition command,
-        UsageSynopsisParseResult usage) =>
-        usage with
+        UsageSynopsisParseResult usage)
+    {
+        usage = NormalizeCommandGroupUsage(command.CommandParts, usage);
+        return usage with
         {
             PositionalArguments = AssociateNamedOptionOperands(
                 command.Options,
                 usage.PositionalArguments),
         };
+    }
+
+    private static UsageSynopsisParseResult NormalizeCommandGroupUsage(
+        IReadOnlyList<string> commandParts,
+        UsageSynopsisParseResult usage) =>
+        commandParts is ["configure"]
+            or ["dscv3"]
+            or ["pin"]
+            or ["settings"]
+            or ["source"]
+            ? UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage)
+            : usage;
 
     private static IReadOnlyList<CliPositionalArgument> AssociateNamedOptionOperands(
         IReadOnlyList<CliOptionDefinition> options,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -589,10 +589,22 @@ public partial class YarnCliScraper : CliScraperBase
 
     private static bool IsOptionalValueOption(
         IReadOnlyList<string> commandParts,
-        string longForm) =>
-        longForm.Equals("--since", StringComparison.OrdinalIgnoreCase)
-        || (commandParts is ["version", "apply"]
-            && longForm.Equals("--prerelease", StringComparison.OrdinalIgnoreCase));
+        string longForm)
+    {
+        if (longForm.Equals("--since", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return commandParts switch
+        {
+            ["init"] => longForm.Equals("--install", StringComparison.OrdinalIgnoreCase),
+            ["run"] => longForm.Equals("--inspect", StringComparison.OrdinalIgnoreCase)
+                       || longForm.Equals("--inspect-brk", StringComparison.OrdinalIgnoreCase),
+            ["version", ..] => longForm.Equals("--prerelease", StringComparison.OrdinalIgnoreCase),
+            _ => false,
+        };
+    }
 
     /// <summary>
     /// Accumulates multi-line descriptions.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -548,7 +548,7 @@ public partial class YarnCliScraper : CliScraperBase
 
             var hasValue = match.Groups["value"].Success;
             var hasOptionalValue = !hasValue
-                                   && longForm.Equals("--since", StringComparison.OrdinalIgnoreCase);
+                                   && IsOptionalValueOption(commandParts, longForm);
             var isFlag = !hasValue && !hasOptionalValue;
             var isCountedFlag = isFlag
                                 && longForm.Equals("--verbose", StringComparison.OrdinalIgnoreCase)
@@ -572,7 +572,7 @@ public partial class YarnCliScraper : CliScraperBase
                 AcceptsMultipleValues = acceptsMultipleValues,
                 IsKeyValue = false,
                 IsNumeric = false,
-                ValueSeparator = " ",
+                ValueSeparator = hasOptionalValue ? "=" : " ",
                 ValueArity = hasOptionalValue
                     ? CliOptionValueArity.Optional
                     : CliOptionValueArity.Required,
@@ -586,6 +586,13 @@ public partial class YarnCliScraper : CliScraperBase
 
         return options;
     }
+
+    private static bool IsOptionalValueOption(
+        IReadOnlyList<string> commandParts,
+        string longForm) =>
+        longForm.Equals("--since", StringComparison.OrdinalIgnoreCase)
+        || (commandParts is ["version", "apply"]
+            && longForm.Equals("--prerelease", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Accumulates multi-line descriptions.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -545,12 +546,19 @@ public partial class YarnCliScraper : CliScraperBase
                 continue;
             }
 
-            // Determine if this is a flag (boolean) or takes a value
-            var isFlag = !match.Groups["value"].Success
-                         && IsBooleanOption(longForm, description);
-            var acceptsMultipleValues = commandParts is ["dlx"]
-                                        && longForm.Equals("--package", StringComparison.OrdinalIgnoreCase);
-            var csharpType = AsCSharpType(isFlag ? "bool?" : "string?", acceptsMultipleValues);
+            var hasValue = match.Groups["value"].Success;
+            var hasOptionalValue = !hasValue
+                                   && longForm.Equals("--since", StringComparison.OrdinalIgnoreCase);
+            var isFlag = !hasValue && !hasOptionalValue;
+            var isCountedFlag = isFlag
+                                && longForm.Equals("--verbose", StringComparison.OrdinalIgnoreCase)
+                                && description.Contains("times", StringComparison.OrdinalIgnoreCase);
+            var acceptsMultipleValues = !isFlag
+                                        && ((commandParts is ["dlx"]
+                                             && longForm.Equals("--package", StringComparison.OrdinalIgnoreCase))
+                                            || IsRepeatableValueOption(description, isFlag));
+            var scalarType = isCountedFlag ? "int?" : isFlag ? "bool?" : "string?";
+            var csharpType = AsCSharpType(scalarType, acceptsMultipleValues);
 
             options.Add(new CliOptionDefinition
             {
@@ -564,59 +572,19 @@ public partial class YarnCliScraper : CliScraperBase
                 AcceptsMultipleValues = acceptsMultipleValues,
                 IsKeyValue = false,
                 IsNumeric = false,
-                ValueSeparator = isFlag ? " " : " ",
+                ValueSeparator = " ",
+                ValueArity = hasOptionalValue
+                    ? CliOptionValueArity.Optional
+                    : CliOptionValueArity.Required,
                 EnumDefinition = null,
-                IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
+                IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag),
+                ValidationConstraints = isCountedFlag
+                    ? new CliValidationConstraints { MinValue = 0, MaxValue = 2 }
+                    : null,
             });
         }
 
         return options;
-    }
-
-    /// <summary>
-    /// Determines if an option is a boolean flag.
-    /// </summary>
-    private static bool IsBooleanOption(string optionName, string description)
-    {
-        // Options that typically take values
-        var valueOptions = new[] { "registry", "cwd", "path", "name", "version", "config", "scope" };
-        var cleanName = optionName.TrimStart('-').ToLowerInvariant();
-
-        if (valueOptions.Any(v => cleanName.Contains(v)))
-        {
-            return false;
-        }
-
-        // Check description for value hints
-        var lowerDesc = description.ToLowerInvariant();
-        if (lowerDesc.Contains("path") || lowerDesc.Contains("name") ||
-            lowerDesc.Contains("url") || lowerDesc.Contains("file"))
-        {
-            return false;
-        }
-
-        // Common boolean option patterns
-        if (cleanName.StartsWith("no-") ||
-            cleanName == "json" ||
-            cleanName == "quiet" ||
-            cleanName == "verbose" ||
-            cleanName == "silent" ||
-            cleanName == "offline" ||
-            cleanName == "prefer-offline" ||
-            cleanName == "exact" ||
-            cleanName == "tilde" ||
-            cleanName == "caret" ||
-            cleanName == "dev" ||
-            cleanName == "peer" ||
-            cleanName == "optional" ||
-            cleanName == "cached" ||
-            cleanName == "mode")
-        {
-            return true;
-        }
-
-        // Default to string for safety
-        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- unblock Snyk scalar-option validation and obsolete alias constructor preservation
- normalize WinGet and pnpm nested command groups
- associate standalone usage metavariables with their named options
- correct Yarn, .NET, pip, Azure, Homebrew, Go, kubectl, Minikube, GitHub CLI, and Gcloud option/operand arity
- preserve explicit Boolean values, repeatable collections, variadic operands, option terminators, and historical literal `ExecuteAsync` overloads

## Validation

- full `ModularPipelines.OptionsGenerator.Tests`: 1,168 passed
- local Docker regeneration advanced past API compatibility and reached the expected local-version coverage guard
- reproduces and fixes failures plus unsafe output from Generate CLI Options runs 32870502336 and 32877160222
- Gcloud-only rerun: https://github.com/thomhurst/ModularPipelines/actions/runs/32890804478
- pnpm-only rerun: https://github.com/thomhurst/ModularPipelines/actions/runs/32888355884
- Yarn-only rerun: https://github.com/thomhurst/ModularPipelines/actions/runs/32893955662
- final affected-tool matrix: https://github.com/thomhurst/ModularPipelines/actions/runs/32900338358
- reviewed generated PRs #4146, #4147, #4149-#4151, #4153-#4156, #4158, #4160, and #4161; unsafe regenerations closed pending corrected reruns

- runtime metadata registration now emits bounded 32-type partial-class chunks; source-generator project and core solution build with 0 warnings/errors
- exact-head Gcloud canary green, including regenerated solution build and API compatibility: https://github.com/thomhurst/ModularPipelines/actions/runs/32917638661

Refs #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI option parsing across Azure, Homebrew, .NET, Kubernetes, Minikube, Yarn, Go, GitHub CLI, and other tools.
  * Improved handling of flags, boolean values, optional and repeatable values, inline values, and positional arguments.
  * Prevented command placeholders and option values from being modeled as positional operands.
  * Preserved compatible generated commands and constructors as definitions evolve.

* **Tests**
  * Added regression coverage for parsing accuracy, command traversal, and API compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->