### PR TITLE
Show skipped marker in module output headers

### DIFF
--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -1,6 +1,7 @@
 using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
+using ModularPipelines.Enums;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.Console;
@@ -114,6 +115,14 @@ internal interface IModuleOutputBuffer
     /// This remains true while an incremental flush owns output and until its final status is rendered.
     /// </summary>
     bool NeedsCompletionFlush { get; }
+
+    /// <summary>
+    /// Sets the final module status used for completion header formatting.
+    /// </summary>
+    /// <param name="status">The final module status.</param>
+    void SetStatus(Status status)
+    {
+    }
 
     /// <summary>
     /// Marks the owning module as complete so periodic flushing no longer selects it.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -7,6 +7,7 @@ using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using Spectre.Console;
+using Status = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.Console;
 
@@ -43,6 +44,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
     private Action<Exception>? _deferredFlushFailureHandler;
+    private Status _status = Status.Successful;
     private bool _isComplete;
     private bool _hasRenderedCompletionHeader;
     private bool _isIncrementalFlushInProgress;
@@ -281,6 +283,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                            && (_hasRenderedIncrementalOutput || _showFailureHeaderWithoutOutput)
                            && !_hasRenderedCompletionHeader);
             }
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetStatus(Status status)
+    {
+        lock (_lock)
+        {
+            _status = status;
         }
     }
 
@@ -791,6 +802,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         var duration = DateTime.UtcNow - _startTimeUtc;
         var durationText = duration.ToDisplayString();
         var continuationText = isContinuation ? " (continued)" : string.Empty;
+        Status status;
+
+        lock (_lock)
+        {
+            status = _status;
+        }
 
         if (exception != null)
         {
@@ -802,8 +819,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return $"{_moduleName} \u2026{continuationText} ({durationText})";
         }
 
+        var completionMarker = status is Status.Skipped ? "\u2298" : "\u2713";
         return _showSuccessMarker
-            ? $"{_moduleName} \u2713{continuationText} ({durationText})"
+            ? $"{_moduleName} {completionMarker}{continuationText} ({durationText})"
             : $"{_moduleName}{continuationText} ({durationText})";
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -802,12 +802,6 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         var duration = DateTime.UtcNow - _startTimeUtc;
         var durationText = duration.ToDisplayString();
         var continuationText = isContinuation ? " (continued)" : string.Empty;
-        Status status;
-
-        lock (_lock)
-        {
-            status = _status;
-        }
 
         if (exception != null)
         {
@@ -819,10 +813,20 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return $"{_moduleName} \u2026{continuationText} ({durationText})";
         }
 
-        var completionMarker = status is Status.Skipped ? "\u2298" : "\u2713";
-        return _showSuccessMarker
-            ? $"{_moduleName} {completionMarker}{continuationText} ({durationText})"
-            : $"{_moduleName}{continuationText} ({durationText})";
+        if (!_showSuccessMarker)
+        {
+            return $"{_moduleName}{continuationText} ({durationText})";
+        }
+
+        Status status;
+
+        lock (_lock)
+        {
+            status = _status;
+        }
+
+        var completionMarker = Markup.Remove(StatusDisplayProvider.GetDisplayInfo(status).Icon);
+        return $"{_moduleName} {completionMarker}{continuationText} ({durationText})";
     }
 
     private static IAnsiConsole CreateDirectConsole(TextWriter writer)

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -388,6 +388,11 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         var skippedResult = ModuleResult<T>.CreateSkipped(skipDecision, executionContext);
 
+        if (logger is IInternalModuleLogger internalLogger)
+        {
+            internalLogger.SetStatus(Status.Skipped);
+        }
+
         logger.LogInformation("Module {ModuleName} skipped: {Reason}",
             executionContext.ModuleType.Name,
             skipDecision.Reason ?? "No reason provided");

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -205,6 +205,11 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         }
         finally
         {
+            if (logger is IInternalModuleLogger internalLogger)
+            {
+                internalLogger.SetStatus(executionContext.Status);
+            }
+
             try
             {
                 moduleResult = await InvokePendingAfterHookAsync(
@@ -387,11 +392,6 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         }
 
         var skippedResult = ModuleResult<T>.CreateSkipped(skipDecision, executionContext);
-
-        if (logger is IInternalModuleLogger internalLogger)
-        {
-            internalLogger.SetStatus(Status.Skipped);
-        }
 
         logger.LogInformation("Module {ModuleName} skipped: {Reason}",
             executionContext.ModuleType.Name,

--- a/src/ModularPipelines/Logging/IInternalModuleLogger.cs
+++ b/src/ModularPipelines/Logging/IInternalModuleLogger.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Enums;
+
 namespace ModularPipelines.Logging;
 
 /// <summary>
@@ -9,4 +11,9 @@ internal interface IInternalModuleLogger : IModuleLogger
     /// Sets the exception that occurred during module execution.
     /// </summary>
     void SetException(Exception exception);
+
+    /// <summary>
+    /// Sets the final module status used when rendering buffered output.
+    /// </summary>
+    void SetStatus(Status status);
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -4,6 +4,7 @@ using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using Spectre.Console;
 using Spectre.Console.Rendering;
+using Status = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.Logging;
 
@@ -40,6 +41,7 @@ internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter, IA
 
     protected readonly object _disposeLock = new();
     protected Exception? _exception;
+    protected Status _status = Status.Successful;
 
     public abstract void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
 
@@ -59,6 +61,11 @@ internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter, IA
     public void SetException(Exception exception)
     {
         _exception = exception;
+    }
+
+    public void SetStatus(Status status)
+    {
+        _status = status;
     }
 }
 
@@ -160,6 +167,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
                 _buffer.SetException(_exception);
             }
 
+            _buffer.SetStatus(_status);
             _buffer.MarkComplete();
         }
 
@@ -184,6 +192,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
                 _buffer.SetException(_exception);
             }
 
+            _buffer.SetStatus(_status);
             _buffer.MarkComplete();
             shouldFlush = true;
         }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
+using ModularPipelines.Enums;
 using ModularPipelines.TestHelpers;
 using Moq;
 
@@ -436,6 +437,27 @@ public class ModuleOutputBufferTests
             OutputFlushKind.Complete);
 
         await Assert.That(writer.ToString()).Contains("ModuleOutputBufferTests ✓");
+    }
+
+    [Test]
+    public async Task CompleteFlush_RendersSkippedMarkerForSkippedModuleOutput()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("skipped output");
+        buffer.SetStatus(Status.Skipped);
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("ModuleOutputBufferTests ⊘");
+        await Assert.That(output).DoesNotContain("ModuleOutputBufferTests ✓");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -440,13 +440,19 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task CompleteFlush_RendersSkippedMarkerForSkippedModuleOutput()
+    [Arguments(Status.Skipped, "⊘")]
+    [Arguments(Status.IgnoredFailure, "⚠")]
+    [Arguments(Status.UsedHistory, "↻")]
+    [Arguments(Status.CachedResult, "↻")]
+    public async Task CompleteFlush_RendersMarkerForFinalModuleStatus(
+        Status status,
+        string expectedMarker)
     {
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer);
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
-        buffer.WriteLine("skipped output");
-        buffer.SetStatus(Status.Skipped);
+        buffer.WriteLine("module output");
+        buffer.SetStatus(status);
 
         await buffer.FlushToAsync(
             writer,
@@ -456,7 +462,7 @@ public class ModuleOutputBufferTests
             OutputFlushKind.Complete);
 
         var output = writer.ToString();
-        await Assert.That(output).Contains("ModuleOutputBufferTests ⊘");
+        await Assert.That(output).Contains($"ModuleOutputBufferTests {expectedMarker}");
         await Assert.That(output).DoesNotContain("ModuleOutputBufferTests ✓");
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -301,7 +301,7 @@ public class ModuleExecutionPipelineTests
     {
         var module = new SuccessfulModule();
         var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
-        var logger = new Mock<IModuleLogger>();
+        var logger = new Mock<IInternalModuleLogger>();
         var services = new Mock<IServicesContext>();
         services.SetupGet(x => x.Options).Returns(new PipelineOptions());
         var moduleContext = new Mock<IModuleContext>();
@@ -347,6 +347,7 @@ public class ModuleExecutionPipelineTests
             It.Is<It.IsAnyType>((state, _) => state.ToString() == expectedMessage),
             null,
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        logger.Verify(x => x.SetStatus(Status.Skipped), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -188,12 +188,15 @@ public class ModuleExecutionPipelineTests
     public async Task ExecuteAsync_HonorsIgnoredTimeoutAfterPipelineCancellation()
     {
         var module = new IgnoredTimeoutExceptionModule();
+        var logger = new Mock<IInternalModuleLogger>();
 
         var result = await ExecuteAfterPipelineCancellation(
             module,
-            cancelPipelineInFailureHook: true);
+            cancelPipelineInFailureHook: true,
+            logger: logger);
 
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.IgnoredFailure);
+        logger.Verify(x => x.SetStatus(Status.IgnoredFailure), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -14,6 +14,7 @@ using NReco.Logging.File;
 using Spectre.Console;
 using File = ModularPipelines.FileSystem.File;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+using Status = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.UnitTests.Logging;
 
@@ -298,6 +299,24 @@ public class ModuleLoggerTests
                 state.ToString()!.Contains("buffered output could not be flushed", StringComparison.Ordinal)),
             It.Is<Exception?>(exception => IsObfuscatedCopyOf(exception, moduleException)),
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+    [Test]
+    public async Task DisposeAsync_PropagatesModuleStatusToOutputBuffer()
+    {
+        var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            Mock.Of<ILogger<ModuleLoggerTests>>(),
+            Mock.Of<ISecretObfuscator>(),
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            CreateConsoleCoordinator(moduleOutputBuffer.Object).Object,
+            Mock.Of<IOutputCoordinator>());
+        logger.SetStatus(Status.Skipped);
+
+        await logger.DisposeAsync();
+
+        moduleOutputBuffer.Verify(x => x.SetStatus(Status.Skipped), Times.Once);
+        moduleOutputBuffer.Verify(x => x.MarkComplete(), Times.Once);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- propagate skipped module status to buffered output headers
- render ⊘ instead of ✓ for skipped module output groups
- cover skip status propagation and header rendering

## Testing
- ModuleOutputBufferTests: 39 passed
- ModuleExecutionPipelineTests: 10 passed
- ModuleLoggerTests: 12 passed
- changed-file whitespace verification passed

## Local validation note
Release solution build could not start because Invoke-AgentDotNet.ps1 split colon-form MSBuild switches under the current PowerShell/SDK combination, producing MSB1008. Focused test runs compiled the affected projects successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion output now displays status-specific markers for skipped, ignored-failure, historical, and cached results instead of always showing a success marker.
  * Final module status is consistently preserved through execution, logging, and output completion, including asynchronous workflows.

* **Tests**
  * Added coverage for status-specific completion markers and propagation of final statuses during execution and disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->