### PR TITLE
Ignore punctuated option tokens in CLI usage

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -237,6 +237,21 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    [Arguments("[--no-secrets]:")]
+    [Arguments("[--json]:")]
+    [Arguments("[--debug]:")]
+    [Arguments("[--file=]:")]
+    public async Task Ignores_Punctuated_Option_Tokens(string optionToken)
+    {
+        var result = UsageSynopsisParser.Parse(
+            $"Usage: tool run [target] {optionToken}",
+            ["tool", "run"]);
+
+        var argument = result.PositionalArguments.Single();
+        await Assert.That(argument.PropertyName).IsEqualTo("Target");
+    }
+
+    [Test]
     public async Task Parses_Forwarded_Option_Tail_As_Multiple_Arguments()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -902,12 +902,16 @@ public static class UsageSynopsisParser
     private static string TrimControlWrappers(string token)
     {
         var content = token.Trim();
-        while (IsWrapped(content))
+        while (true)
         {
+            content = content.TrimEnd(',', ':', ';');
+            if (!IsWrapped(content))
+            {
+                return content;
+            }
+
             content = TrimWrapper(content).Trim();
         }
-
-        return content;
     }
 
     private static bool TokenMatchesCommandPart(string token, string commandPart)


### PR DESCRIPTION
## Summary
- strip trailing synopsis punctuation before classifying wrapped control tokens
- prevent Homebrew forms such as `[--file=]:` and `[--no-secrets]:` from becoming positional operands
- cover all four observed token forms with parser regressions

## Validation
- UsageSynopsisParserTests: 42/42
- OptionsGenerator tests: 1,195/1,195
- Release build: 0 warnings, 0 errors
- scoped whitespace verification: clean

Supersedes unsafe generated Brew PR #4193.