### PR TITLE
[Automated] Update kustomize CLI Options

### DIFF
--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCfgOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCfgOptions.Generated.cs
@@ -32,4 +32,10 @@ public record KustomizeCfgOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeEditAddOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeEditAddOptions.Generated.cs
@@ -32,4 +32,10 @@ public record KustomizeEditAddOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeEditOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeEditOptions.Generated.cs
@@ -32,4 +32,10 @@ public record KustomizeEditOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeEditRemoveOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeEditRemoveOptions.Generated.cs
@@ -32,4 +32,10 @@ public record KustomizeEditRemoveOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeEditSetOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeEditSetOptions.Generated.cs
@@ -32,4 +32,10 @@ public record KustomizeEditSetOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeFnOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeFnOptions.Generated.cs
@@ -32,4 +32,10 @@ public record KustomizeFnOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kustomize** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- kustomize (v5.8.1): 45 commands, tree 0ae36cae52a7633cdaf6161528ae7819e41d2855a07443c9b69a53279326fb08

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator