### PR TITLE
Harden compatibility-only CLI generation

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2821,6 +2821,10 @@ public class GeneratorHardeningTests
                 await Assert.That(generatedOptions)
                     .Contains("[CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, PrependOptionTerminatorIfValueStartsWithDash = true)]");
                 await Assert.That(generatedOptions).Contains("[SecretValue(\"password\", \"token\")]");
+                await Assert.That(generatedOptions)
+                    .Contains($"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
+                await Assert.That(generated)
+                    .Contains($"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
                 await Assert.That(generated).Contains("RemovedAsync(ToolRemovedOptions? options = null");
             }
         }
@@ -2828,6 +2832,63 @@ public class GeneratorHardeningTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task CompatibilityOnly_SubDomain_Facades_Are_Obsolete()
+    {
+        var command = Command(
+            "ToolRemovedChildOptions",
+            "ToolOptions",
+            ["removed", "child"],
+            subDomainGroup: "removed") with
+        {
+            IsCompatibilityOnly = true,
+        };
+        var tool = Tool(command);
+        var obsoleteAttribute =
+            $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]";
+        var rootInterface = (await new ServiceInterfaceGenerator().GenerateAsync(tool)).Single().Content;
+        var rootImplementation = (await new ServiceImplementationGenerator().GenerateAsync(tool)).Single().Content;
+        var subDomainInterface = (await new SubDomainClassGenerator().GenerateAsync(tool))
+            .Single(file => Path.GetFileName(file.RelativePath).Equals(
+                "IToolRemoved.Generated.cs",
+                StringComparison.Ordinal))
+            .Content;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(rootInterface)
+                .Contains($"{obsoleteAttribute}{Environment.NewLine}    IToolRemoved Removed");
+            await Assert.That(rootImplementation)
+                .Contains($"{obsoleteAttribute}{Environment.NewLine}    public IToolRemoved Removed");
+            await Assert.That(subDomainInterface)
+                .Contains($"{obsoleteAttribute}{Environment.NewLine}    public Task<CommandResult> ChildAsync");
+        }
+    }
+
+    [Test]
+    public async Task Live_SubDomain_Parent_Property_Is_Not_Obsolete()
+    {
+        var parent = Command(
+            "ToolMixedOptions",
+            "ToolOptions",
+            ["mixed"]);
+        var compatibilityChild = Command(
+            "ToolMixedRemovedOptions",
+            "ToolOptions",
+            ["mixed", "removed"],
+            subDomainGroup: "mixed") with
+        {
+            IsCompatibilityOnly = true,
+        };
+        var tool = Tool(parent, compatibilityChild);
+        var obsoleteProperty =
+            $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]"
+            + $"{Environment.NewLine}    IToolMixed Mixed";
+        var rootInterface = (await new ServiceInterfaceGenerator().GenerateAsync(tool)).Single().Content;
+
+        await Assert.That(rootInterface).DoesNotContain(obsoleteProperty);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2845,7 +2845,18 @@ public class GeneratorHardeningTests
         {
             IsCompatibilityOnly = true,
         };
-        var tool = Tool(command);
+        var tool = Tool(command) with
+        {
+            CommandGroupAliases =
+            [
+                new CliCommandGroupAlias
+                {
+                    Alias = "legacy",
+                    CanonicalCommand = "removed",
+                    ObsoleteMessage = "Use removed instead.",
+                },
+            ],
+        };
         var obsoleteAttribute =
             $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]";
         var rootInterface = (await new ServiceInterfaceGenerator().GenerateAsync(tool)).Single().Content;
@@ -2853,6 +2864,11 @@ public class GeneratorHardeningTests
         var subDomainInterface = (await new SubDomainClassGenerator().GenerateAsync(tool))
             .Single(file => Path.GetFileName(file.RelativePath).Equals(
                 "IToolRemoved.Generated.cs",
+                StringComparison.Ordinal))
+            .Content;
+        var compatibilityOptionsAlias = (await new OptionsClassGenerator().GenerateAsync(tool))
+            .Single(file => Path.GetFileName(file.RelativePath).Equals(
+                "ToolLegacyChildOptions.Generated.cs",
                 StringComparison.Ordinal))
             .Content;
 
@@ -2869,6 +2885,7 @@ public class GeneratorHardeningTests
                     + $"{Environment.NewLine}        #pragma warning restore CS0618");
             await Assert.That(subDomainInterface)
                 .Contains($"{obsoleteAttribute}{Environment.NewLine}    public Task<CommandResult> ChildAsync");
+            await Assert.That(compatibilityOptionsAlias).Contains(obsoleteAttribute);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2862,6 +2862,11 @@ public class GeneratorHardeningTests
                 .Contains($"{obsoleteAttribute}{Environment.NewLine}    IToolRemoved Removed");
             await Assert.That(rootImplementation)
                 .Contains($"{obsoleteAttribute}{Environment.NewLine}    public IToolRemoved Removed");
+            await Assert.That(rootImplementation)
+                .Contains(
+                    "#pragma warning disable CS0618"
+                    + $"{Environment.NewLine}        Removed = removed;"
+                    + $"{Environment.NewLine}        #pragma warning restore CS0618");
             await Assert.That(subDomainInterface)
                 .Contains($"{obsoleteAttribute}{Environment.NewLine}    public Task<CommandResult> ChildAsync");
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -30,6 +30,16 @@ public class BrewCliScraperTests
     }
 
     [Test]
+    public async Task Rejects_Partial_Help_Output_From_Failed_Command()
+    {
+        var scraper = new TestBrewCliScraper(new FailedHelpExecutor());
+
+        var helpText = await scraper.GetHelp(["brew", "rubocop"]);
+
+        await Assert.That(helpText).IsNull();
+    }
+
+    [Test]
     public async Task Preserves_Positional_Operands_From_Usage()
     {
         const string helpText = """
@@ -412,6 +422,29 @@ public class BrewCliScraperTests
 
         public IReadOnlyList<string> GetSubcommands(string helpText) =>
             ExtractSubcommands(helpText).ToArray();
+
+        public Task<string?> GetHelp(string[] commandPath) =>
+            GetHelpTextAsync(commandPath, CancellationToken.None);
+    }
+
+    private sealed class FailedHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 1,
+                StandardOutput = "Usage: brew install-bundler-gems [--groups=]",
+                StandardError = "cannot load such file -- rubocop",
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
     }
 
     private sealed class CommandInventoryExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -14,6 +14,28 @@ namespace ModularPipelines.OptionsGenerator.Generators;
 /// </summary>
 public static partial class GeneratorUtils
 {
+    internal const string CompatibilityOnlyObsoleteMessage =
+        "This command is no longer supported by the installed CLI and is retained only for compatibility.";
+
+    internal static bool IsCompatibilityOnlySubDomain(
+        CliToolDefinition tool,
+        string subDomainGroup)
+    {
+        var subDomainIdentifier = GetSubDomainIdentifier(tool, subDomainGroup);
+        var commands = tool.Commands
+            .Where(command => string.Equals(
+                command.SubDomainGroup,
+                subDomainGroup,
+                StringComparison.OrdinalIgnoreCase))
+            .Concat(GetSubDomainParentCommands(tool).Where(command =>
+                GetCommandGroupIdentifier(command).Equals(
+                    subDomainIdentifier,
+                    StringComparison.OrdinalIgnoreCase)))
+            .Distinct()
+            .ToArray();
+        return commands.Length > 0 && commands.All(static command => command.IsCompatibilityOnly);
+    }
+
     internal static string GetEnumTypeName(string cSharpType)
     {
         var type = cSharpType.TrimEnd('?');
@@ -787,6 +809,7 @@ public static partial class GeneratorUtils
         }
 
         var compatibilityMethods = GetCompatibilityMethods(command, methodName).ToList();
+        AppendCompatibilityOnlyObsoleteAttribute(sb, command, indent);
         AppendDefaultServiceMethod(
             sb,
             methodName,
@@ -862,6 +885,7 @@ public static partial class GeneratorUtils
             sb.AppendLine($"{indent}/// <inheritdoc />");
         }
 
+        AppendCompatibilityOnlyObsoleteAttribute(sb, command, indent);
         sb.AppendLine($"{indent}public virtual async Task<CommandResult> {methodName}(");
         sb.AppendLine($"{indent}    {BuildOptionsParameter(command)},");
         sb.AppendLine($"{indent}    {ExecutionOptionsParameter},");
@@ -888,6 +912,18 @@ public static partial class GeneratorUtils
                 methodName,
                 command,
                 indent);
+        }
+    }
+
+    private static void AppendCompatibilityOnlyObsoleteAttribute(
+        StringBuilder sb,
+        CliCommandDefinition command,
+        string indent)
+    {
+        if (command.IsCompatibilityOnly)
+        {
+            sb.AppendLine(
+                $"{indent}[Obsolete({FormatStringLiteral(CompatibilityOnlyObsoleteMessage)})]");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -97,11 +97,7 @@ public class OptionsClassGenerator : ICodeGenerator
         sb.AppendLine();
         sb.AppendLine(GeneratorUtils.GeneratedCodeAttribute);
         sb.AppendLine("[ExcludeFromCodeCoverage]");
-        if (command.IsCompatibilityOnly)
-        {
-            sb.AppendLine(
-                $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
-        }
+        GenerateCompatibilityOnlyAttribute(sb, command);
 
         if (enumOptions.Length == 0
             && requiredParameters.Count == 0
@@ -431,11 +427,7 @@ public class OptionsClassGenerator : ICodeGenerator
     {
         sb.AppendLine(GeneratorUtils.GeneratedCodeAttribute);
         sb.AppendLine("[ExcludeFromCodeCoverage]");
-        if (command.IsCompatibilityOnly)
-        {
-            sb.AppendLine(
-                $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
-        }
+        GenerateCompatibilityOnlyAttribute(sb, command);
 
         // CliSubCommand attribute - contains only the subcommand parts (tool name comes from base class)
         if (command.CommandParts.Length > 0)
@@ -444,6 +436,17 @@ public class OptionsClassGenerator : ICodeGenerator
                 ", ",
                 command.CommandParts.Select(GeneratorUtils.FormatStringLiteral));
             sb.AppendLine($"[CliSubCommand({args})]");
+        }
+    }
+
+    private static void GenerateCompatibilityOnlyAttribute(
+        StringBuilder sb,
+        CliCommandDefinition command)
+    {
+        if (command.IsCompatibilityOnly)
+        {
+            sb.AppendLine(
+                $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -425,6 +425,11 @@ public class OptionsClassGenerator : ICodeGenerator
     {
         sb.AppendLine(GeneratorUtils.GeneratedCodeAttribute);
         sb.AppendLine("[ExcludeFromCodeCoverage]");
+        if (command.IsCompatibilityOnly)
+        {
+            sb.AppendLine(
+                $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
+        }
 
         // CliSubCommand attribute - contains only the subcommand parts (tool name comes from base class)
         if (command.CommandParts.Length > 0)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -97,6 +97,12 @@ public class OptionsClassGenerator : ICodeGenerator
         sb.AppendLine();
         sb.AppendLine(GeneratorUtils.GeneratedCodeAttribute);
         sb.AppendLine("[ExcludeFromCodeCoverage]");
+        if (command.IsCompatibilityOnly)
+        {
+            sb.AppendLine(
+                $"[Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
+        }
+
         if (enumOptions.Length == 0
             && requiredParameters.Count == 0
             && compatibilityConstructors.Count == 0

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -110,7 +110,17 @@ public class ServiceImplementationGenerator : ICodeGenerator
             {
                 var rawParamName = char.ToLowerInvariant(subDomain[0]) + subDomain[1..];
                 var paramName = GeneratorUtils.EscapeIdentifier(rawParamName);
+                var isCompatibilityOnly = compatibilityOnlySubDomains.Contains(subDomain);
+                if (isCompatibilityOnly)
+                {
+                    sb.AppendLine("        #pragma warning disable CS0618");
+                }
+
                 sb.AppendLine($"        {subDomain} = {paramName};");
+                if (isCompatibilityOnly)
+                {
+                    sb.AppendLine("        #pragma warning restore CS0618");
+                }
 
                 foreach (var alias in GeneratorUtils.GetCommandGroupAliases(tool, subDomain))
                 {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -56,6 +56,10 @@ public class ServiceImplementationGenerator : ICodeGenerator
         var subDomains = tool.SubDomainGroups
             .Select(group => GeneratorUtils.GetSubDomainIdentifier(tool, group))
             .ToList();
+        var compatibilityOnlySubDomains = tool.SubDomainGroups
+            .Where(group => GeneratorUtils.IsCompatibilityOnlySubDomain(tool, group))
+            .Select(group => GeneratorUtils.GetSubDomainIdentifier(tool, group))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         // Class documentation
         sb.AppendLine("/// <summary>");
@@ -144,6 +148,12 @@ public class ServiceImplementationGenerator : ICodeGenerator
             {
                 var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
                 sb.AppendLine($"    /// <inheritdoc />");
+                if (compatibilityOnlySubDomains.Contains(subDomain))
+                {
+                    sb.AppendLine(
+                        $"    [Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
+                }
+
                 sb.AppendLine($"    public I{subDomainClassName} {subDomain} {{ get; }}");
                 sb.AppendLine();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
@@ -69,6 +69,12 @@ public class ServiceInterfaceGenerator : ICodeGenerator
                 sb.AppendLine($"    /// <summary>");
                 sb.AppendLine($"    /// Gets the {subDomain.ToLowerInvariant()} sub-domain service.");
                 sb.AppendLine($"    /// </summary>");
+                if (GeneratorUtils.IsCompatibilityOnlySubDomain(tool, subDomain))
+                {
+                    sb.AppendLine(
+                        $"    [Obsolete({GeneratorUtils.FormatStringLiteral(GeneratorUtils.CompatibilityOnlyObsoleteMessage)})]");
+                }
+
                 sb.AppendLine(
                     $"    I{subDomainClassName} {subDomainIdentifier} => throw new System.NotSupportedException();");
                 sb.AppendLine();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -119,6 +119,7 @@ public partial class BrewCliScraper : CliScraperBase
         return $"{helpText.TrimEnd()}{Environment.NewLine}{Environment.NewLine}Commands:{Environment.NewLine}{commandSection}";
     }
 
+    // Fail closed: Homebrew can print another command's prerequisite help before failing.
     protected override bool ShouldAcceptHelpResult(
         IReadOnlyList<string> commandPath,
         CliCommandResult result) => result.Success;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -119,6 +119,10 @@ public partial class BrewCliScraper : CliScraperBase
         return $"{helpText.TrimEnd()}{Environment.NewLine}{Environment.NewLine}Commands:{Environment.NewLine}{commandSection}";
     }
 
+    protected override bool ShouldAcceptHelpResult(
+        IReadOnlyList<string> commandPath,
+        CliCommandResult result) => result.Success;
+
     /// <summary>
     /// Extracts subcommand names from Homebrew help text.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -663,6 +663,15 @@ public abstract partial class CliScraperBase : ICliScraper
 
         var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
 
+        if (!ShouldAcceptHelpResult(commandPath, result))
+        {
+            Logger.LogWarning(
+                "Ignoring failed help command for {Command}; exit code {ExitCode}",
+                cacheKey,
+                result.ExitCode);
+            return null;
+        }
+
         // Many CLIs output help to stderr when using --help
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)
             ? result.StandardOutput
@@ -677,6 +686,15 @@ public abstract partial class CliScraperBase : ICliScraper
         Logger.LogWarning("No help text for command: {Command}", cacheKey);
         return null;
     }
+
+    /// <summary>
+    /// Returns whether output from a help invocation is safe to parse.
+    /// Some CLIs intentionally return non-zero exit codes for valid help, so adapters
+    /// can opt into stricter validation when partial failure output is misleading.
+    /// </summary>
+    protected virtual bool ShouldAcceptHelpResult(
+        IReadOnlyList<string> commandPath,
+        CliCommandResult result) => true;
 
     #endregion
 


### PR DESCRIPTION
## Summary
- reject failed Homebrew help invocations before partial output can be parsed or cached
- mark compatibility-only options and execution methods obsolete
- mark wholly compatibility-only command-group properties obsolete while leaving mixed live groups unchanged
- add regressions for the Brew rubocop failure and removed-command facades

## Validation
- OptionsGenerator tests: 1,191/1,191 passed
- OptionsGenerator solution build: 0 warnings, 0 errors
- scoped whitespace verification: clean
- full format verification: blocked by existing unrelated formatting and analyzer debt, including IHelpTextCache.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed Homebrew commands are no longer treated as valid help output, preventing incomplete or misleading option data.
  - Invalid command results are discarded before parsing or caching.

- **New Features**
  - Compatibility-only commands and subcommands are now clearly marked as obsolete in generated APIs.
  - Deprecation warnings are handled consistently while preserving active parent commands.

- **Tests**
  - Added coverage for failed Homebrew help retrieval and compatibility-only command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->