### PR TITLE
Fix post-merge CLI generation regressions

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -660,13 +660,23 @@ jobs:
             -BaselineDirectory "$RUNNER_TEMP/api-baseline" \
             -CurrentDirectory "$RUNNER_TEMP/api-current"
 
+      - name: Revalidate generated changes before PR
+        if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true' && (github.event.inputs.create-pr != 'false')
+        shell: pwsh
+        run: |
+          tools/ModularPipelines.OptionsGenerator/scripts/Stage-GeneratedChanges.ps1 `
+            -RepositoryRoot "$env:GITHUB_WORKSPACE" `
+            -ManifestPath "$env:RUNNER_TEMP/generated-paths.txt" `
+            -AllowedPathFile "$env:RUNNER_TEMP/legacy-generated-paths.txt" `
+            -MaximumFileSizeBytes 5242880
+
       - name: Create Pull Request for ${{ matrix.tool }}
         id: create-pr
         if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true' && (github.event.inputs.create-pr != 'false')
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CLI_SCRAPER_PAT_TOKEN }}
-          # Stage-GeneratedChanges.ps1 already rejects every checkout change outside
+          # The immediately preceding revalidation rejects every checkout change outside
           # the generator manifests before this action commits the validated worktree.
           commit-message: "chore: Update ${{ matrix.tool }} CLI options"
           title: "[Automated] Update ${{ matrix.tool }} CLI Options"
@@ -940,13 +950,23 @@ jobs:
             -BaselineDirectory "$env:RUNNER_TEMP/api-baseline" `
             -CurrentDirectory "$env:RUNNER_TEMP/api-current"
 
+      - name: Revalidate generated changes before PR
+        if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true' && (github.event.inputs.create-pr != 'false')
+        shell: pwsh
+        run: |
+          tools/ModularPipelines.OptionsGenerator/scripts/Stage-GeneratedChanges.ps1 `
+            -RepositoryRoot "$env:GITHUB_WORKSPACE" `
+            -ManifestPath "$env:RUNNER_TEMP/generated-paths.txt" `
+            -AllowedPathFile "$env:RUNNER_TEMP/legacy-generated-paths.txt" `
+            -MaximumFileSizeBytes 5242880
+
       - name: Create Pull Request for ${{ matrix.tool }}
         id: create-pr
         if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true' && (github.event.inputs.create-pr != 'false')
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CLI_SCRAPER_PAT_TOKEN }}
-          # Stage-GeneratedChanges.ps1 already rejects every checkout change outside
+          # The immediately preceding revalidation rejects every checkout change outside
           # the generator manifests before this action commits the validated worktree.
           commit-message: "chore: Update ${{ matrix.tool }} CLI options"
           title: "[Automated] Update ${{ matrix.tool }} CLI Options"

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -621,10 +621,6 @@ jobs:
           if ($hasChanges) {
             "has_changes=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             $stagedPaths = @(git diff --staged --name-only)
-            $delimiter = [guid]::NewGuid().ToString()
-            "add_paths<<$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            $stagedPaths | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            $delimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             Write-Host "Changed files:"
             $stagedPaths
           } else {
@@ -670,7 +666,8 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CLI_SCRAPER_PAT_TOKEN }}
-          add-paths: ${{ steps.changes.outputs.add_paths }}
+          # Stage-GeneratedChanges.ps1 already rejects every checkout change outside
+          # the generator manifests before this action commits the validated worktree.
           commit-message: "chore: Update ${{ matrix.tool }} CLI options"
           title: "[Automated] Update ${{ matrix.tool }} CLI Options"
           body: |
@@ -916,10 +913,6 @@ jobs:
           if ($hasChanges) {
             "has_changes=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             $stagedPaths = @(git diff --staged --name-only)
-            $delimiter = [guid]::NewGuid().ToString()
-            "add_paths<<$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            $stagedPaths | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            $delimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             Write-Host "Changed files:"
             $stagedPaths
           } else {
@@ -953,7 +946,8 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CLI_SCRAPER_PAT_TOKEN }}
-          add-paths: ${{ steps.changes.outputs.add_paths }}
+          # Stage-GeneratedChanges.ps1 already rejects every checkout change outside
+          # the generator manifests before this action commits the validated worktree.
           commit-message: "chore: Update ${{ matrix.tool }} CLI options"
           title: "[Automated] Update ${{ matrix.tool }} CLI Options"
           body: |

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -64,6 +64,32 @@ public class AzCliScraperTests
     }
 
     [Test]
+    public async Task Space_Delimited_Resource_Ids_Are_Grouped_Collections()
+    {
+        const string helpText = """
+            Command
+                az lock delete : Delete a lock.
+
+            Arguments
+                --ids : One or more resource IDs (space-delimited). If provided, no other
+                        "Resource Id" arguments should be specified.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "lock", "delete"],
+            helpText);
+        var option = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(option.AcceptsMultipleValues).IsTrue();
+            await Assert.That(option.GroupValues).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Comma_Separated_Boolean_Values_Are_Recognized()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ChocolateyCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ChocolateyCliScraperTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class ChocolateyCliScraperTests
+{
+    [Test]
+    public async Task Config_Alternatives_Become_An_Optional_Action()
+    {
+        const string helpText = """
+            Chocolatey v2.5.1
+            Config Command
+
+            Usage
+
+                choco config [list]|get|set|unset [<options/switches>]
+
+            Options and Switches
+            ====================
+
+                --name=VALUE
+                Name - The configuration setting name.
+            """;
+        var command = await new TestChocolateyCliScraper().Parse(
+            ["choco", "config"],
+            helpText);
+
+        command!.ValidateOperandCoverage();
+
+        var action = command.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(action.PropertyName).IsEqualTo("Action");
+            await Assert.That(action.CSharpType).IsEqualTo("string?");
+            await Assert.That(action.IsRequired).IsFalse();
+            await Assert.That(command.Options.Single().PropertyName).IsEqualTo("Name");
+        }
+    }
+
+    private sealed class TestChocolateyCliScraper : ChocolateyCliScraper
+    {
+        public TestChocolateyCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<ChocolateyCliScraper>.Instance)
+        {
+        }
+
+        public async Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return await ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -197,6 +197,48 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task DockerTraversal_Removes_Placeholder_From_NonBuildx_Command_Group()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage:
+                  docker COMMAND
+
+                Management Commands:
+                  compose    Docker Compose
+                """,
+            ["compose --help"] = """
+                Usage: docker compose [OPTIONS] COMMAND
+
+                Options:
+                  --ansi string    Control ANSI output
+
+                Commands:
+                  build    Build services
+                """,
+            ["compose build --help"] = """
+                Usage: docker compose build [OPTIONS] [SERVICE...]
+
+                Options:
+                  --pull    Always attempt to pull
+                """,
+        });
+        var scraper = new DockerCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<DockerCliScraper>.Instance);
+
+        var commands = await ScrapeAsync(scraper);
+        var compose = commands.Single(command => command.FullCommand == "docker compose");
+
+        await Assert.That(compose.PositionalArguments).IsEmpty();
+        await Assert.That(commands.Single(command => command.FullCommand == "docker compose build")
+                .PositionalArguments.Single().PropertyName)
+            .IsEqualTo("Service");
+    }
+
+    [Test]
     public async Task CobraTraversal_Parses_Command_Headings_With_Lowercase_Connectors()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -62,6 +62,76 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task SharedTraversal_Preserves_Command_Operand_When_Only_Skipped_Children_Are_Extracted()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage:
+                  fake COMMAND
+
+                Available Commands:
+                  parent:  Execute a parent command
+                """,
+            ["parent --help"] = """
+                Usage:
+                  fake parent COMMAND [flags]
+
+                Available Commands:
+                  help:  Show help
+
+                Flags:
+                  --scope string   Select a scope
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        var command = (await ScrapeAsync(scraper)).Single();
+
+        await Assert.That(command.FullCommand).IsEqualTo("fake parent");
+        await Assert.That(command.PositionalArguments.Single().PropertyName).IsEqualTo("Command");
+        await Assert.That(executor.Arguments).IsEquivalentTo(["--help", "parent --help"]);
+    }
+
+    [Test]
+    public async Task SharedTraversal_Retains_Empty_Command_Group_Definition()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage:
+                  fake COMMAND
+
+                Available Commands:
+                  parent:  Manage parent resources
+                """,
+            ["parent --help"] = """
+                Usage:
+                  fake parent COMMAND
+
+                Available Commands:
+                  child:  Execute a child command
+                """,
+            ["parent child --help"] = """
+                Usage:
+                  fake parent child [flags]
+
+                Flags:
+                  --value string   Supply a value
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        var commands = await ScrapeAsync(scraper);
+        var parent = commands.Single(command => command.FullCommand == "fake parent");
+
+        await Assert.That(parent.Options).IsEmpty();
+        await Assert.That(parent.PositionalArguments).IsEmpty();
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["fake parent", "fake parent child"]);
+    }
+
+    [Test]
     public async Task SharedTraversal_Skips_Invalid_Group_And_Continues_With_Sibling()
     {
         var emptyGroupHelp = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -28,7 +28,7 @@ public class CliScraperTraversalTests
                 Execute or manage parent resources.
 
                 Usage:
-                  fake parent <command> [flags]
+                  fake parent [TARGET] <command> [flags]
 
                 Available Commands:
                   child:  Execute a child command
@@ -54,8 +54,9 @@ public class CliScraperTraversalTests
             .IsEquivalentTo(["fake parent", "fake parent child"]);
         await Assert.That(commands.Single(command => command.FullCommand == "fake parent").Options)
             .Contains(option => option.SwitchName == "--scope");
-        await Assert.That(commands.Single(command => command.FullCommand == "fake parent").PositionalArguments)
-            .IsEmpty();
+        await Assert.That(commands.Single(command => command.FullCommand == "fake parent")
+                .PositionalArguments.Single().PropertyName)
+            .IsEqualTo("Target");
         await Assert.That(executor.Arguments)
             .IsEquivalentTo(["--help", "parent --help", "parent child --help"]);
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -11,7 +11,7 @@ namespace ModularPipelines.OptionsGenerator.Tests.Scrapers.Cli;
 public class CliScraperTraversalTests
 {
     [Test]
-    public async Task SharedTraversal_Discovers_ExecutableParent_And_Children()
+    public async Task SharedTraversal_Discovers_ExecutableParent_And_Children_Without_Command_Placeholders()
     {
         var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -54,9 +54,8 @@ public class CliScraperTraversalTests
             .IsEquivalentTo(["fake parent", "fake parent child"]);
         await Assert.That(commands.Single(command => command.FullCommand == "fake parent").Options)
             .Contains(option => option.SwitchName == "--scope");
-        await Assert.That(commands.Single(command => command.FullCommand == "fake parent")
-                .PositionalArguments.Single().PropertyName)
-            .IsEqualTo("Command");
+        await Assert.That(commands.Single(command => command.FullCommand == "fake parent").PositionalArguments)
+            .IsEmpty();
         await Assert.That(executor.Arguments)
             .IsEquivalentTo(["--help", "parent --help", "parent child --help"]);
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MinikubeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MinikubeCliScraperTests.cs
@@ -48,48 +48,59 @@ public class MinikubeCliScraperTests
     }
 
     [Test]
-    [Arguments("addons")]
-    [Arguments("config")]
-    public async Task Command_Groups_Do_Not_Model_Subcommand_Placeholders(string group)
+    [Arguments("addons", "list")]
+    [Arguments("config", "view")]
+    public async Task Shared_Traversal_Removes_Subcommand_Placeholders(string group, string child)
     {
-        var helpText = $"Usage:\n  minikube {group} SUBCOMMAND [flags]";
-        var scraper = new TestMinikubeCliScraper();
-        var commandPath = new[] { "minikube", group };
-        var command = await scraper.Parse(
-            commandPath,
-            helpText);
-        var usage = scraper.Normalize(
-            command!,
-            UsageSynopsisParser.Parse(helpText, commandPath));
+        var executor = new RecordingExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = $"""
+                Usage:
+                  minikube COMMAND
+
+                Available Commands:
+                  {group}    Manage {group}
+                """,
+            [$"{group} --help"] = $"""
+                Usage:
+                  minikube {group} SUBCOMMAND [flags]
+
+                Available Commands:
+                  {child}    Execute {child}
+
+                Flags:
+                  --output string    Output format
+                """,
+            [$"{group} {child} --help"] = $"""
+                Usage:
+                  minikube {group} {child} [flags]
+
+                Flags:
+                  --output string    Output format
+                """,
+        });
+        var scraper = new MinikubeCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<MinikubeCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
 
         using (Assert.Multiple())
         {
-            await Assert.That(command!.PositionalArguments).IsEmpty();
-            await Assert.That(usage.PositionalArguments).IsEmpty();
-            await Assert.That(usage.HasOperandTokens).IsFalse();
+            await Assert.That(commands.Select(command => command.FullCommand))
+                .IsEquivalentTo([$"minikube {group}", $"minikube {group} {child}"]);
+            await Assert.That(commands.Single(command => command.FullCommand == $"minikube {group}")
+                    .PositionalArguments)
+                .IsEmpty();
         }
     }
 
-    private sealed class TestMinikubeCliScraper()
-        : MinikubeCliScraper(
-            new RecordingExecutor(),
-            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
-            NullLogger<MinikubeCliScraper>.Instance)
-    {
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(
-                commandPath,
-                helpText,
-                UsageSynopsisParser.Parse(helpText, commandPath),
-                CancellationToken.None);
-
-        public UsageSynopsisParseResult Normalize(
-            CliCommandDefinition command,
-            UsageSynopsisParseResult usage) =>
-            NormalizeUsageSynopsis(command, usage);
-    }
-
-    private sealed class RecordingExecutor : ICliCommandExecutor
+    private sealed class RecordingExecutor(
+        IReadOnlyDictionary<string, string>? responses = null) : ICliCommandExecutor
     {
         public string? Arguments { get; private set; }
 
@@ -107,6 +118,21 @@ public class MinikubeCliScraperTests
             string? workingDirectory = null)
         {
             Arguments = arguments;
+            if (responses is not null)
+            {
+                if (!responses.TryGetValue(arguments, out var response))
+                {
+                    throw new InvalidOperationException($"Unexpected invocation: {command} {arguments}");
+                }
+
+                return Task.FromResult(new CliCommandResult
+                {
+                    StandardOutput = response,
+                    StandardError = string.Empty,
+                    ExitCode = 0,
+                });
+            }
+
             return Task.FromResult(Result);
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -678,6 +678,44 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Model_Accepts_Multiword_Usage_Operand_Covered_By_Named_Option()
+    {
+        var usage = UsageSynopsisParser.Parse(
+            "Usage: grype explain --id [VULNERABILITY ID] [flags]",
+            ["grype", "explain"]);
+        var command = new CliCommandDefinition
+        {
+            FullCommand = "grype explain",
+            CommandParts = ["explain"],
+            ClassName = "GrypeExplainOptions",
+            ParentClassName = "GrypeOptions",
+            ToolNamespacePrefix = "Grype",
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--id",
+                    PropertyName = "Id",
+                    CSharpType = "string?",
+                },
+            ],
+        };
+
+        command.ValidateOperandCoverage(
+            usage.HasOperandTokens,
+            usage.Synopsis,
+            usage.PositionalArguments);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(usage.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("VulnerabilityId");
+            await Assert.That(usage.PositionalArguments.Single().AssociatedOptionSwitch)
+                .IsEqualTo("--id");
+        }
+    }
+
+    [Test]
     public async Task Associates_Standalone_Option_Value_With_Its_Switch()
     {
         var usage = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -205,7 +205,6 @@ public record CliCommandDefinition
         usagePositionalArguments is { Count: > 0 }
         && usagePositionalArguments.All(argument => Options.Any(option =>
             !option.IsFlag
-            && option.PropertyName.Equals(argument.PropertyName, StringComparison.OrdinalIgnoreCase)
             && argument.AssociatedOptionSwitch is not null
             && (option.SwitchName.Equals(argument.AssociatedOptionSwitch, StringComparison.OrdinalIgnoreCase)
                 || option.ShortForm?.Equals(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -361,7 +361,7 @@ public partial class AzCliScraper : CliScraperBase
         AzValueDescriptionPattern().IsMatch(description)
         || AzEmbeddedValueDescriptionPattern().IsMatch(description)
         || description.Contains("may be supplied", StringComparison.OrdinalIgnoreCase)
-        || description.Contains("space-separated", StringComparison.OrdinalIgnoreCase)
+        || HelpDeclaresSpaceSeparatedList(description)
         || description.Contains("key=value", StringComparison.OrdinalIgnoreCase);
 
     private static bool HelpDeclaresOptionalValue(string description) =>
@@ -408,8 +408,10 @@ public partial class AzCliScraper : CliScraperBase
         }
 
         // Check for list types (space-separated or multiple values)
-        if (HelpDeclaresSpaceSeparatedList(lowerDesc) || lowerDesc.Contains("list of") ||
-            lowerDesc.Contains("multiple"))
+        if (HelpDeclaresSpaceSeparatedList(lowerDesc)
+            || DescriptionDeclaresRepeatableOption(lowerDesc)
+            || lowerDesc.Contains("list of")
+            || lowerDesc.Contains("multiple"))
         {
             return "IEnumerable<string>?";
         }
@@ -425,6 +427,7 @@ public partial class AzCliScraper : CliScraperBase
 
     private static bool HelpDeclaresSpaceSeparatedList(string description) =>
         description.Contains("space-separated", StringComparison.OrdinalIgnoreCase)
+        || description.Contains("space-delimited", StringComparison.OrdinalIgnoreCase)
         || description.Contains("separated by spaces", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
@@ -212,6 +212,50 @@ public partial class ChocolateyCliScraper : CliScraperBase
         return Task.FromResult<CliCommandDefinition?>(command);
     }
 
+    protected override async Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
+        CancellationToken cancellationToken)
+    {
+        var command = await ParseCommandAsync(commandPath, helpText, cancellationToken);
+        if (command is null)
+        {
+            return null;
+        }
+
+        usage = NormalizeUsageSynopsis(command, usage);
+        return command with
+        {
+            PositionalArguments = GetPositionalArguments(usage, command.Options),
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
+            UsagePositionalArguments = usage.PositionalArguments,
+        };
+    }
+
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        command.CommandParts is ["config"]
+            ? usage with
+            {
+                HasOperandTokens = true,
+                PositionalArguments =
+                [
+                    new CliPositionalArgument
+                    {
+                        PropertyName = "Action",
+                        CSharpType = "string?",
+                        Description = "Configuration action: list, get, set, or unset.",
+                        IsRequired = false,
+                        PositionIndex = 0,
+                    },
+                ],
+                UnparsedOperandTokens = [],
+            }
+            : usage;
+
     /// <summary>
     /// Extracts description from help text.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -474,6 +474,10 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        // Once child commands have been discovered, generic Command/Subcommand operands
+        // select one of those children rather than representing an executable argument.
+        // Handle this centrally so individual adapters cannot leave synthetic operands on
+        // command groups such as docker compose, docker context, or minikube addons.
         if (subcommands.Count > 0)
         {
             usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -478,7 +478,7 @@ public abstract partial class CliScraperBase : ICliScraper
         // select one of those children rather than representing an executable argument.
         // Handle this centrally so individual adapters cannot leave synthetic operands on
         // command groups such as docker compose, docker context, or minikube addons.
-        if (subcommands.Count > 0)
+        if (subcommands.Any(IsTraversableSubcommand))
         {
             usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
         }
@@ -570,7 +570,7 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         foreach (var subcommand in subcommands)
         {
-            if (!IsValidDiscoveredSubcommand(subcommand) || IsSkippableSubcommand(subcommand))
+            if (!IsTraversableSubcommand(subcommand))
             {
                 continue;
             }
@@ -587,6 +587,9 @@ public abstract partial class CliScraperBase : ICliScraper
             await workChannel.Writer.WriteAsync(childPath, cancellationToken);
         }
     }
+
+    private bool IsTraversableSubcommand(string subcommand) =>
+        IsValidDiscoveredSubcommand(subcommand) && !IsSkippableSubcommand(subcommand);
 
     /// <summary>
     /// Validates a subcommand name before traversal queues its command path.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -474,6 +474,11 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        if (subcommands.Count > 0)
+        {
+            usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
+        }
+
         var command = await TryParseCommandAsync(path, helpText, usage, cancellationToken);
         if (command is null)
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
@@ -33,31 +33,6 @@ public class DockerCliScraper : CobraCliScraper
         DockerCliCompatibility.DetectCommandGroupAlias(commandPath, helpText);
 
     /// <inheritdoc />
-    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
-        CliCommandDefinition command,
-        UsageSynopsisParseResult usage) =>
-        IsBuildxCommandGroup(command.CommandParts)
-            ? UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage)
-            : usage;
-
-    /// <inheritdoc />
-    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
-        string[] commandParts,
-        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
-        IsBuildxCommandGroup(commandParts)
-            ? positionalArguments
-                .Where(argument => !UsageSynopsisParser.IsCommandGroupPlaceholder(argument))
-                .ToArray()
-            : positionalArguments;
-
-    private static bool IsBuildxCommandGroup(IReadOnlyList<string> commandParts) =>
-        commandParts is ["buildx"]
-        or ["buildx", "dap"]
-        or ["buildx", "history"]
-        or ["buildx", "imagetools"]
-        or ["buildx", "policy"];
-
-    /// <inheritdoc />
     protected override string NormalizeOptionSwitchName(
         string[] commandParts,
         string switchName) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -75,19 +74,4 @@ public partial class MinikubeCliScraper : CobraCliScraper
         "--help", "-h", "--version", "help", "completion", "version", "update-check"
     };
 
-    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
-        string[] commandParts,
-        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
-        commandParts is ["addons"] or ["config"]
-            ? positionalArguments
-                .Where(argument => !UsageSynopsisParser.IsCommandGroupPlaceholder(argument))
-                .ToArray()
-            : positionalArguments;
-
-    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
-        CliCommandDefinition command,
-        UsageSynopsisParseResult usage) =>
-        command.CommandParts is ["addons"] or ["config"]
-            ? UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage)
-            : usage;
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MinikubeCliScraper.cs
@@ -73,5 +73,4 @@ public partial class MinikubeCliScraper : CobraCliScraper
     {
         "--help", "-h", "--version", "help", "completion", "version", "update-check"
     };
-
 }


### PR DESCRIPTION
## Summary
- remove generic command-group placeholders only when shared traversal discovers real children, while preserving real parent/leaf operands
- accept option-owned usage labels whose text differs from the named option property
- make Chocolatey consume shared positional parsing and normalize its `config` action alternatives
- parse Azure `space-delimited` repeatable values correctly
- avoid Gcloud create-PR argv overflow after exact manifest staging

## Validation
- OptionsGenerator tests: 1171 passed
- focused shared traversal tests: 49 passed
- focused Azure tests: 11 passed
- real Syft 1.51.0 regeneration: 8 commands; no synthetic `Command` on `cataloger`/`config`; required `Image` retained on `attest`
- real Grype 0.117.0 regeneration: 12 commands; zero errors
- exact generated-file staging safety test passed
- Chocolatey full local scrape reached the mandated 2 GB process-tree guard (2.84 GB at local parallelism 20); not retried or raised per repository policy
- changed-file whitespace verification passed
- solution-wide format verification remains blocked by pre-existing diagnostics, beginning with `IHelpTextCache.cs(59,59)`

## All-tools evidence
- Chocolatey and Grype strict-coverage failures have focused fixes above
- Azure skipped 13 commands because `--ids` was misparsed; exact Azure 2.84 help regression added
- Gcloud scraped 7,876 commands and passed build/API compatibility; only create-PR path transport failed
- Cosign Linux 3.0.5 explicitly reports PIV/PKCS11 support absent; reviewed coverage approval will follow after merge
- Homebrew removals are corrected fake child traversals such as `brew command command`; reviewed coverage approval will follow after merge

Refs #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated CLI options for Azure CLI, Chocolatey, Docker, and Minikube commands.
  - Correctly handles space-delimited and repeatable values, optional positional actions, and command-group syntax.
  - Prevents subcommand placeholders from appearing as executable arguments.
  - Improves matching between usage operands and their associated options.

- **Tests**
  - Added regression coverage for updated CLI parsing and command traversal scenarios.

- **Chores**
  - Generation workflows now revalidate generated changes before opening pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->