### PR TITLE
Parse wrapped Homebrew service operands

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -163,6 +163,7 @@ public class BrewCliScraperTests
     [Arguments("info", "(formula | --all)")]
     [Arguments("stop", "(--all | formula)")]
     [Arguments("stop", "(<formula>|--all):")]
+    [Arguments("stop", "[--keep] [--no-wait|--max-wait=] (<formula>|--all):")]
     public async Task Models_Services_Formula_Or_All_As_Optional_Formula(
         string subcommand,
         string usageArguments)
@@ -179,6 +180,46 @@ public class BrewCliScraperTests
             await Assert.That(formula.PropertyName).IsEqualTo("Formula");
             await Assert.That(formula.IsRequired).IsFalse();
             await Assert.That(formula.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
+    public async Task Models_Operand_From_Wrapped_Standalone_Services_Synopsis()
+    {
+        const string helpText = """
+            Usage: brew services [subcommand]
+
+            Manage background services with macOS' launchctl(1) daemon manager.
+
+            [sudo] brew services info (formula|--all):
+                List all managed services.
+
+                  --info-only  Only valid for the info subcommand.
+
+            [sudo] brew services stop [--keep] [--no-wait|--max-wait=]
+            (formula|--all):
+                Stop the service formula immediately and unregister it from
+            launching at login, unless --keep is specified.
+
+                  --all  Apply to all services.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(
+            ["brew", "services", "stop"],
+            helpText);
+
+        var formula = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(formula.PropertyName).IsEqualTo("Formula");
+            await Assert.That(formula.IsRequired).IsFalse();
+            await Assert.That(formula.CSharpType).IsEqualTo("string?");
+            await Assert.That(command.Description)
+                .IsEqualTo("Stop the service formula immediately and unregister it from launching at login, unless --keep is specified.");
+            await Assert.That(command.Options.Select(option => option.SwitchName))
+                .DoesNotContain("--info-only");
+            await Assert.That(command.Options.Select(option => option.SwitchName))
+                .Contains("--all");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -324,8 +324,30 @@ public class UsageSynopsisParserTests
     [Arguments("Usage: brew services stop (formula | --all)")]
     [Arguments("Usage: brew services stop (--all | formula)")]
     [Arguments("Usage: brew services stop (<formula>|--all):")]
+    [Arguments("Usage: [sudo] brew services stop [--keep] [--no-wait|--max-wait=] (<formula>|--all):")]
     public async Task Models_Operand_Or_Option_Alternatives_As_Optional(string helpText)
     {
+        var result = UsageSynopsisParser.Parse(
+            helpText,
+            ["brew", "services", "stop"]);
+
+        var argument = result.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.PropertyName).IsEqualTo("Formula");
+            await Assert.That(argument.IsRequired).IsFalse();
+            await Assert.That(argument.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
+    public async Task Joins_Wrapped_Operand_With_Trailing_Colon()
+    {
+        const string helpText = """
+            Usage: brew services stop [--keep] [--no-wait|--max-wait=]
+            (<formula>|--all):
+            """;
+
         var result = UsageSynopsisParser.Parse(
             helpText,
             ["brew", "services", "stop"]);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -179,6 +179,54 @@ public partial class BrewCliScraper : CliScraperBase
         CliCommandResult result) => result.Success;
 
     /// <summary>
+    /// Homebrew command groups render child synopses without a Usage prefix.
+    /// </summary>
+    protected override IEnumerable<string> GetAdditionalUsageSynopses(
+        string[] commandPath,
+        string helpText)
+    {
+        var command = string.Join(' ', commandPath);
+        var lines = NormalizeLines(helpText);
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var synopsis = lines[index].Trim();
+            if (!StartsWithCommand(synopsis, command))
+            {
+                continue;
+            }
+
+            yield return ReadStandaloneSynopsis(lines, ref index, synopsis);
+        }
+    }
+
+    private static bool StartsWithCommand(string synopsis, string command)
+    {
+        var commandStart = synopsis.StartsWith("[sudo] ", StringComparison.OrdinalIgnoreCase)
+            ? "[sudo] ".Length
+            : 0;
+        var candidate = synopsis.AsSpan(commandStart);
+        return candidate.StartsWith(command, StringComparison.OrdinalIgnoreCase)
+               && (candidate.Length == command.Length
+                   || char.IsWhiteSpace(candidate[command.Length]));
+    }
+
+    private static string ReadStandaloneSynopsis(
+        IReadOnlyList<string> lines,
+        ref int index,
+        string firstLine)
+    {
+        var parts = new List<string> { firstLine };
+        while (index + 1 < lines.Count
+               && UsageSynopsisParser.IsSynopsisContinuation(lines[index + 1]))
+        {
+            parts.Add(lines[++index].Trim());
+        }
+
+        return string.Join(' ', parts);
+    }
+
+    /// <summary>
     /// Extracts subcommand names from Homebrew help text.
     /// </summary>
     protected override IEnumerable<string> ExtractSubcommands(string helpText)
@@ -454,12 +502,15 @@ public partial class BrewCliScraper : CliScraperBase
         string expectedSynopsis)
     {
         var usageMatch = UsageLinePattern().Match(lines[index]);
-        if (!usageMatch.Success)
+        var synopsisStart = usageMatch.Success
+            ? usageMatch.Groups["synopsis"].Value.Trim()
+            : lines[index].Trim();
+        if (!IsSynopsisPrefix(expectedSynopsis, synopsisStart))
         {
             return false;
         }
 
-        var synopsisParts = new List<string> { usageMatch.Groups["synopsis"].Value.Trim() };
+        var synopsisParts = new List<string> { synopsisStart };
         while (index + 1 < lines.Count
                && UsageSynopsisParser.IsSynopsisContinuation(lines[index + 1]))
         {
@@ -468,6 +519,12 @@ public partial class BrewCliScraper : CliScraperBase
 
         return string.Join(' ', synopsisParts).Equals(expectedSynopsis, StringComparison.Ordinal);
     }
+
+    private static bool IsSynopsisPrefix(string expectedSynopsis, string candidate) =>
+        !string.IsNullOrWhiteSpace(candidate)
+        && expectedSynopsis.StartsWith(candidate, StringComparison.Ordinal)
+        && (candidate.Length == expectedSynopsis.Length
+            || char.IsWhiteSpace(expectedSynopsis[candidate.Length]));
 
     private static string? ReadDescriptionParagraph(
         IReadOnlyList<string> lines,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -402,7 +402,7 @@ public static class UsageSynopsisParser
             return false;
         }
 
-        var firstToken = trimmed.Split(' ', 2)[0];
+        var firstToken = TrimTrailingOperandPunctuation(trimmed.Split(' ', 2)[0]);
         if (LooksLikeSectionHeading(trimmed) && !IsWrapped(firstToken))
         {
             return false;


### PR DESCRIPTION
Homebrew command-group help prints child synopses without a \Usage:\ prefix and may wrap a colon-terminated operand onto the next line. This teaches the Brew scraper to supply the matching standalone synopsis and lets the shared parser recognize the wrapped operand.\n\nValidation:\n- BrewCliScraperTests: 22/22\n- UsageSynopsisParserTests: 70/70\n- Full generator tests: 1,229/1,229\n- Release build: 0 warnings, 0 errors\n\nRefs #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of Homebrew command usage synopses, including wrapped and multiline entries.
  - Correctly recognizes optional formula arguments and additional wait-related options.
  - Supports command entries with optional `sudo` prefixes and missing `Usage:` labels.
  - Handles trailing punctuation in synopsis operands more reliably.

- **Tests**
  - Added regression coverage for optional operands, wrapped alternatives, multiline synopses, and standalone service usage entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->