### PR TITLE
[Automated] Update kind CLI Options

### DIFF
--- a/src/ModularPipelines.Kind/Options/KindBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindBuildOptions.Generated.cs
@@ -38,4 +38,10 @@ public record KindBuildOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kind/Options/KindCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindCreateOptions.Generated.cs
@@ -38,4 +38,10 @@ public record KindCreateOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kind/Options/KindDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteOptions.Generated.cs
@@ -38,4 +38,10 @@ public record KindDeleteOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kind/Options/KindExportOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportOptions.Generated.cs
@@ -38,4 +38,10 @@ public record KindExportOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kind/Options/KindGetOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindGetOptions.Generated.cs
@@ -38,4 +38,10 @@ public record KindGetOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Kind/Options/KindLoadOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindLoadOptions.Generated.cs
@@ -38,4 +38,10 @@ public record KindLoadOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Command { get; set; }
+
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kind** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- kind (kind version 0.33.0-alpha+fed268827e21ca): 17 commands, tree a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator