### PR TITLE
Fix circular obsolete guidance in CLI facades

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -5042,7 +5042,20 @@ public class GeneratorHardeningTests
                 "namespace ModularPipelines.Tool.Services; public class Tool { "
                 + "public Task PinInstalled_formulaAsync(ToolPinInstalled_formulaOptions? options = null) "
                 + "=> Task.CompletedTask; }");
-            var current = Command("ToolPinOptions", "ToolOptions", ["pin"]);
+            var current = Command("ToolPinOptions", "ToolOptions", ["pin"]) with
+            {
+                PositionalArguments =
+                [
+                    new CliPositionalArgument
+                    {
+                        PropertyName = "InstalledFormula",
+                        CSharpType = "IEnumerable<string>",
+                        IsRequired = true,
+                        PositionIndex = 0,
+                        Phase = CommandLinePhase.Passthrough,
+                    },
+                ],
+            };
 
             var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(current), root);
             var restored = preserved.Commands.Single(command =>
@@ -5058,6 +5071,9 @@ public class GeneratorHardeningTests
                 await Assert.That(generated).Contains("PinInstalled_formulaAsync(");
                 await Assert.That(generated)
                     .Contains("ToolPinInstalled_formulaOptions? options = null");
+                await Assert.That(generated).Contains("[Obsolete(\"Use PinAsync instead.\")]");
+                await Assert.That(generated)
+                    .DoesNotContain("[Obsolete(\"Use PinInstalledFormulaAsync instead.\")]");
             }
         }
         finally

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -144,6 +144,7 @@ internal static class GeneratedApiCompatibilityPreserver
         var currentOptionTypes = tool.Commands
             .Select(static command => command.ClassName)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var rootCommands = GeneratorUtils.GetNonCollidingRootCommands(tool).ToHashSet();
         var facadeMethodsByOptionsType = facadeMethods
             .GroupBy(static method => method.OptionsType, StringComparer.Ordinal)
             .ToDictionary(
@@ -162,7 +163,8 @@ internal static class GeneratedApiCompatibilityPreserver
             yield return RestoreRemovedCommand(
                 tool,
                 commandBaseline,
-                facadeMethodsByOptionsType.GetValueOrDefault(commandBaseline.ClassName) ?? []);
+                facadeMethodsByOptionsType.GetValueOrDefault(commandBaseline.ClassName) ?? [],
+                rootCommands);
         }
     }
 
@@ -222,7 +224,8 @@ internal static class GeneratedApiCompatibilityPreserver
     private static CliCommandDefinition RestoreRemovedCommand(
         CliToolDefinition tool,
         GeneratedApiBaseline baseline,
-        IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
+        IReadOnlyList<GeneratedFacadeMethod> facadeMethods,
+        HashSet<CliCommandDefinition> rootCommands)
     {
         var commandParts = baseline.CommandParts!;
         var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, baseline, facadeMethods);
@@ -231,7 +234,8 @@ internal static class GeneratedApiCompatibilityPreserver
             && IsNamedFacadeMethod(tool, method));
         var replacementRootMethodName = FindLiveOperandReplacementRootMethodName(
             tool,
-            commandParts);
+            commandParts,
+            rootCommands);
         var subDomainGroup = commandParts.Length > 1 && !preserveRootNamedFacade
             ? GetRestoredSubDomainGroup(tool, commandParts[0], groupIdentifier)
             : null;
@@ -280,9 +284,9 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static string? FindLiveOperandReplacementRootMethodName(
         CliToolDefinition tool,
-        string[] removedCommandParts)
+        string[] removedCommandParts,
+        HashSet<CliCommandDefinition> rootCommands)
     {
-        var rootCommands = GeneratorUtils.GetNonCollidingRootCommands(tool).ToHashSet();
         var candidates = tool.Commands
             .Where(static command => !command.IsCompatibilityOnly)
             .Where(command => command.CommandParts.Length < removedCommandParts.Length)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -229,8 +229,9 @@ internal static class GeneratedApiCompatibilityPreserver
         var preserveRootNamedFacade = facadeMethods.Any(method =>
             IsRootFacadeMethod(tool, method)
             && IsNamedFacadeMethod(tool, method));
-        var currentRootMethodName = GeneratorUtils.EnsureAsyncSuffix(
-            GeneratorUtils.GenerateMethodNameFromCommandParts(commandParts));
+        var replacementRootMethodName = FindLiveOperandReplacementRootMethodName(
+            tool,
+            commandParts);
         var subDomainGroup = commandParts.Length > 1 && !preserveRootNamedFacade
             ? GetRestoredSubDomainGroup(tool, commandParts[0], groupIdentifier)
             : null;
@@ -254,7 +255,9 @@ internal static class GeneratedApiCompatibilityPreserver
                     MethodName = method.MethodName,
                     ObsoleteMessage = !IsRootFacadeMethod(tool, method)
                         ? "Use the current command facade instead."
-                        : $"Use {currentRootMethodName} instead.",
+                        : replacementRootMethodName is null
+                            ? GeneratorUtils.CompatibilityOnlyObsoleteMessage
+                            : $"Use {replacementRootMethodName} instead.",
                 })
                 .DistinctBy(static method => method.MethodName, StringComparer.Ordinal)],
             SubDomainGroup = subDomainGroup,
@@ -273,6 +276,42 @@ internal static class GeneratedApiCompatibilityPreserver
             PreserveRootNamedFacade = preserveRootNamedFacade,
             PreserveOptionalOptionsParameter = facadeMethods.Any(static method => method.IsOptionsOptional),
         };
+    }
+
+    private static string? FindLiveOperandReplacementRootMethodName(
+        CliToolDefinition tool,
+        string[] removedCommandParts)
+    {
+        var rootCommands = GeneratorUtils.GetNonCollidingRootCommands(tool).ToHashSet();
+        var candidates = tool.Commands
+            .Where(static command => !command.IsCompatibilityOnly)
+            .Where(command => command.CommandParts.Length < removedCommandParts.Length)
+            .Where(command => command.CommandParts.SequenceEqual(
+                removedCommandParts.Take(command.CommandParts.Length),
+                StringComparer.OrdinalIgnoreCase))
+            .Where(command => command.PositionalArguments.Any(argument =>
+                argument is { IsRequired: true, PositionIndex: 0 }
+                && argument.PropertyName.Equals(
+                    GeneratorUtils.GenerateMethodNameFromCommandParts(
+                        [.. removedCommandParts.Skip(command.CommandParts.Length)]),
+                    StringComparison.Ordinal)))
+            .Where(rootCommands.Contains)
+            .OrderByDescending(static command => command.CommandParts.Length)
+            .ToArray();
+        if (candidates.Length == 0)
+        {
+            return null;
+        }
+
+        var longestPathLength = candidates[0].CommandParts.Length;
+        var longestMatches = candidates
+            .TakeWhile(command => command.CommandParts.Length == longestPathLength)
+            .Take(2)
+            .ToArray();
+        return longestMatches.Length == 1
+            ? GeneratorUtils.EnsureAsyncSuffix(
+                GeneratorUtils.GenerateMethodNameFromCommandParts(longestMatches[0].CommandParts))
+            : null;
     }
 
     private static string? GetRestoredSubDomainGroup(


### PR DESCRIPTION
## Summary

- detect restored nested commands that became required operands
- point legacy facade aliases to the live root facade
- fall back to the compatibility-only warning instead of targeting another obsolete method
- add regression coverage for the Homebrew pin shape

Generated integration files are intentionally unchanged; the normal automated workflow will regenerate them after this generator fix lands.

## Validation

- OptionsGenerator tests: 1,229 passed with Cobertura coverage
- OptionsGenerator Release build: passed, 0 warnings
- changed-file whitespace verification: passed
- whole-solution format verification: blocked by pre-existing whitespace/analyzer debt outside this change

Closes #4204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility guidance for removed commands by identifying the most relevant replacement command.
  - Preserved accurate guidance for nested commands and required positional arguments.
  - Added safeguards to fall back to the compatibility message when no unique replacement can be determined.
  - Corrected messaging to recommend `PinAsync` where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->