### PR TITLE
Fix CLI regeneration safety

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2748,6 +2748,7 @@ public class GeneratorHardeningTests
             using (Assert.Multiple())
             {
                 await Assert.That(restored.CommandParts).IsEquivalentTo(["removed"]);
+                await Assert.That(restored.IsCompatibilityOnly).IsTrue();
                 await Assert.That(force.IsFlag).IsTrue();
                 await Assert.That(force.ShortForm).IsEqualTo("-f");
                 await Assert.That(force.PreferShortForm).IsTrue();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1547,6 +1547,46 @@ public class GeneratorHardeningTests
             CliCompatibilityForwardingKind.NullableBooleanToString);
     }
 
+    [Test]
+    public async Task ApiCompatibilityPreserver_Preserves_Flag_That_Became_A_Value()
+    {
+        var command = Command("BrewInfoOptions", "BrewOptions", ["info"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--json",
+                    PropertyName = "Json",
+                    CSharpType = "string?",
+                    IsFlag = false,
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty("Json", "bool?", switchName: "--json")]);
+        ExternalToolDefinitionLoader.ValidateCompatibilityMetadata(preserved, []);
+        var option = preserved.Options.Single();
+        var alias = preserved.CompatibilityProperties.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.PropertyName).IsEqualTo("JsonValue");
+            await Assert.That(alias.PropertyName).IsEqualTo("Json");
+            await Assert.That(alias.ForwardToPropertyName).IsEqualTo("JsonValue");
+            await Assert.That(alias.ForwardingKind)
+                .IsEqualTo(CliCompatibilityForwardingKind.NullableBooleanToString);
+        }
+
+        await AssertCompatibilityForwardingRoundTrips(
+            preserved,
+            "Json",
+            "JsonValue",
+            CliCompatibilityForwardingKind.NullableBooleanToString);
+    }
+
     private static async Task AssertCompatibilityForwardingRoundTrips(
         CliCommandDefinition generatedCommand,
         string compatibilityPropertyName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -171,6 +171,23 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
+    public async Task GenerateAsync_Omits_Compatibility_Only_Commands()
+    {
+        var tool = Tool(
+            "fake",
+            Command("fake current", "FakeCurrentOptions", ["current"]),
+            Command("fake removed", "FakeRemovedOptions", ["removed"]) with
+            {
+                IsCompatibilityOnly = true,
+            });
+
+        var files = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(files[0].Content).Contains("| `fake current` | `FakeCurrentOptions` |");
+        await Assert.That(files[0].Content).DoesNotContain("fake removed");
+    }
+
+    [Test]
     public async Task GenerateAsync_UsesExecuteForCollidingPreferredCommands()
     {
         var rootCommand = Command("fake app", "FakeAppOptions", ["app"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -188,6 +188,30 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
+    public async Task GenerateAsync_Rejects_Compatibility_Only_Preferred_Command()
+    {
+        var removedCommand = Command("fake removed", "FakeRemovedOptions", ["removed"]) with
+        {
+            IsCompatibilityOnly = true,
+            IsSafeForDocumentation = true,
+        };
+        var tool = Tool(
+            "fake",
+            Command("fake current", "FakeCurrentOptions", ["current"]),
+            removedCommand) with
+        {
+            PreferredDocumentationExampleCommand = removedCommand.FullCommand,
+        };
+
+        void GenerateDocumentation() =>
+            _ = new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(GenerateDocumentation)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("does not match an emitted command");
+    }
+
+    [Test]
     public async Task GenerateAsync_UsesExecuteForCollidingPreferredCommands()
     {
         var rootCommand = Command("fake app", "FakeAppOptions", ["app"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -239,6 +239,7 @@ public class BrewCliScraperTests
 
                   --formula        List only formulae.
                   --writable       List only writable kegs.
+                  --head           Install the HEAD version of a formula.
                   --formulae=LIST  Use a comma-separated list of formulae.
             """;
 
@@ -249,6 +250,8 @@ public class BrewCliScraperTests
             await Assert.That(command!.Options.Single(option => option.SwitchName == "--formula").IsFlag)
                 .IsTrue();
             await Assert.That(command.Options.Single(option => option.SwitchName == "--writable").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--head").IsFlag)
                 .IsTrue();
             await Assert.That(command.Options.Single(option => option.SwitchName == "--formulae").IsFlag)
                 .IsFalse();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -59,9 +59,16 @@ public class BrewCliScraperTests
     public async Task Models_Exec_Command_And_Value_Options()
     {
         const string helpText = """
-            Usage: brew exec [options] command [args...]
+            Usage: brew exec, x [--formulae=formulae] [--sandbox=path] [--deny-network]
+            [--] command [args ...]
 
-                  --formulae=LIST   Populate the environment with a comma-separated list of formulae.
+            Run command in an environment populated by Homebrew formulae.
+
+                  --formulae      Comma-separated formulae to install and add
+                                  to PATH before running command.
+                  --sandbox       Run command in Homebrew's sandbox, allowing
+                                  writes to path and Homebrew's temporary directories.
+                  --deny-network  Deny network access from inside the sandbox.
             """;
 
         var command = await new TestBrewCliScraper().Parse(["brew", "exec"], helpText);
@@ -72,8 +79,156 @@ public class BrewCliScraperTests
                 .IsEquivalentTo(["Command", "Arguments"]);
             await Assert.That(command.PositionalArguments[0].IsRequired).IsTrue();
             await Assert.That(command.PositionalArguments[1].IsVariadic).IsTrue();
-            await Assert.That(command.Options.Single().IsFlag).IsFalse();
+            await Assert.That(command.Description)
+                .IsEqualTo("Run command in an environment populated by Homebrew formulae.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--formulae").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--sandbox").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--deny-network").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--formulae").Description)
+                .IsEqualTo("Comma-separated formulae to install and add to PATH before running command.");
         }
+    }
+
+    [Test]
+    public async Task Models_Info_Value_Options_From_Wrapped_Descriptions()
+    {
+        const string helpText = """
+            Usage: brew info, abv [options] [formula|cask ...]
+
+            Display brief statistics for your Homebrew installation. If a formula or
+            cask is provided, show summary of information about it.
+
+                  --analytics  List global Homebrew analytics data.
+                  --days       How many days of analytics data to retrieve.
+                               The value for days must be 30, 90 or 365.
+                  --category   Which type of analytics data to retrieve. The
+                               value for category must be install or build-error.
+                  --json       Print a JSON representation. Currently the
+                               default value for version is v1.
+                  --installed  Output an inventory. If --json=v2 is passed,
+                               include installed casks.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "info"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Description)
+                .IsEqualTo("Display brief statistics for your Homebrew installation. If a formula or cask is provided, show summary of information about it.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--analytics").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--days").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--category").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--json").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--installed").IsFlag)
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Preserves_Multiline_Description_Containing_Option_And_Flag_File_Text()
+    {
+        const string helpText = """
+            Usage: brew create [options] URL
+
+            Generate a formula or, with --cask, a cask for the downloadable file at URL
+            and open it in the editor.
+
+                  --HEAD      Indicate that URL points to the package's
+                              repository rather than a file.
+                  --set-name  Explicitly set the name of the new formula
+                              or cask.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "create"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Description)
+                .IsEqualTo("Generate a formula or, with --cask, a cask for the downloadable file at URL and open it in the editor.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--HEAD").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--set-name").IsFlag)
+                .IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Discovers_Colon_Delimited_Bundle_Subcommands()
+    {
+        const string helpText = """
+            Usage: brew bundle [subcommand]
+
+            Subcommands:
+              sh:
+                Run your shell in a brew bundle exec environment.
+              install:
+                Install dependencies from the Brewfile.
+              exec:
+                Run an external command.
+
+              -h, --help  Show this message.
+            """;
+
+        var subcommands = new TestBrewCliScraper().GetSubcommands(helpText);
+
+        await Assert.That(subcommands).IsEquivalentTo(["sh", "install", "exec"]);
+    }
+
+    [Test]
+    public async Task Models_Bundle_Child_Options_From_Wrapped_Help()
+    {
+        const string helpText = """
+            Usage: brew bundle [install|upgrade]:
+                Install and upgrade dependencies from the Brewfile.
+
+                  --file             Read from or write to the Brewfile from
+                                     this location.
+                  --no-upgrade       Do not run brew upgrade.
+                  --upgrade-formulae, --upgrade-formula
+                                     Run brew upgrade on these comma-separated formulae.
+                  --jobs             Run up to this many formula installations in
+                                     parallel. Use auto for the number of CPU cores.
+                  --zap              Use zap instead of uninstall.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "bundle", "install"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Description)
+                .IsEqualTo("Install and upgrade dependencies from the Brewfile.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--file").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--no-upgrade").IsFlag)
+                .IsTrue();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--upgrade-formulae").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--jobs").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--zap").IsFlag)
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Ignores_Description_For_Unrelated_Usage()
+    {
+        const string helpText = """
+            Usage: brew install-bundler-gems [--groups=]
+
+            Install Homebrew's Bundler gems.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "rubocop"], helpText);
+
+        await Assert.That(command!.Description).IsNull();
     }
 
     [Test]
@@ -201,6 +356,9 @@ public class BrewCliScraperTests
             var usage = ParseUsageSynopsis(commandPath, helpText);
             return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
         }
+
+        public IReadOnlyList<string> GetSubcommands(string helpText) =>
+            ExtractSubcommands(helpText).ToArray();
     }
 
     private sealed class CommandInventoryExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CosignCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CosignCliScraperTests.cs
@@ -153,7 +153,26 @@ public class CosignCliScraperTests
         await Assert.That(downloadArguments.Single().PropertyName).IsEqualTo("Image");
         await Assert.That(scraper.IsSecret("NewPin", isFlag: false)).IsTrue();
         await Assert.That(scraper.IsSecret("OldKey", isFlag: false)).IsTrue();
+        await Assert.That(scraper.IsSecret("IdentityToken", isFlag: false)).IsTrue();
+        await Assert.That(scraper.IsSecret("OidcClientSecretFile", isFlag: false)).IsTrue();
         await Assert.That(scraper.IsSecret("NewPin", isFlag: true)).IsFalse();
+        await Assert.That(scraper.IsSecret("IdentityToken", isFlag: true)).IsFalse();
+    }
+
+    [Test]
+    public async Task Extracts_GitVersion_From_Version_Banner()
+    {
+        const string output = """
+            ______   ______        _______. __    _______ .__   __.
+            cosign: A tool for Container Signing, Verification and Storage in an OCI registry
+
+            GitVersion:    v3.1.3
+            GitCommit:     11926fa5bbbbde47e88fc006b625a17769
+            """;
+
+        var version = new TestCosignCliScraper().ParseVersion(output);
+
+        await Assert.That(version).IsEqualTo("v3.1.3");
     }
 
     [Test]
@@ -212,5 +231,12 @@ public class CosignCliScraperTests
             ApplyPositionalArgumentFixes(commandParts, positionalArguments);
 
         public bool IsSecret(string propertyName, bool isFlag) => IsSecretOption(propertyName, isFlag, string.Empty);
+
+        public string? ParseVersion(string standardOutput) => ParseVersionOutput(new CliCommandResult
+        {
+            StandardOutput = standardOutput,
+            StandardError = string.Empty,
+            ExitCode = 0,
+        });
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -60,6 +60,21 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Matches_Command_In_Wrapped_Alternative()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: brew bundle [install|upgrade]:",
+            ["brew", "bundle", "install"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.CommandMatched).IsTrue();
+            await Assert.That(result.MatchedCommandPartCount).IsEqualTo(3);
+            await Assert.That(result.HasOperandTokens).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task Retains_Compound_Endpoint_Placeholders_As_Single_Operands()
     {
         var copy = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1163,6 +1163,14 @@ internal static class GeneratedApiCompatibilityPreserver
             compatibilityProperties,
             renamedProperties,
             violations);
+        preservedTypeChanges.UnionWith(PreserveFlagToValueChanges(
+            command,
+            baselineProperties,
+            positionalArguments,
+            options,
+            compatibilityProperties,
+            renamedProperties,
+            violations));
         preservedTypeChanges.UnionWith(PreserveOptionalValueArityChanges(
             command,
             baselineProperties,
@@ -1600,6 +1608,59 @@ internal static class GeneratedApiCompatibilityPreserver
                     ForwardingKind = baseline.CSharpType.Equals("int?", StringComparison.Ordinal)
                         ? CliCompatibilityForwardingKind.NullableInt32ToCliOptionValue
                         : CliCompatibilityForwardingKind.NullableStringToCliOptionValue,
+                    ObsoleteMessage = $"Use {replacementName} instead.",
+                },
+                compatibilityProperties,
+                violations);
+            renamedProperties[baseline.PropertyName] = replacementName;
+            preserved.Add(baseline.PropertyName);
+        }
+
+        return preserved;
+    }
+
+    private static HashSet<string> PreserveFlagToValueChanges(
+        CliCommandDefinition command,
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
+        CliOptionDefinition[] options,
+        ICollection<CliCompatibilityProperty> compatibilityProperties,
+        IDictionary<string, string> renamedProperties,
+        ICollection<string> violations)
+    {
+        var preserved = new HashSet<string>(StringComparer.Ordinal);
+        var propertyNames = options.Select(static option => option.PropertyName)
+            .Concat(positionalArguments.Select(static argument => argument.PropertyName))
+            .Concat(compatibilityProperties.Select(static property => property.PropertyName))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var baseline in baselineProperties.Where(static property =>
+                     !property.IsCompatibility
+                     && !property.IsRequired
+                     && property.CSharpType.Equals("bool?", StringComparison.Ordinal)))
+        {
+            var optionIndex = Array.FindIndex(options, option =>
+                option.PropertyName.Equals(baseline.PropertyName, StringComparison.Ordinal)
+                && option.PropertyType.Equals("string?", StringComparison.Ordinal)
+                && HasSameCliIdentity(ToGeneratedProperty(option), baseline));
+            if (optionIndex < 0)
+            {
+                continue;
+            }
+
+            var replacementName = GetUniqueReplacementName(
+                $"{baseline.PropertyName}Value",
+                propertyNames);
+            propertyNames.Add(replacementName);
+            options[optionIndex] = options[optionIndex] with { PropertyName = replacementName };
+            PreserveCompatibilityProperty(
+                command,
+                new CliCompatibilityProperty
+                {
+                    PropertyName = baseline.PropertyName,
+                    CSharpType = baseline.CSharpType,
+                    ForwardToPropertyName = replacementName,
+                    ForwardingKind = CliCompatibilityForwardingKind.NullableBooleanToString,
                     ObsoleteMessage = $"Use {replacementName} instead.",
                 },
                 compatibilityProperties,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -242,6 +242,7 @@ internal static class GeneratedApiCompatibilityPreserver
             ClassName = baseline.ClassName,
             ParentClassName = baseline.ParentClassName ?? $"{tool.NamespacePrefix}Options",
             ToolNamespacePrefix = tool.NamespacePrefix,
+            IsCompatibilityOnly = true,
             Options = RestoreRemovedOptions(baseline.Properties),
             PositionalArguments = RestoreRemovedPositionalArguments(baseline.Properties),
             CompatibilityProperties = RestoreRemovedCompatibilityProperties(baseline.Properties),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -188,7 +188,7 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine("## Module example");
         sb.AppendLine();
 
-        var command = SelectExampleCommand(tool);
+        var command = SelectExampleCommand(tool, commands);
         if (command is null)
         {
             var onlyUnsafeCommands = commands.Count > 0
@@ -232,14 +232,16 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine();
     }
 
-    private static CliCommandDefinition? SelectExampleCommand(CliToolDefinition tool)
+    private static CliCommandDefinition? SelectExampleCommand(
+        CliToolDefinition tool,
+        IReadOnlyCollection<CliCommandDefinition> commands)
     {
         if (string.IsNullOrWhiteSpace(tool.PreferredDocumentationExampleCommand))
         {
             return null;
         }
 
-        var command = tool.Commands
+        var command = commands
             .FirstOrDefault(candidate => string.Equals(
                 candidate.FullCommand,
                 tool.PreferredDocumentationExampleCommand,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -498,8 +498,9 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
 
         return tool.Commands
             .Where(command =>
-                command.SubDomainGroup is not null ||
-                exposedRootCommands.Contains(command.ClassName))
+                !command.IsCompatibilityOnly &&
+                (command.SubDomainGroup is not null ||
+                 exposedRootCommands.Contains(command.ClassName)))
             .DistinctBy(command => command.ClassName)
             .ToList();
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -147,6 +147,12 @@ public record CliCommandDefinition
     public IReadOnlyList<CliCompatibilityMethod> CompatibilityMethods { get; init; } = [];
 
     /// <summary>
+    /// Whether this command exists only to preserve a previously generated public API.
+    /// Compatibility-only commands are not part of the currently installed CLI surface.
+    /// </summary>
+    public bool IsCompatibilityOnly { get; init; }
+
+    /// <summary>
     /// Whether this command has been explicitly reviewed as safe for a runnable documentation example.
     /// Commands are unsafe by default; scraped names and descriptions are not enough to establish safety.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -384,45 +384,61 @@ public partial class BrewCliScraper : CliScraperBase
         var lines = NormalizeLines(helpText);
         for (var index = 0; index < lines.Length; index++)
         {
-            var usageMatch = UsageLinePattern().Match(lines[index]);
-            if (!usageMatch.Success)
+            if (!TryMatchUsageSynopsis(lines, ref index, usage.Synopsis))
             {
                 continue;
             }
 
-            var synopsisParts = new List<string> { usageMatch.Groups["synopsis"].Value.Trim() };
-            while (index + 1 < lines.Length
-                   && UsageSynopsisParser.IsSynopsisContinuation(lines[index + 1]))
-            {
-                synopsisParts.Add(lines[++index].Trim());
-            }
-
-            if (!string.Join(' ', synopsisParts).Equals(usage.Synopsis, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            while (index + 1 < lines.Length && string.IsNullOrWhiteSpace(lines[index + 1]))
-            {
-                index++;
-            }
-
-            var descriptionLines = new List<string>();
-            while (index + 1 < lines.Length && !string.IsNullOrWhiteSpace(lines[index + 1]))
-            {
-                var descriptionLine = lines[++index].Trim();
-                if (BrewOptionPattern().IsMatch(lines[index]) || descriptionLine.EndsWith(':'))
-                {
-                    break;
-                }
-
-                descriptionLines.Add(descriptionLine);
-            }
-
-            return descriptionLines.Count == 0 ? null : string.Join(' ', descriptionLines);
+            return ReadDescriptionParagraph(lines, index);
         }
 
         return null;
+    }
+
+    private static bool TryMatchUsageSynopsis(
+        IReadOnlyList<string> lines,
+        ref int index,
+        string expectedSynopsis)
+    {
+        var usageMatch = UsageLinePattern().Match(lines[index]);
+        if (!usageMatch.Success)
+        {
+            return false;
+        }
+
+        var synopsisParts = new List<string> { usageMatch.Groups["synopsis"].Value.Trim() };
+        while (index + 1 < lines.Count
+               && UsageSynopsisParser.IsSynopsisContinuation(lines[index + 1]))
+        {
+            synopsisParts.Add(lines[++index].Trim());
+        }
+
+        return string.Join(' ', synopsisParts).Equals(expectedSynopsis, StringComparison.Ordinal);
+    }
+
+    private static string? ReadDescriptionParagraph(
+        IReadOnlyList<string> lines,
+        int usageEndIndex)
+    {
+        var index = usageEndIndex;
+        while (index + 1 < lines.Count && string.IsNullOrWhiteSpace(lines[index + 1]))
+        {
+            index++;
+        }
+
+        var descriptionLines = new List<string>();
+        while (index + 1 < lines.Count && !string.IsNullOrWhiteSpace(lines[index + 1]))
+        {
+            var descriptionLine = lines[++index].Trim();
+            if (BrewOptionPattern().IsMatch(lines[index]) || descriptionLine.EndsWith(':'))
+            {
+                break;
+            }
+
+            descriptionLines.Add(descriptionLine);
+        }
+
+        return descriptionLines.Count == 0 ? null : string.Join(' ', descriptionLines);
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -619,7 +619,7 @@ public partial class BrewCliScraper : CliScraperBase
     /// <summary>
     /// Matches descriptions that suggest the option takes a value.
     /// </summary>
-    [GeneratedRegex(@"\b(?:path|directory|number|name|value|version|license|location)\b|comma-separated|how many|which type|specified as", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"comma-separated|how many|which type|this many|default value|specified as|\b(?:set|specify)\s+(?:the\s+)?(?:path|file|directory|name|value|version|license|location)\b|\b(?:writes?|output)\s+to\s+(?:the\s+)?(?:path|file|directory|location)\b|\bfrom\s+(?:this|the|a)\s+(?:path|file|directory|location)\b|\b(?:path|file|directory|name|value|version|license|location)\s+to\b|\bspecified\s+(?:path|file|directory|name|value|version|license|location)\b", RegexOptions.IgnoreCase)]
     private static partial Regex DescriptionSuggestsValue();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -127,7 +127,7 @@ public partial class BrewCliScraper : CliScraperBase
         var subcommands = new List<string>();
         var seenCommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // Find "Commands:" section
+        // Find "Commands:" or "Subcommands:" section
         var commandSectionMatch = CommandSectionPattern().Match(helpText);
         if (!commandSectionMatch.Success)
         {
@@ -153,6 +153,11 @@ public partial class BrewCliScraper : CliScraperBase
         {
             // Match pattern: whitespace + command + whitespace + description
             var match = CommandLinePattern().Match(line);
+            if (!match.Success)
+            {
+                match = ColonDelimitedCommandLinePattern().Match(line);
+            }
+
             if (match.Success)
             {
                 var commandName = match.Groups["name"].Value.Trim();
@@ -242,7 +247,7 @@ public partial class BrewCliScraper : CliScraperBase
         }
 
         // Parse description from help text
-        var description = ExtractDescription(helpText);
+        var description = ExtractDescription(helpText, usage);
 
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
@@ -367,39 +372,54 @@ public partial class BrewCliScraper : CliScraperBase
     /// <summary>
     /// Extracts description from help text.
     /// </summary>
-    private static string? ExtractDescription(string helpText)
+    private static string? ExtractDescription(
+        string helpText,
+        UsageSynopsisParseResult usage)
     {
-        var lines = helpText.Split('\n');
-
-        // Look for description after "Usage:" line
-        var foundUsage = false;
-        foreach (var line in lines)
+        if (!usage.CommandMatched || string.IsNullOrWhiteSpace(usage.Synopsis))
         {
-            var trimmed = line.Trim();
+            return null;
+        }
 
-            if (trimmed.StartsWith("Usage:"))
-            {
-                foundUsage = true;
-                continue;
-            }
-
-            // Skip empty lines after Usage
-            if (string.IsNullOrEmpty(trimmed))
+        var lines = NormalizeLines(helpText);
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var usageMatch = UsageLinePattern().Match(lines[index]);
+            if (!usageMatch.Success)
             {
                 continue;
             }
 
-            // Skip lines that look like options or sections
-            if (trimmed.StartsWith('-') || trimmed.EndsWith(':'))
+            var synopsisParts = new List<string> { usageMatch.Groups["synopsis"].Value.Trim() };
+            while (index + 1 < lines.Length
+                   && UsageSynopsisParser.IsSynopsisContinuation(lines[index + 1]))
+            {
+                synopsisParts.Add(lines[++index].Trim());
+            }
+
+            if (!string.Join(' ', synopsisParts).Equals(usage.Synopsis, StringComparison.Ordinal))
             {
                 continue;
             }
 
-            // Found a description line
-            if (foundUsage && trimmed.Length > 5 && !trimmed.Contains("--"))
+            while (index + 1 < lines.Length && string.IsNullOrWhiteSpace(lines[index + 1]))
             {
-                return trimmed;
+                index++;
             }
+
+            var descriptionLines = new List<string>();
+            while (index + 1 < lines.Length && !string.IsNullOrWhiteSpace(lines[index + 1]))
+            {
+                var descriptionLine = lines[++index].Trim();
+                if (BrewOptionPattern().IsMatch(lines[index]) || descriptionLine.EndsWith(':'))
+                {
+                    break;
+                }
+
+                descriptionLines.Add(descriptionLine);
+            }
+
+            return descriptionLines.Count == 0 ? null : string.Join(' ', descriptionLines);
         }
 
         return null;
@@ -416,12 +436,12 @@ public partial class BrewCliScraper : CliScraperBase
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var className = GenerateClassName([ToolName, .. commandParts]);
+        var lines = NormalizeLines(helpText);
 
-        var lines = helpText.Split('\n');
-
-        foreach (var line in lines)
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
         {
+            var line = lines[lineIndex];
+
             // Match option lines
             var match = BrewOptionPattern().Match(line);
             if (!match.Success)
@@ -430,7 +450,21 @@ public partial class BrewCliScraper : CliScraperBase
             }
 
             var flagsPart = match.Groups["flags"].Value.Trim();
-            var descriptionPart = match.Groups["description"].Value.Trim();
+            var descriptionParts = new List<string>();
+            var inlineDescription = match.Groups["description"].Value.Trim();
+            if (!string.IsNullOrEmpty(inlineDescription))
+            {
+                descriptionParts.Add(inlineDescription);
+            }
+
+            while (lineIndex + 1 < lines.Length
+                   && !string.IsNullOrWhiteSpace(lines[lineIndex + 1])
+                   && !BrewOptionPattern().IsMatch(lines[lineIndex + 1]))
+            {
+                descriptionParts.Add(lines[++lineIndex].Trim());
+            }
+
+            var descriptionPart = string.Join(' ', descriptionParts);
 
             // Parse flags (may have multiple: "-d, --debug" or "--formula, --formulae")
             var flags = flagsPart.Split(',').Select(f => f.Trim()).Where(f => !string.IsNullOrEmpty(f)).ToList();
@@ -474,10 +508,10 @@ public partial class BrewCliScraper : CliScraperBase
                 continue;
             }
 
-            // Determine if it's a flag or takes a value
-            // Homebrew options are mostly flags unless they mention a value in description
+            // Homebrew omits value placeholders from option rows, so supplement them
+            // from the usage synopsis and constrained description wording.
             var isFlag = !hasInlineValue &&
-                         !descriptionPart.Contains('=') &&
+                         !helpText.Contains($"{longForm}=", StringComparison.Ordinal) &&
                          !DescriptionSuggestsValue().IsMatch(descriptionPart);
 
             var csharpType = isFlag ? "bool?" : "string?";
@@ -503,6 +537,11 @@ public partial class BrewCliScraper : CliScraperBase
         return options;
     }
 
+    private static string[] NormalizeLines(string helpText) => helpText
+        .Replace("\r\n", "\n", StringComparison.Ordinal)
+        .Replace('\r', '\n')
+        .Split('\n');
+
     /// <summary>
     /// Checks if help text indicates the command has options.
     /// </summary>
@@ -517,7 +556,7 @@ public partial class BrewCliScraper : CliScraperBase
     /// <summary>
     /// Matches "Commands:" section header.
     /// </summary>
-    [GeneratedRegex(@"^Commands:\s*$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^(?:Commands|Subcommands):\s*$", RegexOptions.Multiline)]
     private static partial Regex CommandSectionPattern();
 
     /// <summary>
@@ -539,6 +578,12 @@ public partial class BrewCliScraper : CliScraperBase
     private static partial Regex CommandLinePattern();
 
     /// <summary>
+    /// Matches Homebrew bundle subcommands: "  install:".
+    /// </summary>
+    [GeneratedRegex(@"^\s{2}(?<name>[a-z0-9][a-z0-9+_.-]*):\s*$", RegexOptions.IgnoreCase)]
+    private static partial Regex ColonDelimitedCommandLinePattern();
+
+    /// <summary>
     /// Matches "brew commandname" lines in example usage.
     /// </summary>
     [GeneratedRegex(@"^\s*brew\s+(?<name>[a-z0-9][a-z0-9+_.-]*)", RegexOptions.Multiline | RegexOptions.IgnoreCase)]
@@ -558,8 +603,14 @@ public partial class BrewCliScraper : CliScraperBase
     /// <summary>
     /// Matches descriptions that suggest the option takes a value.
     /// </summary>
-    [GeneratedRegex(@"\b(?:set|specify|use|path|file|directory|number|name|value)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?:path|directory|number|name|value|version|license|location)\b|comma-separated|how many|which type|specified as", RegexOptions.IgnoreCase)]
     private static partial Regex DescriptionSuggestsValue();
+
+    /// <summary>
+    /// Matches an inline Homebrew usage synopsis.
+    /// </summary>
+    [GeneratedRegex(@"^Usage:\s*(?<synopsis>.+)$", RegexOptions.IgnoreCase)]
+    private static partial Regex UsageLinePattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CosignCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CosignCliScraper.cs
@@ -63,6 +63,22 @@ public partial class CosignCliScraper : CobraCliScraper
     protected override string VersionArguments => "version";
 
     /// <summary>
+    /// Cosign prints an ASCII-art banner before its structured version fields.
+    /// Persist only the GitVersion value in command-coverage metadata.
+    /// </summary>
+    protected override string? ParseVersionOutput(CliCommandResult result)
+    {
+        const string versionPrefix = "GitVersion:";
+        var versionLine = result.CombinedOutput
+            .ReplaceLineEndings("\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static line => line.Trim())
+            .FirstOrDefault(line => line.StartsWith(versionPrefix, StringComparison.OrdinalIgnoreCase));
+        var version = versionLine?[versionPrefix.Length..].Trim();
+        return string.IsNullOrEmpty(version) ? base.ParseVersionOutput(result) : version;
+    }
+
+    /// <summary>
     /// Cosign validates many positional arguments in command code without including them
     /// in the generated usage line. Supply that metadata explicitly from the v3 command
     /// validators, and remove login's non-argument [OPTIONS] marker.
@@ -91,6 +107,9 @@ public partial class CosignCliScraper : CobraCliScraper
         string propertyName,
         bool isFlag,
         string description) =>
+        (!isFlag &&
+         (propertyName.Equals("IdentityToken", StringComparison.OrdinalIgnoreCase) ||
+          propertyName.Equals("OidcClientSecretFile", StringComparison.OrdinalIgnoreCase))) ||
         base.IsSecretOption(propertyName, isFlag, description) ||
         (!isFlag &&
          (propertyName.Equals("NewKey", StringComparison.OrdinalIgnoreCase) ||

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -364,7 +364,7 @@ public static class UsageSynopsisParser
                 continue;
             }
 
-            if (!IsSynopsisContinuation(line, trimmed))
+            if (!IsSynopsisContinuationCore(trimmed))
             {
                 break;
             }
@@ -376,10 +376,9 @@ public static class UsageSynopsisParser
         return index - 1;
     }
 
-    private static bool IsSynopsisContinuation(string line, string trimmed)
+    private static bool IsSynopsisContinuationCore(string trimmed)
     {
-        if (string.IsNullOrWhiteSpace(trimmed)
-            || line.Length == trimmed.Length)
+        if (string.IsNullOrWhiteSpace(trimmed))
         {
             return false;
         }
@@ -398,6 +397,9 @@ public static class UsageSynopsisParser
         return firstToken.StartsWith('-')
                || firstToken is "|" or "...";
     }
+
+    internal static bool IsSynopsisContinuation(string line) =>
+        IsSynopsisContinuationCore(line.Trim());
 
     private static bool TryReadUsageHeading(string line, out string synopsis)
     {
@@ -525,9 +527,7 @@ public static class UsageSynopsisParser
                     continue;
                 }
 
-                if (!NormalizeLiteral(tokens[tokenIndex]).Equals(
-                        commandPath[pathIndex],
-                        StringComparison.OrdinalIgnoreCase))
+                if (!TokenMatchesCommandPart(tokens[tokenIndex], commandPath[pathIndex]))
                 {
                     continue;
                 }
@@ -910,8 +910,16 @@ public static class UsageSynopsisParser
         return content;
     }
 
+    private static bool TokenMatchesCommandPart(string token, string commandPart)
+    {
+        var normalized = NormalizeLiteral(token);
+        return normalized.Equals(commandPart, StringComparison.OrdinalIgnoreCase)
+               || normalized.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                   .Contains(commandPart, StringComparer.OrdinalIgnoreCase);
+    }
+
     private static string NormalizeLiteral(string token) =>
-        TrimWrapper(token).Trim().TrimEnd(',', ':');
+        TrimWrapper(token.Trim().TrimEnd(',', ':')).Trim();
 
     private static string TrimWrapper(string token)
     {


### PR DESCRIPTION
## Summary
- preserve secret masking and parse structured version metadata for Cosign
- exclude compatibility-only removed commands from current CLI documentation
- parse Homebrew 6 wrapped usage, option descriptions, and colon-delimited bundle subcommands
- preserve old flag properties when corrected options become value-taking, avoiding API breaks

## Validation
- exact-head CI OptionsGenerator suite: 1,182 passed; generated global options verified
- OptionsGenerator Release build: 0 warnings, 0 errors
- final scoped Release tests: 42 passed (13 Brew, 27 Markdown documentation, 1 synopsis, 1 compatibility)
- final local full-suite rerun hit the repository guard's 2 GB process-tree limit at 2,757 MB; exact-head CI completed the full recheck
- scoped whitespace format completed; earlier diagnostic-format verification reported only pre-existing repository info diagnostics

Continues #3996.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cosign version detection and recognition of sensitive credential options.
  - Improved Brew command and option parsing, including multiline descriptions, subcommands, and value options.
  - Improved command synopsis matching for wrapped and alternative command syntax.
  - Prevents compatibility-only commands from appearing in current Markdown documentation.

- **Compatibility**
  - Preserves removed commands and renamed options for API compatibility while marking them as compatibility-only.

- **Tests**
  - Added regression coverage for compatibility handling, parser behavior, secret detection, and version extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
