### PR TITLE
[Automated] Update liquibase CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/liquibase.md
+++ b/docs/docs/mp-packages/cli/liquibase.md
@@ -35,76 +35,29 @@ Global options are rendered before the selected subcommand.
 
 | CLI option | Property | Availability | Description |
 | --- | --- | --- | --- |
-| `--allow-duplicated-changeset-identifiers` | `AllowDuplicatedChangeSetIdentifiers` | All editions | Allows duplicated changeset identifiers without failing Liquibase execution. DEFAULT: false |
-| `--allow-inherit-logical-file-path` | `AllowInheritLogicalFilePath` | All editions | If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility. DEFAULT: true |
-| `--always-drop-instead-of-replace` | `AlwaysDropInsteadOfReplace` | All editions | If true, drop and recreate a view instead of replacing it. DEFAULT: false |
-| `--always-override-stored-logic-schema` | `AlwaysOverrideStoredLogicSchema` | All editions | When generating SQL for createProcedure, should the procedure schema be forced to the default schema if no schemaName attribute is set? DEFAULT: false |
-| `--analytics-enabled` | `AnalyticsEnabled` | All editions | Enable or disable sending product usage data and analytics to Liquibase. Learn more at https: //docs.liquibase.com/analytics. |
 | `--auto-reorg` | `AutoReorg` | All editions | Should Liquibase automatically include REORG TABLE commands when needed? DEFAULT: true |
-| `--changelog-lock-poll-rate` | `ChangelogLockPollRate` | All editions | Number of seconds wait between checks to the changelog lock when it is locked DEFAULT: 10 |
-| `--changelog-lock-wait-time-in-minutes` | `ChangelogLockWaitTimeInMinutes` | All editions | Number of minutes to wait for the changelog lock to be available before giving up DEFAULT: 5 |
-| `--changelog-parse-mode` | `ChangelogParseMode` | All editions | Configures how to handle unknown fields in changelog files. Possible values: STRICT which causes parsing to fail, and LAX which continues with the parsing. DEFAULT: STRICT |
 | `--classpath` | `Classpath` | All editions | Additional classpath entries to use |
-| `--convert-data-types` | `ConvertDataTypes` | All editions | Should Liquibase convert to/from STANDARD data types. Applies to both snapshot and update commands. DEFAULT: true |
-| `--database-changelog-lock-table-name` | `DatabaseChangelogLockTableName` | All editions | Name of table to use for tracking concurrent Liquibase usage DEFAULT: DATABASECHANGELOGLOCK |
-| `--database-changelog-table-name` | `DatabaseChangelogTableName` | All editions | Name of table to use for tracking change history DEFAULT: DATABASECHANGELOG |
 | `--database-class` | `DatabaseClass` | All editions | Class to use for Database implementation |
 | `--databricks-diff-tblproperties-exclude-patterns` | `DatabricksDiffTblPropertiesExcludePatterns` | Liquibase Secure with the Databricks extension | Comma-separated TBLPROPERTIES key prefixes to exclude from Databricks diff operations. |
 | `--databricks-diff-tblproperties-ignore-all` | `DatabricksDiffTblPropertiesIgnoreAll` | Liquibase Secure with the Databricks extension | Ignore all TBLPROPERTIES during Databricks diff operations. |
-| `--ddl-lock-timeout` | `DdlLockTimeout` | All editions | The DDL_LOCK_TIMEOUT parameter indicates the number of seconds a DDL command should wait for the locks to become available before throwing the resource busy error message. This applies only to Oracle databases. |
 | `--defaults-file` | `DefaultsFile` | All editions | File with default Liquibase properties DEFAULT: liquibase.properties |
-| `--diff-column-default-value-constraint-name` | `DiffColumnDefaultValueConstraintName` | All editions | Should Liquibase compare column default value constraint name in diff operation? DEFAULT: true |
-| `--diff-column-order` | `DiffColumnOrder` | All editions | Should Liquibase compare column order in diff operation? DEFAULT: true |
 | `--driver` | `Driver` | All editions | Database driver class |
-| `--driver-properties-file` | `DriverPropertiesFile` | All editions | Driver-specific properties |
-| `--duplicate-file-mode` | `DuplicateFileMode` | All editions | How to handle multiple files being found in the search path that have duplicate paths. Options are SILENT (do not log and choose one at random), DEBUG, INFO, WARN (log at the given level and choose one at random), or ERROR (fail current operation). DEFAULT: ERROR |
-| `--error-on-circular-include-all` | `ErrorOnCircularIncludeAll` | All editions | Throw an error if Liquibase detects that an includeAll will cause a circular reference (and thus a changelog parse error). DEFAULT: true |
-| `--fail-on-null-snapshot-id` | `FailOnNullSnapshotId` | All editions | If true, referenced objects which do not have a snapshot ID will cause snapshot failure DEFAULT: true |
 | `--file-encoding` | `FileEncoding` | All editions | Encoding to use when reading files. Valid values include: UTF-8, UTF-16, UTF-16BE, UTF-16LE, US-ASCII, or OS to use the system configured encoding. DEFAULT: UTF-8 |
-| `--filter-log-messages` | `FilterLogMessages` | All editions | DEPRECATED: No longer used |
-| `--generate-changeset-created-values` | `GenerateChangeSetCreatedValues` | All editions | Should Liquibase include a 'created' attribute in diff/generateChangelog changesets with the current datetime DEFAULT: false |
-| `--generated-changeset-ids-contains-description` | `GeneratedChangeSetIdsContainsDescription` | All editions | Should Liquibase include the change description in the id when generating changesets? DEFAULT: false |
 | `--headless` | `Headless` | All editions | Force Liquibase to think it has no access to a keyboard DEFAULT: false |
 | `--help` | `Help` | All editions | Show this help message and exit |
-| `--include-catalog-in-specification` | `IncludeCatalogInSpecification` | All editions | Should Liquibase include the catalog name when determining equality? DEFAULT: false |
-| `--include-relations-for-computed-columns` | `IncludeRelationsForComputedColumns` | All editions | If true, the parent relationship for computed columns is preserved in snapshot-dependent commands: snapshot and diff DEFAULT: false |
-| `--include-schema-name-for-default` | `IncludeSchemaNameForDefault` | All editions | If true, the schema name is included for the default schema when loading a snapshot DEFAULT: false |
-| `--include-system-classpath` | `IncludeSystemClasspath` | All editions | Include the system classpath when resolving classes at runtime DEFAULT: true |
 | [`--license-key`](https://docs.liquibase.com/community/reference-guide-5-0/parameters/what-are-parameters) | `LicenseKey` | Liquibase Secure | Specifies the license key that enables Liquibase Secure functionality. |
-| `--liquibase-catalog-name` | `LiquibaseCatalogName` | All editions | Catalog to use for Liquibase objects |
-| `--liquibase-schema-name` | `LiquibaseSchemaName` | All editions | Schema to use for Liquibase objects |
-| `--liquibase-tablespace-name` | `LiquibaseTablespaceName` | All editions | Tablespace to use for Liquibase objects |
 | `--log-channels` | `LogChannels` | All editions | DEFAULT: Controls which log channels have their level set by the liquibase.logLevel setting. Comma separate multiple values. To set the level of all channels, use 'all'. Example: liquibase, org.mariadb.jdbc |
 | `--log-file` | `LogFile` | All editions | Users can use .gz file extension to enable log files compression. |
 | `--log-format` | `LogFormat` | All editions | Sets the format of log output to console or log files. Community users default to unstructured "TEXT" logs to the console or output log files. Pro users have the option to set value as "JSON" or "JSON_PRETTY" to enable json-structured log files to the console or output log files. DEFAULT: TEXT |
 | `--log-level` | `LogLevel` | All editions | DEFAULT: Controls which logs get set to stderr AND to any log file. The CLI defaults, if log file set, to SEVERE. Others vary by integration. The official log levels are: OFF, SEVERE, WARNING, INFO, FINE |
-| `--mirror-console-messages-to-log` | `MirrorConsoleMessagesToLog` | All editions | When set to true, the console messages are mirrored to the logs as [liquibase.ui] to provide a more complete picture of liquibase operations to log analysis tools. Set to false to change this behavior. DEFAULT: true |
-| `--missing-property-mode` | `MissingPropertyMode` | All editions | How to handle changelog property expressions where a value is not set. For example, a string 'null' when no 'address' property was defined. Values can be: 'preserve' which leaves the string as-is, 'empty' which replaces it with an empty string, or 'error' which stops processing with an error. DEFAULT: PRESERVE |
-| `--monitor-performance` | `MonitorPerformance` | All editions | Enable performance tracking. Set to 'false' to disable. If set to 'true', data is stored to a `liquibase-TIMESTAMP.jfr` file in your working directory. Any other value will enable tracking and be used as the name of the file to write the data to. DEFAULT: false |
-| `--mssql-bytes-per-char` | `MssqlBytesPerChar` | All editions | Number of bytes needed to store one character (depends on database's character encoding) DEFAULT: 1 |
-| `--on-missing-include-changelog` | `OnMissingIncludeChangelog` | All editions | If set to WARN, then liquibase will not throw exception on missing changelog file, instead will show a warning message. DEFAULT: FAIL |
 | `--output-file` | `OutputFile` | All editions |  |
-| `--output-file-encoding` | `OutputFileEncoding` | All editions | Encoding to use when writing files DEFAULT: UTF-8 |
-| `--output-line-separator` | `OutputLineSeparator` | All editions | Line separator for output DEFAULT: Line separator(LF or CRLF) for output. Defaults to OS default |
-| `--preserve-classpath-prefix-in-normalized-paths` | `PreserveClasspathPrefixInNormalizedPaths` | All editions | If true 'classpath:' prefix will be preserved in normalized paths, allowing to resolve hierarchical resources under a classpath-based root. DEFAULT: false |
-| `--preserve-schema-case` | `PreserveSchemaCase` | All editions | If true, Liquibase treats schema and catalog names as case sensitive DEFAULT: false |
-| `--prompt-for-non-local-database` | `PromptForNonLocalDatabase` | All editions | Should Liquibase prompt if a non-local database is being accessed |
-| `--property-provider-class` | `PropertyProviderClass` | All editions | Implementation of Properties class to provide additional driver properties |
 | `--search-path` | `SearchPath` | All editions | Complete list of Location(s) to search for files such as changelog files in. Multiple paths can be specified by separating them with commas. |
 | `--secure-parsing` | `SecureParsing` | All editions | If true, remove functionality from file parsers which could be used insecurely. Examples include (but not limited to) disabling remote XML entity support. DEFAULT: true |
 | `--should-run` | `ShouldRun` | All editions | Should Liquibase commands execute DEFAULT: true |
-| `--should-snapshot-data` | `ShouldSnapshotData` | All editions | Should Liquibase snapshot data by default? DEFAULT: false |
 | `--show-banner` | `ShowBanner` | All editions | If true, show a Liquibase banner on startup. DEFAULT: true |
 | `--sql-log-level` | `SqlLogLevel` | All editions | Level to log SQL statements to DEFAULT: FINE |
-| `--sql-show-sql-warnings` | `SqlShowSqlWarnings` | All editions | Show SQLWarning messages DEFAULT: true |
 | `--strict` | `Strict` | All editions | If true, Liquibase enforces certain best practices and proactively looks for common errors DEFAULT: false |
-| `--support-property-escaping` | `SupportPropertyEscaping` | All editions | Support escaping changelog parameters using a colon. Example: null DEFAULT: false |
-| `--supports-method-validation-level` | `SupportsMethodValidationLevel` | All editions | Controls the level of validation performed on the supports method of Change classes. Options are OFF, WARN, FAIL. DEFAULT: WARN |
-| `--suppress-liquibase-sql` | `SuppressLiquibaseSql` | All editions | When set to true, this global property prevents DBCL and DBCLH sql from being present in console and logs during *-sql commands, such as update-sql, rollback-sql, etc. DEFAULT: false |
-| `--trim-load-data-file-header` | `TrimLoadDataFileHeader` | All editions | If true column headers will be trimmed in case they were specified with spaces in the file. DEFAULT: false |
 | `--ui-service` | `UiService` | All editions | Changes the default UI Service Logger used by Liquibase. Options are CONSOLE or LOGGER. DEFAULT: CONSOLE |
-| `--use-procedure-schema` | `UseProcedureSchema` | All editions | If set to true (default value), createProcedure tags with a set schemaName will modify the procedure body with the given schema name. DEFAULT: true |
-| `--validate-xml-changelog-files` | `ValidateXmlChangelogFiles` | All editions | Will perform XSD validation of XML changelog files. When many XML changelog files are included, this validation may impact Liquibase performance. Defaults to true. DEFAULT: true |
 | `--version` | `Version` | All editions | Print version information and exit |
 
 ## Commands

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseChangelogParseMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseChangelogParseMode.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Liquibase.Enums;
 
-/// <summary>
-/// Allowed values for --changelog-parse-mode.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseChangelogParseMode
 {

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseDuplicateFileMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseDuplicateFileMode.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Liquibase.Enums;
 
-/// <summary>
-/// Allowed values for --duplicate-file-mode.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseDuplicateFileMode
 {

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseMissingPropertyMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseMissingPropertyMode.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Liquibase.Enums;
 
-/// <summary>
-/// Allowed values for --missing-property-mode.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseMissingPropertyMode
 {

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseOnMissingIncludeChangelog.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseOnMissingIncludeChangelog.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Liquibase.Enums;
 
-/// <summary>
-/// Allowed values for --on-missing-include-changelog.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseOnMissingIncludeChangelog
 {

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummaryOutput.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummaryOutput.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Liquibase.Enums;
 
-/// <summary>
-/// Allowed values for --show-summary-output.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseShowSummaryOutput
 {

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseSupportsMethodValidationLevel.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseSupportsMethodValidationLevel.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Liquibase.Enums;
 
-/// <summary>
-/// Allowed values for --supports-method-validation-level.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseSupportsMethodValidationLevel
 {

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseCalculateChecksumOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseCalculateChecksumOptions.Generated.cs
@@ -29,22 +29,10 @@ public record LiquibaseCalculateChecksumOptions : LiquibaseOptions
     public string? ChangelogFile { get; set; }
 
     /// <summary>
-    /// ChangeSet Author attribute
-    /// </summary>
-    [CliOption("--changeset-author", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeSetAuthor { get; set; }
-
-    /// <summary>
     /// ChangeSet ID attribute
     /// </summary>
     [CliOption("--changeset-id", Format = OptionFormat.EqualsSeparated)]
     public string? ChangeSetId { get; set; }
-
-    /// <summary>
-    /// ChangeSet identifier of form filepath::id::author
-    /// </summary>
-    [CliOption("--changeset-identifier", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeSetIdentifier { get; set; }
 
     /// <summary>
     /// Changelog path in which the changeSet is included
@@ -57,18 +45,6 @@ public record LiquibaseCalculateChecksumOptions : LiquibaseOptions
     /// </summary>
     [CliOption("-D", Format = OptionFormat.NoSeparator)]
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -89,12 +65,20 @@ public record LiquibaseCalculateChecksumOptions : LiquibaseOptions
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
 
-    [Obsolete("Use ChangeSetAuthor instead.")]
-    public string? ChangesetAuthor
-    {
-        get => ChangeSetAuthor;
-        set => ChangeSetAuthor = value;
-    }
+    [Obsolete("ChangeSetAuthor is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeSetAuthor { get; set; }
+
+    [Obsolete("ChangeSetIdentifier is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeSetIdentifier { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ChangesetAuthor is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangesetAuthor { get; set; }
 
     [Obsolete("Use ChangeSetId instead.")]
     public string? ChangesetId
@@ -103,12 +87,8 @@ public record LiquibaseCalculateChecksumOptions : LiquibaseOptions
         set => ChangeSetId = value;
     }
 
-    [Obsolete("Use ChangeSetIdentifier instead.")]
-    public string? ChangesetIdentifier
-    {
-        get => ChangeSetIdentifier;
-        set => ChangeSetIdentifier = value;
-    }
+    [Obsolete("ChangesetIdentifier is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangesetIdentifier { get; set; }
 
     [Obsolete("Use ChangeSetPath instead.")]
     public string? ChangesetPath

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseChangelogSyncOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -76,5 +64,11 @@ public record LiquibaseChangelogSyncOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncSqlOptions.Generated.cs
@@ -41,34 +41,10 @@ public record LiquibaseChangelogSyncSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -88,5 +64,17 @@ public record LiquibaseChangelogSyncSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncToTagOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncToTagOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseChangelogSyncToTagOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -82,5 +70,11 @@ public record LiquibaseChangelogSyncToTagOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncToTagSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseChangelogSyncToTagSqlOptions.Generated.cs
@@ -41,34 +41,10 @@ public record LiquibaseChangelogSyncToTagSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -94,5 +70,17 @@ public record LiquibaseChangelogSyncToTagSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseClearChecksumsOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseClearChecksumsOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseClearChecksumsOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
@@ -51,5 +39,11 @@ public record LiquibaseClearChecksumsOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseDbDocOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseDbDocOptions.Generated.cs
@@ -41,28 +41,10 @@ public record LiquibaseDbDocOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// The directory where the documentation is generated
-    /// </summary>
-    [CliOption("--output-directory", Format = OptionFormat.EqualsSeparated)]
-    public string? OutputDirectory { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -88,5 +70,14 @@ public record LiquibaseDbDocOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDirectory is no longer supported by the installed CLI and has no effect.")]
+    public string? OutputDirectory { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseDiffChangelogOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseDiffChangelogOptions.Generated.cs
@@ -47,64 +47,10 @@ public record LiquibaseDiffChangelogOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// Specifies a directory to send the loadData output of a diff-changelog/generate-changelog command as a CSV file.
-    /// </summary>
-    [CliOption("--data-output-directory", Format = OptionFormat.EqualsSeparated)]
-    public string? DataOutputDirectory { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Types of objects to compare
     /// </summary>
     [CliOption("--diff-types", Format = OptionFormat.EqualsSeparated)]
     public string? DiffTypes { get; set; }
-
-    /// <summary>
-    /// Objects to exclude from diff. Supports regular expressions. Defaults to null.
-    /// </summary>
-    [CliOption("--exclude-objects", Format = OptionFormat.EqualsSeparated)]
-    public string? ExcludeObjects { get; set; }
-
-    /// <summary>
-    /// If true, diff operations will ignore referenced objects which are not found in a snapshot. DEFAULT: false
-    /// </summary>
-    [CliOption("--ignore-missing-references", Format = OptionFormat.EqualsSeparated)]
-    public bool? IgnoreMissingReferences { get; set; }
-
-    /// <summary>
-    /// If true, the catalog will be included in generated changeSets. Defaults to false. DEFAULT: false
-    /// </summary>
-    [CliOption("--include-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? IncludeCatalog { get; set; }
-
-    /// <summary>
-    /// Objects to include in diff. Supports regular expressions. Defaults to null.
-    /// </summary>
-    [CliOption("--include-objects", Format = OptionFormat.EqualsSeparated)]
-    public string? IncludeObjects { get; set; }
-
-    /// <summary>
-    /// If true, the schema will be included in generated changeSets. Defaults to false. DEFAULT: false
-    /// </summary>
-    [CliOption("--include-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? IncludeSchema { get; set; }
-
-    /// <summary>
-    /// Include the tablespace attribute in the changelog. Defaults to false. DEFAULT: false
-    /// </summary>
-    [CliOption("--include-tablespace", Format = OptionFormat.EqualsSeparated)]
-    public bool? IncludeTablespace { get; set; }
 
     /// <summary>
     /// Changeset labels to generate
@@ -126,77 +72,10 @@ public record LiquibaseDiffChangelogOptions : LiquibaseOptions
     public string? Password { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the reference database connection
-    /// </summary>
-    [CliOption("--reference-default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the reference database connection
-    /// </summary>
-    [CliOption("--reference-default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDefaultSchemaName { get; set; }
-
-    /// <summary>
-    /// The JDBC driver class for the reference database
-    /// </summary>
-    [CliOption("--reference-driver", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDriver { get; set; }
-
-    /// <summary>
-    /// The JDBC driver properties file for the reference database
-    /// </summary>
-    [CliOption("--reference-driver-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDriverPropertiesFile { get; set; }
-
-    /// <summary>
-    /// Reference catalog to use for Liquibase objects
-    /// </summary>
-    [CliOption("--reference-liquibase-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceLiquibaseCatalogName { get; set; }
-
-    /// <summary>
-    /// Reference schema to use for Liquibase objects
-    /// </summary>
-    [CliOption("--reference-liquibase-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceLiquibaseSchemaName { get; set; }
-
-    /// <summary>
-    /// The reference database password
-    /// </summary>
-    [SecretValue]
-    [CliOption("--reference-password", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferencePassword { get; set; }
-
-    /// <summary>
-    /// Schemas names on reference database to use in diff. This is a CSV list.
-    /// </summary>
-    [CliOption("--reference-schemas", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceSchemas { get; set; }
-
-    /// <summary>
     /// The JDBC reference database connection URL
     /// </summary>
     [CliOption("--reference-url", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceUrl { get; set; }
-
-    /// <summary>
-    /// The reference database username
-    /// </summary>
-    [CliOption("--reference-username", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceUsername { get; set; }
-
-    /// <summary>
-    /// Sets replaceIfExists="true" for changes of these types (supported types: createProcedure, createView) DEFAULT: none
-    /// </summary>
-    [CliOption("--replace-if-exists-types", Format = OptionFormat.EqualsSeparated)]
-    public string? ReplaceIfExistsTypes { get; set; }
-
-    /// <summary>
-    /// Sets runOnChange="true" for changesets containing solely changes of these types (e. g. createView, createProcedure, ...). DEFAULT: none
-    /// </summary>
-    [CliOption("--run-on-change-types", Format = OptionFormat.EqualsSeparated)]
-    public string? RunOnChangeTypes { get; set; }
 
     /// <summary>
     /// Schemas to include in diff
@@ -205,27 +84,81 @@ public record LiquibaseDiffChangelogOptions : LiquibaseOptions
     public string? Schemas { get; set; }
 
     /// <summary>
-    /// When true will skip object sorting. This can be useful on databases that have a lot of packages/procedures that are linked to each other DEFAULT: false
-    /// </summary>
-    [CliOption("--skip-object-sorting", Format = OptionFormat.EqualsSeparated)]
-    public bool? SkipObjectSorting { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
     public string? Url { get; set; }
 
     /// <summary>
-    /// If true, will add 'OR REPLACE' option to the create view change object DEFAULT: false
-    /// </summary>
-    [CliOption("--use-or-replace-option", Format = OptionFormat.EqualsSeparated)]
-    public bool? UseOrReplaceOption { get; set; }
-
-    /// <summary>
     /// Username to use to connect to the database
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DataOutputDirectory is no longer supported by the installed CLI and has no effect.")]
+    public string? DataOutputDirectory { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ExcludeObjects is no longer supported by the installed CLI and has no effect.")]
+    public string? ExcludeObjects { get; set; }
+
+    [Obsolete("IgnoreMissingReferences is no longer supported by the installed CLI and has no effect.")]
+    public bool? IgnoreMissingReferences { get; set; }
+
+    [Obsolete("IncludeCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? IncludeCatalog { get; set; }
+
+    [Obsolete("IncludeObjects is no longer supported by the installed CLI and has no effect.")]
+    public string? IncludeObjects { get; set; }
+
+    [Obsolete("IncludeSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? IncludeSchema { get; set; }
+
+    [Obsolete("IncludeTablespace is no longer supported by the installed CLI and has no effect.")]
+    public bool? IncludeTablespace { get; set; }
+
+    [Obsolete("ReferenceDefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDefaultCatalogName { get; set; }
+
+    [Obsolete("ReferenceDefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDefaultSchemaName { get; set; }
+
+    [Obsolete("ReferenceDriver is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDriver { get; set; }
+
+    [Obsolete("ReferenceDriverPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDriverPropertiesFile { get; set; }
+
+    [Obsolete("ReferenceLiquibaseCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceLiquibaseCatalogName { get; set; }
+
+    [Obsolete("ReferenceLiquibaseSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceLiquibaseSchemaName { get; set; }
+
+    [Obsolete("ReferencePassword is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferencePassword { get; set; }
+
+    [Obsolete("ReferenceSchemas is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceSchemas { get; set; }
+
+    [Obsolete("ReferenceUsername is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceUsername { get; set; }
+
+    [Obsolete("ReplaceIfExistsTypes is no longer supported by the installed CLI and has no effect.")]
+    public string? ReplaceIfExistsTypes { get; set; }
+
+    [Obsolete("RunOnChangeTypes is no longer supported by the installed CLI and has no effect.")]
+    public string? RunOnChangeTypes { get; set; }
+
+    [Obsolete("SkipObjectSorting is no longer supported by the installed CLI and has no effect.")]
+    public bool? SkipObjectSorting { get; set; }
+
+    [Obsolete("UseOrReplaceOption is no longer supported by the installed CLI and has no effect.")]
+    public bool? UseOrReplaceOption { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseDiffOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseDiffOptions.Generated.cs
@@ -22,46 +22,10 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseDiffOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Types of objects to compare
     /// </summary>
     [CliOption("--diff-types", Format = OptionFormat.EqualsSeparated)]
     public string? DiffTypes { get; set; }
-
-    /// <summary>
-    /// Objects to exclude from diff
-    /// </summary>
-    [CliOption("--exclude-objects", Format = OptionFormat.EqualsSeparated)]
-    public string? ExcludeObjects { get; set; }
-
-    /// <summary>
-    /// If true, diff operations will ignore referenced objects which are not found in a snapshot. DEFAULT: false
-    /// </summary>
-    [CliOption("--ignore-missing-references", Format = OptionFormat.EqualsSeparated)]
-    public bool? IgnoreMissingReferences { get; set; }
-
-    /// <summary>
-    /// Objects to include in diff
-    /// </summary>
-    [CliOption("--include-objects", Format = OptionFormat.EqualsSeparated)]
-    public string? IncludeObjects { get; set; }
-
-    /// <summary>
-    /// Output schemas names. This is a CSV list.
-    /// </summary>
-    [CliOption("--output-schemas", Format = OptionFormat.EqualsSeparated)]
-    public string? OutputSchemas { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -69,67 +33,6 @@ public record LiquibaseDiffOptions : LiquibaseOptions
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the reference database connection
-    /// </summary>
-    [CliOption("--reference-default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the reference database connection
-    /// </summary>
-    [CliOption("--reference-default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDefaultSchemaName { get; set; }
-
-    /// <summary>
-    /// The JDBC driver class for the reference database
-    /// </summary>
-    [CliOption("--reference-driver", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDriver { get; set; }
-
-    /// <summary>
-    /// The JDBC driver properties file for the reference database
-    /// </summary>
-    [CliOption("--reference-driver-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceDriverPropertiesFile { get; set; }
-
-    /// <summary>
-    /// Reference catalog to use for Liquibase objects
-    /// </summary>
-    [CliOption("--reference-liquibase-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceLiquibaseCatalogName { get; set; }
-
-    /// <summary>
-    /// Reference schema to use for Liquibase objects
-    /// </summary>
-    [CliOption("--reference-liquibase-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceLiquibaseSchemaName { get; set; }
-
-    /// <summary>
-    /// The reference database password
-    /// </summary>
-    [SecretValue]
-    [CliOption("--reference-password", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferencePassword { get; set; }
-
-    /// <summary>
-    /// Schemas names on reference database to use in diff. This is a CSV list.
-    /// </summary>
-    [CliOption("--reference-schemas", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceSchemas { get; set; }
-
-    /// <summary>
-    /// The JDBC reference database connection URL
-    /// </summary>
-    [CliOption("--reference-url", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceUrl { get; set; }
-
-    /// <summary>
-    /// The reference database username
-    /// </summary>
-    [CliOption("--reference-username", Format = OptionFormat.EqualsSeparated)]
-    public string? ReferenceUsername { get; set; }
 
     /// <summary>
     /// Schemas to include in diff
@@ -154,5 +57,53 @@ public record LiquibaseDiffOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--format", Format = OptionFormat.EqualsSeparated)]
     public string? Format { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ExcludeObjects is no longer supported by the installed CLI and has no effect.")]
+    public string? ExcludeObjects { get; set; }
+
+    [Obsolete("IgnoreMissingReferences is no longer supported by the installed CLI and has no effect.")]
+    public bool? IgnoreMissingReferences { get; set; }
+
+    [Obsolete("IncludeObjects is no longer supported by the installed CLI and has no effect.")]
+    public string? IncludeObjects { get; set; }
+
+    [Obsolete("OutputSchemas is no longer supported by the installed CLI and has no effect.")]
+    public string? OutputSchemas { get; set; }
+
+    [Obsolete("ReferenceDefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDefaultCatalogName { get; set; }
+
+    [Obsolete("ReferenceDefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDefaultSchemaName { get; set; }
+
+    [Obsolete("ReferenceDriver is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDriver { get; set; }
+
+    [Obsolete("ReferenceDriverPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceDriverPropertiesFile { get; set; }
+
+    [Obsolete("ReferenceLiquibaseCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceLiquibaseCatalogName { get; set; }
+
+    [Obsolete("ReferenceLiquibaseSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceLiquibaseSchemaName { get; set; }
+
+    [Obsolete("ReferencePassword is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferencePassword { get; set; }
+
+    [Obsolete("ReferenceSchemas is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceSchemas { get; set; }
+
+    [Obsolete("ReferenceUrl is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceUrl { get; set; }
+
+    [Obsolete("ReferenceUsername is no longer supported by the installed CLI and has no effect.")]
+    public string? ReferenceUsername { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseDropAllOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseDropAllOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseDropAllOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Argument to allow use of dropAll with values of 'true' or 'false'. The default is 'false'. DEFAULT: false
     /// </summary>
     [CliOption("--force", Format = OptionFormat.EqualsSeparated)]
@@ -45,12 +33,6 @@ public record LiquibaseDropAllOptions : LiquibaseOptions
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// Argument to require user of dropAll to supply a 'force' argument, with values of 'true' or 'false'. The default is 'false'. DEFAULT: false
-    /// </summary>
-    [CliOption("--require-force", Format = OptionFormat.EqualsSeparated)]
-    public bool? RequireForce { get; set; }
 
     /// <summary>
     /// Schemas to include in drop
@@ -69,5 +51,14 @@ public record LiquibaseDropAllOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("RequireForce is no longer supported by the installed CLI and has no effect.")]
+    public bool? RequireForce { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseExecuteSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseExecuteSqlOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseExecuteSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Delimiter to use when executing SQL script
     /// </summary>
     [CliOption("--delimiter", Format = OptionFormat.EqualsSeparated)]
@@ -69,5 +57,11 @@ public record LiquibaseExecuteSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseFutureRollbackCountSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseFutureRollbackCountSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseFutureRollbackCountSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -59,34 +47,10 @@ public record LiquibaseFutureRollbackCountSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -106,5 +70,23 @@ public record LiquibaseFutureRollbackCountSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseFutureRollbackFromTagSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseFutureRollbackFromTagSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseFutureRollbackFromTagSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -53,34 +41,10 @@ public record LiquibaseFutureRollbackFromTagSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -106,5 +70,23 @@ public record LiquibaseFutureRollbackFromTagSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseFutureRollbackSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseFutureRollbackSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseFutureRollbackSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -53,34 +41,10 @@ public record LiquibaseFutureRollbackSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -100,5 +64,23 @@ public record LiquibaseFutureRollbackSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseGenerateChangelogOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseGenerateChangelogOptions.Generated.cs
@@ -47,64 +47,10 @@ public record LiquibaseGenerateChangelogOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// Specifies a directory to send the loadData output of a diff-changelog/generate-changelog command as a CSV file.
-    /// </summary>
-    [CliOption("--data-output-directory", Format = OptionFormat.EqualsSeparated)]
-    public string? DataOutputDirectory { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Types of objects to compare
     /// </summary>
     [CliOption("--diff-types", Format = OptionFormat.EqualsSeparated)]
     public string? DiffTypes { get; set; }
-
-    /// <summary>
-    /// Objects to exclude from diff. Supports regular expressions. Defaults to null.
-    /// </summary>
-    [CliOption("--exclude-objects", Format = OptionFormat.EqualsSeparated)]
-    public string? ExcludeObjects { get; set; }
-
-    /// <summary>
-    /// If true, diff operations will ignore referenced objects which are not found in a snapshot. DEFAULT: false
-    /// </summary>
-    [CliOption("--ignore-missing-references", Format = OptionFormat.EqualsSeparated)]
-    public bool? IgnoreMissingReferences { get; set; }
-
-    /// <summary>
-    /// If true, the catalog will be included in generated changeSets. Defaults to false. DEFAULT: false
-    /// </summary>
-    [CliOption("--include-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? IncludeCatalog { get; set; }
-
-    /// <summary>
-    /// Objects to include in diff. Supports regular expressions. Defaults to null.
-    /// </summary>
-    [CliOption("--include-objects", Format = OptionFormat.EqualsSeparated)]
-    public string? IncludeObjects { get; set; }
-
-    /// <summary>
-    /// If true, the schema will be included in generated changeSets. Defaults to false. DEFAULT: false
-    /// </summary>
-    [CliOption("--include-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? IncludeSchema { get; set; }
-
-    /// <summary>
-    /// Include the tablespace attribute in the changelog. Defaults to false. DEFAULT: false
-    /// </summary>
-    [CliOption("--include-tablespace", Format = OptionFormat.EqualsSeparated)]
-    public bool? IncludeTablespace { get; set; }
 
     /// <summary>
     /// Changeset labels to generate
@@ -119,29 +65,11 @@ public record LiquibaseGenerateChangelogOptions : LiquibaseOptions
     public string? OutputSchemas { get; set; }
 
     /// <summary>
-    /// Flag to allow overwriting of output changelog file. Default: false DEFAULT: false
-    /// </summary>
-    [CliOption("--overwrite-output-file", Format = OptionFormat.EqualsSeparated)]
-    public bool? OverwriteOutputFile { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// Sets replaceIfExists="true" for changes of these types (supported types: createProcedure, createView) DEFAULT: none
-    /// </summary>
-    [CliOption("--replace-if-exists-types", Format = OptionFormat.EqualsSeparated)]
-    public string? ReplaceIfExistsTypes { get; set; }
-
-    /// <summary>
-    /// Sets runOnChange="true" for changesets containing solely changes of these types (e. g. createView, createProcedure, ...). DEFAULT: none
-    /// </summary>
-    [CliOption("--run-on-change-types", Format = OptionFormat.EqualsSeparated)]
-    public string? RunOnChangeTypes { get; set; }
 
     /// <summary>
     /// Schemas to include in diff
@@ -150,27 +78,57 @@ public record LiquibaseGenerateChangelogOptions : LiquibaseOptions
     public string? Schemas { get; set; }
 
     /// <summary>
-    /// When true will skip object sorting. This can be useful on databases that have a lot of packages/procedures that are linked to each other DEFAULT: false
-    /// </summary>
-    [CliOption("--skip-object-sorting", Format = OptionFormat.EqualsSeparated)]
-    public bool? SkipObjectSorting { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
     public string? Url { get; set; }
 
     /// <summary>
-    /// If true, will add 'OR REPLACE' option to the create view change object DEFAULT: false
-    /// </summary>
-    [CliOption("--use-or-replace-option", Format = OptionFormat.EqualsSeparated)]
-    public bool? UseOrReplaceOption { get; set; }
-
-    /// <summary>
     /// Username to use to connect to the database
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DataOutputDirectory is no longer supported by the installed CLI and has no effect.")]
+    public string? DataOutputDirectory { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ExcludeObjects is no longer supported by the installed CLI and has no effect.")]
+    public string? ExcludeObjects { get; set; }
+
+    [Obsolete("IgnoreMissingReferences is no longer supported by the installed CLI and has no effect.")]
+    public bool? IgnoreMissingReferences { get; set; }
+
+    [Obsolete("IncludeCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? IncludeCatalog { get; set; }
+
+    [Obsolete("IncludeObjects is no longer supported by the installed CLI and has no effect.")]
+    public string? IncludeObjects { get; set; }
+
+    [Obsolete("IncludeSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? IncludeSchema { get; set; }
+
+    [Obsolete("IncludeTablespace is no longer supported by the installed CLI and has no effect.")]
+    public bool? IncludeTablespace { get; set; }
+
+    [Obsolete("OverwriteOutputFile is no longer supported by the installed CLI and has no effect.")]
+    public bool? OverwriteOutputFile { get; set; }
+
+    [Obsolete("ReplaceIfExistsTypes is no longer supported by the installed CLI and has no effect.")]
+    public string? ReplaceIfExistsTypes { get; set; }
+
+    [Obsolete("RunOnChangeTypes is no longer supported by the installed CLI and has no effect.")]
+    public string? RunOnChangeTypes { get; set; }
+
+    [Obsolete("SkipObjectSorting is no longer supported by the installed CLI and has no effect.")]
+    public bool? SkipObjectSorting { get; set; }
+
+    [Obsolete("UseOrReplaceOption is no longer supported by the installed CLI and has no effect.")]
+    public bool? UseOrReplaceOption { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseHistoryOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseHistoryOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseHistoryOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// History output format DEFAULT: TABULAR
     /// </summary>
     [CliOption("--format", Format = OptionFormat.EqualsSeparated)]
@@ -69,5 +57,11 @@ public record LiquibaseHistoryOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseInitOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseInitOptions.Generated.cs
@@ -21,4 +21,10 @@ namespace ModularPipelines.Liquibase.Options;
 [CliSubCommand("init")]
 public record LiquibaseInitOptions : LiquibaseOptions
 {
+    /// <summary>
+    /// The COMMAND operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseInitProjectOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseInitProjectOptions.Generated.cs
@@ -23,12 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseInitProjectOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Relative or fully qualified path to the changelog file DEFAULT: example-changelog
-    /// </summary>
-    [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangelogFile { get; set; }
-
-    /// <summary>
     /// Pass a name/value pair for substitution in the changelog(s) Pass as -D&lt;property.name&gt;=&lt;property.value&gt; [deprecated: set changelog properties in defaults file or environment variables]
     /// </summary>
     [CliOption("-D", Format = OptionFormat.NoSeparator)]
@@ -41,12 +35,6 @@ public record LiquibaseInitProjectOptions : LiquibaseOptions
     public string? Format { get; set; }
 
     /// <summary>
-    /// For remote project locations, do not delete temporary project files DEFAULT: false
-    /// </summary>
-    [CliOption("--keep-temp-files", Format = OptionFormat.EqualsSeparated)]
-    public bool? KeepTempFiles { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database DEFAULT: letmein
     /// </summary>
     [SecretValue]
@@ -54,22 +42,10 @@ public record LiquibaseInitProjectOptions : LiquibaseOptions
     public string? Password { get; set; }
 
     /// <summary>
-    /// File with default Liquibase properties DEFAULT: liquibase.properties
-    /// </summary>
-    [CliOption("--project-defaults-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectDefaultsFile { get; set; }
-
-    /// <summary>
     /// Relative or fully qualified path to the directory where the project files will be created DEFAULT: ./
     /// </summary>
     [CliOption("--project-dir", Format = OptionFormat.EqualsSeparated)]
     public string? ProjectDir { get; set; }
-
-    /// <summary>
-    /// Allow interactive prompts for init project DEFAULT: true
-    /// </summary>
-    [CliOption("--project-guide", Format = OptionFormat.EqualsSeparated)]
-    public bool? ProjectGuide { get; set; }
 
     /// <summary>
     /// The JDBC database connection URL DEFAULT: jdbc:h2:tcp://localhost:9090/mem:dev
@@ -82,5 +58,17 @@ public record LiquibaseInitProjectOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangelogFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangelogFile { get; set; }
+
+    [Obsolete("KeepTempFiles is no longer supported by the installed CLI and has no effect.")]
+    public bool? KeepTempFiles { get; set; }
+
+    [Obsolete("ProjectDefaultsFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ProjectDefaultsFile { get; set; }
+
+    [Obsolete("ProjectGuide is no longer supported by the installed CLI and has no effect.")]
+    public bool? ProjectGuide { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseInitStartH2Options.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseInitStartH2Options.Generated.cs
@@ -40,12 +40,6 @@ public record LiquibaseInitStartH2Options : LiquibaseOptions
     public bool? Detached { get; set; }
 
     /// <summary>
-    /// Whether to open a browser to the database's web interface DEFAULT: true
-    /// </summary>
-    [CliOption("--launch-browser", Format = OptionFormat.EqualsSeparated)]
-    public bool? LaunchBrowser { get; set; }
-
-    /// <summary>
     /// Password to use for created h2 user DEFAULT: letmein
     /// </summary>
     [SecretValue]
@@ -63,5 +57,8 @@ public record LiquibaseInitStartH2Options : LiquibaseOptions
     /// </summary>
     [CliOption("--web-port", Format = OptionFormat.EqualsSeparated)]
     public int? WebPort { get; set; }
+
+    [Obsolete("LaunchBrowser is no longer supported by the installed CLI and has no effect.")]
+    public bool? LaunchBrowser { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseListLocksOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseListLocksOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseListLocksOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
@@ -51,5 +39,11 @@ public record LiquibaseListLocksOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseMarkNextChangesetRanOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseMarkNextChangesetRanOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseMarkNextChangesetRanOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -76,5 +64,11 @@ public record LiquibaseMarkNextChangesetRanOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseMarkNextChangesetRanSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseMarkNextChangesetRanSqlOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseMarkNextChangesetRanSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -76,5 +64,11 @@ public record LiquibaseMarkNextChangesetRanSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseOptions.Generated.cs
@@ -24,88 +24,16 @@ namespace ModularPipelines.Liquibase.Options;
 public abstract record LiquibaseOptions : CommandLineToolOptions
 {
     /// <summary>
-    /// Allows duplicated changeset identifiers without failing Liquibase execution. DEFAULT: false
-    /// </summary>
-    [CliOption("--allow-duplicated-changeset-identifiers", Format = OptionFormat.EqualsSeparated)]
-#pragma warning disable CS0618
-    public virtual bool? AllowDuplicatedChangeSetIdentifiers
-    {
-        get => AllowDuplicatedChangesetIdentifiers;
-        set => AllowDuplicatedChangesetIdentifiers = value;
-    }
-#pragma warning restore CS0618
-
-    /// <summary>
-    /// If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility. DEFAULT: true
-    /// </summary>
-    [CliOption("--allow-inherit-logical-file-path", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? AllowInheritLogicalFilePath { get; set; }
-
-    /// <summary>
-    /// If true, drop and recreate a view instead of replacing it. DEFAULT: false
-    /// </summary>
-    [CliOption("--always-drop-instead-of-replace", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? AlwaysDropInsteadOfReplace { get; set; }
-
-    /// <summary>
-    /// When generating SQL for createProcedure, should the procedure schema be forced to the default schema if no schemaName attribute is set? DEFAULT: false
-    /// </summary>
-    [CliOption("--always-override-stored-logic-schema", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? AlwaysOverrideStoredLogicSchema { get; set; }
-
-    /// <summary>
-    /// Enable or disable sending product usage data and analytics to Liquibase. Learn more at https: //docs.liquibase.com/analytics.
-    /// </summary>
-    [CliOption("--analytics-enabled", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? AnalyticsEnabled { get; set; }
-
-    /// <summary>
     /// Should Liquibase automatically include REORG TABLE commands when needed? DEFAULT: true
     /// </summary>
     [CliOption("--auto-reorg", Format = OptionFormat.EqualsSeparated)]
     public virtual bool? AutoReorg { get; set; }
 
     /// <summary>
-    /// Number of seconds wait between checks to the changelog lock when it is locked DEFAULT: 10
-    /// </summary>
-    [CliOption("--changelog-lock-poll-rate", Format = OptionFormat.EqualsSeparated)]
-    public virtual int? ChangelogLockPollRate { get; set; }
-
-    /// <summary>
-    /// Number of minutes to wait for the changelog lock to be available before giving up DEFAULT: 5
-    /// </summary>
-    [CliOption("--changelog-lock-wait-time-in-minutes", Format = OptionFormat.EqualsSeparated)]
-    public virtual int? ChangelogLockWaitTimeInMinutes { get; set; }
-
-    /// <summary>
-    /// Configures how to handle unknown fields in changelog files. Possible values: STRICT which causes parsing to fail, and LAX which continues with the parsing. DEFAULT: STRICT
-    /// </summary>
-    [CliOption("--changelog-parse-mode", Format = OptionFormat.EqualsSeparated)]
-    public virtual LiquibaseChangelogParseMode? ChangelogParseMode { get; set; }
-
-    /// <summary>
     /// Additional classpath entries to use
     /// </summary>
     [CliOption("--classpath", Format = OptionFormat.EqualsSeparated)]
     public virtual string? Classpath { get; set; }
-
-    /// <summary>
-    /// Should Liquibase convert to/from STANDARD data types. Applies to both snapshot and update commands. DEFAULT: true
-    /// </summary>
-    [CliOption("--convert-data-types", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? ConvertDataTypes { get; set; }
-
-    /// <summary>
-    /// Name of table to use for tracking concurrent Liquibase usage DEFAULT: DATABASECHANGELOGLOCK
-    /// </summary>
-    [CliOption("--database-changelog-lock-table-name", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? DatabaseChangelogLockTableName { get; set; }
-
-    /// <summary>
-    /// Name of table to use for tracking change history DEFAULT: DATABASECHANGELOG
-    /// </summary>
-    [CliOption("--database-changelog-table-name", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? DatabaseChangelogTableName { get; set; }
 
     /// <summary>
     /// Class to use for Database implementation
@@ -126,28 +54,10 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual bool? DatabricksDiffTblPropertiesIgnoreAll { get; set; }
 
     /// <summary>
-    /// The DDL_LOCK_TIMEOUT parameter indicates the number of seconds a DDL command should wait for the locks to become available before throwing the resource busy error message. This applies only to Oracle databases.
-    /// </summary>
-    [CliOption("--ddl-lock-timeout", Format = OptionFormat.EqualsSeparated)]
-    public virtual int? DdlLockTimeout { get; set; }
-
-    /// <summary>
     /// File with default Liquibase properties DEFAULT: liquibase.properties
     /// </summary>
     [CliOption("--defaults-file", Format = OptionFormat.EqualsSeparated)]
     public virtual string? DefaultsFile { get; set; }
-
-    /// <summary>
-    /// Should Liquibase compare column default value constraint name in diff operation? DEFAULT: true
-    /// </summary>
-    [CliOption("--diff-column-default-value-constraint-name", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? DiffColumnDefaultValueConstraintName { get; set; }
-
-    /// <summary>
-    /// Should Liquibase compare column order in diff operation? DEFAULT: true
-    /// </summary>
-    [CliOption("--diff-column-order", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? DiffColumnOrder { get; set; }
 
     /// <summary>
     /// Database driver class
@@ -156,64 +66,10 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual string? Driver { get; set; }
 
     /// <summary>
-    /// Driver-specific properties
-    /// </summary>
-    [CliOption("--driver-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? DriverPropertiesFile { get; set; }
-
-    /// <summary>
-    /// How to handle multiple files being found in the search path that have duplicate paths. Options are SILENT (do not log and choose one at random), DEBUG, INFO, WARN (log at the given level and choose one at random), or ERROR (fail current operation). DEFAULT: ERROR
-    /// </summary>
-    [CliOption("--duplicate-file-mode", Format = OptionFormat.EqualsSeparated)]
-    public virtual LiquibaseDuplicateFileMode? DuplicateFileMode { get; set; }
-
-    /// <summary>
-    /// Throw an error if Liquibase detects that an includeAll will cause a circular reference (and thus a changelog parse error). DEFAULT: true
-    /// </summary>
-    [CliOption("--error-on-circular-include-all", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? ErrorOnCircularIncludeAll { get; set; }
-
-    /// <summary>
-    /// If true, referenced objects which do not have a snapshot ID will cause snapshot failure DEFAULT: true
-    /// </summary>
-    [CliOption("--fail-on-null-snapshot-id", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? FailOnNullSnapshotId { get; set; }
-
-    /// <summary>
     /// Encoding to use when reading files. Valid values include: UTF-8, UTF-16, UTF-16BE, UTF-16LE, US-ASCII, or OS to use the system configured encoding. DEFAULT: UTF-8
     /// </summary>
     [CliOption("--file-encoding", Format = OptionFormat.EqualsSeparated)]
     public virtual string? FileEncoding { get; set; }
-
-    /// <summary>
-    /// DEPRECATED: No longer used
-    /// </summary>
-    [CliOption("--filter-log-messages", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? FilterLogMessages { get; set; }
-
-    /// <summary>
-    /// Should Liquibase include a 'created' attribute in diff/generateChangelog changesets with the current datetime DEFAULT: false
-    /// </summary>
-    [CliOption("--generate-changeset-created-values", Format = OptionFormat.EqualsSeparated)]
-#pragma warning disable CS0618
-    public virtual bool? GenerateChangeSetCreatedValues
-    {
-        get => GenerateChangesetCreatedValues;
-        set => GenerateChangesetCreatedValues = value;
-    }
-#pragma warning restore CS0618
-
-    /// <summary>
-    /// Should Liquibase include the change description in the id when generating changesets? DEFAULT: false
-    /// </summary>
-    [CliOption("--generated-changeset-ids-contains-description", Format = OptionFormat.EqualsSeparated)]
-#pragma warning disable CS0618
-    public virtual bool? GeneratedChangeSetIdsContainsDescription
-    {
-        get => GeneratedChangesetIdsContainsDescription;
-        set => GeneratedChangesetIdsContainsDescription = value;
-    }
-#pragma warning restore CS0618
 
     /// <summary>
     /// Force Liquibase to think it has no access to a keyboard DEFAULT: false
@@ -228,53 +84,11 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual bool? Help { get; set; }
 
     /// <summary>
-    /// Should Liquibase include the catalog name when determining equality? DEFAULT: false
-    /// </summary>
-    [CliOption("--include-catalog-in-specification", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? IncludeCatalogInSpecification { get; set; }
-
-    /// <summary>
-    /// If true, the parent relationship for computed columns is preserved in snapshot-dependent commands: snapshot and diff DEFAULT: false
-    /// </summary>
-    [CliOption("--include-relations-for-computed-columns", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? IncludeRelationsForComputedColumns { get; set; }
-
-    /// <summary>
-    /// If true, the schema name is included for the default schema when loading a snapshot DEFAULT: false
-    /// </summary>
-    [CliOption("--include-schema-name-for-default", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? IncludeSchemaNameForDefault { get; set; }
-
-    /// <summary>
-    /// Include the system classpath when resolving classes at runtime DEFAULT: true
-    /// </summary>
-    [CliOption("--include-system-classpath", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? IncludeSystemClasspath { get; set; }
-
-    /// <summary>
     /// Specifies the license key that enables Liquibase Secure functionality. Availability: Liquibase Secure. Documentation: https://docs.liquibase.com/community/reference-guide-5-0/parameters/what-are-parameters
     /// </summary>
     [SecretValue]
     [CliOption("--license-key", Format = OptionFormat.EqualsSeparated)]
     public virtual string? LicenseKey { get; set; }
-
-    /// <summary>
-    /// Catalog to use for Liquibase objects
-    /// </summary>
-    [CliOption("--liquibase-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? LiquibaseCatalogName { get; set; }
-
-    /// <summary>
-    /// Schema to use for Liquibase objects
-    /// </summary>
-    [CliOption("--liquibase-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? LiquibaseSchemaName { get; set; }
-
-    /// <summary>
-    /// Tablespace to use for Liquibase objects
-    /// </summary>
-    [CliOption("--liquibase-tablespace-name", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? LiquibaseTablespaceName { get; set; }
 
     /// <summary>
     /// DEFAULT: Controls which log channels have their level set by the liquibase.logLevel setting. Comma separate multiple values. To set the level of all channels, use 'all'. Example: liquibase, org.mariadb.jdbc
@@ -300,74 +114,8 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     [CliOption("--log-level", Format = OptionFormat.EqualsSeparated)]
     public virtual LiquibaseLogLevel? LogLevel { get; set; }
 
-    /// <summary>
-    /// When set to true, the console messages are mirrored to the logs as [liquibase.ui] to provide a more complete picture of liquibase operations to log analysis tools. Set to false to change this behavior. DEFAULT: true
-    /// </summary>
-    [CliOption("--mirror-console-messages-to-log", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? MirrorConsoleMessagesToLog { get; set; }
-
-    /// <summary>
-    /// How to handle changelog property expressions where a value is not set. For example, a string 'null' when no 'address' property was defined. Values can be: 'preserve' which leaves the string as-is, 'empty' which replaces it with an empty string, or 'error' which stops processing with an error. DEFAULT: PRESERVE
-    /// </summary>
-    [CliOption("--missing-property-mode", Format = OptionFormat.EqualsSeparated)]
-    public virtual LiquibaseMissingPropertyMode? MissingPropertyMode { get; set; }
-
-    /// <summary>
-    /// Enable performance tracking. Set to 'false' to disable. If set to 'true', data is stored to a `liquibase-TIMESTAMP.jfr` file in your working directory. Any other value will enable tracking and be used as the name of the file to write the data to. DEFAULT: false
-    /// </summary>
-    [CliOption("--monitor-performance", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? MonitorPerformance { get; set; }
-
-    /// <summary>
-    /// Number of bytes needed to store one character (depends on database's character encoding) DEFAULT: 1
-    /// </summary>
-    [CliOption("--mssql-bytes-per-char", Format = OptionFormat.EqualsSeparated)]
-    public virtual int? MssqlBytesPerChar { get; set; }
-
-    /// <summary>
-    /// If set to WARN, then liquibase will not throw exception on missing changelog file, instead will show a warning message. DEFAULT: FAIL
-    /// </summary>
-    [CliOption("--on-missing-include-changelog", Format = OptionFormat.EqualsSeparated)]
-    public virtual LiquibaseOnMissingIncludeChangelog? OnMissingIncludeChangelog { get; set; }
-
     [CliOption("--output-file", Format = OptionFormat.EqualsSeparated)]
     public virtual string? OutputFile { get; set; }
-
-    /// <summary>
-    /// Encoding to use when writing files DEFAULT: UTF-8
-    /// </summary>
-    [CliOption("--output-file-encoding", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? OutputFileEncoding { get; set; }
-
-    /// <summary>
-    /// Line separator for output DEFAULT: Line separator(LF or CRLF) for output. Defaults to OS default
-    /// </summary>
-    [CliOption("--output-line-separator", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? OutputLineSeparator { get; set; }
-
-    /// <summary>
-    /// If true 'classpath:' prefix will be preserved in normalized paths, allowing to resolve hierarchical resources under a classpath-based root. DEFAULT: false
-    /// </summary>
-    [CliOption("--preserve-classpath-prefix-in-normalized-paths", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? PreserveClasspathPrefixInNormalizedPaths { get; set; }
-
-    /// <summary>
-    /// If true, Liquibase treats schema and catalog names as case sensitive DEFAULT: false
-    /// </summary>
-    [CliOption("--preserve-schema-case", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? PreserveSchemaCase { get; set; }
-
-    /// <summary>
-    /// Should Liquibase prompt if a non-local database is being accessed
-    /// </summary>
-    [CliOption("--prompt-for-non-local-database", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? PromptForNonLocalDatabase { get; set; }
-
-    /// <summary>
-    /// Implementation of Properties class to provide additional driver properties
-    /// </summary>
-    [CliOption("--property-provider-class", Format = OptionFormat.EqualsSeparated)]
-    public virtual string? PropertyProviderClass { get; set; }
 
     /// <summary>
     /// Complete list of Location(s) to search for files such as changelog files in. Multiple paths can be specified by separating them with commas.
@@ -388,12 +136,6 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual bool? ShouldRun { get; set; }
 
     /// <summary>
-    /// Should Liquibase snapshot data by default? DEFAULT: false
-    /// </summary>
-    [CliOption("--should-snapshot-data", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? ShouldSnapshotData { get; set; }
-
-    /// <summary>
     /// If true, show a Liquibase banner on startup. DEFAULT: true
     /// </summary>
     [CliOption("--show-banner", Format = OptionFormat.EqualsSeparated)]
@@ -406,40 +148,10 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual string? SqlLogLevel { get; set; }
 
     /// <summary>
-    /// Show SQLWarning messages DEFAULT: true
-    /// </summary>
-    [CliOption("--sql-show-sql-warnings", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? SqlShowSqlWarnings { get; set; }
-
-    /// <summary>
     /// If true, Liquibase enforces certain best practices and proactively looks for common errors DEFAULT: false
     /// </summary>
     [CliOption("--strict", Format = OptionFormat.EqualsSeparated)]
     public virtual bool? Strict { get; set; }
-
-    /// <summary>
-    /// Support escaping changelog parameters using a colon. Example: null DEFAULT: false
-    /// </summary>
-    [CliOption("--support-property-escaping", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? SupportPropertyEscaping { get; set; }
-
-    /// <summary>
-    /// Controls the level of validation performed on the supports method of Change classes. Options are OFF, WARN, FAIL. DEFAULT: WARN
-    /// </summary>
-    [CliOption("--supports-method-validation-level", Format = OptionFormat.EqualsSeparated)]
-    public virtual LiquibaseSupportsMethodValidationLevel? SupportsMethodValidationLevel { get; set; }
-
-    /// <summary>
-    /// When set to true, this global property prevents DBCL and DBCLH sql from being present in console and logs during *-sql commands, such as update-sql, rollback-sql, etc. DEFAULT: false
-    /// </summary>
-    [CliOption("--suppress-liquibase-sql", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? SuppressLiquibaseSql { get; set; }
-
-    /// <summary>
-    /// If true column headers will be trimmed in case they were specified with spaces in the file. DEFAULT: false
-    /// </summary>
-    [CliOption("--trim-load-data-file-header", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? TrimLoadDataFileHeader { get; set; }
 
     /// <summary>
     /// Changes the default UI Service Logger used by Liquibase. Options are CONSOLE or LOGGER. DEFAULT: CONSOLE
@@ -448,22 +160,151 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual LiquibaseUiService? UiService { get; set; }
 
     /// <summary>
-    /// If set to true (default value), createProcedure tags with a set schemaName will modify the procedure body with the given schema name. DEFAULT: true
-    /// </summary>
-    [CliOption("--use-procedure-schema", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? UseProcedureSchema { get; set; }
-
-    /// <summary>
-    /// Will perform XSD validation of XML changelog files. When many XML changelog files are included, this validation may impact Liquibase performance. Defaults to true. DEFAULT: true
-    /// </summary>
-    [CliOption("--validate-xml-changelog-files", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? ValidateXmlChangelogFiles { get; set; }
-
-    /// <summary>
     /// Print version information and exit
     /// </summary>
     [CliFlag("--version", ShortForm = "-v")]
     public virtual bool? Version { get; set; }
+
+    [Obsolete("AllowDuplicatedChangeSetIdentifiers is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? AllowDuplicatedChangeSetIdentifiers { get; set; }
+
+    [Obsolete("AllowInheritLogicalFilePath is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? AllowInheritLogicalFilePath { get; set; }
+
+    [Obsolete("AlwaysDropInsteadOfReplace is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? AlwaysDropInsteadOfReplace { get; set; }
+
+    [Obsolete("AlwaysOverrideStoredLogicSchema is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? AlwaysOverrideStoredLogicSchema { get; set; }
+
+    [Obsolete("AnalyticsEnabled is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? AnalyticsEnabled { get; set; }
+
+    [Obsolete("ChangelogLockPollRate is no longer supported by the installed CLI and has no effect.")]
+    public virtual int? ChangelogLockPollRate { get; set; }
+
+    [Obsolete("ChangelogLockWaitTimeInMinutes is no longer supported by the installed CLI and has no effect.")]
+    public virtual int? ChangelogLockWaitTimeInMinutes { get; set; }
+
+    [Obsolete("ChangelogParseMode is no longer supported by the installed CLI and has no effect.")]
+    public virtual LiquibaseChangelogParseMode? ChangelogParseMode { get; set; }
+
+    [Obsolete("ConvertDataTypes is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? ConvertDataTypes { get; set; }
+
+    [Obsolete("DatabaseChangelogLockTableName is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? DatabaseChangelogLockTableName { get; set; }
+
+    [Obsolete("DatabaseChangelogTableName is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? DatabaseChangelogTableName { get; set; }
+
+    [Obsolete("DdlLockTimeout is no longer supported by the installed CLI and has no effect.")]
+    public virtual int? DdlLockTimeout { get; set; }
+
+    [Obsolete("DiffColumnDefaultValueConstraintName is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? DiffColumnDefaultValueConstraintName { get; set; }
+
+    [Obsolete("DiffColumnOrder is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? DiffColumnOrder { get; set; }
+
+    [Obsolete("DriverPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? DriverPropertiesFile { get; set; }
+
+    [Obsolete("DuplicateFileMode is no longer supported by the installed CLI and has no effect.")]
+    public virtual LiquibaseDuplicateFileMode? DuplicateFileMode { get; set; }
+
+    [Obsolete("ErrorOnCircularIncludeAll is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? ErrorOnCircularIncludeAll { get; set; }
+
+    [Obsolete("FailOnNullSnapshotId is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? FailOnNullSnapshotId { get; set; }
+
+    [Obsolete("FilterLogMessages is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? FilterLogMessages { get; set; }
+
+    [Obsolete("GenerateChangeSetCreatedValues is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? GenerateChangeSetCreatedValues { get; set; }
+
+    [Obsolete("GeneratedChangeSetIdsContainsDescription is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? GeneratedChangeSetIdsContainsDescription { get; set; }
+
+    [Obsolete("IncludeCatalogInSpecification is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? IncludeCatalogInSpecification { get; set; }
+
+    [Obsolete("IncludeRelationsForComputedColumns is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? IncludeRelationsForComputedColumns { get; set; }
+
+    [Obsolete("IncludeSchemaNameForDefault is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? IncludeSchemaNameForDefault { get; set; }
+
+    [Obsolete("IncludeSystemClasspath is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? IncludeSystemClasspath { get; set; }
+
+    [Obsolete("LiquibaseCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? LiquibaseCatalogName { get; set; }
+
+    [Obsolete("LiquibaseSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? LiquibaseSchemaName { get; set; }
+
+    [Obsolete("LiquibaseTablespaceName is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? LiquibaseTablespaceName { get; set; }
+
+    [Obsolete("MirrorConsoleMessagesToLog is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? MirrorConsoleMessagesToLog { get; set; }
+
+    [Obsolete("MissingPropertyMode is no longer supported by the installed CLI and has no effect.")]
+    public virtual LiquibaseMissingPropertyMode? MissingPropertyMode { get; set; }
+
+    [Obsolete("MonitorPerformance is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? MonitorPerformance { get; set; }
+
+    [Obsolete("MssqlBytesPerChar is no longer supported by the installed CLI and has no effect.")]
+    public virtual int? MssqlBytesPerChar { get; set; }
+
+    [Obsolete("OnMissingIncludeChangelog is no longer supported by the installed CLI and has no effect.")]
+    public virtual LiquibaseOnMissingIncludeChangelog? OnMissingIncludeChangelog { get; set; }
+
+    [Obsolete("OutputFileEncoding is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? OutputFileEncoding { get; set; }
+
+    [Obsolete("OutputLineSeparator is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? OutputLineSeparator { get; set; }
+
+    [Obsolete("PreserveClasspathPrefixInNormalizedPaths is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? PreserveClasspathPrefixInNormalizedPaths { get; set; }
+
+    [Obsolete("PreserveSchemaCase is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? PreserveSchemaCase { get; set; }
+
+    [Obsolete("PromptForNonLocalDatabase is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? PromptForNonLocalDatabase { get; set; }
+
+    [Obsolete("PropertyProviderClass is no longer supported by the installed CLI and has no effect.")]
+    public virtual string? PropertyProviderClass { get; set; }
+
+    [Obsolete("ShouldSnapshotData is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? ShouldSnapshotData { get; set; }
+
+    [Obsolete("SqlShowSqlWarnings is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? SqlShowSqlWarnings { get; set; }
+
+    [Obsolete("SupportPropertyEscaping is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? SupportPropertyEscaping { get; set; }
+
+    [Obsolete("SupportsMethodValidationLevel is no longer supported by the installed CLI and has no effect.")]
+    public virtual LiquibaseSupportsMethodValidationLevel? SupportsMethodValidationLevel { get; set; }
+
+    [Obsolete("SuppressLiquibaseSql is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? SuppressLiquibaseSql { get; set; }
+
+    [Obsolete("TrimLoadDataFileHeader is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? TrimLoadDataFileHeader { get; set; }
+
+    [Obsolete("UseProcedureSchema is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? UseProcedureSchema { get; set; }
+
+    [Obsolete("ValidateXmlChangelogFiles is no longer supported by the installed CLI and has no effect.")]
+    public virtual bool? ValidateXmlChangelogFiles { get; set; }
 
     [Obsolete("Use AllowDuplicatedChangeSetIdentifiers instead.")]
     public virtual bool? AllowDuplicatedChangesetIdentifiers { get; set; }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseReleaseLocksOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseReleaseLocksOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseReleaseLocksOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
@@ -51,5 +39,11 @@ public record LiquibaseReleaseLocksOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackCountOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackCountOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseRollbackCountOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -59,18 +47,6 @@ public record LiquibaseRollbackCountOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -84,12 +60,6 @@ public record LiquibaseRollbackCountOptions : LiquibaseOptions
     public string? Password { get; set; }
 
     /// <summary>
-    /// Rollback script to execute
-    /// </summary>
-    [CliOption("--rollback-script", Format = OptionFormat.EqualsSeparated)]
-    public string? RollbackScript { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
@@ -100,5 +70,20 @@ public record LiquibaseRollbackCountOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("RollbackScript is no longer supported by the installed CLI and has no effect.")]
+    public string? RollbackScript { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackCountSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackCountSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseRollbackCountSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -59,34 +47,10 @@ public record LiquibaseRollbackCountSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -94,12 +58,6 @@ public record LiquibaseRollbackCountSqlOptions : LiquibaseOptions
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// Rollback script to execute
-    /// </summary>
-    [CliOption("--rollback-script", Format = OptionFormat.EqualsSeparated)]
-    public string? RollbackScript { get; set; }
 
     /// <summary>
     /// The JDBC database connection URL
@@ -112,5 +70,26 @@ public record LiquibaseRollbackCountSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
+
+    [Obsolete("RollbackScript is no longer supported by the installed CLI and has no effect.")]
+    public string? RollbackScript { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackOptions.Generated.cs
@@ -24,18 +24,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseRollbackOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -54,18 +42,6 @@ public record LiquibaseRollbackOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -77,12 +53,6 @@ public record LiquibaseRollbackOptions : LiquibaseOptions
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// Rollback script to execute
-    /// </summary>
-    [CliOption("--rollback-script", Format = OptionFormat.EqualsSeparated)]
-    public string? RollbackScript { get; set; }
 
     /// <summary>
     /// Tag to rollback to
@@ -107,5 +77,20 @@ public record LiquibaseRollbackOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("RollbackScript is no longer supported by the installed CLI and has no effect.")]
+    public string? RollbackScript { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackSqlOptions.Generated.cs
@@ -24,18 +24,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseRollbackSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -54,34 +42,10 @@ public record LiquibaseRollbackSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -89,12 +53,6 @@ public record LiquibaseRollbackSqlOptions : LiquibaseOptions
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// Rollback script to execute
-    /// </summary>
-    [CliOption("--rollback-script", Format = OptionFormat.EqualsSeparated)]
-    public string? RollbackScript { get; set; }
 
     /// <summary>
     /// Tag to rollback to
@@ -119,5 +77,26 @@ public record LiquibaseRollbackSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
+
+    [Obsolete("RollbackScript is no longer supported by the installed CLI and has no effect.")]
+    public string? RollbackScript { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackToDateOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackToDateOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseRollbackToDateOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -59,18 +47,6 @@ public record LiquibaseRollbackToDateOptions : LiquibaseOptions
     public string? Date { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -84,12 +60,6 @@ public record LiquibaseRollbackToDateOptions : LiquibaseOptions
     public string? Password { get; set; }
 
     /// <summary>
-    /// Rollback script to execute
-    /// </summary>
-    [CliOption("--rollback-script", Format = OptionFormat.EqualsSeparated)]
-    public string? RollbackScript { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
@@ -100,5 +70,20 @@ public record LiquibaseRollbackToDateOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("RollbackScript is no longer supported by the installed CLI and has no effect.")]
+    public string? RollbackScript { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackToDateSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseRollbackToDateSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseRollbackToDateSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -59,34 +47,10 @@ public record LiquibaseRollbackToDateSqlOptions : LiquibaseOptions
     public string? Date { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -94,12 +58,6 @@ public record LiquibaseRollbackToDateSqlOptions : LiquibaseOptions
     [SecretValue]
     [CliOption("--password", Format = OptionFormat.EqualsSeparated)]
     public string? Password { get; set; }
-
-    /// <summary>
-    /// Rollback script to execute
-    /// </summary>
-    [CliOption("--rollback-script", Format = OptionFormat.EqualsSeparated)]
-    public string? RollbackScript { get; set; }
 
     /// <summary>
     /// The JDBC database connection URL
@@ -112,5 +70,26 @@ public record LiquibaseRollbackToDateSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
+
+    [Obsolete("RollbackScript is no longer supported by the installed CLI and has no effect.")]
+    public string? RollbackScript { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseSnapshotOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseSnapshotOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseSnapshotOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
@@ -47,12 +35,6 @@ public record LiquibaseSnapshotOptions : LiquibaseOptions
     public string? Schemas { get; set; }
 
     /// <summary>
-    /// Output format to use (JSON, YAML, or TXT)
-    /// </summary>
-    [CliOption("--snapshot-format", Format = OptionFormat.EqualsSeparated)]
-    public string? SnapshotFormat { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
@@ -63,5 +45,14 @@ public record LiquibaseSnapshotOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("SnapshotFormat is no longer supported by the installed CLI and has no effect.")]
+    public string? SnapshotFormat { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseSnapshotReferenceOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseSnapshotReferenceOptions.Generated.cs
@@ -21,35 +21,34 @@ namespace ModularPipelines.Liquibase.Options;
 [CliSubCommand("snapshot-reference")]
 public record LiquibaseSnapshotReferenceOptions : LiquibaseOptions
 {
-    [CliOption("--reference-default-catalog-name", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceDefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceDefaultCatalogName { get; set; }
 
-    [CliOption("--reference-default-schema-name", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceDefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceDefaultSchemaName { get; set; }
 
-    [CliOption("--reference-driver", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceDriver is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceDriver { get; set; }
 
-    [CliOption("--reference-driver-properties-file", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceDriverPropertiesFile is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceDriverPropertiesFile { get; set; }
 
-    [CliOption("--reference-liquibase-catalog-name", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceLiquibaseCatalogName is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceLiquibaseCatalogName { get; set; }
 
-    [CliOption("--reference-liquibase-schema-name", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceLiquibaseSchemaName is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceLiquibaseSchemaName { get; set; }
 
-    [SecretValue]
-    [CliOption("--reference-password", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferencePassword is no longer supported by the installed CLI and has no effect.")]
     public string? ReferencePassword { get; set; }
 
-    [CliOption("--reference-url", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceUrl is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceUrl { get; set; }
 
-    [CliOption("--reference-username", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("ReferenceUsername is no longer supported by the installed CLI and has no effect.")]
     public string? ReferenceUsername { get; set; }
 
-    [CliOption("--snapshot-format", Format = OptionFormat.EqualsSeparated)]
+    [Obsolete("SnapshotFormat is no longer supported by the installed CLI and has no effect.")]
     public string? SnapshotFormat { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseStatusOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseStatusOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseStatusOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -82,5 +70,11 @@ public record LiquibaseStatusOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--verbose", Format = OptionFormat.EqualsSeparated)]
     public bool? Verbose { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseTagExistsOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseTagExistsOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseTagExistsOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
@@ -57,5 +45,11 @@ public record LiquibaseTagExistsOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseTagOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseTagOptions.Generated.cs
@@ -22,18 +22,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseTagOptions : LiquibaseOptions
 {
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Password to use to connect to the database
     /// </summary>
     [SecretValue]
@@ -57,5 +45,11 @@ public record LiquibaseTagOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUnexpectedChangesetsOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUnexpectedChangesetsOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseUnexpectedChangesetsOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -82,5 +70,11 @@ public record LiquibaseUnexpectedChangesetsOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--verbose", Format = OptionFormat.EqualsSeparated)]
     public bool? Verbose { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateCountOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateCountOptions.Generated.cs
@@ -24,18 +24,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateCountOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -60,18 +48,6 @@ public record LiquibaseUpdateCountOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Changeset labels to match
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -91,12 +67,6 @@ public record LiquibaseUpdateCountOptions : LiquibaseOptions
     public LiquibaseShowSummary? ShowSummary { get; set; }
 
     /// <summary>
-    /// Summary output to report update summary results. Values can be 'log', 'console', or 'all'. DEFAULT: ALL
-    /// </summary>
-    [CliOption("--show-summary-output", Format = OptionFormat.EqualsSeparated)]
-    public LiquibaseShowSummaryOutput? ShowSummaryOutput { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
@@ -107,5 +77,20 @@ public record LiquibaseUpdateCountOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ShowSummaryOutput is no longer supported by the installed CLI and has no effect.")]
+    public LiquibaseShowSummaryOutput? ShowSummaryOutput { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateCountSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateCountSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateCountSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -59,34 +47,10 @@ public record LiquibaseUpdateCountSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Changeset labels to match
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -106,5 +70,23 @@ public record LiquibaseUpdateCountSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateOptions.Generated.cs
@@ -24,18 +24,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -52,18 +40,6 @@ public record LiquibaseUpdateOptions : LiquibaseOptions
     /// </summary>
     [CliOption("-D", Format = OptionFormat.NoSeparator)]
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
 
     /// <summary>
     /// Changeset labels to match
@@ -85,12 +61,6 @@ public record LiquibaseUpdateOptions : LiquibaseOptions
     public LiquibaseShowSummary? ShowSummary { get; set; }
 
     /// <summary>
-    /// Summary output to report update summary results. Values can be 'log', 'console', or 'all'. DEFAULT: ALL
-    /// </summary>
-    [CliOption("--show-summary-output", Format = OptionFormat.EqualsSeparated)]
-    public LiquibaseShowSummaryOutput? ShowSummaryOutput { get; set; }
-
-    /// <summary>
     /// The JDBC database connection URL
     /// </summary>
     [CliOption("--url", Format = OptionFormat.EqualsSeparated)]
@@ -101,5 +71,20 @@ public record LiquibaseUpdateOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ShowSummaryOutput is no longer supported by the installed CLI and has no effect.")]
+    public LiquibaseShowSummaryOutput? ShowSummaryOutput { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -53,34 +41,10 @@ public record LiquibaseUpdateSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Changeset labels to match
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -100,5 +64,23 @@ public record LiquibaseUpdateSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateTestingRollbackOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateTestingRollbackOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateTestingRollbackOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog file
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -51,18 +39,6 @@ public record LiquibaseUpdateTestingRollbackOptions : LiquibaseOptions
     /// </summary>
     [CliOption("-D", Format = OptionFormat.NoSeparator)]
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
 
     /// <summary>
     /// Label expression to use for filtering
@@ -94,5 +70,17 @@ public record LiquibaseUpdateTestingRollbackOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateToTagOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateToTagOptions.Generated.cs
@@ -24,18 +24,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateToTagOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -52,18 +40,6 @@ public record LiquibaseUpdateToTagOptions : LiquibaseOptions
     /// </summary>
     [CliOption("-D", Format = OptionFormat.NoSeparator)]
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
-
-    /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
 
     /// <summary>
     /// Changeset labels to match
@@ -85,12 +61,6 @@ public record LiquibaseUpdateToTagOptions : LiquibaseOptions
     public LiquibaseShowSummary? ShowSummary { get; set; }
 
     /// <summary>
-    /// Summary output to report update summary results. Values can be 'log', 'console', or 'all'. DEFAULT: ALL
-    /// </summary>
-    [CliOption("--show-summary-output", Format = OptionFormat.EqualsSeparated)]
-    public LiquibaseShowSummaryOutput? ShowSummaryOutput { get; set; }
-
-    /// <summary>
     /// The tag to update to
     /// </summary>
     [CliOption("--tag", Format = OptionFormat.EqualsSeparated)]
@@ -107,5 +77,20 @@ public record LiquibaseUpdateToTagOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("ShowSummaryOutput is no longer supported by the installed CLI and has no effect.")]
+    public LiquibaseShowSummaryOutput? ShowSummaryOutput { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateToTagSqlOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseUpdateToTagSqlOptions.Generated.cs
@@ -23,18 +23,6 @@ namespace ModularPipelines.Liquibase.Options;
 public record LiquibaseUpdateToTagSqlOptions : LiquibaseOptions
 {
     /// <summary>
-    /// Fully-qualified class which specifies a ChangeExecListener
-    /// </summary>
-    [CliOption("--change-exec-listener-class", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerClass { get; set; }
-
-    /// <summary>
-    /// Path to a properties file for the ChangeExecListenerClass
-    /// </summary>
-    [CliOption("--change-exec-listener-properties-file", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangeExecListenerPropertiesFile { get; set; }
-
-    /// <summary>
     /// The root changelog
     /// </summary>
     [CliOption("--changelog-file", Format = OptionFormat.EqualsSeparated)]
@@ -53,34 +41,10 @@ public record LiquibaseUpdateToTagSqlOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Changeset labels to match
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
     public string? LabelFilter { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-catalog", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultCatalog { get; set; }
-
-    /// <summary>
-    /// Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified DEFAULT: true
-    /// </summary>
-    [CliOption("--output-default-schema", Format = OptionFormat.EqualsSeparated)]
-    public bool? OutputDefaultSchema { get; set; }
 
     /// <summary>
     /// Password to use to connect to the database
@@ -106,5 +70,23 @@ public record LiquibaseUpdateToTagSqlOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("ChangeExecListenerClass is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerClass { get; set; }
+
+    [Obsolete("ChangeExecListenerPropertiesFile is no longer supported by the installed CLI and has no effect.")]
+    public string? ChangeExecListenerPropertiesFile { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
+
+    [Obsolete("OutputDefaultCatalog is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultCatalog { get; set; }
+
+    [Obsolete("OutputDefaultSchema is no longer supported by the installed CLI and has no effect.")]
+    public bool? OutputDefaultSchema { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseValidateOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseValidateOptions.Generated.cs
@@ -41,18 +41,6 @@ public record LiquibaseValidateOptions : LiquibaseOptions
     public IReadOnlyList<KeyValue>? ChangelogProperty { get; set; }
 
     /// <summary>
-    /// The default catalog name to use for the database connection
-    /// </summary>
-    [CliOption("--default-catalog-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultCatalogName { get; set; }
-
-    /// <summary>
-    /// The default schema name to use for the database connection
-    /// </summary>
-    [CliOption("--default-schema-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DefaultSchemaName { get; set; }
-
-    /// <summary>
     /// Label expression to use for filtering
     /// </summary>
     [CliOption("--label-filter", Format = OptionFormat.EqualsSeparated)]
@@ -76,5 +64,11 @@ public record LiquibaseValidateOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("DefaultCatalogName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultCatalogName { get; set; }
+
+    [Obsolete("DefaultSchemaName is no longer supported by the installed CLI and has no effect.")]
+    public string? DefaultSchemaName { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Services/ILiquibase.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Services/ILiquibase.Generated.cs
@@ -27,7 +27,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CalculateChecksumAsync(LiquibaseCalculateChecksumOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CalculateChecksumAsync(LiquibaseCalculateChecksumOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -37,7 +37,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncAsync(LiquibaseChangelogSyncOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ChangelogSyncAsync(LiquibaseChangelogSyncOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -47,7 +47,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncSqlAsync(LiquibaseChangelogSyncSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ChangelogSyncSqlAsync(LiquibaseChangelogSyncSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -57,7 +57,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncToTagAsync(LiquibaseChangelogSyncToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ChangelogSyncToTagAsync(LiquibaseChangelogSyncToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -67,7 +67,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncToTagSqlAsync(LiquibaseChangelogSyncToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ChangelogSyncToTagSqlAsync(LiquibaseChangelogSyncToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -77,7 +77,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ClearChecksumsAsync(LiquibaseClearChecksumsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ClearChecksumsAsync(LiquibaseClearChecksumsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -87,7 +87,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DbDocAsync(LiquibaseDbDocOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DbDocAsync(LiquibaseDbDocOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -97,7 +97,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DiffChangelogAsync(LiquibaseDiffChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DiffChangelogAsync(LiquibaseDiffChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -107,7 +107,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DiffAsync(LiquibaseDiffOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DiffAsync(LiquibaseDiffOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -117,7 +117,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DropAllAsync(LiquibaseDropAllOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DropAllAsync(LiquibaseDropAllOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -127,7 +127,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteSqlAsync(LiquibaseExecuteSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecuteSqlAsync(LiquibaseExecuteSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -137,7 +137,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FutureRollbackCountSqlAsync(LiquibaseFutureRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> FutureRollbackCountSqlAsync(LiquibaseFutureRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -147,7 +147,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FutureRollbackFromTagSqlAsync(LiquibaseFutureRollbackFromTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> FutureRollbackFromTagSqlAsync(LiquibaseFutureRollbackFromTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -157,7 +157,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FutureRollbackSqlAsync(LiquibaseFutureRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> FutureRollbackSqlAsync(LiquibaseFutureRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -167,7 +167,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> GenerateChangelogAsync(LiquibaseGenerateChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> GenerateChangelogAsync(LiquibaseGenerateChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -177,7 +177,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> HistoryAsync(LiquibaseHistoryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> HistoryAsync(LiquibaseHistoryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -187,7 +187,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitAsync(LiquibaseInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InitAsync(LiquibaseInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -197,7 +197,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitProjectAsync(LiquibaseInitProjectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InitProjectAsync(LiquibaseInitProjectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -207,7 +207,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitStartH2Async(LiquibaseInitStartH2Options? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InitStartH2Async(LiquibaseInitStartH2Options? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -217,7 +217,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListLocksAsync(LiquibaseListLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ListLocksAsync(LiquibaseListLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -228,12 +228,12 @@ public partial interface ILiquibase
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     #pragma warning disable CS0618
-    Task<CommandResult> MarkNextChangeSetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MarkNextChangeSetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => MarkNextChangesetRanAsync(options, executionOptions, cancellationToken);
     #pragma warning restore CS0618
 
     [Obsolete("Use MarkNextChangeSetRanAsync instead.")]
-    Task<CommandResult> MarkNextChangesetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MarkNextChangesetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -244,12 +244,12 @@ public partial interface ILiquibase
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     #pragma warning disable CS0618
-    Task<CommandResult> MarkNextChangeSetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MarkNextChangeSetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => MarkNextChangesetRanSqlAsync(options, executionOptions, cancellationToken);
     #pragma warning restore CS0618
 
     [Obsolete("Use MarkNextChangeSetRanSqlAsync instead.")]
-    Task<CommandResult> MarkNextChangesetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MarkNextChangesetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -259,7 +259,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ReleaseLocksAsync(LiquibaseReleaseLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ReleaseLocksAsync(LiquibaseReleaseLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -269,7 +269,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackCountAsync(LiquibaseRollbackCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RollbackCountAsync(LiquibaseRollbackCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -279,7 +279,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackCountSqlAsync(LiquibaseRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RollbackCountSqlAsync(LiquibaseRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -289,7 +289,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackAsync(LiquibaseRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RollbackAsync(LiquibaseRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -299,7 +299,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackSqlAsync(LiquibaseRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RollbackSqlAsync(LiquibaseRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -309,7 +309,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackToDateAsync(LiquibaseRollbackToDateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RollbackToDateAsync(LiquibaseRollbackToDateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -319,7 +319,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackToDateSqlAsync(LiquibaseRollbackToDateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RollbackToDateSqlAsync(LiquibaseRollbackToDateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -329,7 +329,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SnapshotAsync(LiquibaseSnapshotOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SnapshotAsync(LiquibaseSnapshotOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -339,7 +339,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SnapshotReferenceAsync(LiquibaseSnapshotReferenceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SnapshotReferenceAsync(LiquibaseSnapshotReferenceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -349,7 +349,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> StatusAsync(LiquibaseStatusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StatusAsync(LiquibaseStatusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -359,7 +359,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TagExistsAsync(LiquibaseTagExistsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TagExistsAsync(LiquibaseTagExistsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -369,7 +369,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TagAsync(LiquibaseTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TagAsync(LiquibaseTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -379,7 +379,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UnexpectedChangesetsAsync(LiquibaseUnexpectedChangesetsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UnexpectedChangesetsAsync(LiquibaseUnexpectedChangesetsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -389,7 +389,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateCountAsync(LiquibaseUpdateCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateCountAsync(LiquibaseUpdateCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -399,7 +399,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateCountSqlAsync(LiquibaseUpdateCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateCountSqlAsync(LiquibaseUpdateCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -409,7 +409,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateAsync(LiquibaseUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateAsync(LiquibaseUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -419,7 +419,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateSqlAsync(LiquibaseUpdateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateSqlAsync(LiquibaseUpdateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -429,7 +429,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateTestingRollbackAsync(LiquibaseUpdateTestingRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateTestingRollbackAsync(LiquibaseUpdateTestingRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -439,7 +439,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateToTagAsync(LiquibaseUpdateToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateToTagAsync(LiquibaseUpdateToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -449,7 +449,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateToTagSqlAsync(LiquibaseUpdateToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpdateToTagSqlAsync(LiquibaseUpdateToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -459,7 +459,7 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ValidateAsync(LiquibaseValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ValidateAsync(LiquibaseValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **liquibase** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- liquibase (5.0.3): 43 commands, tree 41e289cc33bbedcb50c94a7ac63a85c7d6ddacbd20208a60c02222e6d2d3c647

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator