### PR TITLE
Rename pipeline builder shortcut to RunAsync

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -158,7 +158,7 @@ yarn start
 - Use `Pipeline.CreateBuilder(args)` to bootstrap
 - Register modules with `builder.AddModule<T>()`
 - Configure services through `builder.Services`
-- Run with `await builder.ExecutePipelineAsync()`
+- Run with `await builder.RunAsync()`
 
 ## Validation Scenarios
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ using ModularPipelines;
 using ModularPipelines.Extensions;
 
 var builder = Pipeline.CreateBuilder(args);
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ## Console Progress

--- a/README_Template.md
+++ b/README_Template.md
@@ -139,7 +139,7 @@ using ModularPipelines;
 using ModularPipelines.Extensions;
 
 using var builder = Pipeline.CreateBuilder(args);
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ## Console Progress

--- a/docs/docs/distributed/getting-started.md
+++ b/docs/docs/distributed/getting-started.md
@@ -60,7 +60,7 @@ builder.AddModule<BuildModule>();
 builder.AddModule<TestModule>();
 builder.AddModule<PublishModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 That's it. When `InstanceIndex` is `0`, the process runs as the master. All other instances run as workers.
@@ -146,7 +146,7 @@ builder.AddModule<RestoreModule>();
 builder.AddModule<BuildModule>();
 builder.AddModule<TestModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 
 public class RestoreModule : Module<string>
 {

--- a/docs/docs/distributed/github-actions.md
+++ b/docs/docs/distributed/github-actions.md
@@ -166,7 +166,7 @@ builder.AddModule<WindowsBuildModule>();
 builder.AddModule<MacBuildModule>();
 builder.AddModule<AggregateResultsModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 
 public class RestoreModule : Module<string>
 {

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -33,7 +33,7 @@ builder
     .AddModule<PackProjectsModule>()
     .AddModule<UploadPackagesToNugetModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 
 public class NugetVersionGeneratorModule : Module<string>
 {

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -59,7 +59,7 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
             .AddModule<UpdateDotnetWorkloads>()
             .AddModule<CheckDotnetSdkModule>()
 
-        builder.RunAsync()
+        builder.ExecutePipelineAsync()
         |> Async.AwaitTask
         |> Async.RunSynchronously
     finally

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -59,7 +59,7 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
             .AddModule<UpdateDotnetWorkloads>()
             .AddModule<CheckDotnetSdkModule>()
 
-        builder.ExecutePipelineAsync()
+        builder.RunAsync()
         |> Async.AwaitTask
         |> Async.RunSynchronously
     finally

--- a/docs/docs/examples/single-file-csharp.md
+++ b/docs/docs/examples/single-file-csharp.md
@@ -36,7 +36,7 @@ Install the .NET 10 SDK, then follow these steps:
         .AddModule<UpdateDotnetWorkloads>()
         .AddModule<CheckDotnetSdkModule>();
 
-    await builder.ExecutePipelineAsync();
+    await builder.RunAsync();
 
     public class UpdateDotnetWorkloads : Module<CommandResult>
     {

--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -12,7 +12,7 @@ Your pipeline is created using `Pipeline.CreateBuilder()`. This follows the ASP.
 ```csharp
 var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ## Modules

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -62,7 +62,7 @@ using ModularPipelines.Modules;
 var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<BuildModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 
 public sealed class BuildModule : Module<CommandResult>
 {

--- a/docs/docs/how-to/categories.md
+++ b/docs/docs/how-to/categories.md
@@ -37,7 +37,7 @@ builder
 
 builder.RunOnlyCategories("UnitTest", "IntegrationTest");
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 
@@ -54,5 +54,5 @@ builder
 
 builder.IgnoreCategories("Publish", "Deploy");
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```

--- a/docs/docs/how-to/command-line.md
+++ b/docs/docs/how-to/command-line.md
@@ -16,7 +16,7 @@ builder
     .AddModule<TestModule>()
     .AddModule<DeployModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ## Options

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -88,7 +88,7 @@ When you declare a required dependency, you don't need to explicitly register it
 var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<Module2>(); // Module1 is auto-registered because Module2 depends on it
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 This simplifies pipeline configuration and ensures all required dependencies are always present. Auto-registration also handles transitive dependencies - if Module1 depends on Module0, both will be auto-registered.

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -49,7 +49,7 @@ use builder = Pipeline.CreateBuilder()
 
 builder
     .AddModule<TestModule>()
-    .ExecutePipelineAsync()
+    .RunAsync()
     .GetAwaiter()
     .GetResult()
 |> ignore

--- a/docs/docs/how-to/logging.md
+++ b/docs/docs/how-to/logging.md
@@ -87,7 +87,7 @@ builder.ConfigurePipelineOptions(options => options with
     },
 });
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ### Using Presets

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -22,7 +22,7 @@ builder
     .AddModule<BuildModule>()
     .AddModule<TestModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 The source generator must run in the application project. Statically declared

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -25,7 +25,7 @@ builder
     .AddModule<TestModule>()
     .AddModule<DeployModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 Passing `args` also enables the [built-in pipeline command line](command-line.md)
@@ -188,7 +188,7 @@ if (validation.HasErrors)
     Environment.Exit(1);
 }
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ## Complete Example
@@ -240,7 +240,7 @@ builder
     .AddModule<ReportModule>();
 
 // Run
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ## Hooks and Requirements
@@ -275,5 +275,5 @@ await builder
     {
         ExecutionMode = ExecutionMode.StopOnFirstException,
     })
-    .ExecutePipelineAsync();
+    .RunAsync();
 ```

--- a/docs/docs/how-to/pipeline-modes.md
+++ b/docs/docs/how-to/pipeline-modes.md
@@ -27,5 +27,5 @@ builder.ConfigurePipelineOptions(options => options with
     ExecutionMode = ExecutionMode.WaitForAllModules,
 });
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -120,7 +120,7 @@ builder.ConfigurePipelineOptions(options => options with
     DefaultRetryCount = 3,
 });
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 This applies to all modules that don't override their retry configuration. Modules can override this default by configuring retries in `Configure()`.

--- a/docs/docs/how-to/storing-and-retrieving-results.md
+++ b/docs/docs/how-to/storing-and-retrieving-results.md
@@ -25,7 +25,7 @@ builder
 
 builder.AddResultsRepository<MyModuleRepository>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 Result history resolves type-erased module results at runtime and is not supported for

--- a/docs/docs/how-to/time-estimator.md
+++ b/docs/docs/how-to/time-estimator.md
@@ -22,7 +22,7 @@ builder
 
 builder.AddModuleEstimatedTimeProvider<MyEstimatedTimeProvider>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ```csharp

--- a/docs/docs/mp-packages/github.md
+++ b/docs/docs/mp-packages/github.md
@@ -72,7 +72,7 @@ builder.Configuration
 // Registers a section from the configuration file with GitHubOptions
 builder.Services.Configure<GitHubOptions>(builder.Configuration.GetSection("ModularPipelines:Secrets:GitHub"));
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 where `appsettings.json` is constructed as follows:

--- a/src/ModularPipelines.Development.Analyzers/Readme.md
+++ b/src/ModularPipelines.Development.Analyzers/Readme.md
@@ -103,7 +103,7 @@ builder
     .AddModule<FindNugetPackagesModule>()
     .AddModule<UploadNugetPackagesModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();
 ```
 
 ### Custom Modules

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -20,4 +20,4 @@ builder
     .AddModule<TestModule>()
     .AddModule<PublishModule>();
 
-await builder.ExecutePipelineAsync();
+await builder.RunAsync();

--- a/src/ModularPipelines/Exceptions/PluginInitializationException.cs
+++ b/src/ModularPipelines/Exceptions/PluginInitializationException.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Exceptions;
 /// <code>
 /// try
 /// {
-///     await pipelineBuilder.ExecutePipelineAsync();
+///     await pipelineBuilder.RunAsync();
 /// }
 /// catch (PluginInitializationException ex)
 /// {

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -214,12 +214,12 @@ public static class PipelineBuilderExtensions
     }
 
     /// <summary>
-    /// Builds the pipeline and executes it.
+    /// Builds and runs the pipeline.
     /// </summary>
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
-    /// <returns>A summary of the pipeline execution results.</returns>
-    public static async Task<Models.PipelineSummary> ExecutePipelineAsync(this PipelineBuilder builder, CancellationToken cancellationToken = default)
+    /// <returns>A summary of the pipeline run results.</returns>
+    public static async Task<Models.PipelineSummary> RunAsync(this PipelineBuilder builder, CancellationToken cancellationToken = default)
     {
         await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
         return await pipeline.RunAsync(cancellationToken).ConfigureAwait(false);

--- a/src/ModularPipelines/Options/SecretMaskingOptions.cs
+++ b/src/ModularPipelines/Options/SecretMaskingOptions.cs
@@ -29,7 +29,7 @@ namespace ModularPipelines.Options;
 ///     options.MaskValue = "[REDACTED]"; // Custom mask text
 /// });
 ///
-/// await builder.ExecutePipelineAsync();
+/// await builder.RunAsync();
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines/Requirements/MacOSRequirement.cs
+++ b/src/ModularPipelines/Requirements/MacOSRequirement.cs
@@ -18,7 +18,7 @@ namespace ModularPipelines.Requirements;
 /// builder.Services.AddRequirement&lt;MacOSRequirement&gt;();
 /// builder.AddModule&lt;BuildMacAppModule&gt;();
 ///
-/// await builder.ExecutePipelineAsync();
+/// await builder.RunAsync();
 /// </code>
 /// </remarks>
 /// <seealso cref="WindowsRequirement"/>

--- a/src/ModularPipelines/Requirements/WindowsAdminRequirement.cs
+++ b/src/ModularPipelines/Requirements/WindowsAdminRequirement.cs
@@ -23,7 +23,7 @@ namespace ModularPipelines.Requirements;
 /// builder.Services.AddRequirement&lt;WindowsAdminRequirement&gt;();
 /// builder.AddModule&lt;InstallServiceModule&gt;();
 ///
-/// await builder.ExecutePipelineAsync();
+/// await builder.RunAsync();
 /// </code>
 /// </remarks>
 /// <seealso cref="WindowsRequirement"/>

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -36,7 +36,7 @@ public static class CurrentApiSnippets
             options.MaskValue = "[REDACTED]";
         });
 
-        return builder.ExecutePipelineAsync();
+        return builder.RunAsync();
     }
 
     public static async Task<int> RunPipelineAndMapExitCode(string[] args)
@@ -64,7 +64,7 @@ public static class CurrentApiSnippets
         });
         builder.AddModule<BuildModule>();
 
-        var result = await builder.ExecutePipelineAsync();
+        var result = await builder.RunAsync();
         if (result.Status != Status.Successful)
         {
             throw new InvalidOperationException("Expected a successful pipeline.");
@@ -78,7 +78,7 @@ public static class CurrentApiSnippets
             .AddModule<UpdateDotnetWorkloads>()
             .AddModule<CheckDotnetSdkModule>();
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
     }
 
     public static async Task ConfigureTestPackPublishPipeline(string[] args)
@@ -90,7 +90,7 @@ public static class CurrentApiSnippets
             .AddModule<PackProjectsModule>()
             .AddModule<UploadPackagesToNugetModule>();
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
     }
 
     public sealed record BuildInfo(string Version, string OutputPath);

--- a/test/ModularPipelines.DocumentationSnippets/GettingStartedSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/GettingStartedSnippets.cs
@@ -13,7 +13,7 @@ public static class GettingStartedSnippets
         var builder = Pipeline.CreateBuilder(args);
         builder.AddModule<BuildModule>();
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
     }
 
     public sealed class BuildModule : Module<CommandResult>

--- a/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
+++ b/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
@@ -58,11 +58,11 @@ type PipelineRunner =
         Pipeline
             .CreateBuilder()
             .AddModule<DependentModule>()
-            .ExecutePipelineAsync()
+            .RunAsync()
 
     static member RunConfiguredAsync() =
         Pipeline
             .CreateBuilder()
             .AddModule<DependencyModule>()
             .AddModule<ConfiguredDependentModule>()
-            .ExecutePipelineAsync()
+            .RunAsync()

--- a/test/ModularPipelines.GitHub.UnitTests/Engine/DistributedPipelineWriterTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/Engine/DistributedPipelineWriterTests.cs
@@ -29,7 +29,7 @@ public class DistributedPipelineWriterTests : TestBase
                 DotNetRunFramework = "net10.0",
                 ExtraWorkers = 1,
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var yaml = (await outputPath.ReadAsync()).ReplaceLineEndings("\n");
 
@@ -89,7 +89,7 @@ public class DistributedPipelineWriterTests : TestBase
                 OutputPath = outputPath,
                 ExtraWorkers = 0,
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var yaml = (await outputPath.ReadAsync()).ReplaceLineEndings("\n");
         var runners = yaml.Split('\n')
@@ -114,7 +114,7 @@ public class DistributedPipelineWriterTests : TestBase
                 OutputPath = outputPath,
                 PipelineProjectPath = new File(@"src\My Pipeline's\Pipeline.csproj"),
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var yaml = (await outputPath.ReadAsync()).ReplaceLineEndings("\n");
 

--- a/test/ModularPipelines.GitHub.UnitTests/Engine/PipelineWriterTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/Engine/PipelineWriterTests.cs
@@ -87,7 +87,7 @@ public class PipelineWriterTests : TestBase
         await TestPipelineBuilder.Create()
             .AddModule<DummyModule>()
             .AddPipelineFileWriter<GitHubYamlWriter>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         // Normalize line endings for cross-platform consistency
         await Assert.That((await RandomFilePath.ReadAsync()).Trim().ReplaceLineEndings("\n")).
             IsEqualTo($$$"""

--- a/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
@@ -78,7 +78,7 @@ public class GitHubMarkdownSummaryGeneratorTests
             builder.AddModule<DependencyModule>();
             builder.AddModule<TargetModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             var summary = await File.ReadAllTextAsync(path);
             using (Assert.Multiple())
@@ -110,7 +110,7 @@ public class GitHubMarkdownSummaryGeneratorTests
             using var builder = Pipeline.CreateBuilder();
             builder.AddModule<SingleUseSkipConditionModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             var summary = await File.ReadAllTextAsync(path);
             using (Assert.Multiple())
@@ -139,7 +139,7 @@ public class GitHubMarkdownSummaryGeneratorTests
             builder.Services.AddSingleton<IDependencyGraphExporter, OversizedDependencyGraphRenderer>();
             builder.AddModule<DependencyModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             var summary = await File.ReadAllTextAsync(path);
             using (Assert.Multiple())

--- a/test/ModularPipelines.UnitTests/Api/RootNamespaceGoldenPathCompileFixture.cs
+++ b/test/ModularPipelines.UnitTests/Api/RootNamespaceGoldenPathCompileFixture.cs
@@ -6,11 +6,11 @@ namespace RootNamespaceConsumer;
 
 internal static class RootNamespaceGoldenPathCompileFixture
 {
-    public static async Task ConfigureAndExecuteAsync(PipelineBuilder builder)
+    public static async Task ConfigureAndRunAsync(PipelineBuilder builder)
     {
         builder.AddModule<GoldenPathModule>();
         builder.ConfigurePipelineOptions(options => options);
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
     }
 
     private sealed class GoldenPathModule : Module<string>

--- a/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
@@ -76,7 +76,7 @@ public class ArtifactContractTests
         builder.AddModule<AmbientArtifactLoggingProducerModule>();
         builder.AddModule<AmbientArtifactLoggingConsumerModule>();
 
-        await Assert.That(async () => await builder.ExecutePipelineAsync())
+        await Assert.That(async () => await builder.RunAsync())
             .Throws<ModuleFailedException>();
 
         await Assert.That(loggerProvider.Entries).Contains(entry =>
@@ -1565,7 +1565,7 @@ public class ArtifactContractTests
             builder.AddModule<LocalProducerModule>();
             builder.AddModule<LocalConsumerModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             await Assert.That(LocalConsumerModule.ConsumedContent).IsEqualTo("local artifact content");
         }
@@ -1617,7 +1617,7 @@ public class ArtifactContractTests
             builder.AddModule<LocalProducerModule>();
             builder.AddModule<ProducerStateConsumerModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<LocalProducerModule>()
                 .Single();
@@ -1655,7 +1655,7 @@ public class ArtifactContractTests
             builder.AddModule<ProducerStateIntermediateModule>();
             builder.AddModule<TransitiveProducerStateConsumerModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var consumerResult = await summary.Modules
                 .OfType<TransitiveProducerStateConsumerModule>()
                 .Single();
@@ -1692,7 +1692,7 @@ public class ArtifactContractTests
             builder.AddModule<StateDependentIntermediateModule>();
             builder.AddModule<TransitiveDependencyStateConsumerModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var consumerResult = await summary.Modules
                 .OfType<TransitiveDependencyStateConsumerModule>()
                 .Single();
@@ -1724,7 +1724,7 @@ public class ArtifactContractTests
             builder.AddModule<AfterHookArtifactProducerModule>();
             builder.AddModule<AfterHookArtifactConsumerModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var consumerResult = await summary.Modules
                 .OfType<AfterHookArtifactConsumerModule>()
                 .Single();
@@ -1749,7 +1749,7 @@ public class ArtifactContractTests
             builder.AddModule<AfterHookArtifactProducerModule>();
             builder.AddModule<AfterHookArtifactConsumerModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var consumerResult = await summary.Modules
                 .OfType<AfterHookArtifactConsumerModule>()
                 .Single();
@@ -1807,7 +1807,7 @@ public class ArtifactContractTests
             builder.AddModule<MultipleDirectoryProducerModule>();
             builder.AddModule<MultipleDirectoryConsumerModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             using (Assert.Multiple())
             {
@@ -1905,7 +1905,7 @@ public class ArtifactContractTests
             builder.AddModule<MissingRuntimeConsumerModule>();
 
             var exception = await Assert.ThrowsAsync<ModuleFailedException>(
-                () => builder.ExecutePipelineAsync());
+                () => builder.RunAsync());
 
             using (Assert.Multiple())
             {
@@ -1977,7 +1977,7 @@ public class ArtifactContractTests
             builder.AddModule<IgnoredMissingRuntimeConsumerModule>();
 
             var exception = await Assert.ThrowsAsync<ModuleFailedException>(
-                () => builder.ExecutePipelineAsync());
+                () => builder.RunAsync());
 
             using (Assert.Multiple())
             {
@@ -2049,7 +2049,7 @@ public class ArtifactContractTests
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<SkippedArtifactConsumerModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             await Assert.That(SkippedArtifactConsumerModule.Executed).IsFalse();
         }
@@ -2072,7 +2072,7 @@ public class ArtifactContractTests
             builder.AddModule<SkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2109,7 +2109,7 @@ public class ArtifactContractTests
             builder.AddModule<SkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2136,7 +2136,7 @@ public class ArtifactContractTests
             builder.AddModule<ConfiguredSkippedHistoricalArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2179,7 +2179,7 @@ public class ArtifactContractTests
             builder.AddModule<ConfiguredSkippedHistoricalArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2215,7 +2215,7 @@ public class ArtifactContractTests
             builder.AddModule<DependencySkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<DependencyOrderedSkippedArtifactProducerModule>()
                 .Single();
@@ -2250,7 +2250,7 @@ public class ArtifactContractTests
             builder.AddModule<IndependentDependencySkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2291,7 +2291,7 @@ public class ArtifactContractTests
             builder.AddModule<UnrelatedFirstHistoryDependentModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2340,7 +2340,7 @@ public class ArtifactContractTests
             builder.AddModule<PrerequisiteStateArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2420,7 +2420,7 @@ public class ArtifactContractTests
             builder.AddModule<HistoryBackedDependencyArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2463,7 +2463,7 @@ public class ArtifactContractTests
             builder.AddModule<DependencyStateArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2513,7 +2513,7 @@ public class ArtifactContractTests
             builder.AddModule<UnrelatedHistoryDependentModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var firstProducerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2561,7 +2561,7 @@ public class ArtifactContractTests
             builder.AddModule<UnrelatedHistoryDependentModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var firstProducerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2609,7 +2609,7 @@ public class ArtifactContractTests
             builder.AddModule<UnrelatedHistoryDependentModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var firstProducerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2663,7 +2663,7 @@ public class ArtifactContractTests
             builder.AddModule<DependencySkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<DependencyOrderedSkippedArtifactProducerModule>()
                 .Single();
@@ -2707,7 +2707,7 @@ public class ArtifactContractTests
             builder.AddModule<TransitiveDependencySkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<DependencyOrderedSkippedArtifactProducerModule>()
                 .Single();
@@ -2742,7 +2742,7 @@ public class ArtifactContractTests
             builder.AddModule<AttributeSkippedHistoricalArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2784,7 +2784,7 @@ public class ArtifactContractTests
             builder.AddModule<SkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2820,7 +2820,7 @@ public class ArtifactContractTests
             builder.AddModule<SkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ProducerAndConsumerArtifactHistoryRepository>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var producerResult = await summary.Modules
                 .OfType<SkippedArtifactProducerModule>()
                 .Single();
@@ -2855,7 +2855,7 @@ public class ArtifactContractTests
             builder.AddModule<IgnoredFailureArtifactConsumerModule>();
 
             var exception = await Assert.ThrowsAsync<ModuleFailedException>(
-                () => builder.ExecutePipelineAsync());
+                () => builder.RunAsync());
 
             using (Assert.Multiple())
             {
@@ -2882,7 +2882,7 @@ public class ArtifactContractTests
             builder.AddModule<MissingRuntimeProducerModule>();
             builder.AddModule<ConfiguredSkippedArtifactConsumerModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             await Assert.That(ConfiguredSkippedArtifactConsumerModule.Executed).IsFalse();
         }
@@ -2907,7 +2907,7 @@ public class ArtifactContractTests
             builder.AddModule<PendingSkipDependencyModule>();
             builder.AddModule<PendingSkippedArtifactConsumerModule>();
 
-            var execution = builder.ExecutePipelineAsync();
+            var execution = builder.RunAsync();
             await PendingSkipArtifactProducerModule.Executed.Task;
             await Task.Delay(100);
             PendingSkipDependencyModule.Release.TrySetResult();
@@ -2949,7 +2949,7 @@ public class ArtifactContractTests
             builder.AddModule<WorkingDirectoryProducerModule>();
             builder.AddModule<WorkingDirectoryConsumerModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             await Assert.That(WorkingDirectoryConsumerModule.ConsumedContent)
                 .IsEqualTo("working directory content");

--- a/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
@@ -101,7 +101,7 @@ public class DynamicDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleA>()
             .AddModule<ModuleB>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(ExecutionOrder).IsEquivalentTo(new[] { "A", "B" });
@@ -117,7 +117,7 @@ public class DynamicDependencyIntegrationTests : TestBase
         await Assert.ThrowsAsync<ModuleNotRegisteredException>(() =>
             TestPipelineBuilder.Create()
                 .AddModule<ModuleWithMissingDynamicDependency>()
-                .ExecutePipelineAsync());
+                .RunAsync());
     }
 
     [Test]
@@ -127,7 +127,7 @@ public class DynamicDependencyIntegrationTests : TestBase
             .AddModule<DynamicallySkippedDependency>()
             .AddModule<DynamicallySkippedDependent>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["test"] })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
 

--- a/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
@@ -117,7 +117,7 @@ public class LifecycleEventIntegrationTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<SuccessfulModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(EventLog).Contains("Start:SuccessfulModule");
@@ -135,7 +135,7 @@ public class LifecycleEventIntegrationTests : TestBase
                 {
                     ExecutionMode = ExecutionMode.WaitForAllModules,
                 })
-                .ExecutePipelineAsync();
+                .RunAsync();
         }
         catch
         {
@@ -151,7 +151,7 @@ public class LifecycleEventIntegrationTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<SkippingModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(EventLog).Contains("Start:SkippingModule");
@@ -163,7 +163,7 @@ public class LifecycleEventIntegrationTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<AttributeSkippingModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(EventLog).Contains("Start:AttributeSkippingModule");

--- a/test/ModularPipelines.UnitTests/Attributes/MetadataCrossPhaseIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/MetadataCrossPhaseIntegrationTests.cs
@@ -87,7 +87,7 @@ public class MetadataCrossPhaseIntegrationTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<MetadataModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
 

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleReadyEventTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleReadyEventTests.cs
@@ -121,7 +121,7 @@ public class ModuleReadyEventTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<SimpleModuleWithReadyEvent>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(EventLog).Contains("Ready:SimpleModuleWithReadyEvent");
@@ -132,7 +132,7 @@ public class ModuleReadyEventTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithTimingCheck>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(EventLog.Any(e => e.Contains("Ready:ModuleWithTimingCheck:ElapsedTime:True"))).IsTrue();
@@ -143,7 +143,7 @@ public class ModuleReadyEventTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithReadyAndStart>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
 
@@ -161,7 +161,7 @@ public class ModuleReadyEventTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<DependencyModule>()
             .AddModule<DependentModuleWithReadyEvent>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(EventLog).Contains("Ready:DependentModuleWithReadyEvent");
@@ -172,7 +172,7 @@ public class ModuleReadyEventTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithThrowingReadyEvent>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -1211,7 +1211,7 @@ public class ModuleCacheTests
             builder.Services.AddSingleton<ILogger<ModuleCacheResultRepository>>(logger);
             builder.AddModule<StableAssemblyVersionKeyModule>();
 
-            await builder.ExecutePipelineAsync();
+            await builder.RunAsync();
 
             var miss = logger.Messages.Single(message => message.Contains("Module cache miss"));
             using (Assert.Multiple())

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -681,7 +681,7 @@ public class PipelineCommandLineTests
     {
         using var builder = CreateExecutionBuilder(["--module", nameof(TargetModule)]);
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -700,7 +700,7 @@ public class PipelineCommandLineTests
             TargetModules = [nameof(TargetModule)],
         });
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -715,7 +715,7 @@ public class PipelineCommandLineTests
     {
         using var builder = CreateExecutionBuilder(["--skip-module", nameof(UnrelatedModule)]);
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -732,7 +732,7 @@ public class PipelineCommandLineTests
         builder.AddModule<SelectedCategoryModule>();
         builder.AddModule<UnrelatedModule>();
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -861,7 +861,7 @@ public class PipelineCommandLineTests
         using var builder = CreateExecutionBuilder(
             ["--module", typeof(TargetModule).AssemblyQualifiedName!]);
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -905,7 +905,7 @@ public class PipelineCommandLineTests
         using var builder = CreateExecutionBuilder(["--module", "MissingModule"]);
 
         var exception = await Assert.ThrowsAsync<PipelineValidationException>(
-            () => builder.ExecutePipelineAsync());
+            () => builder.RunAsync());
 
         await Assert.That(exception!.ValidationResult.Errors.Any(
             error => error.Message.Contains("MissingModule", StringComparison.Ordinal))).IsTrue();
@@ -920,7 +920,7 @@ public class PipelineCommandLineTests
     {
         using var builder = CreateExecutionBuilder([command]);
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -940,7 +940,7 @@ public class PipelineCommandLineTests
             var path = Path.Combine(directory.FullName, "pipeline.json");
             using var builder = CreateExecutionBuilder(["--graph", "json", path]);
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var graph = await File.ReadAllTextAsync(path);
 
             using (Assert.Multiple())
@@ -970,7 +970,7 @@ public class PipelineCommandLineTests
             builder.AddModule<DependencyModule>();
             builder.AddModule<RuntimeOnlyDependencyModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var graph = await File.ReadAllTextAsync(path);
 
             using (Assert.Multiple())
@@ -994,7 +994,7 @@ public class PipelineCommandLineTests
         using var builder = CreateExecutionBuilder([option]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         await Assert.That(consoleWriter.Messages.Single())
             .Contains("ModularPipelines command-line options:")
@@ -1012,7 +1012,7 @@ public class PipelineCommandLineTests
         using var builder = Pipeline.CreateBuilder(["--help"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -1030,7 +1030,7 @@ public class PipelineCommandLineTests
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ThrowingConstructorModule>();
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -1048,7 +1048,7 @@ public class PipelineCommandLineTests
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ThrowingConfigurationModule>();
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -1652,7 +1652,7 @@ public class PipelineCommandLineTests
         using var builder = CreateExecutionBuilder(["--dry-run"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
         var output = Render(consoleWriter.Renderable!);
 
         using (Assert.Multiple())
@@ -1714,7 +1714,7 @@ public class PipelineCommandLineTests
         using var builder = CreateExecutionBuilder();
         builder.ConfigurePipelineOptions(options => options with { DryRun = true });
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         using (Assert.Multiple())
         {
@@ -1732,7 +1732,7 @@ public class PipelineCommandLineTests
         builder.AddModule<InvalidDynamicDependencyModule>();
 
         await Assert.ThrowsAsync<ModuleNotRegisteredException>(
-            () => builder.ExecutePipelineAsync());
+            () => builder.RunAsync());
     }
 
     [Test]
@@ -1743,7 +1743,7 @@ public class PipelineCommandLineTests
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ConfiguredCategoryModule>();
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         var output = Render(consoleWriter.Renderable!);
 
@@ -1759,7 +1759,7 @@ public class PipelineCommandLineTests
     {
         using var builder = CreateExecutionBuilder(["--validate"]);
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         await Assert.That(summary.Status).IsEqualTo(ModularPipelines.Enums.Status.Successful);
     }

--- a/test/ModularPipelines.UnitTests/Configuration/UnifiedModuleConfigurationIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/UnifiedModuleConfigurationIntegrationTests.cs
@@ -117,7 +117,7 @@ public class UnifiedModuleConfigurationIntegrationTests
             .AddModule<DependencyModule>()
             .AddModule<ConfiguredModule>()
             .AddModule<MetadataConsumerModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(ExecutionOrder).IsEquivalentTo(new[] { "dependency", "configured", "consumer" });
@@ -130,7 +130,7 @@ public class UnifiedModuleConfigurationIntegrationTests
             .AddModule<FailingTaggedModule>()
             .AddModule<FailingTagConsumerModule>();
 
-        await Assert.ThrowsAsync<ModuleFailedException>(() => pipeline.ExecutePipelineAsync());
+        await Assert.ThrowsAsync<ModuleFailedException>(() => pipeline.RunAsync());
         await Assert.That(ExecutionOrder).DoesNotContain("selector-consumer");
     }
 
@@ -140,7 +140,7 @@ public class UnifiedModuleConfigurationIntegrationTests
         var pipeline = TestPipelineBuilder.Create()
             .AddModule<SelfDependentModule>();
 
-        var exception = await Assert.ThrowsAsync<PipelineValidationException>(() => pipeline.ExecutePipelineAsync());
+        var exception = await Assert.ThrowsAsync<PipelineValidationException>(() => pipeline.RunAsync());
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)
             .Contains(nameof(SelfDependentModule));
@@ -153,7 +153,7 @@ public class UnifiedModuleConfigurationIntegrationTests
             .AddModule<CircularDependencyModuleA>()
             .AddModule<CircularDependencyModuleB>();
 
-        var exception = await Assert.ThrowsAsync<PipelineValidationException>(() => pipeline.ExecutePipelineAsync());
+        var exception = await Assert.ThrowsAsync<PipelineValidationException>(() => pipeline.RunAsync());
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)
             .Contains("Dependency collision detected");

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -35,7 +35,7 @@ public class ConsoleWriterTests
     [Test]
     public async Task LogToConsole_UsesAmbientModuleConsoleWriter()
     {
-        var output = await ExecutePipelineAsync<LogToConsoleModule>();
+        var output = await RunAsync<LogToConsoleModule>();
 
         await Assert.That(output).Contains("module output");
     }
@@ -43,12 +43,12 @@ public class ConsoleWriterTests
     [Test]
     public async Task Write_UsesAmbientModuleConsoleWriter()
     {
-        var output = await ExecutePipelineAsync<WriteModule>();
+        var output = await RunAsync<WriteModule>();
 
         await Assert.That(output).Contains("module output");
     }
 
-    private static async Task<string> ExecutePipelineAsync<TModule>()
+    private static async Task<string> RunAsync<TModule>()
         where TModule : class, IModule
     {
         using var builder = TestPipelineBuilder.Create();
@@ -62,7 +62,7 @@ public class ConsoleWriterTests
         });
         builder.AddModule<TModule>();
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
 
         return summary.RunReport!.Modules.Single().Output!.StdoutTail ?? string.Empty;
     }

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -125,7 +125,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule<CompileModule>()
             .AddModule<TestModuleWithOptionalDep>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["test"] })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
 
@@ -144,7 +144,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule<CompileModule>()
             .AddModule<TestModuleWithOptionalDepForCategoryFilter>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["test"] })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
 
@@ -162,7 +162,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule<TestModuleWithRequiredDep>()
             .AddModule<TransitiveRequiredDepModule>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["test"] })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
 
@@ -192,7 +192,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule(secondCompileModule)
             .AddModule<TestModuleWithRequiredDep>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["test"] })
-            .ExecutePipelineAsync());
+            .RunAsync());
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)
             .IsEqualTo("Module 'CompileModule' is registered multiple times. Each module type should only be registered once.");
@@ -208,7 +208,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule(compileModule)
             .AddModule<CompileResultConsumerModule>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["compile"] })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
         await Assert.That(pipelineSummary.Modules.Count(module => ReferenceEquals(module, compileModule)))
@@ -231,7 +231,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule<CompileModule>(_ => compileModule)
             .AddModule<CompileResultConsumerModule>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["compile"] })
-            .ExecutePipelineAsync());
+            .RunAsync());
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)
             .IsEqualTo("Module 'CompileModule' is registered multiple times. Each module type should only be registered once.");
@@ -243,7 +243,7 @@ public class CategoryFilterDependencyTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<FluentlySkippedModule>()
             .AddModule<FluentSkipDependentModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var dependentResult = await pipelineSummary.Modules
             .OfType<FluentSkipDependentModule>()
@@ -260,7 +260,7 @@ public class CategoryFilterDependencyTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<FirstValueEqualModule>()
             .AddModule<SecondValueEqualModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That((await pipelineSummary.Modules.OfType<FirstValueEqualModule>().Single()).ValueOrDefault)
             .IsEqualTo("first");
@@ -275,7 +275,7 @@ public class CategoryFilterDependencyTests : TestBase
             .AddModule<CompileModule>()
             .AddModule<TestModuleWithOptionalDep>()
             .ConfigurePipelineOptions(options => options with { RunOnlyCategories = ["compile", "test"] })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
 

--- a/test/ModularPipelines.UnitTests/Dependencies/DependsOnTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/DependsOnTests.cs
@@ -78,7 +78,7 @@ public class DependsOnTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<Module1>()
             .AddModule<Module2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
 
@@ -88,7 +88,7 @@ public class DependsOnTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<Module1>()
             .AddModule<Module3>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
 
@@ -98,7 +98,7 @@ public class DependsOnTests : TestBase
         // New behavior: Required dependencies are auto-registered if not present
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<Module2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
         // Module1 should have been auto-registered
@@ -111,7 +111,7 @@ public class DependsOnTests : TestBase
         // Optional dependencies are NOT auto-registered
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<Module3>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
         // Only Module3 should be registered (Module1 not auto-registered for optional dep)
         await Assert.That(pipelineSummary.Modules.Count()).IsEqualTo(1);
@@ -122,7 +122,7 @@ public class DependsOnTests : TestBase
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<Module3WithGetIfRegistered>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
 
@@ -132,7 +132,7 @@ public class DependsOnTests : TestBase
         // GetModule throws when module is not registered, even for optional deps
         await Assert.That(async () => await TestPipelineBuilder.Create()
                 .AddModule<Module3WithGet>()
-                .ExecutePipelineAsync()).
+                .RunAsync()).
             ThrowsException();
     }
 
@@ -142,7 +142,7 @@ public class DependsOnTests : TestBase
         var exception = await Assert.ThrowsAsync<PipelineValidationException>(
             async () => await TestPipelineBuilder.Create()
                 .AddModule<DependsOnSelfModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)
             .IsEqualTo("Module 'DependsOnSelfModule' cannot reference itself. A module cannot depend on its own result.");
@@ -154,7 +154,7 @@ public class DependsOnTests : TestBase
     {
         await Assert.That(async () => await TestPipelineBuilder.Create()
                 .AddModule<DependsOnNonModule>()
-                .ExecutePipelineAsync()).
+                .RunAsync()).
             Throws<InvalidModuleTypeException>()
             .And.HasMessageEqualTo("ModularPipelines.Exceptions.ModuleFailedException is not a Module (does not implement IModule)");
     }
@@ -171,7 +171,7 @@ public class DependsOnTests : TestBase
         // Optional deps don't require the module to be present
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithOptionalDep>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
 
@@ -187,7 +187,7 @@ public class DependsOnTests : TestBase
         // Required dependencies get auto-registered
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithRequiredDep>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
         // Module1 was auto-registered
@@ -211,7 +211,7 @@ public class DependsOnTests : TestBase
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ModuleCheckingUnregisteredDep>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }

--- a/test/ModularPipelines.UnitTests/Dependencies/DirectCollisionTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/DirectCollisionTests.cs
@@ -16,7 +16,7 @@ public class DirectCollisionTests
             await TestPipelineBuilder.Create()
                 .AddModule<DependencyConflictModule1>()
                 .AddModule<DependencyConflictModule2>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         });
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)

--- a/test/ModularPipelines.UnitTests/Dependencies/FlexibleDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/FlexibleDependencyIntegrationTests.cs
@@ -48,7 +48,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
             .AddModule<DatabaseModuleB>()
             .AddModule<NonDatabaseModule>()
             .AddModule<AfterDatabaseModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -70,7 +70,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<NonDatabaseModule>()
             .AddModule<ModuleDependingOnNonExistentTag>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert - should succeed as no modules have the tag
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -83,7 +83,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithMultipleTags>()
             .AddModule<AfterSlowModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -108,7 +108,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
             .AddModule<InfrastructureModuleB>()
             .AddModule<BuildModule>()
             .AddModule<AfterInfrastructureModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -130,7 +130,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<BuildModule>()
             .AddModule<ModuleDependingOnNonExistentCategory>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert - should succeed as no modules have the category
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -149,7 +149,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
             .AddModule<CriticalModuleB>()
             .AddModule<NonCriticalModule>()
             .AddModule<AfterCriticalModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -171,7 +171,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<DerivedCriticalModule>()
             .AddModule<AfterCriticalModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -190,7 +190,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<NonCriticalModule>()
             .AddModule<AfterCriticalModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert - should succeed as no modules have the attribute
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -207,7 +207,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithConfiguredTags>()
             .AddModule<AfterDatabaseModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -226,7 +226,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithConfiguredCategory>()
             .AddModule<AfterInfrastructureModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -251,7 +251,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
             .AddModule<InfrastructureModuleA>()
             .AddModule<CriticalModuleA>()
             .AddModule<ModuleWithMultipleFlexibleDependencies>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -278,7 +278,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
             .AddModule<DatabaseModuleA>()
             .AddModule<AfterDatabaseModuleWithPhase1Tag>()
             .AddModule<AfterPhase1Module>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);

--- a/test/ModularPipelines.UnitTests/Dependencies/FluentDependencyConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/FluentDependencyConfigurationTests.cs
@@ -178,7 +178,7 @@ public class FluentDependencyConfigurationTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<BaseModule>()
             .AddModule<ModuleWithProgrammaticDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -188,7 +188,7 @@ public class FluentDependencyConfigurationTests : TestBase
     {
         await Assert.That(async () => await TestPipelineBuilder.Create()
                 .AddModule<ModuleWithMissingRequiredDependency>()
-                .ExecutePipelineAsync())
+                .RunAsync())
             .ThrowsException();
     }
 
@@ -198,7 +198,7 @@ public class FluentDependencyConfigurationTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<BaseModule>()
             .AddModule<ModuleWithTypeDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -213,7 +213,7 @@ public class FluentDependencyConfigurationTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<OptionalDependencyModule>()
             .AddModule<ModuleWithOptionalDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -223,7 +223,7 @@ public class FluentDependencyConfigurationTests : TestBase
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithOptionalDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -238,7 +238,7 @@ public class FluentDependencyConfigurationTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ConditionalModule>()
             .AddModule<ModuleWithActiveConditionalDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -248,7 +248,7 @@ public class FluentDependencyConfigurationTests : TestBase
     {
         await Assert.That(async () => await TestPipelineBuilder.Create()
                 .AddModule<ModuleWithActiveConditionalDependency>()
-                .ExecutePipelineAsync())
+                .RunAsync())
             .ThrowsException();
     }
 
@@ -257,7 +257,7 @@ public class FluentDependencyConfigurationTests : TestBase
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ModuleWithInactiveConditionalDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -273,7 +273,7 @@ public class FluentDependencyConfigurationTests : TestBase
             .AddModule<BaseModule>()
             .AddModule<OptionalDependencyModule>()
             .AddModule<ModuleWithBothAttributeAndProgrammaticDependencies>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -284,7 +284,7 @@ public class FluentDependencyConfigurationTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<BaseModule>()
             .AddModule<ModuleWithBothAttributeAndProgrammaticDependencies>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -296,7 +296,7 @@ public class FluentDependencyConfigurationTests : TestBase
             .AddModule<BaseModule>()
             .AddModule<OptionalDependencyModule>()
             .AddModule<ModuleWithChainedDependencies>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -307,7 +307,7 @@ public class FluentDependencyConfigurationTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<BaseModule>()
             .AddModule<ModuleWithChainedDependencies>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }

--- a/test/ModularPipelines.UnitTests/Dependencies/ModuleNotRegisteredExceptionTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/ModuleNotRegisteredExceptionTests.cs
@@ -50,7 +50,7 @@ public class ModuleNotRegisteredExceptionTests : TestBase
         await Assert.ThrowsAsync<ModuleFailedException>(() =>
             TestPipelineBuilder.Create()
                 .AddModule<Module2WithOptionalDep>()
-                .ExecutePipelineAsync()
+                .RunAsync()
         );
     }
 
@@ -60,7 +60,7 @@ public class ModuleNotRegisteredExceptionTests : TestBase
         // With Required dependency (default), missing modules are auto-registered
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<Module2WithRequiredDep>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
         // Module1 was auto-registered
@@ -75,7 +75,7 @@ public class ModuleNotRegisteredExceptionTests : TestBase
             await TestPipelineBuilder.Create()
                 .AddModule<Module1>()
                 .AddModule<Module2WithOptionalDep>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         }).ThrowsNothing();
     }
 }

--- a/test/ModularPipelines.UnitTests/Dependencies/NestedCollisionTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/NestedCollisionTests.cs
@@ -19,7 +19,7 @@ public class NestedCollisionTests
                 .AddModule<DependencyConflictModule3>()
                 .AddModule<DependencyConflictModule4>()
                 .AddModule<DependencyConflictModule5>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         });
 
         await Assert.That(exception!.ValidationResult.Errors.Single().Message)

--- a/test/ModularPipelines.UnitTests/Dependencies/OneWayDependenciesNonCollisionTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/OneWayDependenciesNonCollisionTests.cs
@@ -18,7 +18,7 @@ public class OneWayDependenciesNonCollisionTests
                 .AddModule<DependencyConflictModule3>()
                 .AddModule<DependencyConflictModule4>()
                 .AddModule<DependencyConflictModule5>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         }).ThrowsNothing();
     }
 

--- a/test/ModularPipelines.UnitTests/Dependencies/SingleTypeParameterGetModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/SingleTypeParameterGetModuleTests.cs
@@ -141,7 +141,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<StringModule>()
             .AddModule<ConsumerModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -152,7 +152,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<ComplexResultModule>()
             .AddModule<ComplexConsumerModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -163,7 +163,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<StringModule>()
             .AddModule<OptionalConsumerModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -173,7 +173,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<OptionalConsumerModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
@@ -184,7 +184,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(
             async () => await TestPipelineBuilder.Create()
                 .AddModule<SelfReferencingModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         await Assert.That(exception!.InnerException).IsTypeOf<ModuleReferencingSelfException>();
     }
@@ -195,7 +195,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(
             async () => await TestPipelineBuilder.Create()
                 .AddModule<UnregisteredConsumerModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         await Assert.That(exception!.InnerException).IsTypeOf<ModuleNotRegisteredException>();
     }

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -62,7 +62,7 @@ public class DocumentationSnippetTests
 
         await Assert.That(readme).Contains("dotnet add package ModularPipelines.DotNet");
         await Assert.That(readme).Contains("var builder = Pipeline.CreateBuilder(args);");
-        await Assert.That(readme).Contains("await builder.ExecutePipelineAsync();");
+        await Assert.That(readme).Contains("await builder.RunAsync();");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/FailedModuleNotificationTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FailedModuleNotificationTests.cs
@@ -26,7 +26,7 @@ public class FailedModuleNotificationTests
                 await TestPipelineBuilder.Create()
                     .ConfigureServices(services => services.AddSingleton(mediator.Object))
                     .AddModule<FailingModule>()
-                    .ExecutePipelineAsync())
+                    .RunAsync())
             .Throws<ModuleFailedException>();
 
         mediator.Verify(x => x.Publish(
@@ -54,7 +54,7 @@ public class FailedModuleNotificationTests
                         services.AddSingleton<IModuleEventReceiver, ThrowingFailureReceiver>();
                     })
                     .AddModule<FailingModule>()
-                    .ExecutePipelineAsync())
+                    .RunAsync())
             .Throws<InvalidOperationException>();
 
         mediator.Verify(x => x.Publish(

--- a/test/ModularPipelines.UnitTests/Engine/MetricsCollectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/MetricsCollectorTests.cs
@@ -47,7 +47,7 @@ public class MetricsCollectorTests : TestBase
             .AddModule<QuickModule1>()
             .AddModule<QuickModule2>()
             .AddModule<QuickModule3>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(result.Metrics).IsNotNull();
@@ -59,7 +59,7 @@ public class MetricsCollectorTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
             .AddModule<QuickModule2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Metrics).IsNotNull();
         await Assert.That(result.Metrics!.ParallelismFactor).IsGreaterThanOrEqualTo(0);
@@ -72,7 +72,7 @@ public class MetricsCollectorTests : TestBase
             .AddModule<QuickModule1>()
             .AddModule<QuickModule2>()
             .AddModule<QuickModule3>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Metrics).IsNotNull();
         await Assert.That(result.Metrics!.PeakConcurrency).IsGreaterThanOrEqualTo(1);
@@ -84,7 +84,7 @@ public class MetricsCollectorTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
             .AddModule<QuickModule2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Metrics).IsNotNull();
         await Assert.That(result.Metrics!.AverageConcurrency).IsGreaterThanOrEqualTo(0);
@@ -95,7 +95,7 @@ public class MetricsCollectorTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Metrics).IsNotNull();
         await Assert.That(result.Metrics!.Efficiency).IsGreaterThanOrEqualTo(0);
@@ -109,7 +109,7 @@ public class MetricsCollectorTests : TestBase
             .AddModule<QuickModule1>()
             .AddModule<QuickModule2>()
             .AddModule<QuickModule3>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Metrics).IsNotNull();
         await Assert.That(result.Metrics!.TotalModules).IsEqualTo(3);
@@ -204,7 +204,7 @@ public class MetricsCollectorTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Metrics).IsNotNull();
         await Assert.That(result.Metrics!.WallClockDuration).IsGreaterThan(TimeSpan.Zero);
@@ -217,7 +217,7 @@ public class MetricsCollectorTests : TestBase
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
             .AddModule<QuickModule2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(result.ModuleTimelines).IsNotNull();
@@ -229,7 +229,7 @@ public class MetricsCollectorTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.ModuleTimelines).IsNotNull();
         await Assert.That(result.ModuleTimelines!.Count).IsEqualTo(1);
@@ -241,7 +241,7 @@ public class MetricsCollectorTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<QuickModule1>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.ModuleTimelines).IsNotNull();
         var timeline = result.ModuleTimelines![0];

--- a/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
@@ -127,7 +127,7 @@ public class PipelineProgressTests
                     .AddModule<Module5>()
                     .AddModule<Module6>()
                     .AddModule<Module7>()
-                    .ExecutePipelineAsync()).
+                    .RunAsync()).
             Throws<ModuleFailedException>();
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/PipelineRequirementTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineRequirementTests.cs
@@ -36,7 +36,7 @@ public class PipelineRequirementTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement<FailingRequirement>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -52,7 +52,7 @@ public class PipelineRequirementTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement<FailingRequirementWithReason>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
         await Assert.That(executePipelineDelegate)
             .Throws<FailedRequirementsException>()

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -2153,7 +2153,7 @@ public class RunReportTests
 
         try
         {
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
 
             await Assert.That(summary.RunReport!.Correlation!.GitSha).IsEqualTo("secret-sha");
         }
@@ -2858,7 +2858,7 @@ public class RunReportTests
             builder.AddPipelineGlobalHooks<ThrowingEndHook>();
 
             await Assert.ThrowsAsync<InvalidOperationException>(
-                () => builder.ExecutePipelineAsync());
+                () => builder.RunAsync());
 
             var report = RunReportJsonSerializer.Deserialize(
                 await File.ReadAllTextAsync(reportPath));
@@ -2898,7 +2898,7 @@ public class RunReportTests
             builder.AddModule<SuccessfulModule>();
             builder.AddPipelineGlobalHooks<DelayedEndHook>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var report = RunReportJsonSerializer.Deserialize(
                 await File.ReadAllTextAsync(reportPath));
             var expectedParallelism = Math.Round(
@@ -2947,7 +2947,7 @@ public class RunReportTests
                 builder.AddRequirement(Require.That(_ => false, "requirement failed"));
 
                 await Assert.ThrowsAsync<FailedRequirementsException>(
-                    () => builder.ExecutePipelineAsync());
+                    () => builder.RunAsync());
 
                 failedReport = RunReportJsonSerializer.Deserialize(
                     await File.ReadAllTextAsync(reportPath))!;
@@ -2965,7 +2965,7 @@ public class RunReportTests
                 },
             });
             successfulBuilder.AddModule<SuccessfulModule>();
-            await successfulBuilder.ExecutePipelineAsync();
+            await successfulBuilder.RunAsync();
 
             var successfulReport = RunReportJsonSerializer.Deserialize(
                 await File.ReadAllTextAsync(reportPath))!;
@@ -3079,7 +3079,7 @@ public class RunReportTests
             builder.AddModule<FailingModule>();
 
             await Assert.ThrowsAsync<ModuleFailedException>(
-                () => builder.ExecutePipelineAsync());
+                () => builder.RunAsync());
 
             var report = RunReportJsonSerializer.Deserialize(
                 await File.ReadAllTextAsync(reportPath));
@@ -3118,7 +3118,7 @@ public class RunReportTests
             builder.AddModule<FailingModule>();
             builder.AddPipelineGlobalHooks<MixedFailureEndHook>();
 
-            await Assert.ThrowsAsync<AggregateException>(() => builder.ExecutePipelineAsync());
+            await Assert.ThrowsAsync<AggregateException>(() => builder.RunAsync());
 
             var report = RunReportJsonSerializer.Deserialize(
                 await File.ReadAllTextAsync(reportPath));
@@ -3160,7 +3160,7 @@ public class RunReportTests
             builder.AddPipelineGlobalHooks<WrappedFailureEndHook>();
 
             await Assert.ThrowsAsync<InvalidOperationException>(
-                () => builder.ExecutePipelineAsync());
+                () => builder.RunAsync());
 
             var report = RunReportJsonSerializer.Deserialize(
                 await File.ReadAllTextAsync(reportPath));
@@ -3681,7 +3681,7 @@ public class RunReportTests
         });
         builder.AddModule<OutputExcerptModule>();
 
-        var summary = await builder.ExecutePipelineAsync();
+        var summary = await builder.RunAsync();
         var output = summary.RunReport!.Modules.Single().Output;
 
         using (Assert.Multiple())
@@ -3901,7 +3901,7 @@ public class RunReportTests
         builder.AddModule<CommandModule>();
         builder.AddModule<FailingModule>();
         builder.AddModule<SkippedModule>();
-        return await builder.ExecutePipelineAsync();
+        return await builder.RunAsync();
     }
 
     private static async Task<PipelineSummary> RunPipelineWithoutReportAsync(string historyPath)
@@ -3918,7 +3918,7 @@ public class RunReportTests
             },
         });
         builder.AddModule<SuccessfulModule>();
-        return await builder.ExecutePipelineAsync();
+        return await builder.RunAsync();
     }
 
     private static string CreateTemporaryDirectory()

--- a/test/ModularPipelines.UnitTests/Execution/AsyncDisposableModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/AsyncDisposableModuleTests.cs
@@ -11,7 +11,7 @@ public class AsyncDisposableModuleTests
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<AsyncDisposableModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Modules.OfType<AsyncDisposableModule>().Single().IsDisposed).IsTrue();
     }
 

--- a/test/ModularPipelines.UnitTests/Execution/ComposableModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ComposableModuleTests.cs
@@ -174,7 +174,7 @@ public class ComposableModuleTests
 
         var result = await TestPipelineBuilder.Create()
             .AddModule<MultiBehaviorModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(MultiBehaviorModule.BeforeHookCalled).IsTrue();
         await Assert.That(MultiBehaviorModule.AfterHookCalled).IsTrue();

--- a/test/ModularPipelines.UnitTests/Execution/ConcurrencyOptionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ConcurrencyOptionsTests.cs
@@ -51,7 +51,7 @@ public class ConcurrencyOptionsTests : TestBase
             {
                 Concurrency = options.Concurrency with { MaxParallelism = 2 },
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -65,7 +65,7 @@ public class ConcurrencyOptionsTests : TestBase
             {
                 Concurrency = options.Concurrency with { MaxCpuIntensiveModules = 1 },
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -79,7 +79,7 @@ public class ConcurrencyOptionsTests : TestBase
             {
                 Concurrency = options.Concurrency with { MaxIoIntensiveModules = 10 },
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }

--- a/test/ModularPipelines.UnitTests/Execution/DisposableModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/DisposableModuleTests.cs
@@ -11,7 +11,7 @@ public class DisposableModuleTests
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
             .AddModule<DisposableModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
         await Assert.That(pipelineSummary.Modules.OfType<DisposableModule>().Single().IsDisposed).IsTrue();
     }
 

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -917,7 +917,7 @@ public class EngineCancellationTokenTests : TestBase
             .AddModule<WaitForAllCompletingModule>();
 
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(
-            async () => await builder.ExecutePipelineAsync());
+            async () => await builder.RunAsync());
 
         await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
         await Assert.That(exception.InnerException!).HasMessageEqualTo("Expected test failure");

--- a/test/ModularPipelines.UnitTests/Execution/ExecutionHintTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ExecutionHintTests.cs
@@ -123,7 +123,7 @@ public class ExecutionHintTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<CpuIntensiveModule1>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -133,7 +133,7 @@ public class ExecutionHintTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<NoHintModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -146,7 +146,7 @@ public class ExecutionHintTests : TestBase
             .AddModule<IoIntensiveModule>()
             .AddModule<DefaultExecutionTypeModule>()
             .AddModule<NoHintModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -163,7 +163,7 @@ public class ExecutionHintTests : TestBase
             {
                 Concurrency = options.Concurrency with { MaxCpuIntensiveModules = 2 },
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         // The max concurrency should not exceed 2

--- a/test/ModularPipelines.UnitTests/Execution/FailedPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/FailedPipelineTests.cs
@@ -51,7 +51,7 @@ public class FailedPipelineTests : TestBase
                 .AddModule<Module1>()
                 .AddModule<Module2>()
                 .AddModule<Module3>()
-                .ExecutePipelineAsync()).ThrowsException()
+                .RunAsync()).ThrowsException()
             ;
     }
 
@@ -68,7 +68,7 @@ public class FailedPipelineTests : TestBase
                 })
                 .AddModule<Module1>()
                 .AddModule<Module2>()
-                .ExecutePipelineAsync()).
+                .RunAsync()).
             ThrowsException();
     }
 
@@ -84,7 +84,7 @@ public class FailedPipelineTests : TestBase
                 })
                 .AddModule<Module1>()
                 .AddModule<Module3>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -90,7 +90,7 @@ public class ModuleTimeoutTests : TestBase
                 DefaultModuleTimeout = TimeSpan.FromMilliseconds(10),
             })
             .AddModule<PipelineDefaultTimeoutModule>()
-            .ExecutePipelineAsync()
+            .RunAsync()
             .WaitAsync(TestHostSettings.DefaultTestTimeout));
 
         var timeoutException = exception!.InnerException as ModuleTimeoutException;
@@ -107,7 +107,7 @@ public class ModuleTimeoutTests : TestBase
                 DefaultModuleTimeout = TimeSpan.Zero,
             })
             .AddModule<ZeroDefaultTimeoutModule>()
-            .ExecutePipelineAsync()).ThrowsNothing();
+            .RunAsync()).ThrowsNothing();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
@@ -602,7 +602,7 @@ public class NewRunConditionAttributeTests : TestBase
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => TestPipelineBuilder.Create()
             .AddModule<DiscoveryCancellationModule>()
-            .ExecutePipelineAsync(cancellationTokenSource.Token));
+            .RunAsync(cancellationTokenSource.Token));
 
         await Assert.That(SubsequentConditionWasEvaluated).IsFalse();
     }

--- a/test/ModularPipelines.UnitTests/Execution/NotInParallelTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NotInParallelTests.cs
@@ -59,7 +59,7 @@ public class NotInParallelTests : TestBase
         await TestPipelineBuilder.Create()
             .AddModule<Module1>()
             .AddModule<Module2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(Tracker.Violations).IsEmpty();
     }
@@ -72,7 +72,7 @@ public class NotInParallelTests : TestBase
         await TestPipelineBuilder.Create()
             .AddModule<NotParallelModuleWithParallelDependency>()
             .AddModule<ParallelDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(Tracker.Violations).IsEmpty();
     }
@@ -86,7 +86,7 @@ public class NotInParallelTests : TestBase
             .AddModule<NotParallelModuleWithParallelDependency>()
             .AddModule<ParallelDependency>()
             .AddModule<NotParallelModuleWithNonParallelDependency>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(Tracker.Violations).IsEmpty();
     }

--- a/test/ModularPipelines.UnitTests/Execution/NotInParallelTestsWithConstraintKeys.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NotInParallelTestsWithConstraintKeys.cs
@@ -45,7 +45,7 @@ public class NotInParallelTestsWithConstraintKeys : TestBase
             .AddModule<ModuleWithAConstraintKey2>()
             .AddModule<ModuleWithBConstraintKey1>()
             .AddModule<ModuleWithBConstraintKey2>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(Tracker.Violations).IsEmpty();
     }

--- a/test/ModularPipelines.UnitTests/Execution/NotInParallelTestsWithMultipleConstraintKeys.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NotInParallelTestsWithMultipleConstraintKeys.cs
@@ -46,7 +46,7 @@ public class NotInParallelTestsWithMultipleConstraintKeys : TestBase
             .AddModule<Module2>()
             .AddModule<Module3>()
             .AddModule<Module4>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(Tracker.Violations).IsEmpty();
     }

--- a/test/ModularPipelines.UnitTests/Execution/ParallelLimiterTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ParallelLimiterTests.cs
@@ -161,7 +161,7 @@ public class ParallelLimiterTests
             .AddModule<Module4>()
             .AddModule<Module5>()
             .AddModule<Module6>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(_violations).IsEmpty();
     }

--- a/test/ModularPipelines.UnitTests/Execution/PrioritySchedulingTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/PrioritySchedulingTests.cs
@@ -77,7 +77,7 @@ public class PrioritySchedulingTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<CriticalPriorityModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -87,7 +87,7 @@ public class PrioritySchedulingTests : TestBase
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<DefaultPriorityModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
     }
@@ -100,7 +100,7 @@ public class PrioritySchedulingTests : TestBase
             .AddModule<NormalPriorityModule>()
             .AddModule<HighPriorityModule>()
             .AddModule<CriticalPriorityModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
         await Assert.That(ExecutionOrder.Count).IsEqualTo(4);

--- a/test/ModularPipelines.UnitTests/Execution/SubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/SubModuleTests.cs
@@ -324,7 +324,7 @@ public class SubModuleTests : TestBase
         var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<FailingSubModulesWithReturnTypeModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         using (Assert.Multiple())
         {
@@ -339,14 +339,14 @@ public class SubModuleTests : TestBase
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<FailingSubModulesWithoutReturnTypeModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         await Assert.That(exception!.InnerException).IsTypeOf<SubModuleFailedException>();
 
         var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<FailingSubModulesWithoutReturnTypeModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         using (Assert.Multiple())
         {
@@ -364,7 +364,7 @@ public class SubModuleTests : TestBase
         var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<FailingSubModulesWithReturnTypeModuleSynchronous>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         using (Assert.Multiple())
         {
@@ -379,7 +379,7 @@ public class SubModuleTests : TestBase
         var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<FailingSubModulesWithoutReturnTypeModuleSynchronous>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         using (Assert.Multiple())
         {

--- a/test/ModularPipelines.UnitTests/FileSystem/FolderTests.cs
+++ b/test/ModularPipelines.UnitTests/FileSystem/FolderTests.cs
@@ -93,7 +93,7 @@ public class FolderTests : TestBase
                         new StringLogger<FindFileModule>(stringBuilder))
                     .AddModule<FindFileModule>();
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var actualLogResult = stringBuilder.ToString().Trim();
         await Assert.That(actualLogResult).Contains("x => x.Name == \"Foo.txt\"");
@@ -112,7 +112,7 @@ public class FolderTests : TestBase
                         new StringLogger<ReadFileModule>(stringBuilder))
                     .AddModule<ReadFileModule>();
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var actualLogResult = stringBuilder.ToString();
 

--- a/test/ModularPipelines.UnitTests/FileSystem/MockedFileSystemTests.cs
+++ b/test/ModularPipelines.UnitTests/FileSystem/MockedFileSystemTests.cs
@@ -27,7 +27,7 @@ public class MockedFileSystemTests
                 services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
             })
             .AddModule<ConfigReaderModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Modules).Count().IsEqualTo(1);
@@ -53,7 +53,7 @@ public class MockedFileSystemTests
                 services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
             })
             .AddModule<FileWriterModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);
@@ -79,7 +79,7 @@ public class MockedFileSystemTests
                 services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
             })
             .AddModule<FolderCreatorModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Assert
         await Assert.That(result.Status).IsEqualTo(Status.Successful);

--- a/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
@@ -34,7 +34,7 @@ public class ConfigurationSectionSecretMaskingTests
         using var builder = CreateBuilder(output);
         builder.MaskConfigurationSection("Secrets");
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         var log = output.ToString();
         await Assert.That(log).DoesNotContain("api-secret-123");
@@ -53,7 +53,7 @@ public class ConfigurationSectionSecretMaskingTests
         builder.Services.Configure<SecretMaskingOptions>(options =>
             options.MaskedConfigurationSections = ["Secrets", "ConnectionStrings", "Missing"]);
 
-        await builder.ExecutePipelineAsync();
+        await builder.RunAsync();
 
         var log = output.ToString();
         await Assert.That(log).DoesNotContain("api-secret-123");

--- a/test/ModularPipelines.UnitTests/Logging/LoggingSecretTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/LoggingSecretTests.cs
@@ -50,7 +50,7 @@ public class LoggingSecretTests
                     .AddModule<SecretValueLoggingModule1>()
                     .Configure<MySecretSettings>(settings => settings.Secret1 = secretValue);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var actualLogResult = stringBuilder.ToString().Trim();
         await Assert.That(actualLogResult).Contains($"My Secret Value is: **********");

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
@@ -94,7 +94,7 @@ public class SecretMaskingTests
                     .Configure<SecretSettings>(s => s.ApiKey = secret)
                     .Configure<SecretMaskingOptions>(o => o.CaseInsensitive = false);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -118,7 +118,7 @@ public class SecretMaskingTests
                     .Configure<SecretSettings>(s => s.ApiKey = secret)
                     .Configure<SecretMaskingOptions>(o => o.CaseInsensitive = true);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -146,7 +146,7 @@ public class SecretMaskingTests
                     .Configure<SecretSettings>(s => s.ApiKey = shortSecret)
                     .Configure<SecretMaskingOptions>(o => o.MinimumSecretLength = 3);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -169,7 +169,7 @@ public class SecretMaskingTests
                     .Configure<SecretSettings>(s => s.ApiKey = exactLengthSecret)
                     .Configure<SecretMaskingOptions>(o => o.MinimumSecretLength = 3);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -192,7 +192,7 @@ public class SecretMaskingTests
                     .Configure<SecretSettings>(s => s.ApiKey = tinySecret);
                 // Using default MinimumSecretLength of 1
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -220,7 +220,7 @@ public class SecretMaskingTests
                     .Configure<SecretSettings>(s => s.ApiKey = secret)
                     .Configure<SecretMaskingOptions>(o => o.MaskValue = customMask);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -244,7 +244,7 @@ public class SecretMaskingTests
                     .AddSingleton<ILogger<DynamicSecretModule>>(new StringLogger<DynamicSecretModule>(stringBuilder))
                     .AddModule<DynamicSecretModule>();
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -276,7 +276,7 @@ public class SecretMaskingTests
                         s.Password = password;
                     });
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -299,7 +299,7 @@ public class SecretMaskingTests
                     .AddModule<SecretLoggingModule>()
                     .Configure<SecretSettings>(s => s.Passwords = [firstPassword, secondPassword]);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -329,7 +329,7 @@ public class SecretMaskingTests
                         s.Password = longSecret;
                     });
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -355,7 +355,7 @@ public class SecretMaskingTests
                         s.Password = "   ";
                     });
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         // Should complete without errors - empty/whitespace secrets are silently ignored
         var output = stringBuilder.ToString();
@@ -376,7 +376,7 @@ public class SecretMaskingTests
                     .AddModule<SecretLoggingModule>()
                     .Configure<SecretSettings>(s => s.ApiKey = specialSecret);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 
@@ -398,7 +398,7 @@ public class SecretMaskingTests
                     .AddModule<SecretLoggingModule>()
                     .Configure<SecretSettings>(s => s.ApiKey = unicodeSecret);
             })
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         var output = stringBuilder.ToString();
 

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
@@ -36,7 +36,7 @@ public class SecretObfuscatorTests
     {
         _buildSystemMock.Setup(x => x.GetCurrentBuildSystem()).Returns(BuildSystem.GitHubActions);
 
-        await ExecutePipelineAsync();
+        await RunAsync();
 
         var logOutput = _buildSystemCommands.ToString();
         await Assert.That(logOutput).Contains("::add-mask::This is a secret value!");
@@ -48,7 +48,7 @@ public class SecretObfuscatorTests
     {
         _buildSystemMock.Setup(x => x.GetCurrentBuildSystem()).Returns(BuildSystem.GitHubActions);
 
-        await ExecutePipelineAsync();
+        await RunAsync();
 
         _consoleWriterMock.Verify(
             writer => writer.LogToConsole(It.Is<string>(
@@ -63,7 +63,7 @@ public class SecretObfuscatorTests
     {
         _buildSystemMock.Setup(x => x.GetCurrentBuildSystem()).Returns(BuildSystem.Unknown);
 
-        await ExecutePipelineAsync();
+        await RunAsync();
 
         var logOutput = _buildSystemCommands.ToString();
         await Assert.That(logOutput).DoesNotContain("::add-mask::This is a secret value!");
@@ -81,7 +81,7 @@ public class SecretObfuscatorTests
         return await builder.BuildAsync();
     }
 
-    private async Task ExecutePipelineAsync()
+    private async Task RunAsync()
     {
         var pipeline = await GetPipeline();
         await pipeline.RunAsync();

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -223,11 +223,11 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
-    public async Task ExecutePipelineAsync_ValidatesBeforeRunning()
+    public async Task RunAsync_ValidatesBeforeRunning()
     {
         var builder = Pipeline.CreateBuilder();
 
-        await Assert.That(async () => await builder.ExecutePipelineAsync())
+        await Assert.That(async () => await builder.RunAsync())
             .Throws<PipelineValidationException>();
     }
 

--- a/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
@@ -68,7 +68,7 @@ public class PipelineWorkingDirectoryTests
             builder.AddModuleCache<FileSystemModuleCache>();
             builder.AddModule<ObserveWorkingDirectoryModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var result = await summary.Modules.OfType<ObserveWorkingDirectoryModule>().Single();
             var observation = result.ValueOrDefault!;
 
@@ -114,7 +114,7 @@ public class PipelineWorkingDirectoryTests
                 options.WorkingDirectory = cacheWorkingDirectory.FullName);
             builder.AddModule<ObserveWorkingDirectoryModule>();
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var result = await summary.Modules.OfType<ObserveWorkingDirectoryModule>().Single();
 
             await Assert.That(result.ValueOrDefault!.CacheWorkingDirectory)

--- a/test/ModularPipelines.UnitTests/Requirements/PipelineRequirementBaseClassTests.cs
+++ b/test/ModularPipelines.UnitTests/Requirements/PipelineRequirementBaseClassTests.cs
@@ -36,7 +36,7 @@ public class PipelineRequirementBaseClassTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement<FailingSyncRequirement>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -67,7 +67,7 @@ public class PipelineRequirementBaseClassTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement<FailingAsyncRequirement>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -98,7 +98,7 @@ public class PipelineRequirementBaseClassTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement<WhenFalseRequirement>()
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)

--- a/test/ModularPipelines.UnitTests/Requirements/RequireFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Requirements/RequireFactoryTests.cs
@@ -38,7 +38,7 @@ public class RequireFactoryTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement(Require.That(_ => false, reason))
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -78,7 +78,7 @@ public class RequireFactoryTests
                     await Task.Yield();
                     return false;
                 }, reason))
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -120,7 +120,7 @@ public class RequireFactoryTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement(Require.EnvironmentVariable(varName))
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -139,7 +139,7 @@ public class RequireFactoryTests
             await TestPipelineBuilder.Create()
                 .AddModule<DummyModule>()
                 .AddRequirement(Require.EnvironmentVariable(varName, customReason))
-                .ExecutePipelineAsync();
+                .RunAsync();
         };
 
         await Assert.That(executePipelineDelegate)
@@ -167,7 +167,7 @@ public class RequireFactoryTests
             builder.AddRequirement(Require.FileExists("./appsettings.json"));
             builder.AddRequirement(Require.DirectoryExists("./artifacts"));
 
-            var summary = await builder.ExecutePipelineAsync();
+            var summary = await builder.RunAsync();
             var result = await summary.Modules.OfType<DummyModule>().Single();
 
             using (Assert.Multiple())

--- a/test/ModularPipelines.UnitTests/ScaleTests.cs
+++ b/test/ModularPipelines.UnitTests/ScaleTests.cs
@@ -210,7 +210,7 @@ public class ScaleTests : TestBase
             .AddModule<ScaleModule<M100>>();
 
         // Act
-        var pipelineSummary = await builder.ExecutePipelineAsync();
+        var pipelineSummary = await builder.RunAsync();
 
         // Assert
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
@@ -325,7 +325,7 @@ public class ScaleTests : TestBase
             .AddModule<ChainModule49>().AddModule<ChainModule50>();
 
         // Act
-        var pipelineSummary = await builder.ExecutePipelineAsync();
+        var pipelineSummary = await builder.RunAsync();
 
         // Assert
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
@@ -465,7 +465,7 @@ public class ScaleTests : TestBase
             .AddModule<FanOutDep49>().AddModule<FanOutDep50>();
 
         // Act
-        var pipelineSummary = await builder.ExecutePipelineAsync();
+        var pipelineSummary = await builder.RunAsync();
 
         // Assert
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
@@ -601,7 +601,7 @@ public class ScaleTests : TestBase
             .AddModule<FanInFinalModule>();
 
         // Act
-        var pipelineSummary = await builder.ExecutePipelineAsync();
+        var pipelineSummary = await builder.RunAsync();
 
         // Assert
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);

--- a/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
@@ -206,7 +206,7 @@ public class TelemetryIntegrationTests
 
         var builder = TestPipelineBuilder.Create();
         builder.Services.AddSingleton<ICommandInterceptor, SuccessfulCommandInterceptor>();
-        await builder.AddModule<CommandModule>().ExecutePipelineAsync();
+        await builder.AddModule<CommandModule>().RunAsync();
 
         var pipelineActivity = stoppedActivities.Single(activity => activity.OperationName == "Pipeline.Run");
         var moduleActivity = stoppedActivities.Single(activity => activity.OperationName == $"Module.{nameof(CommandModule)}");
@@ -236,7 +236,7 @@ public class TelemetryIntegrationTests
 
         var builder = TestPipelineBuilder.Create();
         builder.Services.AddSingleton<ICommandInterceptor, SuccessfulCommandInterceptor>();
-        await builder.AddModule<HiddenArgumentsCommandModule>().ExecutePipelineAsync();
+        await builder.AddModule<HiddenArgumentsCommandModule>().RunAsync();
 
         var commandActivity = stoppedActivities.Single(activity =>
             activity.OperationName == "Command.hidden-arguments-tool");
@@ -259,7 +259,7 @@ public class TelemetryIntegrationTests
                 },
             });
         builder.Services.AddSingleton<ICommandInterceptor, SuccessfulCommandInterceptor>();
-        await builder.AddModule<DefaultLoggingCommandModule>().ExecutePipelineAsync();
+        await builder.AddModule<DefaultLoggingCommandModule>().RunAsync();
 
         var commandActivity = stoppedActivities.Single(activity =>
             activity.OperationName == "Command.silent-tool");
@@ -276,7 +276,7 @@ public class TelemetryIntegrationTests
 
         var builder = TestPipelineBuilder.Create();
         builder.Services.AddSingleton<ICommandInterceptor, SuccessfulCommandInterceptor>();
-        await builder.AddModule<ManipulatedInputCommandModule>().ExecutePipelineAsync();
+        await builder.AddModule<ManipulatedInputCommandModule>().RunAsync();
 
         var commandActivity = stoppedActivities.Single(activity =>
             activity.OperationName == "Command.manipulated-input-tool");
@@ -298,7 +298,7 @@ public class TelemetryIntegrationTests
         var builder = TestPipelineBuilder.Create();
         builder.Services.AddSingleton<ICommandInterceptor, SuccessfulCommandInterceptor>();
         await Assert.ThrowsAsync<ModuleFailedException>(async () =>
-            await builder.AddModule<ThrowingInputManipulatorCommandModule>().ExecutePipelineAsync());
+            await builder.AddModule<ThrowingInputManipulatorCommandModule>().RunAsync());
 
         var commandActivity = stoppedActivities.Single(activity =>
             activity.OperationName == "Command.throwing-input-manipulator-tool");
@@ -322,7 +322,7 @@ public class TelemetryIntegrationTests
         await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<InvalidOptionsCommandModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         var commandActivity = stoppedActivities.Single(activity =>
             activity.OperationName == $"Command.{nameof(InvalidCommandOptions)}");
@@ -349,7 +349,7 @@ public class TelemetryIntegrationTests
         var builder = TestPipelineBuilder.Create();
         builder.Services.AddSingleton<ICommandInterceptor, ThrowingCommandInterceptor>();
         await Assert.ThrowsAsync<ModuleFailedException>(async () =>
-            await builder.AddModule<ThrowingInputManipulatorCommandModule>().ExecutePipelineAsync());
+            await builder.AddModule<ThrowingInputManipulatorCommandModule>().RunAsync());
 
         var commandActivity = stoppedActivities.Single(activity =>
             activity.OperationName == "Command.throwing-input-manipulator-tool");
@@ -369,7 +369,7 @@ public class TelemetryIntegrationTests
 
         await TestPipelineBuilder.Create()
             .AddModule<RetriedModule>()
-            .ExecutePipelineAsync();
+            .RunAsync();
 
         using (Assert.Multiple())
         {
@@ -466,7 +466,7 @@ public class TelemetryIntegrationTests
         var builder = TestPipelineBuilder.Create();
         builder.Services.AddSingleton<ICommandInterceptor, ThrowingCommandInterceptor>();
         await Assert.ThrowsAsync<ModuleFailedException>(async () =>
-            await builder.AddModule<CommandModule>().ExecutePipelineAsync());
+            await builder.AddModule<CommandModule>().RunAsync());
 
         var failureActivities = stoppedActivities.Where(activity =>
                 activity.OperationName is "Pipeline.Run"
@@ -586,7 +586,7 @@ public class TelemetryIntegrationTests
         await Assert.ThrowsAsync<ModuleFailedException>(async () =>
             await TestPipelineBuilder.Create()
                 .AddModule<TimedOutModule>()
-                .ExecutePipelineAsync());
+                .RunAsync());
 
         var moduleActivity = stoppedActivities.Single(activity =>
             activity.OperationName == $"Module.{nameof(TimedOutModule)}");


### PR DESCRIPTION
## Summary
- rename the one-call `PipelineBuilder.ExecutePipelineAsync()` extension to `RunAsync()`
- migrate active C#, F#, templates, tests, README content, and current documentation to the new name
- preserve historical v3 release notes, migration guidance, and versioned v3 docs

## Breaking change
`PipelineBuilder.ExecutePipelineAsync()` is removed. Call `PipelineBuilder.RunAsync()` instead. Module implementations continue to use `ExecuteAsync()`.

## Validation
- [x] TDD red: golden-path compile fixture failed with CS1061 before `RunAsync()` existed
- [x] focused `RunAsync_ValidatesBeforeRunning` test (1 passed)
- [x] focused `DocumentationSnippetTests` (4 passed)
- [x] guarded Release build: `ModularPipelines.slnx`
- [x] guarded Release build: documentation snippets project
- [x] guarded Release build: templates solution
- [x] guarded Release build: GitHub integration solution
- [x] `npm run build --prefix docs`
- [x] no unexpected `ExecutePipelineAsync` references outside preserved v3 history
- [x] `git diff --check`

`dotnet format whitespace --verify-no-changes` reports pre-existing formatting debt in unchanged portions of `ScaleTests.cs`; this token-only migration introduces no whitespace diff.

Closes #4222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the pipeline execution method from `ExecutePipelineAsync()` to `RunAsync()`.
  * Update applications and scripts to use `RunAsync()` when starting pipelines.

* **Documentation**
  * Updated quick starts, guides, examples, templates, and API samples to reflect the current method name.

* **Tests**
  * Updated automated coverage and documentation checks to use `RunAsync()` while preserving existing scenarios and validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->