### PR TITLE
Fix trailing-colon usage synopsis parsing

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -160,13 +160,14 @@ public class BrewCliScraperTests
     }
 
     [Test]
-    [Arguments("info", "formula | --all")]
-    [Arguments("stop", "--all | formula")]
+    [Arguments("info", "(formula | --all)")]
+    [Arguments("stop", "(--all | formula)")]
+    [Arguments("stop", "(<formula>|--all):")]
     public async Task Models_Services_Formula_Or_All_As_Optional_Formula(
         string subcommand,
-        string alternative)
+        string usageArguments)
     {
-        var helpText = $"Usage: brew services {subcommand} ({alternative})\n\n  --all  Apply to all services.";
+        var helpText = $"Usage: brew services {subcommand} {usageArguments}\n\n  --all  Apply to all services.";
 
         var command = await new TestBrewCliScraper().Parse(
             ["brew", "services", subcommand],

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -269,10 +269,12 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
-    public async Task Splits_Nested_Command_And_Argument_Operands()
+    [Arguments("")]
+    [Arguments(":")]
+    public async Task Splits_Nested_Command_And_Argument_Operands(string trailingPunctuation)
     {
         var result = UsageSynopsisParser.Parse(
-            "Usage: podman run [options] IMAGE [COMMAND [ARG...]]",
+            $"Usage: podman run [options] IMAGE [COMMAND [ARG...]]{trailingPunctuation}",
             ["podman", "run"]);
 
         using (Assert.Multiple())
@@ -321,6 +323,7 @@ public class UsageSynopsisParserTests
     [Test]
     [Arguments("Usage: brew services stop (formula | --all)")]
     [Arguments("Usage: brew services stop (--all | formula)")]
+    [Arguments("Usage: brew services stop (<formula>|--all):")]
     public async Task Models_Operand_Or_Option_Alternatives_As_Optional(string helpText)
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -569,7 +569,7 @@ public static class UsageSynopsisParser
         int positionIndex,
         CommandLinePhase phase)
     {
-        var trimmed = token.Trim().TrimEnd(',', ';');
+        var trimmed = TrimTrailingOperandPunctuation(token);
         var isRequired = !trimmed.StartsWith('[')
                          || HasRequiredSuffixOutsideOptionalPrefix(trimmed);
         var content = TrimWrapper(trimmed).Trim();
@@ -630,12 +630,13 @@ public static class UsageSynopsisParser
         out IReadOnlyList<CliPositionalArgument> arguments)
     {
         arguments = [];
-        if (!IsWrapped(token))
+        var normalizedToken = TrimTrailingOperandPunctuation(token);
+        if (!IsWrapped(normalizedToken))
         {
             return false;
         }
 
-        var content = TrimWrapper(token).Trim();
+        var content = TrimWrapper(normalizedToken).Trim();
         if (!content.Contains('[') || content.Contains('|'))
         {
             return false;
@@ -688,6 +689,9 @@ public static class UsageSynopsisParser
         arguments = parsedArguments;
         return true;
     }
+
+    private static string TrimTrailingOperandPunctuation(string token) =>
+        token.Trim().TrimEnd(',', ';', ':');
 
     private static bool HasRequiredSuffixOutsideOptionalPrefix(string token)
     {


### PR DESCRIPTION
## Summary
- strip trailing synopsis colons before parsing positional operands
- normalize nested groups before wrapper detection
- cover the exact Homebrew 6.0.18 `brew services stop (<formula>|--all):` syntax
- preserve the optional `Formula` operand alongside `--all`

## Validation
- UsageSynopsisParserTests: 68 passed
- BrewCliScraperTests: 20 passed
- full OptionsGenerator tests: 1,225 passed
- Release build: 0 warnings, 0 errors
- format verification: blocked by pre-existing IHelpTextCache.cs whitespace and unrelated info diagnostics

Refs #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line usage parsing when operand descriptions end with a colon, comma, or semicolon.
  - Correctly handles optional formula and `--all` alternatives in service command syntax.

- **Tests**
  - Added coverage for punctuation-terminated usage patterns and expanded alternative argument scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->