### PR TITLE
Allow cleared findings in merge reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,13 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Resolve pull request head
+        id: pull_request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: echo "head_sha=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -58,7 +65,8 @@ jobs:
             Instructions:
             - ALWAYS post a review comment, even if no issues are found. If the code is good, acknowledge it.
             - Compare the current state of the PR against any previous PR comments to make sure they have been addressed.
-            - You MUST post your review as a PR comment using `gh pr review` or `gh pr comment` before finishing. Do not just output the review - actually post it to the PR.
+            - You MUST post the complete review using `gh pr review --comment --body`, including the verdict marker, before finishing. Do not use `gh pr comment` for the final review and do not just output the review.
+            - End the top-level review body with exactly one machine-readable verdict marker. Use `<!-- REVIEW_VERDICT: CLEAR HEAD: ${{ steps.pull_request.outputs.head_sha }} -->` only when there are no actionable findings. Use `<!-- REVIEW_VERDICT: BLOCKING HEAD: ${{ steps.pull_request.outputs.head_sha }} -->` whenever any actionable finding remains. Never use CLEAR to resolve an inline review thread.
             - When you find issues, ALWAYS suggest better approaches or architectural improvements, not just minor optimizations.
             - Focus on:
               * Design patterns that could be improved

--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -7,8 +7,8 @@
 #   - mergeStateStatus == CLEAN
 #   - every status check is terminal AND passing (CheckRun: status=COMPLETED and
 #     conclusion in SUCCESS/SKIPPED/NEUTRAL; StatusContext: state=SUCCESS)
-#   - no current-head top-level review has actionable finding headings, unless a
-#     trusted collaborator explicitly clears that reviewer on the exact head
+#   - no current-head top-level review has actionable finding headings, unless
+#     the trusted review workflow posts an exact-head CLEAR verdict
 #   - no unresolved review threads
 #
 # Any other state — pending/queued/in-progress checks, an empty rollup, a failed
@@ -86,15 +86,6 @@ if ($bad.Count -gt 0) {
     Deny ("checks not green: " + ($bad -join '; '))
 }
 
-if ($Repo) {
-    $owner, $name = $Repo -split '/', 2
-}
-else {
-    $nwo = gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>$null
-    if ($LASTEXITCODE -ne 0 -or -not $nwo) { Deny "could not resolve repo" }
-    $owner, $name = $nwo.Trim() -split '/', 2
-}
-
 $headCommit = @($view.commits | Where-Object { $null -ne $_ }) | Select-Object -Last 1
 $headCommittedAt = if ($headCommit) { ConvertTo-UtcDateTimeOffset $headCommit.committedDate } else { $null }
 
@@ -119,48 +110,26 @@ foreach ($review in $latestReviews) {
 
     $body = [string]$review.body
     $reason = Get-ActionableReviewBodyReason -Body $body
-    if ($reason) {
-        $actionableReviews += [pscustomobject]@{
-            Review = $review
-            Reason = $reason
-        }
+    if ($reason -and -not (Test-TrustedBotClearVerdict `
+            -Review $review `
+            -HeadSha ([string]$view.headRefOid))) {
+        $actionableReviews += "$($review.author.login): $reason"
     }
 }
 if ($actionableReviews.Count -gt 0) {
-    # Natural-language "all clear" prose is too ambiguous to override an
-    # actionable heading. Only an exact, trusted, current-head marker can do so.
-    $commentsRaw = gh api "repos/$owner/$name/issues/$Pr/comments" --paginate --slurp 2>$null
-    if ($LASTEXITCODE -ne 0) { Deny "could not fetch review override comments" }
-    try {
-        $commentPages = $commentsRaw | ConvertFrom-Json
-        $reviewOverrideComments = @(
-            foreach ($page in @($commentPages)) {
-                foreach ($comment in @($page)) {
-                    $comment
-                }
-            }
-        )
-    }
-    catch {
-        Deny "could not parse review override comments: $($_.Exception.Message)"
-    }
-
-    $unoverriddenReviews = @(
-        foreach ($actionableReview in $actionableReviews) {
-            if (-not (Test-ReviewHasTrustedClearanceOverride `
-                    -Review $actionableReview.Review `
-                    -Comments $reviewOverrideComments `
-                    -HeadSha ([string]$view.headRefOid))) {
-                "$($actionableReview.Review.author.login): $($actionableReview.Reason)"
-            }
-        }
-    )
-    if ($unoverriddenReviews.Count -gt 0) {
-        Deny ("latest top-level review comment has actionable finding(s): " + ($unoverriddenReviews -join '; '))
-    }
+    Deny ("latest top-level review comment has actionable finding(s): " + ($actionableReviews -join '; '))
 }
 
 # Unresolved review threads block merge even when a review's state is COMMENTED.
+if ($Repo) {
+    $owner, $name = $Repo -split '/', 2
+}
+else {
+    $nwo = gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $nwo) { Deny "could not resolve repo for review-thread check" }
+    $owner, $name = $nwo.Trim() -split '/', 2
+}
+
 $query = 'query($owner:String!,$repo:String!,$pr:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}'
 $unresolved = 0
 $after = $null

--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -7,7 +7,8 @@
 #   - mergeStateStatus == CLEAN
 #   - every status check is terminal AND passing (CheckRun: status=COMPLETED and
 #     conclusion in SUCCESS/SKIPPED/NEUTRAL; StatusContext: state=SUCCESS)
-#   - no current-head top-level review has actionable finding headings
+#   - no current-head top-level review has actionable finding headings, unless a
+#     trusted collaborator explicitly clears that reviewer on the exact head
 #   - no unresolved review threads
 #
 # Any other state — pending/queued/in-progress checks, an empty rollup, a failed
@@ -40,7 +41,7 @@ $repoArgs = @()
 if ($Repo) { $repoArgs = @('--repo', $Repo) }
 
 # Re-fetch fresh — survey output goes stale within seconds.
-$raw = gh pr view $Pr @repoArgs --json number,state,mergeable,mergeStateStatus,statusCheckRollup,latestReviews,commits 2>$null
+$raw = gh pr view $Pr @repoArgs --json number,state,mergeable,mergeStateStatus,statusCheckRollup,latestReviews,commits,headRefOid 2>$null
 if ($LASTEXITCODE -ne 0) { Deny "gh pr view failed (exit $LASTEXITCODE)" }
 try {
     $view = $raw | ConvertFrom-Json
@@ -85,6 +86,15 @@ if ($bad.Count -gt 0) {
     Deny ("checks not green: " + ($bad -join '; '))
 }
 
+if ($Repo) {
+    $owner, $name = $Repo -split '/', 2
+}
+else {
+    $nwo = gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $nwo) { Deny "could not resolve repo" }
+    $owner, $name = $nwo.Trim() -split '/', 2
+}
+
 $headCommit = @($view.commits | Where-Object { $null -ne $_ }) | Select-Object -Last 1
 $headCommittedAt = if ($headCommit) { ConvertTo-UtcDateTimeOffset $headCommit.committedDate } else { $null }
 
@@ -110,23 +120,47 @@ foreach ($review in $latestReviews) {
     $body = [string]$review.body
     $reason = Get-ActionableReviewBodyReason -Body $body
     if ($reason) {
-        $actionableReviews += "$($review.author.login): $reason"
+        $actionableReviews += [pscustomobject]@{
+            Review = $review
+            Reason = $reason
+        }
     }
 }
 if ($actionableReviews.Count -gt 0) {
-    Deny ("latest top-level review comment has actionable finding(s): " + ($actionableReviews -join '; '))
+    # Natural-language "all clear" prose is too ambiguous to override an
+    # actionable heading. Only an exact, trusted, current-head marker can do so.
+    $commentsRaw = gh api "repos/$owner/$name/issues/$Pr/comments" --paginate --slurp 2>$null
+    if ($LASTEXITCODE -ne 0) { Deny "could not fetch review override comments" }
+    try {
+        $commentPages = $commentsRaw | ConvertFrom-Json
+        $reviewOverrideComments = @(
+            foreach ($page in @($commentPages)) {
+                foreach ($comment in @($page)) {
+                    $comment
+                }
+            }
+        )
+    }
+    catch {
+        Deny "could not parse review override comments: $($_.Exception.Message)"
+    }
+
+    $unoverriddenReviews = @(
+        foreach ($actionableReview in $actionableReviews) {
+            if (-not (Test-ReviewHasTrustedClearanceOverride `
+                    -Review $actionableReview.Review `
+                    -Comments $reviewOverrideComments `
+                    -HeadSha ([string]$view.headRefOid))) {
+                "$($actionableReview.Review.author.login): $($actionableReview.Reason)"
+            }
+        }
+    )
+    if ($unoverriddenReviews.Count -gt 0) {
+        Deny ("latest top-level review comment has actionable finding(s): " + ($unoverriddenReviews -join '; '))
+    }
 }
 
 # Unresolved review threads block merge even when a review's state is COMMENTED.
-if ($Repo) {
-    $owner, $name = $Repo -split '/', 2
-}
-else {
-    $nwo = gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>$null
-    if ($LASTEXITCODE -ne 0 -or -not $nwo) { Deny "could not resolve repo for review-thread check" }
-    $owner, $name = $nwo.Trim() -split '/', 2
-}
-
 $query = 'query($owner:String!,$repo:String!,$pr:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}'
 $unresolved = 0
 $after = $null

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -222,10 +222,14 @@ function Get-ActionableReviewBodyReason {
     $positiveCategoryVerdictLine =
         "(?im)^$horizontalWhitespace*(?:[-*]$horizontalWhitespace*)?(?![^\r\n]*\b(?:but|however|though|except)\b)(?:$positiveVerdictLineAlternatives)\.?$horizontalWhitespace*\r?$"
 
-    $clearedFindingSection =
-        "(?i)\b(?:false[- ]positive|does(?:n['’]t|\s+not)\s+reproduce|cannot\s+be\s+reproduced|no\s+action\s+(?:is\s+)?needed|(?:finding|report|concern|risk)\s+(?:is|was|has\s+been)\s+(?:withdrawn|resolved|cleared))\b"
+    $clearedFindingEvidence =
+        "(?i)\b(?:false[- ]positive|does(?:n['’]t|\s+not)\s+reproduce|cannot\s+be\s+reproduced|(?:finding|report|concern|risk)\s+(?:is|was|has\s+been)\s+(?:withdrawn|resolved|cleared))\b"
+    $clearedFindingNoActionVerdict =
+        '(?i)\b(?:no\s+(?:action|changes?)\s+(?:(?:is|are)\s+)?needed(?:\s+here)?|nothing\s+(?:needs?\s+to\s+be|to\s+be)\s+changed)\b'
     $clearedFindingContradiction =
         '(?is)\b(?:but|however|though|except)\b[\s\S]{0,300}\b(?:bugs?|issues?|concerns?|risks?|blockers?|incorrect|broken|fix|require(?:d|s)?|must|should|needs?)\b'
+    $clearedFindingRemainingAction =
+        '(?i)\b(?:needs?|requires?|must|should|worth)\s+(?:be\s+)?(?:fixed|addressed|changed|investigated|handled|reworked|updated|attention|follow[- ]up)\b'
 
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
     $categoryHeadingPattern = "(?im)^$horizontalWhitespace*#{2,4}$horizontalWhitespace+($categoryOnlyHeading)(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*(?<verdict>\S[^\r\n#]*))|(?:$horizontalWhitespace*\((?<parentheticalVerdict>[^)\r\n#]+)\))|(?:$horizontalWhitespace+(?<bareVerdict>\S[^\r\n#]*)))?:?$horizontalWhitespace*\r?$"
@@ -291,8 +295,10 @@ function Get-ActionableReviewBodyReason {
         }
 
         $isClearedFinding =
-            $sectionBody -match $clearedFindingSection -and
+            $sectionBody -match $clearedFindingEvidence -and
+            $sectionBody -match $clearedFindingNoActionVerdict -and
             $sectionBody -notmatch $clearedFindingContradiction -and
+            $sectionBody -notmatch $clearedFindingRemainingAction -and
             $sectionBody -notmatch $positiveVerdictContinuationBlocker
         if ($isClearedFinding) {
             continue

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -222,6 +222,11 @@ function Get-ActionableReviewBodyReason {
     $positiveCategoryVerdictLine =
         "(?im)^$horizontalWhitespace*(?:[-*]$horizontalWhitespace*)?(?![^\r\n]*\b(?:but|however|though|except)\b)(?:$positiveVerdictLineAlternatives)\.?$horizontalWhitespace*\r?$"
 
+    $clearedFindingSection =
+        "(?i)\b(?:false[- ]positive|does(?:n['’]t|\s+not)\s+reproduce|cannot\s+be\s+reproduced|no\s+action\s+(?:is\s+)?needed|(?:finding|report|concern|risk)\s+(?:is|was|has\s+been)\s+(?:withdrawn|resolved|cleared))\b"
+    $clearedFindingContradiction =
+        '(?is)\b(?:but|however|though|except)\b[\s\S]{0,300}\b(?:bugs?|issues?|concerns?|risks?|blockers?|incorrect|broken|fix|require(?:d|s)?|must|should|needs?)\b'
+
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
     $categoryHeadingPattern = "(?im)^$horizontalWhitespace*#{2,4}$horizontalWhitespace+($categoryOnlyHeading)(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*(?<verdict>\S[^\r\n#]*))|(?:$horizontalWhitespace*\((?<parentheticalVerdict>[^)\r\n#]+)\))|(?:$horizontalWhitespace+(?<bareVerdict>\S[^\r\n#]*)))?:?$horizontalWhitespace*\r?$"
     foreach ($heading in [regex]::Matches($Body, $categoryHeadingPattern)) {
@@ -273,11 +278,30 @@ function Get-ActionableReviewBodyReason {
         }
     }
 
+    $actionableHeadingPattern =
+        "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryHeadingWithOptionalVerdict\s*$).*\b($actionableHeadingWord)\b"
+    foreach ($heading in [regex]::Matches($Body, $actionableHeadingPattern)) {
+        $sectionStart = $heading.Index + $heading.Length
+        $sectionRemainder = $Body.Substring($sectionStart)
+        $nextHeading = [regex]::Match($sectionRemainder, '(?m)^\s*#{2,4}\s+')
+        $sectionBody = if ($nextHeading.Success) {
+            $sectionRemainder.Substring(0, $nextHeading.Index)
+        } else {
+            $sectionRemainder
+        }
+
+        $isClearedFinding =
+            $sectionBody -match $clearedFindingSection -and
+            $sectionBody -notmatch $clearedFindingContradiction -and
+            $sectionBody -notmatch $positiveVerdictContinuationBlocker
+        if ($isClearedFinding) {
+            continue
+        }
+
+        return "actionable heading: $($heading.Value.Trim())"
+    }
+
     $patterns = @(
-        @{
-            Reason = 'actionable heading'
-            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryHeadingWithOptionalVerdict\s*$).*\b($actionableHeadingWord)\b"
-        },
         @{
             Reason = 'numbered finding heading'
             Pattern = '(?im)^\s*#{2,4}\s+\d+\.\s+(?!(?:minor|optional|nit|non[- ]blocking)\b).+'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -229,7 +229,7 @@ function Get-ActionableReviewBodyReason {
     $clearedFindingContradiction =
         '(?is)\b(?:but|however|though|except)\b[\s\S]{0,300}\b(?:bugs?|issues?|concerns?|risks?|blockers?|incorrect|broken|fix|require(?:d|s)?|must|should|needs?)\b'
     $clearedFindingRemainingAction =
-        '(?i)\b(?:needs?|requires?|must|should|worth)\s+(?:be\s+)?(?:fixed|addressed|changed|investigated|handled|reworked|updated|attention|follow[- ]up)\b'
+        '(?i)\b(?:needs?|requires?|must|should|worth)\s+(?:be\s+)?(?:a\s+)?(?:fix(?:ed|ing)?|addressed|changed|investigated|handled|reworked|updated|attention|follow[- ]up)\b'
     $clearedFindingMultipleReport =
         '(?i)\b(?:separate(?:ly)?|another|additional|unrelated)\b'
     $globalClearVerdict =

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -105,51 +105,29 @@ function Test-StaleBotReviewCanBeIgnored {
     return Test-StatusCheckCompletedAfterInstant -Checks $Checks -Name 'claude-review' -InstantUtc $HeadCommitCommittedAt
 }
 
-function Test-ReviewHasTrustedClearanceOverride {
+function Test-TrustedBotClearVerdict {
     [CmdletBinding()]
     param(
         [AllowNull()]$Review,
-        [AllowNull()]$Comments,
         [Parameter(Mandatory)][string]$HeadSha
     )
 
     $author = [string]$Review.author.login
-    $submittedAt = ConvertTo-UtcDateTimeOffset $Review.submittedAt
-    if ([string]::IsNullOrWhiteSpace($author) -or
-        $HeadSha -notmatch '^[0-9a-f]{40}$' -or
-        $null -eq $submittedAt) {
+    if ($author -notmatch '^claude(?:\[bot\])?$' -or $HeadSha -notmatch '^[0-9a-f]{40}$') {
         return $false
     }
 
-    $markerPattern =
-        '(?im)^\s*<!--\s*REVIEW_VERDICT_OVERRIDE:\s*CLEAR\s+' +
-        'AUTHOR:\s*' + [regex]::Escape($author) + '\s+' +
-        'HEAD:\s*' + [regex]::Escape($HeadSha) + '\s*-->\s*$'
-    $trustedAssociations = @('OWNER', 'MEMBER', 'COLLABORATOR')
-
-    foreach ($comment in @($Comments | Where-Object { $null -ne $_ })) {
-        $association = [string]$comment.author_association
-        if ([string]::IsNullOrWhiteSpace($association)) {
-            $association = [string]$comment.authorAssociation
-        }
-        if ($trustedAssociations -notcontains $association) {
-            continue
-        }
-
-        $createdAt = ConvertTo-UtcDateTimeOffset $comment.created_at
-        if ($null -eq $createdAt) {
-            $createdAt = ConvertTo-UtcDateTimeOffset $comment.createdAt
-        }
-        if ($null -eq $createdAt -or $createdAt -le $submittedAt) {
-            continue
-        }
-
-        if ([string]$comment.body -match $markerPattern) {
-            return $true
-        }
+    $markers = [regex]::Matches(
+        [string]$Review.body,
+        '(?im)^\s*<!--\s*REVIEW_VERDICT:\s*(CLEAR|BLOCKING)\s+HEAD:\s*([0-9a-f]{40})\s*-->\s*$'
+    )
+    if ($markers.Count -ne 1 -or
+        $markers[0].Groups[1].Value -ne 'CLEAR' -or
+        $markers[0].Groups[2].Value -ne $HeadSha) {
+        return $false
     }
 
-    return $false
+    return $true
 }
 
 function Test-ReviewCategoryAllowsGlobalNoIssueVerdict {
@@ -191,7 +169,7 @@ function Get-ActionableReviewBodyReason {
         return $null
     }
 
-    $verdictMarkers = [regex]::Matches($Body, '(?im)^\s*<!--\s*REVIEW_VERDICT:\s*(CLEAR|BLOCKING)\s*-->\s*$')
+    $verdictMarkers = [regex]::Matches($Body, '(?im)^\s*<!--\s*REVIEW_VERDICT:\s*(CLEAR|BLOCKING)(?:\s+HEAD:\s*[0-9a-f]{40})?\s*-->\s*$')
     if ($verdictMarkers.Count -gt 0) {
         foreach ($marker in $verdictMarkers) {
             if ($marker.Groups[1].Value -eq 'BLOCKING') {

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -105,6 +105,53 @@ function Test-StaleBotReviewCanBeIgnored {
     return Test-StatusCheckCompletedAfterInstant -Checks $Checks -Name 'claude-review' -InstantUtc $HeadCommitCommittedAt
 }
 
+function Test-ReviewHasTrustedClearanceOverride {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Review,
+        [AllowNull()]$Comments,
+        [Parameter(Mandatory)][string]$HeadSha
+    )
+
+    $author = [string]$Review.author.login
+    $submittedAt = ConvertTo-UtcDateTimeOffset $Review.submittedAt
+    if ([string]::IsNullOrWhiteSpace($author) -or
+        $HeadSha -notmatch '^[0-9a-f]{40}$' -or
+        $null -eq $submittedAt) {
+        return $false
+    }
+
+    $markerPattern =
+        '(?im)^\s*<!--\s*REVIEW_VERDICT_OVERRIDE:\s*CLEAR\s+' +
+        'AUTHOR:\s*' + [regex]::Escape($author) + '\s+' +
+        'HEAD:\s*' + [regex]::Escape($HeadSha) + '\s*-->\s*$'
+    $trustedAssociations = @('OWNER', 'MEMBER', 'COLLABORATOR')
+
+    foreach ($comment in @($Comments | Where-Object { $null -ne $_ })) {
+        $association = [string]$comment.author_association
+        if ([string]::IsNullOrWhiteSpace($association)) {
+            $association = [string]$comment.authorAssociation
+        }
+        if ($trustedAssociations -notcontains $association) {
+            continue
+        }
+
+        $createdAt = ConvertTo-UtcDateTimeOffset $comment.created_at
+        if ($null -eq $createdAt) {
+            $createdAt = ConvertTo-UtcDateTimeOffset $comment.createdAt
+        }
+        if ($null -eq $createdAt -or $createdAt -le $submittedAt) {
+            continue
+        }
+
+        if ([string]$comment.body -match $markerPattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function Test-ReviewCategoryAllowsGlobalNoIssueVerdict {
     [CmdletBinding()]
     param(
@@ -222,21 +269,6 @@ function Get-ActionableReviewBodyReason {
     $positiveCategoryVerdictLine =
         "(?im)^$horizontalWhitespace*(?:[-*]$horizontalWhitespace*)?(?![^\r\n]*\b(?:but|however|though|except)\b)(?:$positiveVerdictLineAlternatives)\.?$horizontalWhitespace*\r?$"
 
-    $clearedFindingEvidence =
-        "(?i)\b(?:false[- ]positive|does(?:n['’]t|\s+not)\s+reproduce|cannot\s+be\s+reproduced|(?:finding|report|concern|risk)\s+(?:is|was|has\s+been)\s+(?:withdrawn|resolved|cleared))\b"
-    $clearedFindingNoActionVerdict =
-        '(?i)\b(?:no\s+(?:action|changes?)\s+(?:(?:is|are)\s+)?needed(?:\s+here)?|nothing\s+(?:needs?\s+to\s+be|to\s+be)\s+changed)\b'
-    $clearedFindingContradiction =
-        '(?is)\b(?:but|however|though|except)\b[\s\S]{0,300}\b(?:bugs?|issues?|concerns?|risks?|blockers?|incorrect|broken|fix|require(?:d|s)?|must|should|needs?)\b'
-    $clearedFindingRemainingAction =
-        '(?i)\b(?:needs?|requires?|must|should|worth)\s+(?:be\s+)?(?:a\s+)?(?:fix(?:ed|ing)?|addressed|changed|investigated|handled|reworked|updated|attention|follow[- ]up)\b'
-    $clearedFindingMultipleReport =
-        '(?i)\b(?:separate(?:ly)?|another|additional|unrelated)\b'
-    $clearedFindingReviewHeading =
-        '(?i)^\s*#{2,4}\s+(?:on|about|regarding)\b[^\r\n]*\b(?:flagged|reported|review|finding|report|risk)\b'
-    $globalClearVerdict =
-        $Body -match "(?im)^\s*(?![^\r\n]*\b(?:but|however|though|except)\b)[^\r\n]*\b(?:I\s+don['’]t\s+see\s+anything\s+to\s+change|no\s+changes?\s+(?:(?:is|are)\s+)?needed)\b[^\r\n]*\r?$"
-
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
     $categoryHeadingPattern = "(?im)^$horizontalWhitespace*#{2,4}$horizontalWhitespace+($categoryOnlyHeading)(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*(?<verdict>\S[^\r\n#]*))|(?:$horizontalWhitespace*\((?<parentheticalVerdict>[^)\r\n#]+)\))|(?:$horizontalWhitespace+(?<bareVerdict>\S[^\r\n#]*)))?:?$horizontalWhitespace*\r?$"
     foreach ($heading in [regex]::Matches($Body, $categoryHeadingPattern)) {
@@ -288,40 +320,11 @@ function Get-ActionableReviewBodyReason {
         }
     }
 
-    $actionableHeadingPattern =
-        "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryHeadingWithOptionalVerdict\s*$).*\b($actionableHeadingWord)\b"
-    foreach ($heading in [regex]::Matches($Body, $actionableHeadingPattern)) {
-        $sectionStart = $heading.Index + $heading.Length
-        $sectionRemainder = $Body.Substring($sectionStart)
-        $nextHeading = [regex]::Match($sectionRemainder, '(?m)^\s*#{2,4}\s+')
-        $sectionBody = if ($nextHeading.Success) {
-            $sectionRemainder.Substring(0, $nextHeading.Index)
-        } else {
-            $sectionRemainder
-        }
-        $sectionParagraphs = @(
-            [regex]::Split($sectionBody.Trim(), '\r?\n\s*\r?\n') |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-        )
-
-        $isClearedFinding =
-            $heading.Value -match $clearedFindingReviewHeading -and
-            $sectionParagraphs.Count -eq 1 -and
-            $sectionBody -match $clearedFindingEvidence -and
-            $sectionBody -match $clearedFindingNoActionVerdict -and
-            $sectionBody -notmatch $clearedFindingContradiction -and
-            $sectionBody -notmatch $clearedFindingRemainingAction -and
-            $sectionBody -notmatch $clearedFindingMultipleReport -and
-            $globalClearVerdict -and
-            $sectionBody -notmatch $positiveVerdictContinuationBlocker
-        if ($isClearedFinding) {
-            continue
-        }
-
-        return "actionable heading: $($heading.Value.Trim())"
-    }
-
     $patterns = @(
+        @{
+            Reason = 'actionable heading'
+            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryHeadingWithOptionalVerdict\s*$).*\b($actionableHeadingWord)\b"
+        },
         @{
             Reason = 'numbered finding heading'
             Pattern = '(?im)^\s*#{2,4}\s+\d+\.\s+(?!(?:minor|optional|nit|non[- ]blocking)\b).+'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -230,6 +230,10 @@ function Get-ActionableReviewBodyReason {
         '(?is)\b(?:but|however|though|except)\b[\s\S]{0,300}\b(?:bugs?|issues?|concerns?|risks?|blockers?|incorrect|broken|fix|require(?:d|s)?|must|should|needs?)\b'
     $clearedFindingRemainingAction =
         '(?i)\b(?:needs?|requires?|must|should|worth)\s+(?:be\s+)?(?:fixed|addressed|changed|investigated|handled|reworked|updated|attention|follow[- ]up)\b'
+    $clearedFindingMultipleReport =
+        '(?i)\b(?:separate(?:ly)?|another|additional|unrelated)\b'
+    $globalClearVerdict =
+        $Body -match "(?im)^\s*(?![^\r\n]*\b(?:but|however|though|except)\b)[^\r\n]*\b(?:I\s+don['’]t\s+see\s+anything\s+to\s+change|no\s+changes?\s+(?:(?:is|are)\s+)?needed)\b[^\r\n]*\r?$"
 
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
     $categoryHeadingPattern = "(?im)^$horizontalWhitespace*#{2,4}$horizontalWhitespace+($categoryOnlyHeading)(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*(?<verdict>\S[^\r\n#]*))|(?:$horizontalWhitespace*\((?<parentheticalVerdict>[^)\r\n#]+)\))|(?:$horizontalWhitespace+(?<bareVerdict>\S[^\r\n#]*)))?:?$horizontalWhitespace*\r?$"
@@ -299,6 +303,8 @@ function Get-ActionableReviewBodyReason {
             $sectionBody -match $clearedFindingNoActionVerdict -and
             $sectionBody -notmatch $clearedFindingContradiction -and
             $sectionBody -notmatch $clearedFindingRemainingAction -and
+            $sectionBody -notmatch $clearedFindingMultipleReport -and
+            $globalClearVerdict -and
             $sectionBody -notmatch $positiveVerdictContinuationBlocker
         if ($isClearedFinding) {
             continue

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -232,6 +232,8 @@ function Get-ActionableReviewBodyReason {
         '(?i)\b(?:needs?|requires?|must|should|worth)\s+(?:be\s+)?(?:a\s+)?(?:fix(?:ed|ing)?|addressed|changed|investigated|handled|reworked|updated|attention|follow[- ]up)\b'
     $clearedFindingMultipleReport =
         '(?i)\b(?:separate(?:ly)?|another|additional|unrelated)\b'
+    $clearedFindingReviewHeading =
+        '(?i)^\s*#{2,4}\s+(?:on|about|regarding)\b[^\r\n]*\b(?:flagged|reported|review|finding|report|risk)\b'
     $globalClearVerdict =
         $Body -match "(?im)^\s*(?![^\r\n]*\b(?:but|however|though|except)\b)[^\r\n]*\b(?:I\s+don['’]t\s+see\s+anything\s+to\s+change|no\s+changes?\s+(?:(?:is|are)\s+)?needed)\b[^\r\n]*\r?$"
 
@@ -297,8 +299,14 @@ function Get-ActionableReviewBodyReason {
         } else {
             $sectionRemainder
         }
+        $sectionParagraphs = @(
+            [regex]::Split($sectionBody.Trim(), '\r?\n\s*\r?\n') |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
 
         $isClearedFinding =
+            $heading.Value -match $clearedFindingReviewHeading -and
+            $sectionParagraphs.Count -eq 1 -and
             $sectionBody -match $clearedFindingEvidence -and
             $sectionBody -match $clearedFindingNoActionVerdict -and
             $sectionBody -notmatch $clearedFindingContradiction -and

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -198,8 +198,6 @@ function Get-ActionableReviewBodyReason {
                 return 'review verdict marker: BLOCKING'
             }
         }
-
-        return $null
     }
 
     $resolvedPriorFindingLineContinuationGuard =

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -117,13 +117,15 @@ function Test-TrustedBotClearVerdict {
         return $false
     }
 
+    $body = [string]$Review.body
     $markers = [regex]::Matches(
-        [string]$Review.body,
+        $body,
         '(?im)^\s*<!--\s*REVIEW_VERDICT:\s*(CLEAR|BLOCKING)\s+HEAD:\s*([0-9a-f]{40})\s*-->\s*$'
     )
     if ($markers.Count -ne 1 -or
         $markers[0].Groups[1].Value -ne 'CLEAR' -or
-        $markers[0].Groups[2].Value -ne $HeadSha) {
+        $markers[0].Groups[2].Value -ne $HeadSha -or
+        -not [string]::IsNullOrWhiteSpace($body.Substring($markers[0].Index + $markers[0].Length))) {
         return $false
     }
 

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -83,7 +83,7 @@ machine-readable all-clear marker.
 
 No issues found.
 
-<!-- REVIEW_VERDICT: BLOCKING -->
+<!-- REVIEW_VERDICT: BLOCKING HEAD: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->
 '@
         Blocks = $true
     },
@@ -1163,79 +1163,69 @@ foreach ($case in $staleReviewCases) {
     }
 }
 
-$overrideHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-$overrideReview = [pscustomobject]@{
-    submittedAt = '2026-07-06T01:41:00Z'
-    author = [pscustomobject]@{ login = 'claude' }
-}
-$overrideCases = @(
+$verdictHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+$verdictCases = @(
     @{
-        Name = 'allows trusted current-head override after review'
-        Comments = @([pscustomobject]@{
-            author_association = 'OWNER'
-            created_at = '2026-07-06T01:42:00Z'
-            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
-        })
-        Head = $overrideHead
+        Name = 'allows trusted exact-head bot verdict'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude' }
+            body = "### Risk`nNo action is needed.`n<!-- REVIEW_VERDICT: CLEAR HEAD: $verdictHead -->"
+        }
         Clears = $true
     },
     @{
-        Name = 'rejects untrusted override'
-        Comments = @([pscustomobject]@{
-            author_association = 'NONE'
-            created_at = '2026-07-06T01:42:00Z'
-            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
-        })
-        Head = $overrideHead
+        Name = 'rejects verdict from untrusted reviewer'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'alice' }
+            body = "<!-- REVIEW_VERDICT: CLEAR HEAD: $verdictHead -->"
+        }
         Clears = $false
     },
     @{
-        Name = 'rejects override before review'
-        Comments = @([pscustomobject]@{
-            author_association = 'MEMBER'
-            created_at = '2026-07-06T01:40:00Z'
-            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
-        })
-        Head = $overrideHead
+        Name = 'rejects verdict for another head'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude' }
+            body = "<!-- REVIEW_VERDICT: CLEAR HEAD: $('b' * 40) -->"
+        }
         Clears = $false
     },
     @{
-        Name = 'rejects override at review timestamp'
-        Comments = @([pscustomobject]@{
-            author_association = 'OWNER'
-            created_at = '2026-07-06T01:41:00Z'
-            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
-        })
-        Head = $overrideHead
+        Name = 'rejects blocking verdict'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude' }
+            body = "<!-- REVIEW_VERDICT: BLOCKING HEAD: $verdictHead -->"
+        }
         Clears = $false
     },
     @{
-        Name = 'rejects override for another head'
-        Comments = @([pscustomobject]@{
-            authorAssociation = 'COLLABORATOR'
-            createdAt = '2026-07-06T01:42:00Z'
-            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $('b' * 40) -->"
-        })
-        Head = $overrideHead
+        Name = 'rejects legacy verdict without head'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude' }
+            body = '<!-- REVIEW_VERDICT: CLEAR -->'
+        }
         Clears = $false
     },
     @{
-        Name = 'rejects override for another reviewer'
-        Comments = @([pscustomobject]@{
-            author_association = 'OWNER'
-            created_at = '2026-07-06T01:42:00Z'
-            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: coderabbitai HEAD: $overrideHead -->"
-        })
-        Head = $overrideHead
+        Name = 'rejects multiple verdict markers'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude' }
+            body = "<!-- REVIEW_VERDICT: CLEAR HEAD: $verdictHead -->`n<!-- REVIEW_VERDICT: BLOCKING HEAD: $verdictHead -->"
+        }
         Clears = $false
     }
 )
 
-foreach ($case in $overrideCases) {
-    $clears = Test-ReviewHasTrustedClearanceOverride -Review $overrideReview -Comments $case.Comments -HeadSha $case.Head
+foreach ($case in $verdictCases) {
+    $clears = Test-TrustedBotClearVerdict -Review $case.Review -HeadSha $verdictHead
     if ($clears -ne $case.Clears) {
         throw "Case '$($case.Name)' expected Clears=$($case.Clears), got Clears=$clears"
     }
 }
 
-Write-Host "OK review heuristic tests passed ($($cases.Count) body cases, $($staleReviewCases.Count) stale review cases, $($overrideCases.Count) override cases)."
+Write-Host "OK review heuristic tests passed ($($cases.Count) body cases, $($staleReviewCases.Count) stale review cases, $($verdictCases.Count) verdict cases)."

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -1004,8 +1004,11 @@ I don't see anything to change.
 ## Review
 
 ### On CodeRabbit's flagged risk
-The documentation report is a false positive. However, the generated service
-still throws an exception for the same command and requires a fix.
+The documentation report is a false positive. No action is needed here.
+However, the generated service still throws an exception for the same command.
+
+### Verdict
+I don't see anything to change.
 '@
         Blocks = $true
     },
@@ -1037,6 +1040,20 @@ The documentation report is a false positive, so no action is needed here.
 ### On CodeRabbit's flagged risk
 The documentation report is a false positive, so no action is needed there.
 The retry path separately needs follow-up under contention.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks cleared report with bare fix phrase'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive, so no action is needed there.
+The retry path still requires a fix.
+
+### Verdict
+I don't see anything to change.
 '@
         Blocks = $true
     },

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -984,6 +984,32 @@ The missing tests are now present.
         Blocks = $false
     },
     @{
+        Name = 'allows false-positive report heading with cleared section'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+CodeRabbit reported that `BrewUpdateResetOptions` was removed. I checked the
+generated replacement directly; the report is a false positive. The type and
+service method still exist, so no action is needed here.
+
+### Verdict
+I don't see anything to change.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks false-positive report heading with contradictory defect'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive. However, the generated service
+still throws an exception for the same command and requires a fix.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks test coverage gap closed heading with trailing vulnerability'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -64,7 +64,7 @@ Scope check passed.
         Blocks = $false
     },
     @{
-        Name = 'allows explicit clear verdict marker'
+        Name = 'blocks self-issued clear verdict marker with actionable heading'
         Body = @'
 ## Review
 
@@ -74,7 +74,7 @@ machine-readable all-clear marker.
 
 <!-- REVIEW_VERDICT: CLEAR -->
 '@
-        Blocks = $false
+        Blocks = $true
     },
     @{
         Name = 'blocks explicit blocking verdict marker'

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -1010,6 +1010,27 @@ still throws an exception for the same command and requires a fix.
         Blocks = $true
     },
     @{
+        Name = 'blocks false-positive report without no-action verdict'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive. The generated type exists.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks cleared report section with separate follow-up'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive, so no action is needed there.
+The retry path separately needs follow-up under contention.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks test coverage gap closed heading with trailing vulnerability'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -1218,6 +1218,15 @@ $verdictCases = @(
             body = "<!-- REVIEW_VERDICT: CLEAR HEAD: $verdictHead -->`n<!-- REVIEW_VERDICT: BLOCKING HEAD: $verdictHead -->"
         }
         Clears = $false
+    },
+    @{
+        Name = 'rejects content after clear verdict marker'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude' }
+            body = "<!-- REVIEW_VERDICT: CLEAR HEAD: $verdictHead -->`n### Risk`nThe retry path loses updates."
+        }
+        Clears = $false
     }
 )
 

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -1072,6 +1072,34 @@ I don't see anything to change.
         Blocks = $true
     },
     @{
+        Name = 'blocks cleared report followed by unclassified paragraph'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive, so no action is needed there.
+
+The second path returns yesterday's snapshot under load.
+
+### Verdict
+I don't see anything to change.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks cleared risk under non-review heading'
+        Body = @'
+## Review
+
+### Runtime risk
+The documentation report is a false positive, so no action is needed there.
+
+### Verdict
+I don't see anything to change.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks test coverage gap closed heading with trailing vulnerability'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -1020,6 +1020,16 @@ The documentation report is a false positive. The generated type exists.
         Blocks = $true
     },
     @{
+        Name = 'blocks locally cleared report without global verdict'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive, so no action is needed here.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks cleared report section with separate follow-up'
         Body = @'
 ## Review
@@ -1027,6 +1037,20 @@ The documentation report is a false positive. The generated type exists.
 ### On CodeRabbit's flagged risk
 The documentation report is a false positive, so no action is needed there.
 The retry path separately needs follow-up under contention.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks mixed report despite contradictory global verdict'
+        Body = @'
+## Review
+
+### On CodeRabbit's flagged risk
+The documentation report is a false positive, so no action is needed there.
+The retry path separately loses updates under contention.
+
+### Verdict
+I don't see anything to change.
 '@
         Blocks = $true
     },

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -984,7 +984,7 @@ The missing tests are now present.
         Blocks = $false
     },
     @{
-        Name = 'allows false-positive report heading with cleared section'
+        Name = 'blocks natural-language clearance under actionable heading'
         Body = @'
 ## Review
 
@@ -992,107 +992,6 @@ The missing tests are now present.
 CodeRabbit reported that `BrewUpdateResetOptions` was removed. I checked the
 generated replacement directly; the report is a false positive. The type and
 service method still exist, so no action is needed here.
-
-### Verdict
-I don't see anything to change.
-'@
-        Blocks = $false
-    },
-    @{
-        Name = 'blocks false-positive report heading with contradictory defect'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive. No action is needed here.
-However, the generated service still throws an exception for the same command.
-
-### Verdict
-I don't see anything to change.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks false-positive report without no-action verdict'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive. The generated type exists.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks locally cleared report without global verdict'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive, so no action is needed here.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks cleared report section with separate follow-up'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive, so no action is needed there.
-The retry path separately needs follow-up under contention.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks cleared report with bare fix phrase'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive, so no action is needed there.
-The retry path still requires a fix.
-
-### Verdict
-I don't see anything to change.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks mixed report despite contradictory global verdict'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive, so no action is needed there.
-The retry path separately loses updates under contention.
-
-### Verdict
-I don't see anything to change.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks cleared report followed by unclassified paragraph'
-        Body = @'
-## Review
-
-### On CodeRabbit's flagged risk
-The documentation report is a false positive, so no action is needed there.
-
-The second path returns yesterday's snapshot under load.
-
-### Verdict
-I don't see anything to change.
-'@
-        Blocks = $true
-    },
-    @{
-        Name = 'blocks cleared risk under non-review heading'
-        Body = @'
-## Review
-
-### Runtime risk
-The documentation report is a false positive, so no action is needed there.
 
 ### Verdict
 I don't see anything to change.
@@ -1264,4 +1163,79 @@ foreach ($case in $staleReviewCases) {
     }
 }
 
-Write-Host "OK review heuristic tests passed ($($cases.Count) body cases, $($staleReviewCases.Count) stale review cases)."
+$overrideHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+$overrideReview = [pscustomobject]@{
+    submittedAt = '2026-07-06T01:41:00Z'
+    author = [pscustomobject]@{ login = 'claude' }
+}
+$overrideCases = @(
+    @{
+        Name = 'allows trusted current-head override after review'
+        Comments = @([pscustomobject]@{
+            author_association = 'OWNER'
+            created_at = '2026-07-06T01:42:00Z'
+            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
+        })
+        Head = $overrideHead
+        Clears = $true
+    },
+    @{
+        Name = 'rejects untrusted override'
+        Comments = @([pscustomobject]@{
+            author_association = 'NONE'
+            created_at = '2026-07-06T01:42:00Z'
+            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
+        })
+        Head = $overrideHead
+        Clears = $false
+    },
+    @{
+        Name = 'rejects override before review'
+        Comments = @([pscustomobject]@{
+            author_association = 'MEMBER'
+            created_at = '2026-07-06T01:40:00Z'
+            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
+        })
+        Head = $overrideHead
+        Clears = $false
+    },
+    @{
+        Name = 'rejects override at review timestamp'
+        Comments = @([pscustomobject]@{
+            author_association = 'OWNER'
+            created_at = '2026-07-06T01:41:00Z'
+            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $overrideHead -->"
+        })
+        Head = $overrideHead
+        Clears = $false
+    },
+    @{
+        Name = 'rejects override for another head'
+        Comments = @([pscustomobject]@{
+            authorAssociation = 'COLLABORATOR'
+            createdAt = '2026-07-06T01:42:00Z'
+            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: claude HEAD: $('b' * 40) -->"
+        })
+        Head = $overrideHead
+        Clears = $false
+    },
+    @{
+        Name = 'rejects override for another reviewer'
+        Comments = @([pscustomobject]@{
+            author_association = 'OWNER'
+            created_at = '2026-07-06T01:42:00Z'
+            body = "<!-- REVIEW_VERDICT_OVERRIDE: CLEAR AUTHOR: coderabbitai HEAD: $overrideHead -->"
+        })
+        Head = $overrideHead
+        Clears = $false
+    }
+)
+
+foreach ($case in $overrideCases) {
+    $clears = Test-ReviewHasTrustedClearanceOverride -Review $overrideReview -Comments $case.Comments -HeadSha $case.Head
+    if ($clears -ne $case.Clears) {
+        throw "Case '$($case.Name)' expected Clears=$($case.Clears), got Clears=$clears"
+    }
+}
+
+Write-Host "OK review heuristic tests passed ($($cases.Count) body cases, $($staleReviewCases.Count) stale review cases, $($overrideCases.Count) override cases)."


### PR DESCRIPTION
## Summary

- keep natural-language actionable review headings fail-closed
- require the trusted Claude review workflow to emit one structured CLEAR/BLOCKING verdict bound to the exact PR head
- accept CLEAR only from the `claude` reviewer identity; new heads, wrong reviewers, legacy markers, blocking markers, or multiple markers fail closed
- keep unresolved threads and all status checks as independent merge blockers

## Validation

- `pwsh scripts/Test-AssertPrGreenReviewHeuristics.ps1` (112 body, 4 stale-review, 6 verdict cases)
- exact live #4202 review remains blocked without a structured verdict
- synthesized exact-head Claude verdict clears the live #4202 false-positive review shape
- `git diff --check`

Closes #4206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated validation of review verdicts against the current pull request commit.
  - Trusted automated reviews can explicitly clear actionable findings when they include the required exact-head verdict.
  - Review workflows now resolve the pull request head and publish standardized clear or blocking verdicts.

- **Bug Fixes**
  - Prevented natural-language clearance, outdated verdicts, untrusted reviews, and ambiguous multiple verdicts from bypassing review safeguards.
  - Improved handling of review findings and repository checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->