### PR TITLE
Preserve CLI option generation safety

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -228,7 +228,33 @@ public class BrewCliScraperTests
 
         var command = await new TestBrewCliScraper().Parse(["brew", "rubocop"], helpText);
 
-        await Assert.That(command!.Description).IsNull();
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Description).IsNull();
+            await Assert.That(command.Options).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Ignores_Prerequisite_Options_Before_Matching_Usage()
+    {
+        const string helpText = """
+            Usage: brew install-bundler-gems [--groups=]
+
+                  --groups        Install Bundler gem groups.
+
+            Usage: rubocop [options] [file1, file2, ...]
+
+                -l, --lint        Run only lint cops.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "rubocop"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options).Contains(option => option.SwitchName == "--lint");
+            await Assert.That(command.Options).DoesNotContain(option => option.SwitchName == "--groups");
+        }
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -218,12 +218,14 @@ public class BrewCliScraperTests
     }
 
     [Test]
-    public async Task Ignores_Description_For_Unrelated_Usage()
+    public async Task Falls_Back_To_Options_For_Unmatched_Usage()
     {
         const string helpText = """
             Usage: brew install-bundler-gems [--groups=]
 
             Install Homebrew's Bundler gems.
+
+                  --groups        Install Bundler gem groups.
             """;
 
         var command = await new TestBrewCliScraper().Parse(["brew", "rubocop"], helpText);
@@ -231,7 +233,7 @@ public class BrewCliScraperTests
         using (Assert.Multiple())
         {
             await Assert.That(command!.Description).IsNull();
-            await Assert.That(command.Options).IsEmpty();
+            await Assert.That(command.Options).Contains(option => option.SwitchName == "--groups");
         }
     }
 
@@ -246,6 +248,28 @@ public class BrewCliScraperTests
             Usage: rubocop [options] [file1, file2, ...]
 
                 -l, --lint        Run only lint cops.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "rubocop"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options).Contains(option => option.SwitchName == "--lint");
+            await Assert.That(command.Options).DoesNotContain(option => option.SwitchName == "--groups");
+        }
+    }
+
+    [Test]
+    public async Task Ignores_Unrelated_Options_After_Matching_Usage()
+    {
+        const string helpText = """
+            Usage: rubocop [options] [file1, file2, ...]
+
+                -l, --lint        Run only lint cops.
+
+            Usage: brew install-bundler-gems [--groups=]
+
+                  --groups        Install Bundler gem groups.
             """;
 
         var command = await new TestBrewCliScraper().Parse(["brew", "rubocop"], helpText);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
@@ -142,6 +142,35 @@ public class OptionTypeEnhancerTests
     }
 
     [Test]
+    [Arguments("--identity-token", "IdentityToken", "Token or path to a file containing the token.")]
+    [Arguments("--oidc-client-secret-file", "OidcClientSecretFile", "Path to the OIDC client secret file.")]
+    public async Task Cosign_Override_Preserves_Path_Capable_Secrets(
+        string switchName,
+        string propertyName,
+        string description)
+    {
+        var detector = new ManualOverrideDetector(
+            NullLogger<ManualOverrideDetector>.Instance,
+            Path.Combine(AppContext.BaseDirectory, "TypeOverrides"));
+        var pipeline = new OptionTypeDetectorPipeline(
+            [detector],
+            NullLogger<OptionTypeDetectorPipeline>.Instance);
+        var enhancer = new OptionTypeEnhancer(pipeline, NullLogger<OptionTypeEnhancer>.Instance);
+        var tool = CreateTool(new CliOptionDefinition
+        {
+            SwitchName = switchName,
+            PropertyName = propertyName,
+            CSharpType = "string?",
+            Description = description,
+            IsSecret = true,
+        }, toolName: "cosign");
+
+        var enhanced = await enhancer.EnhanceAsync(tool);
+
+        await Assert.That(enhanced.Commands.Single().Options.Single().IsSecret).IsTrue();
+    }
+
+    [Test]
     public async Task EnhanceAsync_Removes_Inferred_Secret_From_Path_Option()
     {
         var pipeline = new OptionTypeDetectorPipeline(
@@ -215,11 +244,13 @@ public class OptionTypeEnhancerTests
         }
     }
 
-    private static CliToolDefinition CreateTool(CliOptionDefinition option)
+    private static CliToolDefinition CreateTool(
+        CliOptionDefinition option,
+        string toolName = "docker")
     {
         return new CliToolDefinition
         {
-            ToolName = "docker",
+            ToolName = toolName,
             NamespacePrefix = "Docker",
             TargetNamespace = "ModularPipelines.Docker",
             OutputDirectory = "src/ModularPipelines.Docker",

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -249,8 +249,9 @@ public partial class BrewCliScraper : CliScraperBase
         // Parse description from help text
         var description = ExtractDescription(helpText, usage);
 
-        // Parse options from the help text
-        var options = ParseOptions(helpText, commandParts);
+        // Wrapper commands can print prerequisite help before their own usage.
+        // Only options at or after the selected command synopsis belong here.
+        var options = ParseOptions(ExtractHelpFromMatchingUsage(helpText, usage), commandParts);
         var positionalArguments = NormalizePositionalArguments(
             commandParts,
             DisambiguatePositionalArguments(
@@ -439,6 +440,28 @@ public partial class BrewCliScraper : CliScraperBase
         }
 
         return descriptionLines.Count == 0 ? null : string.Join(' ', descriptionLines);
+    }
+
+    private static string ExtractHelpFromMatchingUsage(
+        string helpText,
+        UsageSynopsisParseResult usage)
+    {
+        if (!usage.CommandMatched || string.IsNullOrWhiteSpace(usage.Synopsis))
+        {
+            return string.Empty;
+        }
+
+        var lines = NormalizeLines(helpText);
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var usageStartIndex = index;
+            if (TryMatchUsageSynopsis(lines, ref index, usage.Synopsis))
+            {
+                return string.Join(Environment.NewLine, lines[usageStartIndex..]);
+            }
+        }
+
+        return string.Empty;
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -377,23 +377,13 @@ public partial class BrewCliScraper : CliScraperBase
         string helpText,
         UsageSynopsisParseResult usage)
     {
-        if (!usage.CommandMatched || string.IsNullOrWhiteSpace(usage.Synopsis))
+        var lines = NormalizeLines(helpText);
+        if (!TryFindMatchingUsage(lines, usage, out _, out var usageEndIndex))
         {
             return null;
         }
 
-        var lines = NormalizeLines(helpText);
-        for (var index = 0; index < lines.Length; index++)
-        {
-            if (!TryMatchUsageSynopsis(lines, ref index, usage.Synopsis))
-            {
-                continue;
-            }
-
-            return ReadDescriptionParagraph(lines, index);
-        }
-
-        return null;
+        return ReadDescriptionParagraph(lines, usageEndIndex);
     }
 
     private static bool TryMatchUsageSynopsis(
@@ -446,22 +436,56 @@ public partial class BrewCliScraper : CliScraperBase
         string helpText,
         UsageSynopsisParseResult usage)
     {
-        if (!usage.CommandMatched || string.IsNullOrWhiteSpace(usage.Synopsis))
+        var lines = NormalizeLines(helpText);
+        if (!TryFindMatchingUsage(
+                lines,
+                usage,
+                out var usageStartIndex,
+                out var usageEndIndex))
         {
-            return string.Empty;
+            return helpText;
         }
 
-        var lines = NormalizeLines(helpText);
-        for (var index = 0; index < lines.Length; index++)
+        var sectionEndIndex = lines.Length;
+        for (var index = usageEndIndex + 1; index < lines.Length; index++)
         {
-            var usageStartIndex = index;
-            if (TryMatchUsageSynopsis(lines, ref index, usage.Synopsis))
+            if (UsageLinePattern().IsMatch(lines[index]))
             {
-                return string.Join(Environment.NewLine, lines[usageStartIndex..]);
+                sectionEndIndex = index;
+                break;
             }
         }
 
-        return string.Empty;
+        return string.Join(Environment.NewLine, lines[usageStartIndex..sectionEndIndex]);
+    }
+
+    private static bool TryFindMatchingUsage(
+        IReadOnlyList<string> lines,
+        UsageSynopsisParseResult usage,
+        out int usageStartIndex,
+        out int usageEndIndex)
+    {
+        usageStartIndex = -1;
+        usageEndIndex = -1;
+        if (!usage.CommandMatched || string.IsNullOrWhiteSpace(usage.Synopsis))
+        {
+            return false;
+        }
+
+        for (var index = 0; index < lines.Count; index++)
+        {
+            var candidateStartIndex = index;
+            if (!TryMatchUsageSynopsis(lines, ref index, usage.Synopsis))
+            {
+                continue;
+            }
+
+            usageStartIndex = candidateStartIndex;
+            usageEndIndex = index;
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/cosign.json
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/cosign.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./schema.json",
+  "global": {
+    "--identity-token": {
+      "type": "string",
+      "isSecret": true,
+      "reason": "Cosign identity tokens must remain masked even when supplied through a file path"
+    },
+    "--oidc-client-secret-file": {
+      "type": "string",
+      "isSecret": true,
+      "reason": "Cosign OIDC client secret files are explicitly classified as sensitive"
+    }
+  },
+  "commands": {}
+}


### PR DESCRIPTION
## Summary
- add explicit Cosign type overrides for identity tokens and OIDC client secret files
- preserve masking after type enhancement recognizes path-capable values
- scope Homebrew option parsing to the selected usage block so wrapper help cannot leak unrelated options
- retain full-help fallback when usage matching fails and stop matched slices at the next usage block
- share usage-location logic between option and description parsing

## Validation
- exact-head CI OptionsGenerator suite: 1,186 passed; generated global options verified
- local OptionTypeEnhancerTests Release: 9 passed
- local BrewCliScraperTests Release: 15 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- scoped whitespace format and diff checks passed
- Homebrew 6.0.19 live help reproduced the rubocop/install-bundler-gems dual-usage boundary

Continues #3996.