### PR TITLE
Keep module output inside collapsible log sections

### DIFF
--- a/src/ModularPipelines/ConsoleWriter.cs
+++ b/src/ModularPipelines/ConsoleWriter.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Logging;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -9,6 +10,12 @@ internal class ConsoleWriter : IConsoleWriter
 {
     public void LogToConsole(string value)
     {
+        if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
+        {
+            moduleConsoleWriter.LogToConsole(value);
+            return;
+        }
+
         try
         {
             AnsiConsole.MarkupLine(value);
@@ -23,6 +30,12 @@ internal class ConsoleWriter : IConsoleWriter
 
     public void Write(IRenderable renderable)
     {
+        if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
+        {
+            moduleConsoleWriter.Write(renderable);
+            return;
+        }
+
         AnsiConsole.Write(renderable);
     }
 }

--- a/src/ModularPipelines/Distributed/Artifacts/ArtifactLifecycleManager.cs
+++ b/src/ModularPipelines/Distributed/Artifacts/ArtifactLifecycleManager.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Caching;
+using ModularPipelines.Logging;
 
 namespace ModularPipelines.Distributed.Artifacts;
 
@@ -18,6 +19,8 @@ internal class ArtifactLifecycleManager
     private readonly ArtifactOptions _options;
     private readonly ILogger<ArtifactLifecycleManager> _logger;
     private readonly string _workingDirectory;
+
+    private ILogger Logger => (ILogger?) ModuleLogger.Values.Value ?? _logger;
 
     /// <summary>
     /// Tracks completed and in-flight restores keyed by "{producerType}:{artifactName}:{normalizedRestorePath}".
@@ -94,7 +97,7 @@ internal class ArtifactLifecycleManager
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex,
+                Logger.LogError(ex,
                     "Failed to upload artifact '{Name}' for module {Module}",
                     attr.Name, moduleType.Name);
                 throw;
@@ -112,7 +115,7 @@ internal class ArtifactLifecycleManager
         var resolvedPaths = ResolvePathPattern(attribute.PathPattern);
         if (resolvedPaths.Count == 0)
         {
-            _logger.LogWarning(
+            Logger.LogWarning(
                 "No files matched pattern '{Pattern}' for artifact '{Name}' on module {Module}",
                 attribute.PathPattern,
                 attribute.Name,
@@ -129,9 +132,9 @@ internal class ArtifactLifecycleManager
                 resolvedPaths,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (_logger.IsEnabled(LogLevel.Information))
+        if (Logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation(
+            Logger.LogInformation(
                 "Uploaded artifact '{Name}' ({Size} bytes, {FileCount} files) for module {Module}",
                 attribute.Name,
                 reference.SizeBytes,
@@ -373,7 +376,7 @@ internal class ArtifactLifecycleManager
         {
             // Remove failed entry so a retry can attempt it again
             _completedRestores.TryRemove(restoreKey, out _);
-            _logger.LogError(ex,
+            Logger.LogError(ex,
                 "Failed to download artifact '{Name}' for module {Module}",
                 artifactName, consumerModuleType.Name);
             throw;
@@ -409,7 +412,7 @@ internal class ArtifactLifecycleManager
                 throw new InvalidOperationException(message);
             }
 
-            _logger.LogWarning(
+            Logger.LogWarning(
                 "Artifact '{Name}' from module '{Producer}' was not found for consumer {Module}",
                 artifactName, producerTypeName, consumerModuleType.Name);
             return;
@@ -431,9 +434,9 @@ internal class ArtifactLifecycleManager
             await stream.CopyToAsync(fileStream, cancellationToken);
         }
 
-        if (_logger.IsEnabled(LogLevel.Information))
+        if (Logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation(
+            Logger.LogInformation(
                 "Restored artifact '{Name}' from module '{Producer}' to '{Path}'",
                 artifactName, producerTypeName, restorePath);
         }

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -9,6 +10,7 @@ using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
@@ -29,6 +31,7 @@ internal class DistributedModuleExecutor(
     IModuleDependencyRegistry dependencyRegistry,
     IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
+    IServiceScopeFactory serviceScopeFactory,
     ArtifactLifecycleManager? artifactLifecycleManager,
     ILogger<DistributedModuleExecutor> logger) : IModuleExecutor
 {
@@ -46,6 +49,7 @@ internal class DistributedModuleExecutor(
     private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
+    private readonly IServiceScopeFactory _serviceScopeFactory = serviceScopeFactory;
     private readonly ArtifactLifecycleManager? _artifactLifecycleManager = artifactLifecycleManager;
     private readonly ILogger<DistributedModuleExecutor> _logger = logger;
 
@@ -342,12 +346,19 @@ internal class DistributedModuleExecutor(
         WorkerModuleScheduler workerScheduler,
         CancellationToken cancellationToken)
     {
+        var moduleType = module.GetType();
+        await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+        var moduleLogger = serviceScope.ServiceProvider
+            .GetRequiredService<IInternalModuleLoggerProvider>()
+            .GetLogger(moduleType);
+        await using var loggerScope = new ModuleLoggerScope(moduleLogger, moduleType);
+
         if (_artifactLifecycleManager is not null)
         {
-            await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(module.GetType(), cancellationToken);
+            await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(moduleType, cancellationToken);
         }
 
-        var moduleState = new ModuleState(module, module.GetType());
+        var moduleState = new ModuleState(module, moduleType);
         ModuleStateDependencyInitializer.Populate(
             moduleState,
             _typeRegistry.GetRegisteredModuleTypes(),

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -350,45 +350,59 @@ internal class DistributedModuleExecutor(
         await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
         var moduleLogger = serviceScope.ServiceProvider
             .GetRequiredService<IInternalModuleLoggerProvider>()
-            .GetLogger(moduleType);
+            .GetLogger(moduleType) as IInternalModuleLogger
+            ?? throw new InvalidOperationException($"No internal module logger is available for {moduleType.Name}.");
         await using var loggerScope = new ModuleLoggerScope(moduleLogger, moduleType);
 
-        if (_artifactLifecycleManager is not null)
+        try
         {
-            await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(moduleType, cancellationToken);
+            if (_artifactLifecycleManager is not null)
+            {
+                await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(moduleType, cancellationToken);
+            }
+
+            var moduleState = new ModuleState(module, moduleType);
+            ModuleStateDependencyInitializer.Populate(
+                moduleState,
+                _typeRegistry.GetRegisteredModuleTypes(),
+                _dependencyRegistry,
+                _metadataRegistry);
+            await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, workerScheduler, cancellationToken);
+
+            var result = await module.AsInternal().ResultTask;
+            var artifactReferences = await TryUploadArtifactsAsync(
+                module,
+                assignment.ModuleTypeName,
+                moduleLogger,
+                cancellationToken);
+            if (result is null)
+            {
+                return;
+            }
+
+            var serialized = _serializer.Serialize(
+                result,
+                assignment.ModuleTypeName,
+                assignment.ResultTypeName,
+                _options.Value.InstanceIndex);
+            if (artifactReferences is not null)
+            {
+                serialized = serialized with { Artifacts = artifactReferences };
+            }
+
+            await _coordinator.PublishResultAsync(serialized, cancellationToken);
         }
-
-        var moduleState = new ModuleState(module, moduleType);
-        ModuleStateDependencyInitializer.Populate(
-            moduleState,
-            _typeRegistry.GetRegisteredModuleTypes(),
-            _dependencyRegistry,
-            _metadataRegistry);
-        await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, workerScheduler, cancellationToken);
-
-        var result = await module.AsInternal().ResultTask;
-        var artifactReferences = await TryUploadArtifactsAsync(module, assignment.ModuleTypeName, cancellationToken);
-        if (result is null)
+        catch (Exception ex)
         {
-            return;
+            moduleLogger.SetException(ex);
+            throw;
         }
-
-        var serialized = _serializer.Serialize(
-            result,
-            assignment.ModuleTypeName,
-            assignment.ResultTypeName,
-            _options.Value.InstanceIndex);
-        if (artifactReferences is not null)
-        {
-            serialized = serialized with { Artifacts = artifactReferences };
-        }
-
-        await _coordinator.PublishResultAsync(serialized, cancellationToken);
     }
 
     private async Task<IReadOnlyList<ArtifactReference>?> TryUploadArtifactsAsync(
         IModule module,
         string moduleTypeName,
+        IModuleLogger moduleLogger,
         CancellationToken cancellationToken)
     {
         if (_artifactLifecycleManager is null)
@@ -403,7 +417,7 @@ internal class DistributedModuleExecutor(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to upload artifacts for {Module}", moduleTypeName);
+            moduleLogger.LogError(ex, "Failed to upload artifacts for {Module}", moduleTypeName);
             return null;
         }
     }

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -7,6 +8,7 @@ using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModuleResultFactory = ModularPipelines.Engine.Execution.ModuleResultFactory;
@@ -24,6 +26,7 @@ internal class WorkerModuleExecutor(
     IModuleDependencyRegistry dependencyRegistry,
     IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
+    IServiceScopeFactory serviceScopeFactory,
     ArtifactLifecycleManager? artifactLifecycleManager,
     ILogger<WorkerModuleExecutor> logger) : IModuleExecutor
 {
@@ -40,6 +43,7 @@ internal class WorkerModuleExecutor(
     private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
+    private readonly IServiceScopeFactory _serviceScopeFactory = serviceScopeFactory;
     private readonly ArtifactLifecycleManager? _artifactLifecycleManager = artifactLifecycleManager;
     private readonly ILogger<WorkerModuleExecutor> _logger = logger;
 
@@ -177,12 +181,19 @@ internal class WorkerModuleExecutor(
         int instanceIndex,
         CancellationToken cancellationToken)
     {
+        var moduleType = module.GetType();
+        await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+        var moduleLogger = serviceScope.ServiceProvider
+            .GetRequiredService<IInternalModuleLoggerProvider>()
+            .GetLogger(moduleType);
+        await using var loggerScope = new ModuleLoggerScope(moduleLogger, moduleType);
+
         if (_artifactLifecycleManager is not null)
         {
-            await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(module.GetType(), cancellationToken);
+            await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(moduleType, cancellationToken);
         }
 
-        var moduleState = new ModuleState(module, module.GetType());
+        var moduleState = new ModuleState(module, moduleType);
         ModuleStateDependencyInitializer.Populate(
             moduleState,
             _typeRegistry.GetRegisteredModuleTypes(),

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
@@ -185,45 +185,59 @@ internal class WorkerModuleExecutor(
         await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
         var moduleLogger = serviceScope.ServiceProvider
             .GetRequiredService<IInternalModuleLoggerProvider>()
-            .GetLogger(moduleType);
+            .GetLogger(moduleType) as IInternalModuleLogger
+            ?? throw new InvalidOperationException($"No internal module logger is available for {moduleType.Name}.");
         await using var loggerScope = new ModuleLoggerScope(moduleLogger, moduleType);
 
-        if (_artifactLifecycleManager is not null)
+        try
         {
-            await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(moduleType, cancellationToken);
+            if (_artifactLifecycleManager is not null)
+            {
+                await _artifactLifecycleManager.DownloadConsumedArtifactsAsync(moduleType, cancellationToken);
+            }
+
+            var moduleState = new ModuleState(module, moduleType);
+            ModuleStateDependencyInitializer.Populate(
+                moduleState,
+                _typeRegistry.GetRegisteredModuleTypes(),
+                _dependencyRegistry,
+                _metadataRegistry);
+            await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, workerScheduler, cancellationToken);
+
+            var result = await module.AsInternal().ResultTask;
+            var artifactReferences = await TryUploadArtifactsAsync(
+                module,
+                assignment.ModuleTypeName,
+                moduleLogger,
+                cancellationToken);
+            if (result is null)
+            {
+                return;
+            }
+
+            var serialized = _serializer.Serialize(
+                result,
+                assignment.ModuleTypeName,
+                assignment.ResultTypeName,
+                instanceIndex);
+            if (artifactReferences is not null)
+            {
+                serialized = serialized with { Artifacts = artifactReferences };
+            }
+
+            await _coordinator.PublishResultAsync(serialized, cancellationToken);
         }
-
-        var moduleState = new ModuleState(module, moduleType);
-        ModuleStateDependencyInitializer.Populate(
-            moduleState,
-            _typeRegistry.GetRegisteredModuleTypes(),
-            _dependencyRegistry,
-            _metadataRegistry);
-        await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, workerScheduler, cancellationToken);
-
-        var result = await module.AsInternal().ResultTask;
-        var artifactReferences = await TryUploadArtifactsAsync(module, assignment.ModuleTypeName, cancellationToken);
-        if (result is null)
+        catch (Exception ex)
         {
-            return;
+            moduleLogger.SetException(ex);
+            throw;
         }
-
-        var serialized = _serializer.Serialize(
-            result,
-            assignment.ModuleTypeName,
-            assignment.ResultTypeName,
-            instanceIndex);
-        if (artifactReferences is not null)
-        {
-            serialized = serialized with { Artifacts = artifactReferences };
-        }
-
-        await _coordinator.PublishResultAsync(serialized, cancellationToken);
     }
 
     private async Task<IReadOnlyList<ArtifactReference>?> TryUploadArtifactsAsync(
         IModule module,
         string moduleTypeName,
+        IModuleLogger moduleLogger,
         CancellationToken cancellationToken)
     {
         if (_artifactLifecycleManager is null)
@@ -238,7 +252,7 @@ internal class WorkerModuleExecutor(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to upload artifacts for module {Module}", moduleTypeName);
+            moduleLogger.LogError(ex, "Failed to upload artifacts for module {Module}", moduleTypeName);
             return null;
         }
     }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -804,7 +804,9 @@ internal class ModuleRunner : IModuleRunner
         var pipelineContext = scopedServiceProvider.GetRequiredService<IPipelineContext>();
 
         // Create module-specific context
-        var logger = GetModuleLogger(scopedServiceProvider, moduleType);
+        var logger = ModuleLogger.CurrentModuleType.Value == moduleType
+            ? ModuleLogger.Values.Value ?? GetModuleLogger(scopedServiceProvider, moduleType)
+            : GetModuleLogger(scopedServiceProvider, moduleType);
         var moduleContext = new ModuleContext(
             pipelineContext,
             module,

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,6 +17,7 @@ using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -81,6 +83,14 @@ public class DistributedModuleExecutorTests
         protected internal override Task<int> ExecuteAsync(
             Context.IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult(42);
+    }
+
+    [ProducesArtifact("distributed-output", "missing-output.txt")]
+    private class ArtifactLoggingModule : Module<SimpleResult>
+    {
+        protected internal override Task<SimpleResult> ExecuteAsync(
+            Context.IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(new SimpleResult { Message = "done" });
     }
 
     [ModularPipelines.Attributes.DependsOn<DistributedModule>]
@@ -205,7 +215,8 @@ public class DistributedModuleExecutorTests
         DistributedResultCollector? resultCollector = null,
         ArtifactLifecycleManager? artifactManager = null,
         DistributedOptions? distributedOptions = null,
-        CancellationToken applicationStopping = default)
+        CancellationToken applicationStopping = default,
+        IModuleLogger? moduleLogger = null)
     {
         var lifetime = new Mock<IHostApplicationLifetime>();
         lifetime.Setup(l => l.ApplicationStopping).Returns(applicationStopping);
@@ -240,8 +251,19 @@ public class DistributedModuleExecutorTests
             NewDependencyRegistry(),
             NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions ?? new DistributedOptions()),
+            NewModuleLoggerScopeFactory(moduleLogger),
             artifactManager,
             NullLogger<DistributedModuleExecutor>.Instance);
+    }
+
+    private static IServiceScopeFactory NewModuleLoggerScopeFactory(IModuleLogger? moduleLogger = null)
+    {
+        moduleLogger ??= Mock.Of<IModuleLogger>();
+        var loggerProvider = new Mock<IInternalModuleLoggerProvider>();
+        loggerProvider.Setup(provider => provider.GetLogger(It.IsAny<Type>())).Returns(moduleLogger);
+        var services = new ServiceCollection();
+        services.AddScoped(_ => loggerProvider.Object);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 
     // =================================================================
@@ -614,6 +636,74 @@ public class DistributedModuleExecutorTests
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
         await Assert.That(registeredResult).IsNotNull();
         await Assert.That(registeredResult!.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task Master_Worker_ArtifactLogging_UsesModuleScope()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), $"distributed-artifact-logging-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        var module = new ArtifactLoggingModule();
+        var moduleState = new ModuleState(module, typeof(ArtifactLoggingModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        var resultRegistry = new ModuleResultRegistry();
+        var coordinator = new InMemoryDistributedCoordinator();
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(ArtifactLoggingModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var resultCollector = new DistributedResultCollector(coordinator, serializer);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var fallbackLogger = new Mock<ILogger<ArtifactLifecycleManager>>();
+        var moduleLogger = new Mock<IModuleLogger>();
+        moduleLogger.Setup(logger => logger.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        IModuleLogger? ambientLogger = null;
+
+        moduleRunner.Setup(runner => runner.ExecuteWithoutDependencyWaitAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<ModuleState, IModuleScheduler, CancellationToken>((_, _, _) =>
+            {
+                ambientLogger = ModuleLogger.Values.Value;
+                var result = CreateSuccessResult(
+                    new SimpleResult { Message = "master-executed" },
+                    nameof(ArtifactLoggingModule));
+                ModuleCompletionSourceApplicator.TryApply(module, result);
+            })
+            .Returns(Task.CompletedTask);
+        var artifactManager = new ArtifactLifecycleManager(
+            Mock.Of<IDistributedArtifactStore>(),
+            Microsoft.Extensions.Options.Options.Create(new ArtifactOptions()),
+            fallbackLogger.Object,
+            workingDirectory);
+        var executor = CreateExecutor(
+            scheduler,
+            moduleRunner,
+            resultRegistry,
+            coordinator,
+            resultCollector,
+            artifactManager,
+            moduleLogger: moduleLogger.Object);
+
+        try
+        {
+            await executor.ExecuteAsync([module]);
+
+            await Assert.That(ambientLogger).IsSameReferenceAs(moduleLogger.Object);
+            moduleLogger.Verify(
+                logger => logger.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("No files matched pattern")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            fallbackLogger.VerifyNoOtherCalls();
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
     }
 
     [Test]
@@ -1112,6 +1202,7 @@ public class DistributedModuleExecutorTests
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
+            NewModuleLoggerScopeFactory(),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act
@@ -1160,6 +1251,7 @@ public class DistributedModuleExecutorTests
             noDequeue, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
+            NewModuleLoggerScopeFactory(),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act
@@ -1252,6 +1344,7 @@ public class DistributedModuleExecutorTests
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
+            NewModuleLoggerScopeFactory(),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act — should proceed after 3 seconds timeout even though only 1/3 workers registered

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -93,6 +93,14 @@ public class DistributedModuleExecutorTests
             => Task.FromResult(new SimpleResult { Message = "done" });
     }
 
+    [ConsumesArtifact(typeof(ArtifactLoggingModule), "distributed-output")]
+    private class ArtifactDownloadModule : Module<SimpleResult>
+    {
+        protected internal override Task<SimpleResult> ExecuteAsync(
+            Context.IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(new SimpleResult { Message = "done" });
+    }
+
     [ModularPipelines.Attributes.DependsOn<DistributedModule>]
     private class DependsOnDistributedModule : Module<string>
     {
@@ -216,7 +224,8 @@ public class DistributedModuleExecutorTests
         ArtifactLifecycleManager? artifactManager = null,
         DistributedOptions? distributedOptions = null,
         CancellationToken applicationStopping = default,
-        IModuleLogger? moduleLogger = null)
+        IInternalModuleLogger? moduleLogger = null,
+        ILogger<DistributedModuleExecutor>? executorLogger = null)
     {
         var lifetime = new Mock<IHostApplicationLifetime>();
         lifetime.Setup(l => l.ApplicationStopping).Returns(applicationStopping);
@@ -253,12 +262,12 @@ public class DistributedModuleExecutorTests
             Microsoft.Extensions.Options.Options.Create(distributedOptions ?? new DistributedOptions()),
             NewModuleLoggerScopeFactory(moduleLogger),
             artifactManager,
-            NullLogger<DistributedModuleExecutor>.Instance);
+            executorLogger ?? NullLogger<DistributedModuleExecutor>.Instance);
     }
 
-    private static IServiceScopeFactory NewModuleLoggerScopeFactory(IModuleLogger? moduleLogger = null)
+    private static IServiceScopeFactory NewModuleLoggerScopeFactory(IInternalModuleLogger? moduleLogger = null)
     {
-        moduleLogger ??= Mock.Of<IModuleLogger>();
+        moduleLogger ??= Mock.Of<IInternalModuleLogger>();
         var loggerProvider = new Mock<IInternalModuleLoggerProvider>();
         loggerProvider.Setup(provider => provider.GetLogger(It.IsAny<Type>())).Returns(moduleLogger);
         var services = new ServiceCollection();
@@ -654,7 +663,7 @@ public class DistributedModuleExecutorTests
         var resultCollector = new DistributedResultCollector(coordinator, serializer);
         var moduleRunner = new Mock<IModuleRunner>();
         var fallbackLogger = new Mock<ILogger<ArtifactLifecycleManager>>();
-        var moduleLogger = new Mock<IModuleLogger>();
+        var moduleLogger = new Mock<IInternalModuleLogger>();
         moduleLogger.Setup(logger => logger.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
         IModuleLogger? ambientLogger = null;
 
@@ -699,6 +708,108 @@ public class DistributedModuleExecutorTests
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
             fallbackLogger.VerifyNoOtherCalls();
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Master_Worker_ArtifactDownloadFailure_MarksModuleLoggerFailed()
+    {
+        var failure = new InvalidOperationException("download failed");
+        var module = new ArtifactDownloadModule();
+        var scheduler = CreateMockScheduler(new ModuleState(module, typeof(ArtifactDownloadModule)));
+        var moduleRunner = new Mock<IModuleRunner>();
+        var moduleLogger = new Mock<IInternalModuleLogger>();
+        moduleLogger.Setup(logger => logger.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        var store = new Mock<IDistributedArtifactStore>();
+        store.Setup(artifactStore => artifactStore.ListArtifactsAsync(
+                typeof(ArtifactLoggingModule).FullName!,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(failure);
+        var artifactManager = new ArtifactLifecycleManager(
+            store.Object,
+            Microsoft.Extensions.Options.Options.Create(new ArtifactOptions()),
+            NullLogger<ArtifactLifecycleManager>.Instance);
+        var executor = CreateExecutor(
+            scheduler,
+            moduleRunner,
+            artifactManager: artifactManager,
+            moduleLogger: moduleLogger.Object);
+
+        await executor.ExecuteAsync([module]);
+
+        moduleLogger.Verify(logger => logger.SetException(failure), Times.Once);
+        moduleRunner.Verify(runner => runner.ExecuteWithoutDependencyWaitAsync(
+            It.IsAny<ModuleState>(),
+            It.IsAny<IModuleScheduler>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Master_Worker_ArtifactUploadFailure_UsesModuleLogger()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), $"distributed-artifact-upload-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        await File.WriteAllTextAsync(Path.Combine(workingDirectory, "missing-output.txt"), "output");
+        var module = new ArtifactLoggingModule();
+        var scheduler = CreateMockScheduler(new ModuleState(module, typeof(ArtifactLoggingModule)));
+        var moduleRunner = new Mock<IModuleRunner>();
+        var moduleLogger = new Mock<IInternalModuleLogger>();
+        moduleLogger.Setup(logger => logger.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        var executorLogger = new Mock<ILogger<DistributedModuleExecutor>>();
+        var store = new Mock<IDistributedArtifactStore>();
+        store.Setup(artifactStore => artifactStore.UploadAsync(
+                It.IsAny<ArtifactDescriptor>(),
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("upload failed"));
+        moduleRunner.Setup(runner => runner.ExecuteWithoutDependencyWaitAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<ModuleState, IModuleScheduler, CancellationToken>((_, _, _) =>
+            {
+                var result = CreateSuccessResult(
+                    new SimpleResult { Message = "master-executed" },
+                    nameof(ArtifactLoggingModule));
+                ModuleCompletionSourceApplicator.TryApply(module, result);
+            })
+            .Returns(Task.CompletedTask);
+        var artifactManager = new ArtifactLifecycleManager(
+            store.Object,
+            Microsoft.Extensions.Options.Options.Create(new ArtifactOptions()),
+            NullLogger<ArtifactLifecycleManager>.Instance,
+            workingDirectory);
+        var executor = CreateExecutor(
+            scheduler,
+            moduleRunner,
+            artifactManager: artifactManager,
+            moduleLogger: moduleLogger.Object,
+            executorLogger: executorLogger.Object);
+
+        try
+        {
+            await executor.ExecuteAsync([module]);
+
+            moduleLogger.Verify(
+                logger => logger.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Failed to upload artifacts for")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            executorLogger.Verify(
+                logger => logger.Log(
+                    It.IsAny<LogLevel>(),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Failed to upload artifacts for")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
         }
         finally
         {

--- a/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,9 +12,9 @@ using ModularPipelines.Distributed.Artifacts;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Interfaces;
-using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
 using ModularPipelines.Validation;
 using Moq;
 
@@ -37,43 +38,53 @@ public class ArtifactContractTests
     private const string CacheKeyArtifactFile = "cache-key-input.txt";
     private const string CacheKeyRestoreDirectory = "cache-key-restored";
 
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<(string Category, string Message)> Entries { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(categoryName, Entries);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class RecordingLogger(
+            string category,
+            ConcurrentQueue<(string Category, string Message)> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                entries.Enqueue((category, formatter(state, exception)));
+        }
+    }
+
     [Test]
     public async Task ArtifactLifecycleLoggingUsesAmbientModuleLogger()
     {
-        var workingDirectory = Path.Combine(Path.GetTempPath(), $"artifact-logging-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(workingDirectory);
-        var fallbackLogger = new Mock<ILogger<ArtifactLifecycleManager>>();
-        var moduleLogger = new Mock<IModuleLogger>();
-        moduleLogger.Setup(logger => logger.IsEnabled(LogLevel.Warning)).Returns(true);
-        var manager = new ArtifactLifecycleManager(
-            Mock.Of<IDistributedArtifactStore>(),
-            Microsoft.Extensions.Options.Options.Create(new ArtifactOptions()),
-            fallbackLogger.Object,
-            workingDirectory);
+        var loggerProvider = new RecordingLoggerProvider();
+        using var builder = TestPipelineBuilder.Create();
+        builder.ConfigureServices(services => services.AddLogging(logging => logging.AddProvider(loggerProvider)));
+        builder.AddModule<AmbientArtifactLoggingProducerModule>();
+        builder.AddModule<AmbientArtifactLoggingConsumerModule>();
 
-        try
-        {
-            await using (new ModuleLoggerScope(moduleLogger.Object, typeof(DeclaredProducerModule)))
-            {
-                _ = await manager.UploadProducedArtifactsAsync(
-                    typeof(DeclaredProducerModule),
-                    CancellationToken.None);
-            }
+        await Assert.That(async () => await builder.ExecutePipelineAsync())
+            .Throws<ModuleFailedException>();
 
-            moduleLogger.Verify(
-                logger => logger.Log(
-                    LogLevel.Warning,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("No files matched pattern")),
-                    null,
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-                Times.Once);
-            fallbackLogger.VerifyNoOtherCalls();
-        }
-        finally
-        {
-            Directory.Delete(workingDirectory, recursive: true);
-        }
+        await Assert.That(loggerProvider.Entries).Contains(entry =>
+            entry.Category.Contains(nameof(AmbientArtifactLoggingProducerModule), StringComparison.Ordinal)
+            && entry.Message.Contains("No files matched pattern", StringComparison.Ordinal));
+        await Assert.That(loggerProvider.Entries).DoesNotContain(entry =>
+            entry.Category.Contains(nameof(ArtifactLifecycleManager), StringComparison.Ordinal)
+            && entry.Message.Contains("No files matched pattern", StringComparison.Ordinal));
     }
 
     [Test]
@@ -111,6 +122,25 @@ public class ArtifactContractTests
             IModuleContext context,
             CancellationToken cancellationToken) =>
             Task.FromResult<string?>("produced");
+    }
+
+    [ProducesArtifact("ambient-logging-output", ".modular-pipelines-ambient-logging/missing.txt")]
+    private sealed class AmbientArtifactLoggingProducerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("produced");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<AmbientArtifactLoggingProducerModule>]
+    [ConsumesArtifact(typeof(AmbientArtifactLoggingProducerModule), "ambient-logging-output")]
+    private sealed class AmbientArtifactLoggingConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("consumed");
     }
 
     [ConsumesArtifact(typeof(DeclaredProducerModule), "missing-output")]

--- a/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Attributes;
 using ModularPipelines.Caching;
@@ -10,6 +11,7 @@ using ModularPipelines.Distributed.Artifacts;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Interfaces;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Validation;
@@ -34,6 +36,45 @@ public class ArtifactContractTests
     private const string FailedRestoreDirectory = LocalArtifactRoot + "/failed-restored";
     private const string CacheKeyArtifactFile = "cache-key-input.txt";
     private const string CacheKeyRestoreDirectory = "cache-key-restored";
+
+    [Test]
+    public async Task ArtifactLifecycleLoggingUsesAmbientModuleLogger()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), $"artifact-logging-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        var fallbackLogger = new Mock<ILogger<ArtifactLifecycleManager>>();
+        var moduleLogger = new Mock<IModuleLogger>();
+        moduleLogger.Setup(logger => logger.IsEnabled(LogLevel.Warning)).Returns(true);
+        var manager = new ArtifactLifecycleManager(
+            Mock.Of<IDistributedArtifactStore>(),
+            Microsoft.Extensions.Options.Options.Create(new ArtifactOptions()),
+            fallbackLogger.Object,
+            workingDirectory);
+
+        try
+        {
+            await using (new ModuleLoggerScope(moduleLogger.Object, typeof(DeclaredProducerModule)))
+            {
+                _ = await manager.UploadProducedArtifactsAsync(
+                    typeof(DeclaredProducerModule),
+                    CancellationToken.None);
+            }
+
+            moduleLogger.Verify(
+                logger => logger.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("No files matched pattern")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            fallbackLogger.VerifyNoOtherCalls();
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+    }
 
     [Test]
     public async Task ResolvePathPatternMatchesWildcardDirectoryComponents()

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,5 +1,6 @@
-using ModularPipelines.Logging;
-using Moq;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -8,36 +9,61 @@ namespace ModularPipelines.UnitTests.Console;
 [TUnit.Core.NotInParallel(nameof(ConsoleWriterTests))]
 public class ConsoleWriterTests
 {
+    private sealed class LogToConsoleModule(IConsoleWriter consoleWriter) : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            consoleWriter.LogToConsole("[green]module output[/]");
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class WriteModule(IConsoleWriter consoleWriter) : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            IRenderable table = new Table().AddColumn("Value").AddRow("module output");
+            consoleWriter.Write(table);
+            return Task.FromResult(true);
+        }
+    }
+
     [Test]
     public async Task LogToConsole_UsesAmbientModuleConsoleWriter()
     {
-        var moduleLogger = new Mock<IModuleLogger>();
-        var moduleConsoleWriter = moduleLogger.As<IConsoleWriter>();
-        var consoleWriter = new ConsoleWriter();
+        var output = await ExecutePipelineAsync<LogToConsoleModule>();
 
-        await using (new ModuleLoggerScope(moduleLogger.Object, typeof(ConsoleWriterTests)))
-        {
-            consoleWriter.LogToConsole("[green]module output[/]");
-        }
-
-        moduleConsoleWriter.Verify(
-            writer => writer.LogToConsole("[green]module output[/]"),
-            Times.Once);
+        await Assert.That(output).Contains("module output");
     }
 
     [Test]
     public async Task Write_UsesAmbientModuleConsoleWriter()
     {
-        var moduleLogger = new Mock<IModuleLogger>();
-        var moduleConsoleWriter = moduleLogger.As<IConsoleWriter>();
-        var consoleWriter = new ConsoleWriter();
-        IRenderable table = new Table().AddColumn("Value").AddRow("module output");
+        var output = await ExecutePipelineAsync<WriteModule>();
 
-        await using (new ModuleLoggerScope(moduleLogger.Object, typeof(ConsoleWriterTests)))
+        await Assert.That(output).Contains("module output");
+    }
+
+    private static async Task<string> ExecutePipelineAsync<TModule>()
+        where TModule : class, IModule
+    {
+        using var builder = TestPipelineBuilder.Create();
+        builder.ConfigurePipelineOptions(options => options with
         {
-            consoleWriter.Write(table);
-        }
+            RunReport = options.RunReport with
+            {
+                IncludeModuleOutput = true,
+                MaxOutputBytesPerModule = 1024,
+            },
+        });
+        builder.AddModule<TModule>();
 
-        moduleConsoleWriter.Verify(writer => writer.Write(table), Times.Once);
+        var summary = await builder.ExecutePipelineAsync();
+
+        return summary.RunReport!.Modules.Single().Output!.StdoutTail ?? string.Empty;
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,0 +1,43 @@
+using ModularPipelines.Logging;
+using Moq;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace ModularPipelines.UnitTests.Console;
+
+[TUnit.Core.NotInParallel(nameof(ConsoleWriterTests))]
+public class ConsoleWriterTests
+{
+    [Test]
+    public async Task LogToConsole_UsesAmbientModuleConsoleWriter()
+    {
+        var moduleLogger = new Mock<IModuleLogger>();
+        var moduleConsoleWriter = moduleLogger.As<IConsoleWriter>();
+        var consoleWriter = new ConsoleWriter();
+
+        await using (new ModuleLoggerScope(moduleLogger.Object, typeof(ConsoleWriterTests)))
+        {
+            consoleWriter.LogToConsole("[green]module output[/]");
+        }
+
+        moduleConsoleWriter.Verify(
+            writer => writer.LogToConsole("[green]module output[/]"),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Write_UsesAmbientModuleConsoleWriter()
+    {
+        var moduleLogger = new Mock<IModuleLogger>();
+        var moduleConsoleWriter = moduleLogger.As<IConsoleWriter>();
+        var consoleWriter = new ConsoleWriter();
+        IRenderable table = new Table().AddColumn("Value").AddRow("module output");
+
+        await using (new ModuleLoggerScope(moduleLogger.Object, typeof(ConsoleWriterTests)))
+        {
+            consoleWriter.Write(table);
+        }
+
+        moduleConsoleWriter.Verify(writer => writer.Write(table), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- route rich console output through the active module logger when module context is available
- keep artifact lifecycle messages inside the producing or consuming module log section
- preserve direct pipeline-level output when no module context exists
- add regression coverage for rich console and artifact lifecycle routing

## Validation
- built test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj in Release mode
- passed 2 ConsoleWriterTests
- passed ArtifactLifecycleLoggingUsesAmbientModuleLogger

## Context
Fixes output appearing outside collapsible module sections in https://github.com/thomhurst/ModularPipelines/actions/runs/33034954637/job/98395953521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Console output now consistently uses the active module-level console writer when available.
  - Artifact upload and download messages now use the active module logger, improving consistency for warnings, errors, and informational messages.
  - Distributed module execution now preserves module-specific logging across artifact handling and execution.
  - Existing fallback behavior remains available when no module-level logger is configured.

- **Tests**
  - Added coverage validating module-level console and artifact logging behavior in local and distributed execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->