### PR TITLE
Shorten environment variable API

### DIFF
--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -123,7 +123,7 @@ public class UploadPackagesToNugetModule : Module<CommandResult[]>
         IModuleContext context,
         CancellationToken cancellationToken)
     {
-        var apiKey = context.Environment.Variables.GetEnvironmentVariable("NUGET_API_KEY");
+        var apiKey = context.Environment.Variables.Get("NUGET_API_KEY");
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
 
         var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)

--- a/docs/docs/how-to/run-conditions.md
+++ b/docs/docs/how-to/run-conditions.md
@@ -43,7 +43,7 @@ public sealed class RunIfRegionAttribute(string region) : RunIfAllAttribute
 {
     public override Task<bool> EvaluateAsync(IPipelineContext context) =>
         Task.FromResult(
-            context.Environment.Variables.GetEnvironmentVariable("REGION") == region);
+            context.Environment.Variables.Get("REGION") == region);
 }
 
 [RunIfRegion("eu-west-2")]

--- a/src/ModularPipelines.Azure.Pipelines/AzurePipeline.cs
+++ b/src/ModularPipelines.Azure.Pipelines/AzurePipeline.cs
@@ -23,7 +23,7 @@ internal class AzurePipeline : IAzurePipeline
     }
 
     public bool IsRunningOnAzurePipelines
-        => !string.IsNullOrWhiteSpace(_environment.EnvironmentVariables.GetEnvironmentVariable("TF_BUILD"));
+        => !string.IsNullOrWhiteSpace(_environment.EnvironmentVariables.Get("TF_BUILD"));
 
     public AzurePipelineVariables Variables { get; }
 

--- a/src/ModularPipelines.Build/Settings/FastFailValidation.cs
+++ b/src/ModularPipelines.Build/Settings/FastFailValidation.cs
@@ -8,7 +8,7 @@ internal static class FastFailValidation
 
     public static bool IsComplete(IModuleContext context) =>
         string.Equals(
-            context.Environment.Variables.GetEnvironmentVariable(EnvironmentVariableName),
+            context.Environment.Variables.Get(EnvironmentVariableName),
             bool.TrueString,
             StringComparison.OrdinalIgnoreCase);
 }

--- a/src/ModularPipelines.GitHub/Attributes/SkipIfNoGitHubToken.cs
+++ b/src/ModularPipelines.GitHub/Attributes/SkipIfNoGitHubToken.cs
@@ -13,7 +13,7 @@ public class SkipIfNoGitHubToken : Attribute, IConditionAttribute
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
-        var token = pipelineContext.Environment.Variables.GetEnvironmentVariable("GITHUB_TOKEN");
+        var token = pipelineContext.Environment.Variables.Get("GITHUB_TOKEN");
 
         return Task.FromResult(string.IsNullOrEmpty(token));
     }

--- a/src/ModularPipelines.GitHub/GitHubMarkdownSummaryGenerator.cs
+++ b/src/ModularPipelines.GitHub/GitHubMarkdownSummaryGenerator.cs
@@ -33,7 +33,7 @@ internal class GitHubMarkdownSummaryGenerator : IPipelineGlobalHooks
         PipelineSummary pipelineSummary)
     {
         var stepSummaryVariable = pipelineContext.Environment.Variables
-            .GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+            .Get("GITHUB_STEP_SUMMARY");
         if (string.IsNullOrEmpty(stepSummaryVariable))
         {
             return;

--- a/src/ModularPipelines/Attributes/EnvironmentVariableConditionAttributes.cs
+++ b/src/ModularPipelines/Attributes/EnvironmentVariableConditionAttributes.cs
@@ -150,5 +150,5 @@ internal static class EnvironmentVariableCondition
         GetValue(context, variableName) is not null;
 
     private static string? GetValue(IPipelineContext context, string variableName) =>
-        context.Environment.Variables.GetEnvironmentVariable(variableName);
+        context.Environment.Variables.Get(variableName);
 }

--- a/src/ModularPipelines/BuildSystemDetector.cs
+++ b/src/ModularPipelines/BuildSystemDetector.cs
@@ -64,7 +64,7 @@ internal class BuildSystemDetector : IBuildSystemDetector
     {
         foreach (var (variable, buildSystem) in DetectionOrder)
         {
-            if (string.IsNullOrEmpty(_environmentVariables.GetEnvironmentVariable(variable)))
+            if (string.IsNullOrEmpty(_environmentVariables.Get(variable)))
             {
                 continue;
             }

--- a/src/ModularPipelines/Conditions/IRunCondition.cs
+++ b/src/ModularPipelines/Conditions/IRunCondition.cs
@@ -18,7 +18,7 @@ namespace ModularPipelines.Conditions;
 /// {
 ///     public Task&lt;bool&gt; EvaluateAsync(IPipelineContext context)
 ///         =&gt; Task.FromResult(!string.IsNullOrEmpty(
-///             context.Environment.Variables.GetEnvironmentVariable("GITHUB_TOKEN")));
+///             context.Environment.Variables.Get("GITHUB_TOKEN")));
 /// }
 /// </code>
 /// </example>

--- a/src/ModularPipelines/Conditions/IsCI.cs
+++ b/src/ModularPipelines/Conditions/IsCI.cs
@@ -25,7 +25,7 @@ public sealed class IsCI : IPlanningRunCondition
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)
     {
-        var ciEnvVar = context.Environment.Variables.GetEnvironmentVariable("CI");
+        var ciEnvVar = context.Environment.Variables.Get("CI");
         var isCI = !string.IsNullOrEmpty(ciEnvVar) &&
                    !string.Equals(ciEnvVar, "false", StringComparison.OrdinalIgnoreCase);
         return Task.FromResult(isCI);

--- a/src/ModularPipelines/Conditions/IsLocal.cs
+++ b/src/ModularPipelines/Conditions/IsLocal.cs
@@ -24,7 +24,7 @@ public sealed class IsLocal : IPlanningRunCondition
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)
     {
-        var ciEnvVar = context.Environment.Variables.GetEnvironmentVariable("CI");
+        var ciEnvVar = context.Environment.Variables.Get("CI");
         var isLocal = string.IsNullOrEmpty(ciEnvVar) ||
                       string.Equals(ciEnvVar, "false", StringComparison.OrdinalIgnoreCase);
         return Task.FromResult(isLocal);

--- a/src/ModularPipelines/Context/Domains/Environment/IEnvironmentVariablesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Environment/IEnvironmentVariablesContext.cs
@@ -19,7 +19,7 @@ public interface IEnvironmentVariablesContext
     /// The value of the environment variable specified by <paramref name="name"/>,
     /// or <c>null</c> if the environment variable is not found.
     /// </returns>
-    string? GetEnvironmentVariable(string name, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
+    string? Get(string name, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
 
     /// <summary>
     /// Gets all environment variables as a dictionary.
@@ -32,18 +32,18 @@ public interface IEnvironmentVariablesContext
     /// A dictionary containing all environment variable names and their values
     /// for the specified target scope.
     /// </returns>
-    IReadOnlyDictionary<string, string> GetEnvironmentVariables(EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
+    IReadOnlyDictionary<string, string?> GetAll(EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
 
     /// <summary>
     /// Sets the value of an environment variable.
     /// </summary>
-    /// <param name="variableName">The name of the environment variable to set.</param>
-    /// <param name="value">The value to assign to the environment variable.</param>
+    /// <param name="name">The name of the environment variable to set.</param>
+    /// <param name="value">The value to assign, or <c>null</c> to delete the variable.</param>
     /// <param name="target">
     /// The target scope in which to set the environment variable.
     /// Defaults to <see cref="EnvironmentVariableTarget.Process"/>.
     /// </param>
-    void SetEnvironmentVariable(string variableName, string value, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
+    void Set(string name, string? value, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
 
     /// <summary>
     /// Gets the PATH environment variable as a list of individual paths.

--- a/src/ModularPipelines/Context/EnvironmentVariables.cs
+++ b/src/ModularPipelines/Context/EnvironmentVariables.cs
@@ -9,35 +9,35 @@ internal class EnvironmentVariables : IEnvironmentVariablesContext
 
     private static char Delimiter => OperatingSystem.IsWindows() ? ';' : ':';
 
-    public string? GetEnvironmentVariable(string name, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+    public string? Get(string name, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
     {
         return Environment.GetEnvironmentVariable(name, target);
     }
 
-    public IReadOnlyDictionary<string, string> GetEnvironmentVariables(
+    public IReadOnlyDictionary<string, string?> GetAll(
         EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
     {
         return Environment.GetEnvironmentVariables(target)
             .Cast<DictionaryEntry>()
-            .ToDictionary(variable => variable.Key.ToString()!, variable => variable.Value!.ToString()!);
+            .ToDictionary(variable => variable.Key.ToString()!, variable => variable.Value?.ToString());
     }
 
-    public void SetEnvironmentVariable(string variableName, string value, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+    public void Set(string name, string? value, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
     {
-        Environment.SetEnvironmentVariable(variableName, value, target);
+        Environment.SetEnvironmentVariable(name, value, target);
     }
 
     public IReadOnlyList<string> GetPath(EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
     {
-        return GetEnvironmentVariable(PathVariableName, target)?.Split(Delimiter) ?? [];
+        return Get(PathVariableName, target)?.Split(Delimiter) ?? [];
     }
 
     public void AddToPath(string pathToAdd, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
     {
-        var oldValue = Environment.GetEnvironmentVariable(PathVariableName, target);
+        var oldValue = Get(PathVariableName, target);
 
         var newValue = $"{oldValue}{Delimiter}{pathToAdd}";
 
-        Environment.SetEnvironmentVariable(PathVariableName, newValue, target);
+        Set(PathVariableName, newValue, target);
     }
 }

--- a/src/ModularPipelines/Context/PredefinedInstallers.cs
+++ b/src/ModularPipelines/Context/PredefinedInstallers.cs
@@ -104,7 +104,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
             ],
         }, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        var allUsersProfile = _environmentVariables.GetEnvironmentVariable("ALLUSERSPROFILE")
+        var allUsersProfile = _environmentVariables.Get("ALLUSERSPROFILE")
                               ?? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
         _environmentVariables.AddToPath(Path.Combine(allUsersProfile, "chocolatey", "bin"));
 
@@ -161,8 +161,8 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
 
             var symLinkFolder = newFolder.CreateFolder("nvm_symlink").GetFolder(Guid.NewGuid().ToString("N"));
 
-            _environmentVariables.SetEnvironmentVariable("NVM_HOME", newFolder);
-            _environmentVariables.SetEnvironmentVariable("NVM_SYMLINK", symLinkFolder);
+            _environmentVariables.Set("NVM_HOME", newFolder);
+            _environmentVariables.Set("NVM_SYMLINK", symLinkFolder);
             _environmentVariables.AddToPath(newFolder);
             _environmentVariables.AddToPath(symLinkFolder);
 

--- a/src/ModularPipelines/Requirements/Require.cs
+++ b/src/ModularPipelines/Requirements/Require.cs
@@ -99,7 +99,7 @@ public static class Require
         string? failureReason = null,
         int order = 0)
         => new DelegateRequirement(
-            ctx => !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable(variableName)),
+            ctx => !string.IsNullOrEmpty(ctx.Environment.Variables.Get(variableName)),
             failureReason ?? $"Environment variable '{variableName}' must be set",
             order);
 
@@ -186,13 +186,13 @@ public static class Require
         int order = 0)
         => new DelegateRequirement(
             ctx =>
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("CI")) ||
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("TF_BUILD")) ||
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("GITHUB_ACTIONS")) ||
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("GITLAB_CI")) ||
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("CIRCLECI")) ||
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("JENKINS_URL")) ||
-                !string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("TEAMCITY_VERSION")),
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("CI")) ||
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("TF_BUILD")) ||
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("GITHUB_ACTIONS")) ||
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("GITLAB_CI")) ||
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("CIRCLECI")) ||
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("JENKINS_URL")) ||
+                !string.IsNullOrEmpty(ctx.Environment.Variables.Get("TEAMCITY_VERSION")),
             failureReason ?? "This pipeline must run in a CI environment",
             order);
 
@@ -213,13 +213,13 @@ public static class Require
         int order = 0)
         => new DelegateRequirement(
             ctx =>
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("CI")) &&
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("TF_BUILD")) &&
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("GITHUB_ACTIONS")) &&
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("GITLAB_CI")) &&
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("CIRCLECI")) &&
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("JENKINS_URL")) &&
-                string.IsNullOrEmpty(ctx.Environment.Variables.GetEnvironmentVariable("TEAMCITY_VERSION")),
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("CI")) &&
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("TF_BUILD")) &&
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("GITHUB_ACTIONS")) &&
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("GITLAB_CI")) &&
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("CIRCLECI")) &&
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("JENKINS_URL")) &&
+                string.IsNullOrEmpty(ctx.Environment.Variables.Get("TEAMCITY_VERSION")),
             failureReason ?? "This pipeline must run locally (not in CI)",
             order);
 }

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -273,7 +273,7 @@ public static class CurrentApiSnippets
             IModuleContext context,
             CancellationToken cancellationToken)
         {
-            var apiKey = context.Environment.Variables.GetEnvironmentVariable("NUGET_API_KEY");
+            var apiKey = context.Environment.Variables.Get("NUGET_API_KEY");
             ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
 
             var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
@@ -317,7 +317,7 @@ public static class CurrentApiSnippets
     {
         public Task<bool> EvaluateAsync(IPipelineContext context)
             => Task.FromResult(!string.IsNullOrEmpty(
-                context.Environment.Variables.GetEnvironmentVariable("GITHUB_TOKEN")));
+                context.Environment.Variables.Get("GITHUB_TOKEN")));
     }
 
     public sealed class VersionCalculator : SyncModule<string>

--- a/test/ModularPipelines.UnitTests/Attributes/ParameterizedRunConditionAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ParameterizedRunConditionAttributeTests.cs
@@ -69,9 +69,9 @@ public class ParameterizedRunConditionAttributeTests
     public async Task EnvironmentVariableAttributes_SupportSetValueAndUnsetChecks()
     {
         var variables = new Mock<IEnvironmentVariablesContext>();
-        variables.Setup(x => x.GetEnvironmentVariable("CI", EnvironmentVariableTarget.Process))
+        variables.Setup(x => x.Get("CI", EnvironmentVariableTarget.Process))
             .Returns("true");
-        variables.Setup(x => x.GetEnvironmentVariable("MISSING", EnvironmentVariableTarget.Process))
+        variables.Setup(x => x.Get("MISSING", EnvironmentVariableTarget.Process))
             .Returns((string?) null);
         var context = CreateContext(variables.Object);
 

--- a/test/ModularPipelines.UnitTests/Engine/BuildSystemDetectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/BuildSystemDetectorTests.cs
@@ -44,7 +44,7 @@ public class BuildSystemDetectorTests : TestBase
     public async Task When_Known_BuildAgent_Variable_Then_IsKnownBuildAgent_Returns_True(string environmentVariableName)
     {
         _environmentVariables
-            .Setup(x => x.GetEnvironmentVariable(environmentVariableName, It.IsAny<EnvironmentVariableTarget>()))
+            .Setup(x => x.Get(environmentVariableName, It.IsAny<EnvironmentVariableTarget>()))
             .Returns("dummy value");
         await Assert.That(_buildSystemDetector.IsKnownBuildAgent).IsTrue();
     }
@@ -78,7 +78,7 @@ public class BuildSystemDetectorTests : TestBase
     public async Task Expected_Build_Agent(string environmentVariableName, BuildSystem expectedBuildSystem)
     {
         _environmentVariables
-            .Setup(x => x.GetEnvironmentVariable(environmentVariableName, It.IsAny<EnvironmentVariableTarget>()))
+            .Setup(x => x.Get(environmentVariableName, It.IsAny<EnvironmentVariableTarget>()))
             .Returns("dummy value");
         await Assert.That(_buildSystemDetector.GetCurrentBuildSystem()).IsEqualTo(expectedBuildSystem);
     }
@@ -103,7 +103,7 @@ public class BuildSystemDetectorTests : TestBase
                  })
         {
             _environmentVariables.Verify(
-                variables => variables.GetEnvironmentVariable(
+                variables => variables.Get(
                     environmentVariable,
                     It.IsAny<EnvironmentVariableTarget>()),
                 Times.Once);
@@ -114,12 +114,12 @@ public class BuildSystemDetectorTests : TestBase
     public async Task Detection_Uses_Explicit_Precedence()
     {
         _environmentVariables
-            .Setup(variables => variables.GetEnvironmentVariable(
+            .Setup(variables => variables.Get(
                 "TF_BUILD",
                 It.IsAny<EnvironmentVariableTarget>()))
             .Returns("true");
         _environmentVariables
-            .Setup(variables => variables.GetEnvironmentVariable(
+            .Setup(variables => variables.Get(
                 "GITHUB_ACTIONS",
                 It.IsAny<EnvironmentVariableTarget>()))
             .Returns("true");
@@ -131,7 +131,7 @@ public class BuildSystemDetectorTests : TestBase
     public async Task Detection_Reports_Matched_Environment_Variable()
     {
         _environmentVariables
-            .Setup(variables => variables.GetEnvironmentVariable(
+            .Setup(variables => variables.Get(
                 "TF_BUILD",
                 It.IsAny<EnvironmentVariableTarget>()))
             .Returns("true");

--- a/test/ModularPipelines.UnitTests/Helpers/EnvironmentContextTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/EnvironmentContextTests.cs
@@ -17,7 +17,7 @@ public class EnvironmentContextTests : TestBase
 
             var context = await GetService<IEnvironmentContext>();
 
-            var result = context.EnvironmentVariables.GetEnvironmentVariable(guid);
+            var result = context.EnvironmentVariables.Get(guid);
             await Assert.That(result).IsEqualTo(TestConstants.TestString);
         });
     }
@@ -33,9 +33,9 @@ public class EnvironmentContextTests : TestBase
 
             var context = await GetService<IEnvironmentContext>();
 
-            var result = context.EnvironmentVariables.GetEnvironmentVariables();
+            var result = context.EnvironmentVariables.GetAll();
             await Assert.That(result).IsNotNull();
-            await Assert.That((object) result).IsAssignableTo<IReadOnlyDictionary<string, string>>();
+            await Assert.That((object) result).IsAssignableTo<IReadOnlyDictionary<string, string?>>();
             await Assert.That(result[guid]).IsEqualTo(TestConstants.TestString);
         });
     }
@@ -49,10 +49,26 @@ public class EnvironmentContextTests : TestBase
         {
             var context = await GetService<IEnvironmentContext>();
 
-            context.EnvironmentVariables.SetEnvironmentVariable(guid, TestConstants.TestString);
+            context.EnvironmentVariables.Set(guid, TestConstants.TestString);
 
             var result = Environment.GetEnvironmentVariable(guid);
             await Assert.That(result).IsEqualTo(TestConstants.TestString);
+        });
+    }
+
+    [Test]
+    public async Task Can_Remove_Environment_Variables()
+    {
+        var guid = Guid.NewGuid().ToString("N");
+
+        await RunWithEnvironmentRestored(guid, async () =>
+        {
+            Environment.SetEnvironmentVariable(guid, TestConstants.TestString);
+
+            var context = await GetService<IEnvironmentContext>();
+            context.EnvironmentVariables.Set(guid, null);
+
+            await Assert.That(Environment.GetEnvironmentVariable(guid)).IsNull();
         });
     }
 

--- a/test/ModularPipelines.UnitTests/Helpers/PredefinedInstallersTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/PredefinedInstallersTests.cs
@@ -35,7 +35,7 @@ public class PredefinedInstallersTests
                 })
             .ReturnsAsync(result);
         var environmentVariables = new Mock<IEnvironmentVariablesContext>();
-        environmentVariables.Setup(context => context.GetEnvironmentVariable(
+        environmentVariables.Setup(context => context.Get(
                 "ALLUSERSPROFILE",
                 EnvironmentVariableTarget.Process))
             .Returns(allUsersProfile);


### PR DESCRIPTION
## Summary
- rename `IEnvironmentVariablesContext` APIs to `Get`, `GetAll`, and `Set`
- allow `Set(name, null)` to delete a variable and preserve nullable values from `GetAll`
- migrate source, tests, snippets, and current documentation to the shorter API

## Validation
- `ModularPipelines.Tests.slnf` Release build passed
- 46 focused core tests passed
- GitHub and Azure Pipelines integration solution Release builds passed
- documentation snippets Release build passed
- Docusaurus production build passed
- whitespace formatting and `git diff --check` passed for touched files
- full core unit-test run hit unrelated `CommandLoggerTests.Command_Header_Precedes_Streamed_Output_And_Completion` timing failure, then repository guard stopped the stalled run at 600 seconds (exit 124)

Closes #4235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified environment-variable access across the pipeline.
  * Updated integrations, conditions, build detection, installers, and examples to use the streamlined API.
  * Environment-variable collections now support null values, including removing variables by setting them to null.

* **Tests**
  * Updated automated tests and documentation snippets to reflect the revised environment-variable behavior.
  * Added coverage for removing environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->