### PR TITLE
Fix Homebrew option value generation

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -142,6 +142,46 @@ public class BrewCliScraperTests
     }
 
     [Test]
+    public async Task Uses_Homebrew_Parser_Metadata_For_Option_Types()
+    {
+        var scraper = new TestBrewCliScraper(new OptionMetadataExecutor());
+        var helpText = await scraper.GetHelp(["brew", "typecheck"]);
+        var command = await scraper.Parse(["brew", "typecheck"], helpText!);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Single(option => option.SwitchName == "--dir").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--severity").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--fix").IsFlag)
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    [Arguments("info", "formula | --all")]
+    [Arguments("stop", "--all | formula")]
+    public async Task Models_Services_Formula_Or_All_As_Optional_Formula(
+        string subcommand,
+        string alternative)
+    {
+        var helpText = $"Usage: brew services {subcommand} ({alternative})\n\n  --all  Apply to all services.";
+
+        var command = await new TestBrewCliScraper().Parse(
+            ["brew", "services", subcommand],
+            helpText);
+
+        var formula = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(formula.PropertyName).IsEqualTo("Formula");
+            await Assert.That(formula.IsRequired).IsFalse();
+            await Assert.That(formula.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
     public async Task Preserves_Multiline_Description_Containing_Option_And_Flag_File_Text()
     {
         const string helpText = """
@@ -466,6 +506,40 @@ public class BrewCliScraperTests
                 StandardError = arguments == "commands --quiet"
                     ? "warning stale diagnostic"
                     : string.Empty,
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class OptionMetadataExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = arguments switch
+                {
+                    "typecheck --help" => """
+                        Usage: brew typecheck [options]
+
+                              --dir       Choose input.
+                              --severity  Choose threshold.
+                              --fix       Write corrections.
+                        """,
+                    _ when arguments.Contains(
+                        "p.send(:option_allowed_for_subcommand?,n,s)",
+                        StringComparison.Ordinal) =>
+                        "dir\trequired_flag\nseverity\trequired_flag\nfix\tswitch\n",
+                    _ => string.Empty,
+                },
+                StandardError = string.Empty,
             });
 
         public Task<bool> IsAvailableAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -365,6 +365,24 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    [Arguments("--config|KEY=VALUE")]
+    [Arguments("KEY=VALUE|--config")]
+    public async Task Models_Assignment_Operand_Alternatives_As_Optional(string alternative)
+    {
+        var result = UsageSynopsisParser.Parse(
+            $"Usage: tool run {alternative}",
+            ["tool", "run"]);
+
+        var argument = result.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.PropertyName).IsEqualTo("KeyValue");
+            await Assert.That(argument.IsRequired).IsFalse();
+            await Assert.That(argument.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
     public async Task Does_Not_Model_Option_Control_Alternatives_As_Operands()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -337,10 +337,12 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
-    public async Task Treats_Lone_Dash_Alternative_As_A_Required_Operand()
+    [Arguments("SRC_PATH|-")]
+    [Arguments("-|SRC_PATH")]
+    public async Task Treats_Lone_Dash_Alternative_As_A_Required_Operand(string sourceAlternative)
     {
         var result = UsageSynopsisParser.Parse(
-            "Usage: docker cp SRC_PATH|- CONTAINER:DEST_PATH",
+            $"Usage: docker cp {sourceAlternative} CONTAINER:DEST_PATH",
             ["docker", "cp"]);
 
         var source = result.PositionalArguments[0];
@@ -350,6 +352,16 @@ public class UsageSynopsisParserTests
             await Assert.That(source.IsRequired).IsTrue();
             await Assert.That(source.CSharpType).IsEqualTo("string");
         }
+    }
+
+    [Test]
+    public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run --format=<json|yaml>",
+            ["tool", "run"]);
+
+        await Assert.That(result.PositionalArguments).IsEmpty();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -359,6 +359,8 @@ public class UsageSynopsisParserTests
     [Arguments("[--format <json|yaml>]")]
     [Arguments("[--format {json|yaml}]")]
     [Arguments("[--format [json|yaml]]")]
+    [Arguments("[--format JSON|YAML]")]
+    [Arguments("[--format JSON | YAML]")]
     public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands(string option)
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -363,6 +363,8 @@ public class UsageSynopsisParserTests
     [Arguments("[--format JSON | YAML]")]
     [Arguments("[-f|--format <json|yaml>]")]
     [Arguments("[-f|--format JSON|YAML]")]
+    [Arguments("[-f|--format=<json|yaml>]")]
+    [Arguments("[-f|--format=JSON|YAML]")]
     public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands(string option)
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -395,6 +395,21 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Spaced_Mixed_Alternatives_Are_Not_Option_Values()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run (--config | KEY=VALUE | FILE)",
+            ["tool", "run"]);
+
+        var argument = result.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.PropertyName).IsEqualTo("KeyValue");
+            await Assert.That(argument.IsRequired).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task Does_Not_Model_Option_Control_Alternatives_As_Operands()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -361,6 +361,8 @@ public class UsageSynopsisParserTests
     [Arguments("[--format [json|yaml]]")]
     [Arguments("[--format JSON|YAML]")]
     [Arguments("[--format JSON | YAML]")]
+    [Arguments("[-f|--format <json|yaml>]")]
+    [Arguments("[-f|--format JSON|YAML]")]
     public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands(string option)
     {
         var result = UsageSynopsisParser.Parse(
@@ -410,6 +412,27 @@ public class UsageSynopsisParserTests
         {
             await Assert.That(source.PropertyName).IsEqualTo("Source");
             await Assert.That(source.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+        }
+    }
+
+    [Test]
+    [Arguments("--fast|DEST")]
+    [Arguments("DEST|--fast")]
+    public async Task Mixed_Alternatives_Transition_Following_Operands(string alternative)
+    {
+        var result = UsageSynopsisParser.Parse(
+            $"Usage: tool copy SOURCE ({alternative}) TARGET",
+            ["tool", "copy"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.PositionalArguments[0].PropertyName).IsEqualTo("Source");
+            await Assert.That(result.PositionalArguments[0].Phase).IsEqualTo(CommandLinePhase.EarlyOperand);
+            await Assert.That(result.PositionalArguments[1].PropertyName).IsEqualTo("Dest");
+            await Assert.That(result.PositionalArguments[1].IsRequired).IsFalse();
+            await Assert.That(result.PositionalArguments[1].Phase).IsEqualTo(CommandLinePhase.EarlyOperand);
+            await Assert.That(result.PositionalArguments[2].PropertyName).IsEqualTo("Target");
+            await Assert.That(result.PositionalArguments[2].Phase).IsEqualTo(CommandLinePhase.Passthrough);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -319,6 +319,65 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    [Arguments("Usage: brew services stop (formula | --all)")]
+    [Arguments("Usage: brew services stop (--all | formula)")]
+    public async Task Models_Operand_Or_Option_Alternatives_As_Optional(string helpText)
+    {
+        var result = UsageSynopsisParser.Parse(
+            helpText,
+            ["brew", "services", "stop"]);
+
+        var argument = result.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.PropertyName).IsEqualTo("Formula");
+            await Assert.That(argument.IsRequired).IsFalse();
+            await Assert.That(argument.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
+    public async Task Treats_Lone_Dash_Alternative_As_A_Required_Operand()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: docker cp SRC_PATH|- CONTAINER:DEST_PATH",
+            ["docker", "cp"]);
+
+        var source = result.PositionalArguments[0];
+        using (Assert.Multiple())
+        {
+            await Assert.That(source.PropertyName).IsEqualTo("SrcPath");
+            await Assert.That(source.IsRequired).IsTrue();
+            await Assert.That(source.CSharpType).IsEqualTo("string");
+        }
+    }
+
+    [Test]
+    public async Task Does_Not_Model_Option_Control_Alternatives_As_Operands()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run (options | --all)",
+            ["tool", "run"]);
+
+        await Assert.That(result.PositionalArguments).IsEmpty();
+    }
+
+    [Test]
+    public async Task Precommand_Mixed_Alternatives_Select_Passthrough_Phase()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool (--config | CONFIG) run <SOURCE>",
+            ["tool", "run"]);
+
+        var source = result.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(source.PropertyName).IsEqualTo("Source");
+            await Assert.That(source.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+        }
+    }
+
+    [Test]
     public async Task Applies_Bracketed_Standalone_Repeat_To_Preceding_Operand()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -355,10 +355,14 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
-    public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands()
+    [Arguments("--format=<json|yaml>")]
+    [Arguments("[--format <json|yaml>]")]
+    [Arguments("[--format {json|yaml}]")]
+    [Arguments("[--format [json|yaml]]")]
+    public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands(string option)
     {
         var result = UsageSynopsisParser.Parse(
-            "Usage: tool run --format=<json|yaml>",
+            $"Usage: tool run {option}",
             ["tool", "run"]);
 
         await Assert.That(result.PositionalArguments).IsEmpty();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -365,6 +365,8 @@ public class UsageSynopsisParserTests
     [Arguments("[-f|--format JSON|YAML]")]
     [Arguments("[-f|--format=<json|yaml>]")]
     [Arguments("[-f|--format=JSON|YAML]")]
+    [Arguments("[-f | --format <json|yaml>]")]
+    [Arguments("[-f | --format JSON | YAML]")]
     public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands(string option)
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -367,6 +367,7 @@ public class UsageSynopsisParserTests
     [Arguments("[-f|--format=JSON|YAML]")]
     [Arguments("[-f | --format <json|yaml>]")]
     [Arguments("[-f | --format JSON | YAML]")]
+    [Arguments("[-f | --format | --output <json|yaml>]")]
     public async Task Does_Not_Model_Option_Value_Alternatives_As_Operands(string option)
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -35,6 +35,14 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public partial class BrewCliScraper : CliScraperBase
 {
+    private const string OptionTypeMarker = "MODULARPIPELINES_BREW_OPTION_TYPE";
+    private const string OptionMetadataScript =
+        "require 'commands';require 'cli/parser';c=ARGV.shift;s=ARGV.shift;" +
+        "p=Homebrew::CLI::Parser.from_cmd_path(Commands.path(c));" +
+        "abort 'parser unavailable' if p.nil?;" +
+        "t=p.instance_variable_get(:@option_types);" +
+        "t.each{|n,k|puts [n,k].join(9.chr) if p.send(:option_allowed_for_subcommand?,n,s)}";
+
     public BrewCliScraper(ICliCommandExecutor executor, IHelpTextCache helpCache, ILogger<BrewCliScraper> logger)
         : base(executor, helpCache, logger)
     {
@@ -75,9 +83,20 @@ public partial class BrewCliScraper : CliScraperBase
         CancellationToken cancellationToken)
     {
         var helpText = await base.GetHelpTextAsync(commandPath, cancellationToken);
-        if (commandPath.Length != 1
-            || string.IsNullOrWhiteSpace(helpText)
-            || CommandSectionPattern().IsMatch(helpText))
+        if (string.IsNullOrWhiteSpace(helpText))
+        {
+            return helpText;
+        }
+
+        if (commandPath.Length > 1)
+        {
+            return await AppendOptionTypeMetadataAsync(
+                commandPath,
+                helpText,
+                cancellationToken);
+        }
+
+        if (CommandSectionPattern().IsMatch(helpText))
         {
             return helpText;
         }
@@ -117,6 +136,41 @@ public partial class BrewCliScraper : CliScraperBase
             Environment.NewLine,
             commands.Select(static command => $"  {command}  Discovered by brew commands --quiet."));
         return $"{helpText.TrimEnd()}{Environment.NewLine}{Environment.NewLine}Commands:{Environment.NewLine}{commandSection}";
+    }
+
+    private async Task<string> AppendOptionTypeMetadataAsync(
+        IReadOnlyList<string> commandPath,
+        string helpText,
+        CancellationToken cancellationToken)
+    {
+        var command = commandPath[1];
+        var subcommand = commandPath.Count > 2 ? $" {commandPath[2]}" : string.Empty;
+        var escapedScript = OptionMetadataScript.Replace("\"", "\\\"", StringComparison.Ordinal);
+        var result = await Executor.ExecuteAsync(
+            ExecutablePath,
+            $"ruby -e \"{escapedScript}\" -- {command}{subcommand}",
+            cancellationToken);
+        if (!result.Success || string.IsNullOrWhiteSpace(result.StandardOutput))
+        {
+            Logger.LogDebug(
+                "Could not query Homebrew parser metadata for {Command}; using help-text fallback",
+                string.Join(' ', commandPath));
+            return helpText;
+        }
+
+        var metadataLines = result.StandardOutput
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(static line => line.Count(static character => character == '\t') == 1)
+            .Select(static line => $"{OptionTypeMarker}\t{line}")
+            .ToArray();
+        if (metadataLines.Length == 0)
+        {
+            return helpText;
+        }
+
+        return $"{helpText.TrimEnd()}{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, metadataLines)}";
     }
 
     // Fail closed: Homebrew can print another command's prerequisite help before failing.
@@ -256,7 +310,10 @@ public partial class BrewCliScraper : CliScraperBase
 
         // Wrapper commands can print prerequisite help before their own usage.
         // Only options at or after the selected command synopsis belong here.
-        var options = ParseOptions(ExtractHelpFromMatchingUsage(helpText, usage), commandParts);
+        var optionTypes = ParseOptionTypes(NormalizeLines(helpText));
+        var options = ParseOptions(
+            ExtractHelpFromMatchingUsage(helpText, usage),
+            optionTypes);
         var positionalArguments = NormalizePositionalArguments(
             commandParts,
             DisambiguatePositionalArguments(
@@ -500,7 +557,9 @@ public partial class BrewCliScraper : CliScraperBase
     ///   -d, --debug                  Display any debugging information.
     ///       --[no-]quarantine        Enable/disable quarantine of downloads.
     /// </summary>
-    private List<CliOptionDefinition> ParseOptions(string helpText, string[] commandParts)
+    private List<CliOptionDefinition> ParseOptions(
+        string helpText,
+        IReadOnlyDictionary<string, string> optionTypes)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -578,9 +637,12 @@ public partial class BrewCliScraper : CliScraperBase
 
             // Homebrew omits value placeholders from option rows, so supplement them
             // from the usage synopsis and constrained description wording.
-            var isFlag = !hasInlineValue &&
-                         !helpText.Contains($"{longForm}=", StringComparison.Ordinal) &&
-                         !DescriptionSuggestsValue().IsMatch(descriptionPart);
+            var metadataName = longForm.TrimStart('-').Replace('-', '_');
+            var isFlag = optionTypes.TryGetValue(metadataName, out var optionType)
+                ? optionType.Equals("switch", StringComparison.Ordinal)
+                : !hasInlineValue &&
+                  !helpText.Contains($"{longForm}=", StringComparison.Ordinal) &&
+                  !DescriptionSuggestsValue().IsMatch(descriptionPart);
 
             var csharpType = isFlag ? "bool?" : "string?";
 
@@ -604,6 +666,17 @@ public partial class BrewCliScraper : CliScraperBase
 
         return options;
     }
+
+    private static IReadOnlyDictionary<string, string> ParseOptionTypes(IEnumerable<string> lines) =>
+        lines
+            .Where(static line => line.StartsWith($"{OptionTypeMarker}\t", StringComparison.Ordinal))
+            .Select(static line => line.Split('\t', 3, StringSplitOptions.TrimEntries))
+            .Where(static parts => parts.Length == 3)
+            .GroupBy(static parts => parts[1], StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Last()[2],
+                StringComparer.OrdinalIgnoreCase);
 
     private static string[] NormalizeLines(string helpText) => helpText
         .Replace("\r\n", "\n", StringComparison.Ordinal)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -977,6 +977,7 @@ public static class UsageSynopsisParser
         return valueStartIndex > 1
                && valueStartIndex < normalized.Length
                && normalized.StartsWith('-')
+               && normalized[valueStartIndex] != '|'
                && normalized.IndexOf('|', valueStartIndex + 1) >= 0;
     }
 
@@ -991,6 +992,11 @@ public static class UsageSynopsisParser
         }
 
         var aliasStartIndex = SkipWhitespace(content, valueStartIndex + 1);
+        if (aliasStartIndex >= content.Length || content[aliasStartIndex] != '-')
+        {
+            return valueStartIndex;
+        }
+
         var aliasEndIndex = content.IndexOfAny([' ', '\t', '='], aliasStartIndex);
         return aliasEndIndex < 0
             ? content.Length

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -191,17 +191,7 @@ public static class UsageSynopsisParser
 
         foreach (var token in TrimTrailingUsageExplanation(CollapseAlternatives(operandTokens)))
         {
-            var isOptionControlToken = IsOptionControlToken(token);
-            var operandPhase = phase;
-            if (isOptionControlToken || IsPhaseControlToken(token))
-            {
-                phase = CommandLinePhase.Passthrough;
-            }
-
-            if (isOptionControlToken)
-            {
-                operandPhase = phase;
-            }
+            var operandPhase = TransitionPhase(token, ref phase);
 
             if (IsStandaloneOptionTerminator(token))
             {
@@ -263,6 +253,25 @@ public static class UsageSynopsisParser
         }
 
         return new ParsedOperands(arguments, unparsedTokens);
+    }
+
+    private static CommandLinePhase TransitionPhase(
+        string token,
+        ref CommandLinePhase phase)
+    {
+        var operandPhase = phase;
+        if (IsOptionControlToken(token))
+        {
+            phase = CommandLinePhase.Passthrough;
+            return phase;
+        }
+
+        if (IsPhaseControlToken(token))
+        {
+            phase = CommandLinePhase.Passthrough;
+        }
+
+        return operandPhase;
     }
 
     private readonly record struct ParsedOperands(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -972,19 +972,41 @@ public static class UsageSynopsisParser
             return true;
         }
 
-        var valueStartIndex = normalized.IndexOfAny([' ', '\t']);
-        while (valueStartIndex >= 0
-               && valueStartIndex < normalized.Length
-               && char.IsWhiteSpace(normalized[valueStartIndex]))
-        {
-            valueStartIndex++;
-        }
+        var valueStartIndex = GetOptionValueStartIndex(normalized);
 
         return valueStartIndex > 1
                && valueStartIndex < normalized.Length
                && normalized.StartsWith('-')
-               && normalized[valueStartIndex] != '|'
                && normalized.IndexOf('|', valueStartIndex + 1) >= 0;
+    }
+
+    private static int GetOptionValueStartIndex(string content)
+    {
+        var valueStartIndex = SkipWhitespace(content, content.IndexOfAny([' ', '\t']));
+        if (valueStartIndex < 0
+            || valueStartIndex >= content.Length
+            || content[valueStartIndex] != '|')
+        {
+            return valueStartIndex;
+        }
+
+        var aliasStartIndex = SkipWhitespace(content, valueStartIndex + 1);
+        var aliasEndIndex = content.IndexOfAny([' ', '\t', '='], aliasStartIndex);
+        return aliasEndIndex < 0
+            ? content.Length
+            : SkipWhitespace(content, aliasEndIndex);
+    }
+
+    private static int SkipWhitespace(string content, int startIndex)
+    {
+        while (startIndex >= 0
+               && startIndex < content.Length
+               && char.IsWhiteSpace(content[startIndex]))
+        {
+            startIndex++;
+        }
+
+        return startIndex;
     }
 
     private static bool HasOptionAssignment(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -191,7 +191,17 @@ public static class UsageSynopsisParser
 
         foreach (var token in TrimTrailingUsageExplanation(CollapseAlternatives(operandTokens)))
         {
-            phase = IsOptionControlToken(token) ? CommandLinePhase.Passthrough : phase;
+            var isOptionControlToken = IsOptionControlToken(token);
+            var operandPhase = phase;
+            if (isOptionControlToken || IsPhaseControlToken(token))
+            {
+                phase = CommandLinePhase.Passthrough;
+            }
+
+            if (isOptionControlToken)
+            {
+                operandPhase = phase;
+            }
 
             if (IsStandaloneOptionTerminator(token))
             {
@@ -221,7 +231,7 @@ public static class UsageSynopsisParser
             if (TryParseNestedOperandGroup(
                     operandToken,
                     arguments.Count,
-                    phase,
+                    operandPhase,
                     out var nestedArguments))
             {
                 arguments.AddRange(nestedArguments);
@@ -229,7 +239,7 @@ public static class UsageSynopsisParser
                 continue;
             }
 
-            var argument = ParseOperand(operandToken, arguments.Count, phase);
+            var argument = ParseOperand(operandToken, arguments.Count, operandPhase);
             if (argument is null)
             {
                 unparsedTokens.Add(operandToken);
@@ -968,7 +978,8 @@ public static class UsageSynopsisParser
         return valueStartIndex > 1
                && valueStartIndex < normalized.Length
                && normalized.StartsWith('-')
-               && alternativeSeparatorIndex > valueStartIndex;
+               && normalized[valueStartIndex] != '|'
+               && normalized.IndexOf('|', valueStartIndex + 1) >= 0;
     }
 
     private static bool HasLoneDashOperandAlternatives(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -744,7 +744,10 @@ public static class UsageSynopsisParser
             StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (alternatives.Length > 1)
         {
-            return alternatives.FirstOrDefault(IsOperandAlternative)
+            return alternatives.FirstOrDefault(static alternative =>
+                       TrimControlWrappers(alternative) != "-"
+                       && IsOperandAlternative(alternative))
+                   ?? alternatives.FirstOrDefault(IsOperandAlternative)
                    ?? alternatives[0];
         }
 
@@ -865,7 +868,8 @@ public static class UsageSynopsisParser
         }
 
         var content = TrimControlWrappers(token);
-        if (HasMixedOptionOperandAlternatives(content))
+        if (HasMixedOptionOperandAlternatives(content)
+            || HasLoneDashOperandAlternatives(content))
         {
             return false;
         }
@@ -896,6 +900,7 @@ public static class UsageSynopsisParser
     {
         var content = TrimControlWrappers(token);
         return !HasMixedOptionOperandAlternatives(content)
+               && !HasLoneDashOperandAlternatives(content)
                && (IsOptionAlternative(content)
                    || OptionControlTokens.Contains(content));
     }
@@ -910,7 +915,8 @@ public static class UsageSynopsisParser
     private static bool TryGetOptionSwitch(string token, out string optionSwitch)
     {
         var content = TrimControlWrappers(token);
-        if (HasMixedOptionOperandAlternatives(content))
+        if (HasMixedOptionOperandAlternatives(content)
+            || HasLoneDashOperandAlternatives(content))
         {
             optionSwitch = "";
             return false;
@@ -933,9 +939,27 @@ public static class UsageSynopsisParser
     private static bool HasMixedOptionOperandAlternatives(string content)
     {
         var alternatives = GetAlternatives(content);
-        return alternatives.Length > 1
+        return !IsOptionAssignment(content)
+               && alternatives.Length > 1
                && alternatives.Any(IsOptionAlternative)
                && alternatives.Any(IsOperandAlternative);
+    }
+
+    private static bool IsOptionAssignment(string content)
+    {
+        var normalized = TrimControlWrappers(content);
+        var assignmentIndex = normalized.IndexOf('=');
+        return assignmentIndex > 1 && normalized.StartsWith('-');
+    }
+
+    private static bool HasLoneDashOperandAlternatives(string content)
+    {
+        var alternatives = GetAlternatives(content);
+        return alternatives.Length > 1
+               && alternatives.Any(static alternative => TrimControlWrappers(alternative) == "-")
+               && alternatives.Any(static alternative =>
+                   TrimControlWrappers(alternative) != "-"
+                   && IsOperandAlternative(alternative));
     }
 
     private static bool HasOnlyOptionControlAlternatives(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -156,9 +156,9 @@ public static class UsageSynopsisParser
             return UsageSynopsisParseResult.Unmatched(synopsis);
         }
 
-        var phase = tokens
-            .Take(commandMatch.EndIndex + 1)
-            .Any(IsOptionControlToken)
+        var phase = CollapseAlternatives(tokens
+                .Take(commandMatch.EndIndex + 1))
+            .Any(IsPhaseControlToken)
                 ? CommandLinePhase.Passthrough
                 : CommandLinePhase.EarlyOperand;
         var operandTokens = tokens.Skip(commandMatch.EndIndex + 1);
@@ -555,6 +555,10 @@ public static class UsageSynopsisParser
                          || HasRequiredSuffixOutsideOptionalPrefix(trimmed);
         var content = TrimWrapper(trimmed).Trim();
         var canonicalName = SelectCanonicalAlternative(content);
+        if (HasMixedOptionOperandAlternatives(content))
+        {
+            isRequired = false;
+        }
         if (TrySelectRequiredCompoundPlaceholder(trimmed, out var requiredPlaceholder))
         {
             isRequired = true;
@@ -735,10 +739,13 @@ public static class UsageSynopsisParser
 
     private static string SelectCanonicalAlternative(string content)
     {
-        var pipeIndex = content.IndexOf('|');
-        if (pipeIndex >= 0)
+        var alternatives = content.Split(
+            '|',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (alternatives.Length > 1)
         {
-            return content[..pipeIndex].Trim();
+            return alternatives.FirstOrDefault(IsOperandAlternative)
+                   ?? alternatives[0];
         }
 
         return content
@@ -858,6 +865,16 @@ public static class UsageSynopsisParser
         }
 
         var content = TrimControlWrappers(token);
+        if (HasMixedOptionOperandAlternatives(content))
+        {
+            return false;
+        }
+
+        if (HasOnlyOptionControlAlternatives(content))
+        {
+            return true;
+        }
+
         return string.IsNullOrWhiteSpace(content)
                || content.StartsWith('-')
                || IsOptionControlLabel(content)
@@ -878,13 +895,27 @@ public static class UsageSynopsisParser
     private static bool IsOptionControlToken(string token)
     {
         var content = TrimControlWrappers(token);
-        return content.StartsWith('-')
-               || OptionControlTokens.Contains(content);
+        return !HasMixedOptionOperandAlternatives(content)
+               && (IsOptionAlternative(content)
+                   || OptionControlTokens.Contains(content));
+    }
+
+    private static bool IsPhaseControlToken(string token)
+    {
+        var content = TrimControlWrappers(token);
+        return IsOptionControlToken(token)
+               || GetAlternatives(content).Any(IsOptionAlternative);
     }
 
     private static bool TryGetOptionSwitch(string token, out string optionSwitch)
     {
         var content = TrimControlWrappers(token);
+        if (HasMixedOptionOperandAlternatives(content))
+        {
+            optionSwitch = "";
+            return false;
+        }
+
         var endIndex = content.IndexOfAny([' ', '\t', '=']);
         optionSwitch = content.TrimEnd(',', ':');
         if (optionSwitch.Length > 1
@@ -897,6 +928,44 @@ public static class UsageSynopsisParser
 
         optionSwitch = "";
         return false;
+    }
+
+    private static bool HasMixedOptionOperandAlternatives(string content)
+    {
+        var alternatives = GetAlternatives(content);
+        return alternatives.Length > 1
+               && alternatives.Any(IsOptionAlternative)
+               && alternatives.Any(IsOperandAlternative);
+    }
+
+    private static bool HasOnlyOptionControlAlternatives(string content)
+    {
+        var alternatives = GetAlternatives(content);
+        return alternatives.Length > 1
+               && alternatives.All(static alternative =>
+               {
+                   var normalized = TrimControlWrappers(alternative);
+                   return IsOptionAlternative(normalized)
+                          || IsOptionControlLabel(normalized);
+               });
+    }
+
+    private static string[] GetAlternatives(string content) => content.Split(
+        '|',
+        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static bool IsOptionAlternative(string alternative)
+    {
+        var content = TrimControlWrappers(alternative);
+        return content.Length > 1 && content.StartsWith('-');
+    }
+
+    private static bool IsOperandAlternative(string alternative)
+    {
+        var content = TrimControlWrappers(alternative);
+        return !string.IsNullOrWhiteSpace(content)
+               && !IsOptionAlternative(content)
+               && !IsOptionControlLabel(content);
     }
 
     private static string TrimControlWrappers(string token)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -949,7 +949,10 @@ public static class UsageSynopsisParser
     {
         var normalized = TrimControlWrappers(content);
         var assignmentIndex = normalized.IndexOf('=');
-        return assignmentIndex > 1 && normalized.StartsWith('-');
+        var alternativeSeparatorIndex = normalized.IndexOf('|');
+        return assignmentIndex > 1
+               && normalized.StartsWith('-')
+               && (alternativeSeparatorIndex < 0 || assignmentIndex < alternativeSeparatorIndex);
     }
 
     private static bool HasLoneDashOperandAlternatives(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -984,23 +984,26 @@ public static class UsageSynopsisParser
     private static int GetOptionValueStartIndex(string content)
     {
         var valueStartIndex = SkipWhitespace(content, content.IndexOfAny([' ', '\t']));
-        if (valueStartIndex < 0
-            || valueStartIndex >= content.Length
-            || content[valueStartIndex] != '|')
+        while (valueStartIndex >= 0
+               && valueStartIndex < content.Length
+               && content[valueStartIndex] == '|')
         {
-            return valueStartIndex;
+            var aliasStartIndex = SkipWhitespace(content, valueStartIndex + 1);
+            if (aliasStartIndex >= content.Length || content[aliasStartIndex] != '-')
+            {
+                return valueStartIndex;
+            }
+
+            var aliasEndIndex = content.IndexOfAny([' ', '\t', '='], aliasStartIndex);
+            if (aliasEndIndex < 0)
+            {
+                return content.Length;
+            }
+
+            valueStartIndex = SkipWhitespace(content, aliasEndIndex);
         }
 
-        var aliasStartIndex = SkipWhitespace(content, valueStartIndex + 1);
-        if (aliasStartIndex >= content.Length || content[aliasStartIndex] != '-')
-        {
-            return valueStartIndex;
-        }
-
-        var aliasEndIndex = content.IndexOfAny([' ', '\t', '='], aliasStartIndex);
-        return aliasEndIndex < 0
-            ? content.Length
-            : SkipWhitespace(content, aliasEndIndex);
+        return valueStartIndex;
     }
 
     private static int SkipWhitespace(string content, int startIndex)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -968,9 +968,7 @@ public static class UsageSynopsisParser
         return valueStartIndex > 1
                && valueStartIndex < normalized.Length
                && normalized.StartsWith('-')
-               && TryGetClosingDelimiter(normalized[valueStartIndex], out var closingDelimiter)
-               && normalized[^1] == closingDelimiter
-               && normalized.IndexOf('|', valueStartIndex + 1) >= 0;
+               && alternativeSeparatorIndex > valueStartIndex;
     }
 
     private static bool HasLoneDashOperandAlternatives(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -967,11 +967,7 @@ public static class UsageSynopsisParser
     private static bool HasOptionValueAlternatives(string content)
     {
         var normalized = TrimControlWrappers(content);
-        var assignmentIndex = normalized.IndexOf('=');
-        var alternativeSeparatorIndex = normalized.IndexOf('|');
-        if (assignmentIndex > 1
-            && normalized.StartsWith('-')
-            && (alternativeSeparatorIndex < 0 || assignmentIndex < alternativeSeparatorIndex))
+        if (HasOptionAssignment(normalized))
         {
             return true;
         }
@@ -989,6 +985,24 @@ public static class UsageSynopsisParser
                && normalized.StartsWith('-')
                && normalized[valueStartIndex] != '|'
                && normalized.IndexOf('|', valueStartIndex + 1) >= 0;
+    }
+
+    private static bool HasOptionAssignment(string content)
+    {
+        var assignmentIndex = content.IndexOf('=');
+        if (assignmentIndex <= 1 || !content.StartsWith('-'))
+        {
+            return false;
+        }
+
+        var branchStartIndex = content.LastIndexOf('|', assignmentIndex) + 1;
+        while (branchStartIndex < assignmentIndex && char.IsWhiteSpace(content[branchStartIndex]))
+        {
+            branchStartIndex++;
+        }
+
+        return branchStartIndex + 1 < assignmentIndex
+               && content[branchStartIndex] == '-';
     }
 
     private static bool HasLoneDashOperandAlternatives(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -939,20 +939,38 @@ public static class UsageSynopsisParser
     private static bool HasMixedOptionOperandAlternatives(string content)
     {
         var alternatives = GetAlternatives(content);
-        return !IsOptionAssignment(content)
+        return !HasOptionValueAlternatives(content)
                && alternatives.Length > 1
                && alternatives.Any(IsOptionAlternative)
                && alternatives.Any(IsOperandAlternative);
     }
 
-    private static bool IsOptionAssignment(string content)
+    private static bool HasOptionValueAlternatives(string content)
     {
         var normalized = TrimControlWrappers(content);
         var assignmentIndex = normalized.IndexOf('=');
         var alternativeSeparatorIndex = normalized.IndexOf('|');
-        return assignmentIndex > 1
+        if (assignmentIndex > 1
+            && normalized.StartsWith('-')
+            && (alternativeSeparatorIndex < 0 || assignmentIndex < alternativeSeparatorIndex))
+        {
+            return true;
+        }
+
+        var valueStartIndex = normalized.IndexOfAny([' ', '\t']);
+        while (valueStartIndex >= 0
+               && valueStartIndex < normalized.Length
+               && char.IsWhiteSpace(normalized[valueStartIndex]))
+        {
+            valueStartIndex++;
+        }
+
+        return valueStartIndex > 1
+               && valueStartIndex < normalized.Length
                && normalized.StartsWith('-')
-               && (alternativeSeparatorIndex < 0 || assignmentIndex < alternativeSeparatorIndex);
+               && TryGetClosingDelimiter(normalized[valueStartIndex], out var closingDelimiter)
+               && normalized[^1] == closingDelimiter
+               && normalized.IndexOf('|', valueStartIndex + 1) >= 0;
     }
 
     private static bool HasLoneDashOperandAlternatives(string content)


### PR DESCRIPTION
## Summary
- query Homebrew's loaded parser for exact switch/flag kinds before modeling options
- treat `operand | --flag` synopsis alternatives as optional operands regardless of order
- add regressions for value options and Homebrew services `formula | --all`

## Validation
- OptionsGenerator tests: 1,200 passed with coverage (`--maximum-parallel-tests 1`)
- focused UsageSynopsisParser tests: 44 passed
- focused BrewCliScraper tests: 19 passed
- Release build: 0 warnings, 0 errors

Follow-up for #3996. Supersedes unsafe generated PR #4195.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew command parsing using parser-provided option type information when available.
  * Correctly models optional formula operands, including `brew services` alternatives.
  * Enhanced synopsis parsing for commands combining options, operands, assignments, and alternatives.
  * Improved handling of optional, required, and nullable command arguments.
  * Preserves help output when enhanced metadata is unavailable.
* **Tests**
  * Added coverage for complex option and operand alternatives, including phase detection and canonical operand naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->