### PR TITLE
Fix CI pipeline summary output

### DIFF
--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -327,6 +327,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         var effectiveFallbackLoggers = fallbackLoggers ?? [];
         var failedStructuredDeliveries = new List<StructuredDeliveryRetry>();
         var renderedCount = 0;
+        var renderedConsoleOutput = false;
 
         try
         {
@@ -357,6 +358,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                     effectiveFallbackLoggers,
                     failedStructuredDeliveries,
                     ref renderedCount,
+                    ref renderedConsoleOutput,
                     cancellationToken);
             }
         }
@@ -364,7 +366,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             if (flushKind is OutputFlushKind.Incremental)
             {
-                RecordRenderedOutput(OutputFlushKind.Incremental, shouldRenderOutputGroup);
+                RecordRenderedOutput(OutputFlushKind.Incremental, renderedConsoleOutput);
             }
 
             RestoreUnrenderedOutputs(outputs, renderedCount);
@@ -375,7 +377,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             RestoreStructuredDeliveryRetries(failedStructuredDeliveries);
         }
 
-        RecordRenderedOutput(flushKind, shouldRenderOutputGroup);
+        RecordRenderedOutput(flushKind, renderedConsoleOutput);
     }
 
     internal IAnsiConsole GetDirectConsole(TextWriter writer)
@@ -513,10 +515,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IReadOnlyList<ILogger> fallbackLoggers,
         List<StructuredDeliveryRetry> failedStructuredDeliveries,
         ref int renderedCount,
+        ref bool renderedConsoleOutput,
         CancellationToken cancellationToken)
     {
         if (renderGate is null)
         {
+            renderedConsoleOutput = true;
             console.WriteLine(
                 $"Timed out waiting for the console logger render gate for {_moduleName}; writing buffered output directly.");
             RenderOutputGroup(
@@ -533,6 +537,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 failedStructuredDeliveries,
                 writeStructuredLogsDirectly: true,
                 ref renderedCount,
+                ref renderedConsoleOutput,
                 cancellationToken);
             return;
         }
@@ -553,6 +558,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 failedStructuredDeliveries,
                 writeStructuredLogsDirectly: false,
                 ref renderedCount,
+                ref renderedConsoleOutput,
                 cancellationToken);
         }
     }
@@ -571,6 +577,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         List<StructuredDeliveryRetry> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
+        ref bool renderedConsoleOutput,
         CancellationToken cancellationToken)
     {
         var header = FormatHeader(exception, flushKind, isContinuation);
@@ -586,6 +593,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
+            renderedConsoleOutput |= shouldRenderOutputGroup;
 
             // Keep the synchronization gate for the complete group. MEL.Spectre uses
             // synchronous rendering, so unrelated logger calls cannot enter this group.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -336,7 +336,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 console,
                 cancellationToken);
 
-            if (outputs.Count > 0 || shouldRenderOutputGroup)
+            if (shouldRenderOutputGroup
+                || outputs.Any(static output => output.LogEvent is not null))
             {
                 using var renderGate = await loggerControl
                     .TryAcquireRenderGateAsync(_renderGateTimeout, cancellationToken)
@@ -363,7 +364,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             if (flushKind is OutputFlushKind.Incremental)
             {
-                RecordRenderedOutput(OutputFlushKind.Incremental, renderedCount);
+                RecordRenderedOutput(OutputFlushKind.Incremental, shouldRenderOutputGroup);
             }
 
             RestoreUnrenderedOutputs(outputs, renderedCount);
@@ -374,7 +375,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             RestoreStructuredDeliveryRetries(failedStructuredDeliveries);
         }
 
-        RecordRenderedOutput(flushKind, renderedCount);
+        RecordRenderedOutput(flushKind, shouldRenderOutputGroup);
     }
 
     internal IAnsiConsole GetDirectConsole(TextWriter writer)
@@ -688,7 +689,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
     }
 
-    private void RecordRenderedOutput(OutputFlushKind flushKind, int renderedCount)
+    private void RecordRenderedOutput(OutputFlushKind flushKind, bool renderedConsoleOutput)
     {
         lock (_lock)
         {
@@ -701,7 +702,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             else
             {
                 _isIncrementalFlushInProgress = false;
-                if (renderedCount > 0)
+                if (renderedConsoleOutput)
                 {
                     _hasRenderedIncrementalOutput = true;
                 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -336,7 +336,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 console,
                 cancellationToken);
 
-            if (shouldRenderOutputGroup)
+            if (outputs.Count > 0 || shouldRenderOutputGroup)
             {
                 using var renderGate = await loggerControl
                     .TryAcquireRenderGateAsync(_renderGateTimeout, cancellationToken)
@@ -352,6 +352,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                     flushKind,
                     isContinuation,
                     outputs,
+                    shouldRenderOutputGroup,
                     effectiveFallbackLoggers,
                     failedStructuredDeliveries,
                     ref renderedCount,
@@ -485,7 +486,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
             outputs = [.. _outputs];
             structuredDeliveryRetries = [.. _structuredDeliveryRetries];
-            shouldRenderOutputGroup = _outputs.Count > 0 || needsExceptionHeader;
+            shouldRenderOutputGroup = needsExceptionHeader || _outputs.Any(ProducesConsoleOutput);
             isContinuation = _hasRenderedIncrementalOutput;
             _outputs.Clear();
             _structuredDeliveryRetries.Clear();
@@ -507,6 +508,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         OutputFlushKind flushKind,
         bool isContinuation,
         List<BufferedOutput> outputs,
+        bool shouldRenderOutputGroup,
         IReadOnlyList<ILogger> fallbackLoggers,
         List<StructuredDeliveryRetry> failedStructuredDeliveries,
         ref int renderedCount,
@@ -525,6 +527,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 flushKind,
                 isContinuation,
                 outputs,
+                shouldRenderOutputGroup,
                 fallbackLoggers,
                 failedStructuredDeliveries,
                 writeStructuredLogsDirectly: true,
@@ -544,6 +547,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 flushKind,
                 isContinuation,
                 outputs,
+                shouldRenderOutputGroup,
                 fallbackLoggers,
                 failedStructuredDeliveries,
                 writeStructuredLogsDirectly: false,
@@ -561,6 +565,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         OutputFlushKind flushKind,
         bool isContinuation,
         List<BufferedOutput> outputs,
+        bool shouldRenderOutputGroup,
         IReadOnlyList<ILogger> fallbackLoggers,
         List<StructuredDeliveryRetry> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly,
@@ -568,8 +573,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         CancellationToken cancellationToken)
     {
         var header = FormatHeader(exception, flushKind, isContinuation);
-        var startCommand = formatter.GetStartBlockCommand(header);
-        var endCommand = formatter.GetEndBlockCommand(header);
+        var startCommand = shouldRenderOutputGroup
+            ? formatter.GetStartBlockCommand(header)
+            : null;
+        var endCommand = shouldRenderOutputGroup
+            ? formatter.GetEndBlockCommand(header)
+            : null;
         var groupStarted = false;
         var flushCompleted = false;
 
@@ -606,7 +615,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 WriteGroupCommand(console, directConsole, formatter, endCommand);
             }
 
-            if (groupStarted || flushCompleted)
+            if (groupStarted || (flushCompleted && shouldRenderOutputGroup))
             {
                 // Add blank line between module sections for visual separation.
                 console.WriteLine();
@@ -805,6 +814,21 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return _showSuccessMarker
             ? $"{_moduleName} \u2713{continuationText} ({durationText})"
             : $"{_moduleName}{continuationText} ({durationText})";
+    }
+
+    private bool ProducesConsoleOutput(BufferedOutput output)
+    {
+        if (output.IsRawBuildSystemCommand)
+        {
+            return true;
+        }
+
+        if (output.IsString)
+        {
+            return !string.IsNullOrEmpty(output.StringValue);
+        }
+
+        return output.LogEvent is { } logEvent && _isSpectreEnabled(logEvent.Level);
     }
 
     private static IAnsiConsole CreateDirectConsole(TextWriter writer)

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -20,17 +20,10 @@ internal class SpectreResultsPrinter : IResultsPrinter
     private const int MaxStackFrames = 5;
 
     private readonly IOptions<PipelineOptions> _options;
-    private readonly IBuildSystemCommandWriter _commandWriter;
-    private readonly IBuildSystemFormatter _formatter;
 
-    public SpectreResultsPrinter(
-        IOptions<PipelineOptions> options,
-        IBuildSystemCommandWriter commandWriter,
-        IBuildSystemFormatterProvider formatterProvider)
+    public SpectreResultsPrinter(IOptions<PipelineOptions> options)
     {
         _options = options;
-        _commandWriter = commandWriter;
-        _formatter = formatterProvider.GetFormatter();
     }
 
     public void PrintResults(PipelineSummary pipelineSummary)
@@ -47,7 +40,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
 
         // Create and print the main results table
         var table = CreateModulesTable(pipelineSummary);
-        PrintModulesTable(table);
+        AnsiConsole.Write(table);
 
         // Print failed module details if pipeline failed
         if (pipelineSummary.Status == ModuleStatus.Failed)
@@ -59,36 +52,6 @@ internal class SpectreResultsPrinter : IResultsPrinter
         PrintMetrics(pipelineSummary);
 
         System.Console.WriteLine();
-    }
-
-    private void PrintModulesTable(Table table)
-    {
-        if (!_formatter.UsesRawCommands)
-        {
-            AnsiConsole.Write(table);
-            return;
-        }
-
-        var startCommand = _formatter.GetStartBlockCommand("Module Results");
-        if (startCommand is null)
-        {
-            AnsiConsole.Write(table);
-            return;
-        }
-
-        _commandWriter.WriteLine(startCommand);
-        try
-        {
-            AnsiConsole.Write(table);
-        }
-        finally
-        {
-            var endCommand = _formatter.GetEndBlockCommand("Module Results");
-            if (endCommand is not null)
-            {
-                _commandWriter.WriteLine(endCommand);
-            }
-        }
     }
 
     internal static Table CreateModulesTable(PipelineSummary pipelineSummary) =>

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -993,6 +993,64 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task IncrementalFlush_CancelledRenderGateWait_DoesNotMarkRetryAsContinued()
+    {
+        var writer = new StringWriter();
+        var renderGateWaitStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var loggerControl = new SynchronousLoggerControl(writer)
+        {
+            RenderGateWaitStarted = renderGateWaitStarted,
+        };
+        var buffer = CreateBufferWithStructuredLog();
+        var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lockHolder = Task.Run(() =>
+        {
+            lock (loggerControl.SynchronizationLock)
+            {
+                lockAcquired.TrySetResult();
+                releaseLock.Task.GetAwaiter().GetResult();
+            }
+        });
+
+        await lockAcquired.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        try
+        {
+            var flush = buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                OutputFlushKind.Incremental,
+                cancellationToken: cancellationTokenSource.Token);
+
+            await renderGateWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
+            await cancellationTokenSource.CancelAsync();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await flush.WaitAsync(TestHostSettings.DefaultTestTimeout));
+        }
+        finally
+        {
+            releaseLock.TrySetResult();
+            await lockHolder;
+        }
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("ModuleOutputBufferTests … (");
+        await Assert.That(output).DoesNotContain("(continued)");
+    }
+
+    [Test]
     public async Task Flush_RenderGateTimeout_WritesBufferedOutputDirectly()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -462,6 +462,32 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task BlankPipelineOutput_DoesNotRenderEmptyGroup()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            "Pipeline",
+            typeof(void),
+            showSuccessMarker: false);
+        buffer.WriteLine(string.Empty);
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).DoesNotContain("::group::Pipeline");
+            await Assert.That(output).DoesNotContain("::endgroup::");
+        }
+    }
+
+    [Test]
     public async Task IncrementalFlush_DoesNotDrainCompletedModule()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -488,6 +488,32 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task BlankPipelineOutput_DoesNotAcquireRenderGate()
+    {
+        var writer = new StringWriter();
+        var renderGateWaitStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var loggerControl = new SynchronousLoggerControl(writer)
+        {
+            RenderGateWaitStarted = renderGateWaitStarted,
+        };
+        var buffer = new ModuleOutputBuffer(
+            "Pipeline",
+            typeof(void),
+            showSuccessMarker: false);
+        buffer.WriteLine(string.Empty);
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(renderGateWaitStarted.Task.IsCompleted).IsFalse();
+    }
+
+    [Test]
     public async Task IncrementalFlush_DoesNotDrainCompletedModule()
     {
         var writer = new StringWriter();
@@ -680,6 +706,33 @@ public class ModuleOutputBufferTests
             OutputFlushKind.Incremental);
 
         await Assert.That(writer.ToString()).Contains("ModuleOutputBufferTests … (continued) (");
+    }
+
+    [Test]
+    public async Task VisibleOutputAfterFilteredIncrementalFlush_IsNotLabelledAsContinued()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog(isSpectreEnabled: static _ => false);
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            new RecordingLogger(),
+            loggerControl,
+            OutputFlushKind.Incremental);
+        buffer.WriteLine("visible output");
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("ModuleOutputBufferTests … (");
+        await Assert.That(output).DoesNotContain("(continued)");
+        await Assert.That(output).Contains("visible output");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -1,6 +1,5 @@
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
-using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -276,15 +275,13 @@ public class SpectreResultsPrinterTests
     }
 
     [Test]
-    public async Task GitHubOutput_GroupsOnlyModuleResultsTable()
+    public async Task ResultsTable_IsVisibleWithoutBuildSystemGroup()
     {
-        var output = PrintResults(CreateFailedSummary(), new GitHubActionsFormatter());
+        var output = PrintResults(CreateFailedSummary());
 
         var headline = output.IndexOf("Pipeline Failed", StringComparison.Ordinal);
         var counts = output.IndexOf("1 failed", StringComparison.Ordinal);
-        var groupStart = output.IndexOf("::group::Module Results", StringComparison.Ordinal);
-        var table = output.IndexOf(nameof(FailedModule), groupStart, StringComparison.Ordinal);
-        var groupEnd = output.IndexOf("::endgroup::", groupStart, StringComparison.Ordinal);
+        var table = output.IndexOf(nameof(FailedModule), StringComparison.Ordinal);
         var failureDetails = output.IndexOf("Failed Modules", StringComparison.Ordinal);
         var metrics = output.IndexOf("Speedup:", StringComparison.Ordinal);
 
@@ -292,11 +289,10 @@ public class SpectreResultsPrinterTests
         {
             await Assert.That(headline).IsGreaterThanOrEqualTo(0);
             await Assert.That(counts).IsGreaterThan(headline);
-            await Assert.That(groupStart).IsGreaterThan(counts);
-            await Assert.That(table).IsGreaterThan(groupStart);
-            await Assert.That(groupEnd).IsGreaterThan(table);
-            await Assert.That(failureDetails).IsGreaterThan(groupEnd);
+            await Assert.That(table).IsGreaterThan(counts);
+            await Assert.That(failureDetails).IsGreaterThan(table);
             await Assert.That(metrics).IsGreaterThan(failureDetails);
+            await Assert.That(output).DoesNotContain("::group::Module Results");
             await Assert.That(output).Contains("root failure");
         }
     }
@@ -346,7 +342,7 @@ public class SpectreResultsPrinterTests
     [Test]
     public async Task LocalOutput_DoesNotAddModuleResultsGroup()
     {
-        var output = PrintResults(CreateFailedSummary(), new DefaultFormatter());
+        var output = PrintResults(CreateFailedSummary());
 
         using (Assert.Multiple())
         {
@@ -401,9 +397,7 @@ public class SpectreResultsPrinterTests
             ]);
     }
 
-    private static string PrintResults(
-        PipelineSummary summary,
-        IBuildSystemFormatter formatter)
+    private static string PrintResults(PipelineSummary summary)
     {
         using var writer = new StringWriter();
         var originalAnsiConsole = AnsiConsole.Console;
@@ -417,12 +411,8 @@ public class SpectreResultsPrinterTests
                 ColorSystem = ColorSystemSupport.NoColors,
             });
 
-            var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
-            formatterProvider.Setup(x => x.GetFormatter()).Returns(formatter);
             var printer = new SpectreResultsPrinter(
-                Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
-                new BuildSystemCommandWriter(writer),
-                formatterProvider.Object);
+                Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
 
             printer.PrintResults(summary);
             return writer.ToString();


### PR DESCRIPTION
## Summary

- avoid empty CI `Pipeline` groups when buffered entries produce no console output
- render module results table inline so status and duration remain visible
- add regression coverage for both output behaviors

## Validation

- `ModularPipelines.UnitTests.csproj` Release build: 0 errors
- `ModuleOutputBufferTests`: 39 passed
- `SpectreResultsPrinterTests`: 10 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty pipeline output from creating blank console groups or separator lines.
  * Structured events without visible output are no longer rendered as empty groups.
  * Improved incremental output labels after filtered or cancelled rendering attempts.
  * Module results now display consistently without unnecessary grouping markers.

* **Tests**
  * Added coverage for blank output, filtered incremental output, and cancelled rendering retries.
  * Updated results-printing tests to verify clean output across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->