### PR TITLE
Remove redundant get file logging

### DIFF
--- a/src/ModularPipelines/FileSystem/Folder.cs
+++ b/src/ModularPipelines/FileSystem/Folder.cs
@@ -439,11 +439,7 @@ public class Folder : IEquatable<Folder>
 
     public File GetFile(string name)
     {
-        var combinedPath = _provider.Combine(Path, name);
-
-        LogFolderOperation("Getting File: {Path}", combinedPath);
-
-        return new File(combinedPath, _provider);
+        return new File(_provider.Combine(Path, name), _provider);
     }
 
     public File CreateFile(string name)

--- a/test/ModularPipelines.UnitTests/FileSystem/FolderTests.cs
+++ b/test/ModularPipelines.UnitTests/FileSystem/FolderTests.cs
@@ -43,6 +43,17 @@ public class FolderTests : TestBase
                 ?? throw new InvalidOperationException("Foo.txt was not found."));
     }
 
+    private class ReadFileModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            context.Files
+                .GetFolder(Path.Combine(TestContext.OutputDirectory!, "Data"))
+                .GetFile("Foo.txt")
+                .ReadAsync(cancellationToken);
+    }
+
     [Test]
     public async Task CleanFolders()
     {
@@ -86,6 +97,30 @@ public class FolderTests : TestBase
 
         var actualLogResult = stringBuilder.ToString().Trim();
         await Assert.That(actualLogResult).Contains("x => x.Name == \"Foo.txt\"");
+    }
+
+    [Test]
+    public async Task Reading_File_Does_Not_Log_Getting_File()
+    {
+        var stringBuilder = new StringBuilder();
+
+        await TestPipelineBuilder.Create()
+            .ConfigureServices(collection =>
+            {
+                collection
+                    .AddSingleton<ILogger<ReadFileModule>>(
+                        new StringLogger<ReadFileModule>(stringBuilder))
+                    .AddModule<ReadFileModule>();
+            })
+            .ExecutePipelineAsync();
+
+        var actualLogResult = stringBuilder.ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(actualLogResult).Contains("Reading File:");
+            await Assert.That(actualLogResult).DoesNotContain("Getting File:");
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- stop logging path-object lookup from Folder.GetFile
- retain operation-specific file logs such as Reading File
- add regression coverage for the GetFile/ReadAsync chain

## Testing
- focused FolderTests regression test (1 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unnecessary “Getting File” informational log when accessing a file.
  * File access now retains the expected “Reading File” logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->