### PR TITLE
Unify pipeline builder creation settings

### DIFF
--- a/README_Template.md
+++ b/README_Template.md
@@ -138,7 +138,7 @@ Then configure and execute the pipeline from `Program.cs`:
 using ModularPipelines;
 using ModularPipelines.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 await builder.RunAsync();
 ```
 

--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -23,6 +23,28 @@ protected override void Configure(ModuleConfigurationBuilder module)
 }
 ```
 
+## Pipeline builder creation
+
+`Pipeline.CreateBuilder(args)` now infers the pipeline project directory from the
+calling source file. `Pipeline.CreateBuilderFromSource` has been removed; use
+`CreateBuilder` for both inferred and explicitly configured builders.
+
+`PipelineBuilderOptions` is now `PipelineBuilderSettings`. The build-time assembly
+discovery flag moved from `PipelineOptions.LoadModularPipelineAssemblies` to
+`PipelineBuilderSettings.LoadModularPipelinesAssemblies`:
+
+```csharp
+var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
+{
+    Args = args,
+    LoadModularPipelinesAssemblies = true,
+});
+```
+
+`PipelineBuilder` no longer implements `IDisposable`; its previous `Dispose` method
+performed no cleanup. Remove `using` declarations around builders. Resources created
+by a successful build remain owned by the resulting pipeline.
+
 ## CLI argument ordering
 
 `CommandLinePhase` is now the only ordering model for flags, options, and arguments.

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -46,25 +46,15 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
 
     let args = System.Environment.GetCommandLineArgs()
     let builder = Pipeline.CreateBuilder(args)
-    // PipelineBuilder became disposable in v4; retain compatibility with the v3 package above.
-    let builderLifetime =
-        match box builder with
-        | :? System.IDisposable as disposable -> disposable
-        | _ -> null
+    builder.Services.RegisterDotNetContext()
 
-    try
-        builder.Services.RegisterDotNetContext()
+    builder
+        .AddModule<UpdateDotnetWorkloads>()
+        .AddModule<CheckDotnetSdkModule>()
 
-        builder
-            .AddModule<UpdateDotnetWorkloads>()
-            .AddModule<CheckDotnetSdkModule>()
-
-        builder.ExecutePipelineAsync()
-        |> Async.AwaitTask
-        |> Async.RunSynchronously
-    finally
-        if not (isNull builderLifetime) then
-            builderLifetime.Dispose()
+    builder.ExecutePipelineAsync()
+    |> Async.AwaitTask
+    |> Async.RunSynchronously
     ``` 
 4. **Run your F# script:** You can run your F# script using the F# Interactive environment. If you are using Visual Studio, you can simply open the `example.fsx` file and execute it. Alternatively, you can run it from the command line using:
 

--- a/docs/docs/how-to/command-line.md
+++ b/docs/docs/how-to/command-line.md
@@ -120,7 +120,7 @@ To forward every argument to host configuration, disable pipeline command-line
 options:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
 {
     Args = args,
     EnableCommandLineOptions = false,

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -69,7 +69,7 @@ You can also export programmatically:
 ```csharp
 using ModularPipelines.Enums;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<Module2>();
 
 await builder.ExportDependencyGraphAsync(

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -45,7 +45,7 @@ type TestModule() =
             return $"tested {build.ValueOrDefault}"
         }
 
-use builder = Pipeline.CreateBuilder()
+let builder = Pipeline.CreateBuilder()
 
 builder
     .AddModule<TestModule>()

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -181,9 +181,10 @@ If the integration DLL is copied beside the application without a compile-time r
 opt in to filename-based assembly discovery before building the pipeline:
 
 ```csharp
-builder.ConfigurePipelineOptions(options => options with
+var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
 {
-    LoadModularPipelineAssemblies = true,
+    Args = args,
+    LoadModularPipelinesAssemblies = true,
 });
 ```
 

--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -16,10 +16,10 @@ using ModularPipelines.Extensions;
 using Octokit;
 using Octokit.Internal;
 
-var builder = Pipeline.CreateBuilder(args);
-builder.ConfigurePipelineOptions(options => options with
+var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
 {
-    LoadModularPipelineAssemblies = true,
+    Args = args,
+    LoadModularPipelinesAssemblies = true,
 });
 
 builder.Configuration

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -6,7 +6,7 @@ using TemplatePipeline;
 using TemplatePipeline.Modules;
 using TemplatePipeline.Settings;
 
-var builder = Pipeline.CreateBuilderFromSource(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: false)

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -166,7 +166,7 @@ public class ModuleTestBuilder<TModule>
             recorder.SetHandler(_commandHandler);
         }
 
-        var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+        var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
         {
             EnableCommandLineOptions = false,
         });

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -166,7 +166,7 @@ public class ModuleTestBuilder<TModule>
             recorder.SetHandler(_commandHandler);
         }
 
-        var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
+        var builder = Pipeline.CreateBuilderWithoutProjectInference(new PipelineBuilderSettings
         {
             EnableCommandLineOptions = false,
         });

--- a/src/ModularPipelines/Context/Domains/IEnvironmentContext.cs
+++ b/src/ModularPipelines/Context/Domains/IEnvironmentContext.cs
@@ -33,7 +33,7 @@ public interface IEnvironmentContext
     /// Gets the pipeline's configured working directory.
     /// </summary>
     /// <remarks>
-    /// Set <see cref="PipelineBuilderOptions.WorkingDirectory"/> when creating the pipeline,
+    /// Set <see cref="PipelineBuilderSettings.WorkingDirectory"/> when creating the pipeline,
     /// or override an individual command with
     /// <see cref="Options.CommandExecutionOptions.WorkingDirectory"/>.
     /// </remarks>

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -148,16 +148,6 @@ public record PipelineOptions
     }
 
     /// <summary>
-    /// Gets a value indicating whether assemblies whose filenames contain
-    /// <c>ModularPipeline</c> are eagerly loaded from the application directory.
-    /// </summary>
-    /// <remarks>
-    /// Disabled by default. Enable this only when a plugin relies on module initializers
-    /// instead of explicit assembly or service registration.
-    /// </remarks>
-    public bool LoadModularPipelineAssemblies { get; init; }
-
-    /// <summary>
     /// Gets the default number of retry attempts for failed operations.
     /// </summary>
     /// <remarks>

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -67,12 +67,9 @@ public static class Pipeline
     {
         ArgumentNullException.ThrowIfNull(settings);
 
-        return new PipelineBuilder(settings with
-        {
-            WorkingDirectory = settings.WorkingDirectory
-                               ?? settings.ContentRootPath
-                               ?? PipelineDirectory.TryFindPipelineProject(sourceFilePath),
-        });
+        return new PipelineBuilder(
+            settings,
+            PipelineDirectory.TryFindPipelineProject(sourceFilePath));
     }
 
     internal static PipelineBuilder CreateBuilderWithoutProjectInference(PipelineBuilderSettings settings)

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ModularPipelines;
 
 /// <summary>
@@ -9,6 +11,7 @@ public static class Pipeline
     /// Creates a new pipeline builder.
     /// </summary>
     /// <param name="args">Optional command line arguments.</param>
+    /// <param name="sourceFilePath">The calling source file path, supplied by the compiler.</param>
     /// <returns>A new pipeline builder instance.</returns>
     /// <example>
     /// <code>
@@ -24,45 +27,30 @@ public static class Pipeline
     /// var summary = await pipeline.RunAsync();
     /// </code>
     /// </example>
-    public static PipelineBuilder CreateBuilder(string[]? args = null)
+    public static PipelineBuilder CreateBuilder(
+        string[]? args = null,
+        [CallerFilePath] string sourceFilePath = "")
     {
-        return new PipelineBuilder(new PipelineBuilderOptions { Args = args });
+        return CreateBuilder(new PipelineBuilderSettings
+        {
+            Args = args,
+        }, sourceFilePath);
     }
 
     /// <summary>
-    /// Creates a new pipeline builder whose working directory is inferred from the calling source file.
+    /// Creates a new pipeline builder with the specified settings.
     /// </summary>
-    /// <param name="args">Optional command line arguments.</param>
+    /// <param name="settings">The builder settings.</param>
     /// <param name="sourceFilePath">The calling source file path, supplied by the compiler.</param>
     /// <returns>A new pipeline builder instance.</returns>
     /// <remarks>
-    /// <c>MODULAR_PIPELINES_DIRECTORY</c> can override the inferred project directory. If neither can
-    /// be resolved, the process working directory is used.
-    /// </remarks>
-    public static PipelineBuilder CreateBuilderFromSource(
-        string[]? args = null,
-        [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "")
-    {
-        return new PipelineBuilder(new PipelineBuilderOptions
-        {
-            Args = args,
-            WorkingDirectory = PipelineDirectory.TryFindPipelineProject(sourceFilePath),
-        });
-    }
-
-    /// <summary>
-    /// Creates a new pipeline builder with the specified options.
-    /// </summary>
-    /// <param name="options">The builder options.</param>
-    /// <returns>A new pipeline builder instance.</returns>
-    /// <remarks>
-    /// This overload does not infer a pipeline project directory. When
-    /// <see cref="PipelineBuilderOptions.WorkingDirectory"/> is
-    /// unset, the configured content root is used, falling back to the process working directory.
+    /// When <see cref="PipelineBuilderSettings.WorkingDirectory"/> is unset, the calling source file's
+    /// project directory is used when available, then the configured content root, and finally the
+    /// process working directory.
     /// </remarks>
     /// <example>
     /// <code>
-    /// var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+    /// var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
     /// {
     ///     Args = args,
     ///     EnvironmentName = "Development"
@@ -73,8 +61,16 @@ public static class Pipeline
     /// var summary = await pipeline.RunAsync();
     /// </code>
     /// </example>
-    public static PipelineBuilder CreateBuilder(PipelineBuilderOptions options)
+    public static PipelineBuilder CreateBuilder(
+        PipelineBuilderSettings settings,
+        [CallerFilePath] string sourceFilePath = "")
     {
-        return new PipelineBuilder(options);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        return new PipelineBuilder(settings with
+        {
+            WorkingDirectory = settings.WorkingDirectory
+                               ?? PipelineDirectory.TryFindPipelineProject(sourceFilePath),
+        });
     }
 }

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -69,7 +69,7 @@ public static class Pipeline
 
         return new PipelineBuilder(
             settings,
-            PipelineDirectory.TryFindPipelineProject(sourceFilePath));
+            sourceFilePath);
     }
 
     internal static PipelineBuilder CreateBuilderWithoutProjectInference(PipelineBuilderSettings settings)

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -44,9 +44,9 @@ public static class Pipeline
     /// <param name="sourceFilePath">The calling source file path, supplied by the compiler.</param>
     /// <returns>A new pipeline builder instance.</returns>
     /// <remarks>
-    /// When <see cref="PipelineBuilderSettings.WorkingDirectory"/> is unset, the calling source file's
-    /// project directory is used when available, then the configured content root, and finally the
-    /// process working directory.
+    /// When <see cref="PipelineBuilderSettings.WorkingDirectory"/> is unset, the configured content
+    /// root is used when available, then the calling source file's project directory, and finally
+    /// the process working directory.
     /// </remarks>
     /// <example>
     /// <code>
@@ -70,7 +70,14 @@ public static class Pipeline
         return new PipelineBuilder(settings with
         {
             WorkingDirectory = settings.WorkingDirectory
+                               ?? settings.ContentRootPath
                                ?? PipelineDirectory.TryFindPipelineProject(sourceFilePath),
         });
+    }
+
+    internal static PipelineBuilder CreateBuilderWithoutProjectInference(PipelineBuilderSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        return new PipelineBuilder(settings);
     }
 }

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -31,7 +31,7 @@ namespace ModularPipelines;
 /// <remarks>
 /// Resources created while configuring the builder are transferred to the built pipeline.
 /// </remarks>
-public sealed class PipelineBuilder : IDisposable
+public sealed class PipelineBuilder
 {
     private readonly IHostBuilder _hostBuilder;
     private readonly ServiceCollection _services;
@@ -39,17 +39,19 @@ public sealed class PipelineBuilder : IDisposable
     private readonly PipelineHostEnvironment _environment;
     private readonly PipelineBuilderResources _resources;
     private readonly PipelineCommandLineOptions _commandLineOptions;
+    private readonly PipelineBuilderSettings _settings;
     private PipelineOptions _options;
 
-    internal PipelineBuilder(PipelineBuilderOptions options)
+    internal PipelineBuilder(PipelineBuilderSettings settings)
     {
-        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
 
-        _commandLineOptions = options.EnableCommandLineOptions
-            ? PipelineCommandLineParser.Parse(options.Args)
+        _commandLineOptions = settings.EnableCommandLineOptions
+            ? PipelineCommandLineParser.Parse(settings.Args)
             : PipelineCommandLineOptions.Empty with
             {
-                HostArguments = options.Args?.ToArray() ?? [],
+                HostArguments = settings.Args?.ToArray() ?? [],
             };
         var args = _commandLineOptions.HostArguments.ToArray();
         _services = new ServiceCollection();
@@ -73,7 +75,7 @@ public sealed class PipelineBuilder : IDisposable
             _configuration.AddCommandLine(args);
         }
 
-        _environment = CreateHostEnvironment(options, args);
+        _environment = CreateHostEnvironment(settings, args);
         _resources = _environment.Resources;
         _configuration.SetBasePath(_environment.WorkingDirectory);
         _hostBuilder.UseEnvironment(_environment.EnvironmentName);
@@ -123,13 +125,6 @@ public sealed class PipelineBuilder : IDisposable
     /// Gets the default working directory for commands and relative file paths.
     /// </summary>
     public string WorkingDirectory => _environment.WorkingDirectory;
-
-    /// <summary>
-    /// Retained for source compatibility. Resources are owned by the built pipeline.
-    /// </summary>
-    public void Dispose()
-    {
-    }
 
     /// <summary>
     /// Sets the minimum log level for the pipeline.
@@ -284,7 +279,7 @@ public sealed class PipelineBuilder : IDisposable
     }
 
     private static PipelineHostEnvironment CreateHostEnvironment(
-        PipelineBuilderOptions options,
+        PipelineBuilderSettings settings,
         IReadOnlyList<string> hostArguments)
     {
         var hostConfiguration = new ConfigurationManager();
@@ -296,21 +291,21 @@ public sealed class PipelineBuilder : IDisposable
 
         var environmentName = FirstNonEmpty(
             Environments.Production,
-            options.EnvironmentName,
+            settings.EnvironmentName,
             hostConfiguration[HostDefaults.EnvironmentKey],
             System.Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
         var workingDirectory = Path.GetFullPath(FirstNonEmpty(
             Directory.GetCurrentDirectory(),
-            options.WorkingDirectory,
-            options.ContentRootPath,
+            settings.WorkingDirectory,
+            settings.ContentRootPath,
             hostConfiguration[HostDefaults.ContentRootKey]));
         var contentRootPath = Path.GetFullPath(FirstNonEmpty(
             workingDirectory,
-            options.ContentRootPath,
+            settings.ContentRootPath,
             hostConfiguration[HostDefaults.ContentRootKey]));
         var applicationName = FirstNonEmpty(
             string.Empty,
-            options.ApplicationName,
+            settings.ApplicationName,
             hostConfiguration[HostDefaults.ApplicationKey],
             Assembly.GetEntryAssembly()?.GetName().Name);
 
@@ -334,7 +329,7 @@ public sealed class PipelineBuilder : IDisposable
 
     private async Task<IPipeline> BuildPipelineAsync(bool initializePipeline)
     {
-        LoadModularPipelineAssembliesIfNotLoadedYet();
+        LoadModularPipelinesAssembliesIfNotLoadedYet();
 
         // Apply plugin configuration to the builder (modules, hooks, options)
         PluginIntegration.ApplyPluginConfiguration(this);
@@ -384,7 +379,7 @@ public sealed class PipelineBuilder : IDisposable
         return await PipelineImpl.CreateAsync(_hostBuilder, _resources, initializePipeline).ConfigureAwait(false);
     }
 
-    private void LoadModularPipelineAssembliesIfNotLoadedYet()
+    private void LoadModularPipelinesAssembliesIfNotLoadedYet()
     {
         if (!RuntimeFeature.IsDynamicCodeSupported)
         {
@@ -394,7 +389,7 @@ public sealed class PipelineBuilder : IDisposable
         var coreVersion = typeof(PipelineBuilder).Assembly.GetName().Version;
         LoadReferencedModularPipelineAssemblies(coreVersion);
 
-        if (!_options.LoadModularPipelineAssemblies)
+        if (!_settings.LoadModularPipelinesAssemblies)
         {
             return;
         }

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -44,7 +44,7 @@ public sealed class PipelineBuilder
 
     internal PipelineBuilder(
         PipelineBuilderSettings settings,
-        string? inferredWorkingDirectory = null)
+        string? projectInferenceSourcePath = null)
     {
         _settings = settings;
 
@@ -76,7 +76,7 @@ public sealed class PipelineBuilder
             _configuration.AddCommandLine(args);
         }
 
-        _environment = CreateHostEnvironment(settings, args, inferredWorkingDirectory);
+        _environment = CreateHostEnvironment(settings, args, projectInferenceSourcePath);
         _resources = _environment.Resources;
         _configuration.SetBasePath(_environment.WorkingDirectory);
         _hostBuilder.UseEnvironment(_environment.EnvironmentName);
@@ -282,7 +282,7 @@ public sealed class PipelineBuilder
     private static PipelineHostEnvironment CreateHostEnvironment(
         PipelineBuilderSettings settings,
         IReadOnlyList<string> hostArguments,
-        string? inferredWorkingDirectory)
+        string? projectInferenceSourcePath)
     {
         var hostConfiguration = new ConfigurationManager();
         hostConfiguration.AddEnvironmentVariables(prefix: "DOTNET_");
@@ -296,12 +296,19 @@ public sealed class PipelineBuilder
             settings.EnvironmentName,
             hostConfiguration[HostDefaults.EnvironmentKey],
             System.Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
-        var workingDirectory = Path.GetFullPath(FirstNonEmpty(
-            Directory.GetCurrentDirectory(),
+        var configuredWorkingDirectory = FirstNonEmpty(
+            string.Empty,
             settings.WorkingDirectory,
             settings.ContentRootPath,
-            hostConfiguration[HostDefaults.ContentRootKey],
-            inferredWorkingDirectory));
+            hostConfiguration[HostDefaults.ContentRootKey]);
+        var workingDirectory = Path.GetFullPath(
+            !string.IsNullOrEmpty(configuredWorkingDirectory)
+                ? configuredWorkingDirectory
+                : FirstNonEmpty(
+                    Directory.GetCurrentDirectory(),
+                    projectInferenceSourcePath is null
+                        ? null
+                        : PipelineDirectory.TryFindPipelineProject(projectInferenceSourcePath)));
         var contentRootPath = Path.GetFullPath(FirstNonEmpty(
             workingDirectory,
             settings.ContentRootPath,

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -44,7 +44,6 @@ public sealed class PipelineBuilder
 
     internal PipelineBuilder(PipelineBuilderSettings settings)
     {
-        ArgumentNullException.ThrowIfNull(settings);
         _settings = settings;
 
         _commandLineOptions = settings.EnableCommandLineOptions
@@ -387,7 +386,7 @@ public sealed class PipelineBuilder
         }
 
         var coreVersion = typeof(PipelineBuilder).Assembly.GetName().Version;
-        LoadReferencedModularPipelineAssemblies(coreVersion);
+        LoadReferencedModularPipelinesAssemblies(coreVersion);
 
         if (!_settings.LoadModularPipelinesAssemblies)
         {
@@ -408,7 +407,7 @@ public sealed class PipelineBuilder
         }
     }
 
-    private static void LoadReferencedModularPipelineAssemblies(Version? coreVersion)
+    private static void LoadReferencedModularPipelinesAssemblies(Version? coreVersion)
     {
         ReferencedAssemblyTraversal.LoadModularPipelinesAssemblies(
             AppDomain.CurrentDomain.GetAssemblies(),

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -42,7 +42,9 @@ public sealed class PipelineBuilder
     private readonly PipelineBuilderSettings _settings;
     private PipelineOptions _options;
 
-    internal PipelineBuilder(PipelineBuilderSettings settings)
+    internal PipelineBuilder(
+        PipelineBuilderSettings settings,
+        string? inferredWorkingDirectory = null)
     {
         _settings = settings;
 
@@ -74,7 +76,7 @@ public sealed class PipelineBuilder
             _configuration.AddCommandLine(args);
         }
 
-        _environment = CreateHostEnvironment(settings, args);
+        _environment = CreateHostEnvironment(settings, args, inferredWorkingDirectory);
         _resources = _environment.Resources;
         _configuration.SetBasePath(_environment.WorkingDirectory);
         _hostBuilder.UseEnvironment(_environment.EnvironmentName);
@@ -279,7 +281,8 @@ public sealed class PipelineBuilder
 
     private static PipelineHostEnvironment CreateHostEnvironment(
         PipelineBuilderSettings settings,
-        IReadOnlyList<string> hostArguments)
+        IReadOnlyList<string> hostArguments,
+        string? inferredWorkingDirectory)
     {
         var hostConfiguration = new ConfigurationManager();
         hostConfiguration.AddEnvironmentVariables(prefix: "DOTNET_");
@@ -297,7 +300,8 @@ public sealed class PipelineBuilder
             Directory.GetCurrentDirectory(),
             settings.WorkingDirectory,
             settings.ContentRootPath,
-            hostConfiguration[HostDefaults.ContentRootKey]));
+            hostConfiguration[HostDefaults.ContentRootKey],
+            inferredWorkingDirectory));
         var contentRootPath = Path.GetFullPath(FirstNonEmpty(
             workingDirectory,
             settings.ContentRootPath,

--- a/src/ModularPipelines/PipelineBuilderSettings.cs
+++ b/src/ModularPipelines/PipelineBuilderSettings.cs
@@ -35,8 +35,8 @@ public sealed record PipelineBuilderSettings
     /// Gets the default working directory for commands and relative file paths.
     /// </summary>
     /// <remarks>
-    /// When omitted, the calling source file's project directory is used when available,
-    /// then the configured content root, and finally the process working directory.
+    /// When omitted, the configured content root is used when available, then the calling
+    /// source file's project directory, and finally the process working directory.
     /// </remarks>
     public string? WorkingDirectory { get; init; }
 

--- a/src/ModularPipelines/PipelineBuilderSettings.cs
+++ b/src/ModularPipelines/PipelineBuilderSettings.cs
@@ -1,9 +1,9 @@
 namespace ModularPipelines;
 
 /// <summary>
-/// Options for configuring the pipeline builder.
+/// Settings for creating a pipeline builder.
 /// </summary>
-public sealed record PipelineBuilderOptions
+public sealed record PipelineBuilderSettings
 {
     /// <summary>
     /// Gets the command line arguments.
@@ -35,7 +35,18 @@ public sealed record PipelineBuilderOptions
     /// Gets the default working directory for commands and relative file paths.
     /// </summary>
     /// <remarks>
-    /// When omitted, the configured content root is used, falling back to the process working directory.
+    /// When omitted, the calling source file's project directory is used when available,
+    /// then the configured content root, and finally the process working directory.
     /// </remarks>
     public string? WorkingDirectory { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether assemblies whose filenames contain
+    /// <c>ModularPipelines</c> are eagerly loaded from the application directory.
+    /// </summary>
+    /// <remarks>
+    /// Disabled by default. Enable this only when a plugin relies on module initializers
+    /// instead of explicit assembly or service registration.
+    /// </remarks>
+    public bool LoadModularPipelinesAssemblies { get; init; }
 }

--- a/test/ModularPipelines.Distributed.Artifacts.S3.UnitTests/Caching/S3ModuleCacheTests.cs
+++ b/test/ModularPipelines.Distributed.Artifacts.S3.UnitTests/Caching/S3ModuleCacheTests.cs
@@ -96,7 +96,7 @@ public class S3ModuleCacheTests
     [Test]
     public async Task CacheRegistrationDoesNotReplaceArtifactStoreOptions()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddS3DistributedArtifactStore(options =>
         {
             options.BucketName = "artifact-bucket";

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/Caching/RedisModuleCacheTests.cs
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/Caching/RedisModuleCacheTests.cs
@@ -211,7 +211,7 @@ public class RedisModuleCacheTests
     [Test]
     public async Task CacheRegistrationDoesNotReplaceDistributedOptions()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddRedisDistributed(
             options =>
             {

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/Extensions/RedisDistributedExtensionsTests.cs
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/Extensions/RedisDistributedExtensionsTests.cs
@@ -21,7 +21,7 @@ public class RedisDistributedExtensionsTests
     [Test]
     public async Task CoordinatorRunIdentifierScopesWorkerRegistrations()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddDistributedMode(_ => { });
         builder.AddRedisDistributedCoordinator(options =>
         {
@@ -56,7 +56,7 @@ public class RedisDistributedExtensionsTests
                 Environment.SetEnvironmentVariable(name, null);
             }
 
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddDistributedMode(_ => { });
 
             var exception = Assert.Throws<InvalidOperationException>(() =>

--- a/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
@@ -73,7 +73,7 @@ public class GitHubMarkdownSummaryGeneratorTests
         try
         {
             Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", path);
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<DependencyModule>();
             builder.AddModule<TargetModule>();
 
@@ -106,7 +106,7 @@ public class GitHubMarkdownSummaryGeneratorTests
         {
             _skipConditionEvaluations = 0;
             Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", path);
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SingleUseSkipConditionModule>();
 
             await builder.RunAsync();
@@ -134,7 +134,7 @@ public class GitHubMarkdownSummaryGeneratorTests
         try
         {
             Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", path);
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.Services.AddSingleton<IDependencyGraphExporter, OversizedDependencyGraphRenderer>();
             builder.AddModule<DependencyModule>();
 

--- a/test/ModularPipelines.TestHelpers/TestPipelineBuilder.cs
+++ b/test/ModularPipelines.TestHelpers/TestPipelineBuilder.cs
@@ -17,7 +17,7 @@ public static class TestPipelineBuilder
 
     public static PipelineBuilder Create(TestHostSettings testHostSettings, TimeProvider? timeProvider)
     {
-        var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilderWithoutProjectInference(new PipelineBuilderSettings());
 
         builder.SetLogLevel(testHostSettings.LogLevel);
 

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -17,7 +17,7 @@ if (args is [SmokeState.ChildArgument, var childValue])
     return;
 }
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Exercise OptionsProvider's runtime-discovered IOptions<T> path after trimming.
 builder.Services.AddSingleton<IOptions<SmokePipelineOptions>>(
@@ -37,7 +37,7 @@ if (SmokeState.HookInvocations != 3)
         $"Expected three generated hook invocations, got {SmokeState.HookInvocations}.");
 }
 
-using var failureBuilder = Pipeline.CreateBuilder(args);
+var failureBuilder = Pipeline.CreateBuilder(args);
 failureBuilder
     .AddModule<FailingModule>()
     .AddModule<PendingAfterFailureModule>();

--- a/test/ModularPipelines.UnitTests/Api/ModuleApiSurfaceTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/ModuleApiSurfaceTests.cs
@@ -40,7 +40,7 @@ public class ModuleApiSurfaceTests
     [Test]
     public async Task DirectIModuleImplementationsFailAtRegistrationWithGuidance()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
 
         var genericException = Assert.Throws<InvalidOperationException>(
             () => builder.AddModule<DirectModule>());

--- a/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
@@ -71,7 +71,7 @@ public class ArtifactContractTests
     public async Task ArtifactLifecycleLoggingUsesAmbientModuleLogger()
     {
         var loggerProvider = new RecordingLoggerProvider();
-        using var builder = TestPipelineBuilder.Create();
+        var builder = TestPipelineBuilder.Create();
         builder.ConfigureServices(services => services.AddLogging(logging => logging.AddProvider(loggerProvider)));
         builder.AddModule<AmbientArtifactLoggingProducerModule>();
         builder.AddModule<AmbientArtifactLoggingConsumerModule>();
@@ -1263,7 +1263,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsUnknownProducedArtifactName()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<MissingArtifactConsumerModule>();
 
@@ -1279,7 +1279,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsUnregisteredArtifactProducer()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<UnregisteredProducerConsumerModule>();
 
         var exception = await Assert.ThrowsAsync<PipelineValidationException>(() => builder.BuildAsync());
@@ -1293,7 +1293,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsDuplicateProducedArtifactName()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DuplicateArtifactProducerModule>();
         builder.AddModule<DuplicateArtifactConsumerModule>();
 
@@ -1308,7 +1308,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsConsumerWithoutProducerDependency()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<UnorderedArtifactConsumerModule>();
 
@@ -1323,7 +1323,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsOptionalProducerDependency()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<OptionalArtifactConsumerModule>();
 
@@ -1338,7 +1338,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncIgnoresInvalidContractOnExcludedConsumer()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             SkippedModules = [nameof(MissingArtifactConsumerModule)],
@@ -1354,7 +1354,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsInvalidContractOnAttributeSkippedConsumer()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<AttributeSkippedInvalidArtifactConsumerModule>();
 
@@ -1368,7 +1368,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsInvalidContractOnConfiguredSkippedConsumer()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<ConfiguredSkippedInvalidArtifactConsumerModule>();
 
@@ -1383,7 +1383,7 @@ public class ArtifactContractTests
     public async Task BuildAsyncRejectsInvalidContractOnDynamicallySkippedConsumer()
     {
         DynamicSkippedInvalidArtifactConsumerModule.ShouldSkip = true;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<DynamicSkippedInvalidArtifactConsumerModule>();
 
@@ -1398,7 +1398,7 @@ public class ArtifactContractTests
     public async Task BuildAsyncKeepsConsumerWhoseSkipDependsOnDependencyState()
     {
         ArtifactConsumerStateDependencyModule.IsReady = false;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<ArtifactConsumerStateDependencyModule>();
         builder.AddModule<DependencyStateInvalidArtifactConsumerModule>();
@@ -1414,7 +1414,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsInvalidContractOnDependencySkippedConsumer()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<SkippedArtifactValidationDependencyModule>();
         builder.AddModule<DependencySkippedInvalidArtifactConsumerModule>();
@@ -1429,7 +1429,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsInvalidContractWhenSkippedDependencyHasHistory()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddResultsRepository<ArtifactValidationHistoryRepository>();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<SkippedArtifactValidationDependencyModule>();
@@ -1446,7 +1446,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsInvalidContractWhenSelectedDependencyHasHistory()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             SkippedModules = [nameof(SkippedArtifactValidationDependencyModule)],
@@ -1466,7 +1466,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncRejectsInvalidContractWhenConsumedSkippedProducerHasHistory()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddResultsRepository<ArtifactHistoryRepository>();
         builder.AddModule<SkippedArtifactProducerModule>();
         builder.AddModule<InvalidSkippedArtifactConsumerModule>();
@@ -1482,7 +1482,7 @@ public class ArtifactContractTests
     [Test]
     public async Task BuildAsyncPreservesValidationAcrossArtifactDemandCycle()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddResultsRepository<ArtifactHistoryRepository>();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<SkippedArtifactProducerModule>();
@@ -1503,7 +1503,7 @@ public class ArtifactContractTests
     public async Task BuildAsyncDoesNotUseMutableSkipAsFallbackDemand()
     {
         MutableArtifactConsumerModule.ShouldSkip = false;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddResultsRepository<ArtifactHistoryRepository>();
         builder.AddModule<DeclaredProducerModule>();
         builder.AddModule<SkippedArtifactProducerModule>();
@@ -1522,7 +1522,7 @@ public class ArtifactContractTests
     [Test]
     public async Task ValidateAsyncAcceptsMatchingArtifactContract()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LocalProducerModule>();
         builder.AddModule<LocalConsumerModule>();
 
@@ -1542,7 +1542,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<LocalProducerModule>();
             builder.AddModule<LocalConsumerModule>();
 
@@ -1594,7 +1594,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<LocalProducerModule>();
             builder.AddModule<ProducerStateConsumerModule>();
 
@@ -1631,7 +1631,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<LocalProducerModule>();
             builder.AddModule<ProducerStateIntermediateModule>();
             builder.AddModule<TransitiveProducerStateConsumerModule>();
@@ -1666,7 +1666,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<LocalProducerModule>();
             builder.AddModule<DependencyStateSourceModule>();
             builder.AddModule<SharedDependencySiblingModule>();
@@ -1701,7 +1701,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<AfterHookArtifactProducerModule>();
             builder.AddModule<AfterHookArtifactConsumerModule>();
 
@@ -1725,7 +1725,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModuleEventReceiver<EndHookArtifactReceiver>();
             builder.AddModule<AfterHookArtifactProducerModule>();
             builder.AddModule<AfterHookArtifactConsumerModule>();
@@ -1784,7 +1784,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<MultipleDirectoryProducerModule>();
             builder.AddModule<MultipleDirectoryConsumerModule>();
 
@@ -1812,7 +1812,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<CacheOnlyProducerModule>();
             await using var pipeline = await builder.BuildAsync();
 
@@ -1833,7 +1833,7 @@ public class ArtifactContractTests
     [Test]
     public async Task StandaloneExecutionUsesFilesystemBackedArtifactStore()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<CacheOnlyProducerModule>();
         await using var pipeline = await builder.BuildAsync();
 
@@ -1849,7 +1849,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(LocalConsumerModule)],
@@ -1881,7 +1881,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<MissingRuntimeProducerModule>();
             builder.AddModule<MissingRuntimeConsumerModule>();
 
@@ -1913,7 +1913,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<MissingRuntimeProducerModule>();
             builder.AddModule<MissingRuntimeIntermediateModule>();
             builder.AddModule<TransitiveMissingRuntimeConsumerModule>();
@@ -1953,7 +1953,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<MissingRuntimeProducerModule>();
             builder.AddModule<IgnoredMissingRuntimeConsumerModule>();
 
@@ -1981,7 +1981,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.Services.AddSingleton<IDistributedArtifactStore, FailingUploadArtifactStore>();
             builder.AddResultsRepository<RecordingResultRepository>();
             builder.AddModuleEventReceiver<AwaitingEndHookReceiver>();
@@ -2026,7 +2026,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<SkippedArtifactConsumerModule>();
 
@@ -2048,7 +2048,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<SkippedArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
@@ -2081,7 +2081,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(SkippedArtifactConsumerModule)],
@@ -2112,7 +2112,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<ConfiguredSkippedHistoricalArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
@@ -2151,7 +2151,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(SkippedArtifactProducerModule)],
@@ -2190,7 +2190,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactBlockerModule>();
             builder.AddModule<DependencyOrderedSkippedArtifactProducerModule>();
             builder.AddModule<DependencySkippedArtifactConsumerModule>();
@@ -2225,7 +2225,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<SkippedArtifactBlockerModule>();
             builder.AddModule<IndependentDependencySkippedArtifactConsumerModule>();
@@ -2261,7 +2261,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(SkippedArtifactProducerModule)],
@@ -2309,7 +2309,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(SkippedArtifactProducerModule)],
@@ -2354,7 +2354,7 @@ public class ArtifactContractTests
         {
             Directory.CreateDirectory(Path.GetDirectoryName(ProducedFile)!);
             await File.WriteAllTextAsync(ProducedFile, "cached artifact content");
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.Services.AddSingleton<IModuleCacheResultRepository, LocalProducerCacheRepository>();
             builder.Services.AddSingleton<IDistributedArtifactStore, FailingUploadArtifactStore>();
             builder.AddModule<LocalProducerModule>();
@@ -2395,7 +2395,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<HistoryBackedSkippedDependencyModule>();
             builder.AddModule<HistoryBackedDependencyArtifactConsumerModule>();
@@ -2434,7 +2434,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(SkippedArtifactProducerModule)],
@@ -2478,7 +2478,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules =
@@ -2525,7 +2525,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules =
@@ -2581,7 +2581,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<DependencyOrderedSkippedArtifactProducerModule>();
             builder.AddModule<OscillatingFirstArtifactConsumerModule>();
@@ -2630,7 +2630,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules =
@@ -2673,7 +2673,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules =
@@ -2718,7 +2718,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<SkippedArtifactProducerModule>();
             builder.AddModule<AttributeSkippedHistoricalArtifactConsumerModule>();
             builder.AddResultsRepository<ArtifactHistoryRepository>();
@@ -2752,7 +2752,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules =
@@ -2792,7 +2792,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 SkippedModules = [nameof(SkippedArtifactConsumerModule)],
@@ -2831,7 +2831,7 @@ public class ArtifactContractTests
         {
             Directory.CreateDirectory(Path.GetDirectoryName(FailedRuntimeFile)!);
             await File.WriteAllTextAsync(FailedRuntimeFile, "stale artifact");
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<IgnoredFailureArtifactProducerModule>();
             builder.AddModule<IgnoredFailureArtifactConsumerModule>();
 
@@ -2859,7 +2859,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<MissingRuntimeProducerModule>();
             builder.AddModule<ConfiguredSkippedArtifactConsumerModule>();
 
@@ -2883,7 +2883,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<PendingSkipArtifactProducerModule>();
             builder.AddModule<PendingSkipDependencyModule>();
             builder.AddModule<PendingSkippedArtifactConsumerModule>();
@@ -2924,7 +2924,7 @@ public class ArtifactContractTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.Services.Configure<ModuleCacheOptions>(options =>
                 options.WorkingDirectory = workingDirectory.FullName);
             builder.AddModule<WorkingDirectoryProducerModule>();
@@ -2971,7 +2971,7 @@ public class ArtifactContractTests
         string workingDirectory,
         string cacheDirectory)
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModuleCache<FileSystemModuleCache>(options =>
         {
             options.WorkingDirectory = workingDirectory;

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -1188,7 +1188,7 @@ public class ModuleCacheTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModuleCache<FileSystemModuleCache>(options =>
             {
                 options.WorkingDirectory = temporaryDirectory;

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -664,7 +664,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task ModuleOptionRunsTargetAndDependencyClosure()
     {
-        using var builder = CreateExecutionBuilder(["--module", nameof(TargetModule)]);
+        var builder = CreateExecutionBuilder(["--module", nameof(TargetModule)]);
 
         await builder.RunAsync();
 
@@ -679,7 +679,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task ProgrammaticTargetModulesRunsDependencyClosure()
     {
-        using var builder = CreateExecutionBuilder();
+        var builder = CreateExecutionBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             TargetModules = [nameof(TargetModule)],
@@ -698,7 +698,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task SkipModuleOptionExcludesNamedModule()
     {
-        using var builder = CreateExecutionBuilder(["--skip-module", nameof(UnrelatedModule)]);
+        var builder = CreateExecutionBuilder(["--skip-module", nameof(UnrelatedModule)]);
 
         await builder.RunAsync();
 
@@ -713,7 +713,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task CategoriesOptionBindsExistingPipelineOption()
     {
-        using var builder = Pipeline.CreateBuilder(["--categories", "selected"]);
+        var builder = Pipeline.CreateBuilder(["--categories", "selected"]);
         builder.AddModule<SelectedCategoryModule>();
         builder.AddModule<UnrelatedModule>();
 
@@ -730,7 +730,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task NoCacheOptionBindsPipelineOption()
     {
-        using var builder = Pipeline.CreateBuilder(["--no-cache"]);
+        var builder = Pipeline.CreateBuilder(["--no-cache"]);
 
         await Assert.That(builder.Options.DisableModuleCache).IsTrue();
         await Assert.That(builder.Configuration["no-cache"]).IsNull();
@@ -739,7 +739,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task UnknownArgumentsStillFlowToHostConfiguration()
     {
-        using var builder = Pipeline.CreateBuilder(
+        var builder = Pipeline.CreateBuilder(
         [
             "--module", nameof(TargetModule),
             "--custom-setting", "custom-value",
@@ -752,7 +752,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task ShortHostOptionIsNotMistakenForPipelineTypo()
     {
-        using var builder = Pipeline.CreateBuilder(["--mode", "safe"]);
+        var builder = Pipeline.CreateBuilder(["--mode", "safe"]);
 
         await Assert.That(builder.Configuration["mode"]).IsEqualTo("safe");
     }
@@ -760,7 +760,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task SeparatorForwardsLikelyTypoToHostConfiguration()
     {
-        using var builder = Pipeline.CreateBuilder(["--", "--skip-modules", "Deploy"]);
+        var builder = Pipeline.CreateBuilder(["--", "--skip-modules", "Deploy"]);
 
         await Assert.That(builder.Options.SkippedModules).IsNull();
         await Assert.That(builder.Configuration["skip-modules"]).IsEqualTo("Deploy");
@@ -818,7 +818,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task RepeatedCommaSeparatedAndEqualsValuesAreParsed()
     {
-        using var builder = Pipeline.CreateBuilder(
+        var builder = Pipeline.CreateBuilder(
         [
             "--module", "FirstModule,SecondModule",
             "--module=ThirdModule",
@@ -843,7 +843,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task AssemblyQualifiedModuleNameIsPreserved()
     {
-        using var builder = CreateExecutionBuilder(
+        var builder = CreateExecutionBuilder(
             ["--module", typeof(TargetModule).AssemblyQualifiedName!]);
 
         await builder.RunAsync();
@@ -859,7 +859,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task SelectionValidationDoesNotEvaluateRunConditions()
     {
-        using var builder = Pipeline.CreateBuilder(["--module", nameof(ConditionalModule)]);
+        var builder = Pipeline.CreateBuilder(["--module", nameof(ConditionalModule)]);
         builder.AddModule<ConditionalModule>();
 
         var result = await builder.ValidateAsync();
@@ -874,7 +874,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task CommandLineParsingCanBeDisabled()
     {
-        using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+        var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
         {
             Args = ["--module", "forwarded-value"],
             EnableCommandLineOptions = false,
@@ -887,7 +887,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task UnknownTargetProducesValidationError()
     {
-        using var builder = CreateExecutionBuilder(["--module", "MissingModule"]);
+        var builder = CreateExecutionBuilder(["--module", "MissingModule"]);
 
         var exception = await Assert.ThrowsAsync<PipelineValidationException>(
             () => builder.RunAsync());
@@ -903,7 +903,7 @@ public class PipelineCommandLineTests
     [Arguments("--validate")]
     public async Task InformationalCommandsDoNotExecuteModules(string command)
     {
-        using var builder = CreateExecutionBuilder([command]);
+        var builder = CreateExecutionBuilder([command]);
 
         var summary = await builder.RunAsync();
 
@@ -923,7 +923,7 @@ public class PipelineCommandLineTests
         try
         {
             var path = Path.Combine(directory.FullName, "pipeline.json");
-            using var builder = CreateExecutionBuilder(["--graph", "json", path]);
+            var builder = CreateExecutionBuilder(["--graph", "json", path]);
 
             var summary = await builder.RunAsync();
             var graph = await File.ReadAllTextAsync(path);
@@ -951,7 +951,7 @@ public class PipelineCommandLineTests
         try
         {
             var path = Path.Combine(directory.FullName, "pipeline.json");
-            using var builder = Pipeline.CreateBuilder(["--graph", "json", path]);
+            var builder = Pipeline.CreateBuilder(["--graph", "json", path]);
             builder.AddModule<DependencyModule>();
             builder.AddModule<RuntimeOnlyDependencyModule>();
 
@@ -976,7 +976,7 @@ public class PipelineCommandLineTests
     public async Task HelpOptionsPrintUsage(string option)
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = CreateExecutionBuilder([option]);
+        var builder = CreateExecutionBuilder([option]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
 
         await builder.RunAsync();
@@ -994,7 +994,7 @@ public class PipelineCommandLineTests
     public async Task HelpDoesNotRequireAValidPipeline()
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = Pipeline.CreateBuilder(["--help"]);
+        var builder = Pipeline.CreateBuilder(["--help"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
 
         var summary = await builder.RunAsync();
@@ -1011,7 +1011,7 @@ public class PipelineCommandLineTests
     public async Task HelpDoesNotActivateModules()
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = Pipeline.CreateBuilder(["--help"]);
+        var builder = Pipeline.CreateBuilder(["--help"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ThrowingConstructorModule>();
 
@@ -1029,7 +1029,7 @@ public class PipelineCommandLineTests
     public async Task HelpDoesNotReadModuleConfiguration()
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = Pipeline.CreateBuilder(["--help"]);
+        var builder = Pipeline.CreateBuilder(["--help"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ThrowingConfigurationModule>();
 
@@ -1046,7 +1046,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncBuildsDependencyOrderedWavesWithoutExecutingModules()
     {
-        using var builder = CreateExecutionBuilder();
+        var builder = CreateExecutionBuilder();
         builder.AddModuleEstimatedTimeProvider<PlanEstimatedTimeProvider>();
         await using var pipeline = await builder.BuildAsync();
 
@@ -1071,7 +1071,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncSerializesModulesSharingNotInParallelKeyInEstimate()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<FirstLockedModule>();
         builder.AddModule<SecondLockedModule>();
         builder.AddModuleEstimatedTimeProvider<PlanEstimatedTimeProvider>();
@@ -1085,7 +1085,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncSimulatesMaxParallelismSlotsInEstimate()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with { MaxParallelism = 2 },
@@ -1105,7 +1105,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncSchedulesReadyModulesByPriorityInEstimate()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with { MaxParallelism = 2 },
@@ -1124,7 +1124,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncAppliesExecutionTypeLimitsInEstimate()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with
@@ -1149,7 +1149,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncAppliesCustomParallelLimitersInEstimate()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<FirstLimitedModule>();
         builder.AddModule<SecondLimitedModule>();
         builder.AddModuleEstimatedTimeProvider<PlanEstimatedTimeProvider>();
@@ -1163,7 +1163,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncCountsParallelLimiterWaitersAgainstWorkerSlots()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with { MaxParallelism = 2 },
@@ -1183,7 +1183,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncModelsLimiterAcquisitionBeforeExecutionTypeWait()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with
@@ -1206,7 +1206,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncReprioritizesModulesWhenConstraintReleases()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with { MaxParallelism = 2 },
@@ -1226,7 +1226,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncPreservesReadyChannelQueueOrder()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Concurrency = options.Concurrency with { MaxParallelism = 2 },
@@ -1247,7 +1247,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncDefersOptionalRegistrationChecks()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<RegistrationOnlyOptionalSkipModule>();
         await using var pipeline = await builder.BuildAsync();
 
@@ -1357,7 +1357,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncMarksAwaitedOptionalResultUnknown()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<OptionalResultDependentSkipModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -1373,7 +1373,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncKeepsExcludedDependencyCyclesVisible()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             RunOnlyCategories = ["selected"],
@@ -1400,7 +1400,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncUsesRunnableSubsetWhenExcludedModuleHasInvalidDependency()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             RunOnlyCategories = ["selected"],
@@ -1420,7 +1420,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncDoesNotCascadeSkipWhenDependencyHistoryExists()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SkippedDependencyModule>();
         builder.AddModule<DependentOnSkippedModule>();
         builder.AddResultsRepository<PlanHistoryRepository>();
@@ -1441,7 +1441,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncRevalidatesHistoryAwareRunnableGraph()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             RunOnlyCategories = ["selected"],
@@ -1458,7 +1458,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncIncludesRegistrationTimeDependenciesInWaves()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<RegistrationDependentModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -1476,7 +1476,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncMarksResultDependentFluentSkipDecisionUnknown()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<ResultDependentSkipModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -1498,7 +1498,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncContinuesOrConditionsAfterUnknownDecision()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<UnknownThenSkippedModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -1519,7 +1519,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncContinuesAndConditionsAfterUnknownDecision()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<UnknownAndDoNotSkipModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -1539,7 +1539,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncPropagatesUnknownDecisionsToRequiredDependents()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<ResultDependentSkipModule>();
         builder.AddModule<DependentOnUnknownModule>();
@@ -1556,7 +1556,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncPrefersCascadeSkipOverUnknownDecision()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SkippedDependencyModule>();
         builder.AddModule<ResultDependentOnSkippedModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -1578,7 +1578,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncEvaluatesAllSkipSourcesAndCascadesDependencies()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             RunOnlyCategories = ["selected"],
@@ -1612,7 +1612,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task PlanAsyncDoesNotValidateLimiterForExcludedModule()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             SkippedModules = [nameof(ExcludedInvalidLimitModule)],
@@ -1634,7 +1634,7 @@ public class PipelineCommandLineTests
     public async Task DryRunOptionPrintsPlanAndDoesNotExecuteModules()
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = CreateExecutionBuilder(["--dry-run"]);
+        var builder = CreateExecutionBuilder(["--dry-run"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
 
         var summary = await builder.RunAsync();
@@ -1659,7 +1659,7 @@ public class PipelineCommandLineTests
     public async Task DryRunMarksCacheCandidatesAndQualifiesEstimate()
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = Pipeline.CreateBuilder(["--dry-run"]);
+        var builder = Pipeline.CreateBuilder(["--dry-run"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModuleCache<FileSystemModuleCache>();
         builder.AddModule<CacheCandidateModule>();
@@ -1682,7 +1682,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task DryRunDoesNotMarkCacheCandidatesWhenCacheIsDisabled()
     {
-        using var builder = Pipeline.CreateBuilder(["--dry-run", "--no-cache"]);
+        var builder = Pipeline.CreateBuilder(["--dry-run", "--no-cache"]);
         builder.AddModuleCache<FileSystemModuleCache>();
         builder.AddModule<CacheCandidateModule>();
 
@@ -1696,7 +1696,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task ProgrammaticDryRunOptionDoesNotExecuteModules()
     {
-        using var builder = CreateExecutionBuilder();
+        var builder = CreateExecutionBuilder();
         builder.ConfigurePipelineOptions(options => options with { DryRun = true });
 
         var summary = await builder.RunAsync();
@@ -1713,7 +1713,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task ValidateCommandChecksRegistrationTimeDependencies()
     {
-        using var builder = Pipeline.CreateBuilder(["--validate"]);
+        var builder = Pipeline.CreateBuilder(["--validate"]);
         builder.AddModule<InvalidDynamicDependencyModule>();
 
         await Assert.ThrowsAsync<ModuleNotRegisteredException>(
@@ -1724,7 +1724,7 @@ public class PipelineCommandLineTests
     public async Task ListModulesUsesFinalizedFluentCategory()
     {
         var consoleWriter = new CapturingConsoleWriter();
-        using var builder = Pipeline.CreateBuilder(["--list-modules"]);
+        var builder = Pipeline.CreateBuilder(["--list-modules"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ConfiguredCategoryModule>();
 
@@ -1742,7 +1742,7 @@ public class PipelineCommandLineTests
     [Test]
     public async Task ValidateCommandReturnsSuccessfulSummary()
     {
-        using var builder = CreateExecutionBuilder(["--validate"]);
+        var builder = CreateExecutionBuilder(["--validate"]);
 
         var summary = await builder.RunAsync();
 

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -51,7 +51,7 @@ public class ConsoleWriterTests
     private static async Task<string> RunAsync<TModule>()
         where TModule : class, IModule
     {
-        using var builder = TestPipelineBuilder.Create();
+        var builder = TestPipelineBuilder.Create();
         builder.ConfigurePipelineOptions(options => options with
         {
             RunReport = options.RunReport with

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -2191,7 +2191,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Renderers_Describe_The_Same_Annotated_Graph()
     {
-        using var builder = CreateBuilder();
+        var builder = CreateBuilder();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
 
@@ -2229,7 +2229,7 @@ public class DependencyGraphExporterTests
         try
         {
             var path = Path.Combine(directory.FullName, "graph.json");
-            using var builder = CreateBuilder();
+            var builder = CreateBuilder();
 
             await builder.ExportDependencyGraphAsync(
                 DependencyGraphFormat.Json,
@@ -2253,7 +2253,7 @@ public class DependencyGraphExporterTests
         try
         {
             var path = Path.Combine(directory.FullName, "graph.json");
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<DependencyModule>();
             builder.AddModule<RuntimePredicateConsumerModule>();
             _customDependencyAttributeConstructions = 0;
@@ -2281,7 +2281,7 @@ public class DependencyGraphExporterTests
         {
             _singleUseConfigurationCalls = 0;
             var path = Path.Combine(directory.FullName, "graph.json");
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule(_ => new SingleUseConfigurationFactoryModule());
 
             await builder.ExportDependencyGraphAsync(DependencyGraphFormat.Json, path);
@@ -2302,7 +2302,7 @@ public class DependencyGraphExporterTests
         {
             _singleUseConfigurationCalls = 0;
             var path = Path.Combine(directory.FullName, "graph.json");
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule(new SingleUseConfigurationFactoryModule());
 
             await builder.ExportDependencyGraphAsync(DependencyGraphFormat.Json, path);
@@ -2318,7 +2318,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Does_Not_Expose_Runtime_Modules_To_Planning_Skip_Conditions()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<OptionalPlanningDependencyModule>();
         builder.AddModule<OptionalLookupPlanningSkipModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -2336,7 +2336,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Rejects_Planning_Predicates_That_Require_Target_Attribute_Values()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<StatefulPlanningTargetModule>();
         builder.AddModule<PlanningAttributeValueConsumerModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -2357,7 +2357,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Historical_Ignored_Dependency_Does_Not_Skip_Dependent()
     {
-        using var builder = CreateBuilder();
+        var builder = CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(new DependencyHistoryRepository());
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2399,7 +2399,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Historical_Artifact_Producer_Remains_Skipped_When_Artifact_Is_Demanded()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(
             new ModuleTypeHistoryRepository(typeof(HistoricalArtifactProducerModule)));
         builder.ConfigurePipelineOptions(options => options with
@@ -2432,7 +2432,7 @@ public class DependencyGraphExporterTests
     public async Task Artifact_Demand_Does_Not_Run_Async_Configured_Conditions()
     {
         _asyncSkipConditionEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(
             new ModuleTypeHistoryRepository(typeof(HistoricalArtifactProducerModule)));
         builder.ConfigurePipelineOptions(options => options with
@@ -2464,7 +2464,7 @@ public class DependencyGraphExporterTests
     public async Task Definitive_Fluent_Skip_Avoids_Artifact_Demand()
     {
         _asyncSkipConditionEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(
             new ModuleTypeHistoryRepository(typeof(HistoricalArtifactProducerModule)));
         builder.ConfigurePipelineOptions(options => options with
@@ -2496,7 +2496,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Complete_Runtime_Module_Results()
     {
         var repository = new ChangingHistoryRepository();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(repository);
         builder.ConfigurePipelineOptions(options => options with
         {
@@ -2524,7 +2524,7 @@ public class DependencyGraphExporterTests
     {
         var dependency = new HistoricalDependencyModule();
         var repository = new InstanceBoundHistoryRepository(dependency);
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(repository);
         builder.ConfigurePipelineOptions(options => options with
         {
@@ -2550,7 +2550,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Configured_Skip_With_History_Does_Not_Skip_Dependent()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(new DependencyHistoryRepository());
         builder.AddModule<ConfiguredSkippedModule>();
         builder.AddModule<DependentOnConfiguredSkippedModule>();
@@ -2577,7 +2577,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Run_Condition_With_History_Does_Not_Skip_Dependent()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(new DependencyHistoryRepository());
         builder.AddModule<ConditionSkippedModule>();
         builder.AddModule<DependentOnConditionSkippedModule>();
@@ -2604,7 +2604,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Cascaded_Dependency_With_History_Does_Not_Skip_Downstream_Module()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(
             new ModuleTypeHistoryRepository(typeof(DependentOnConditionSkippedModule)));
         builder.AddModule<ConditionSkippedModule>();
@@ -2635,7 +2635,7 @@ public class DependencyGraphExporterTests
     public async Task Cascaded_History_Lookup_Observes_Cancellation()
     {
         using var cancellationTokenSource = new CancellationTokenSource();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(
             new CancelingModuleTypeHistoryRepository(
                 typeof(DependentOnConditionSkippedModule),
@@ -2659,7 +2659,7 @@ public class DependencyGraphExporterTests
         var repository = new CancelingModuleTypeHistoryRepository(
             typeof(HistoricalDependencyModule),
             cancellationTokenSource);
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleResultRepository>(repository);
         builder.ConfigurePipelineOptions(options => options with
         {
@@ -2685,7 +2685,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Run_Conditions_And_Their_Cascade_Are_Annotated_As_Skipped()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ConditionSkippedModule>();
         builder.AddModule<DependentOnConditionSkippedModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -2714,7 +2714,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Configured_Skip_Conditions_And_Their_Cascade_Are_Annotated()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ConfiguredSkippedModule>();
         builder.AddModule<DependentOnConfiguredSkippedModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -2742,7 +2742,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Result_Dependent_Configured_Skips_Are_Annotated_As_Unresolved()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<ResultDependentConfiguredSkipModule>();
         builder.AddModule<DependentOnUnresolvedSkipModule>();
@@ -2769,7 +2769,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Async_Configured_Skip_Is_Unresolved_Without_Starting_Work()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<AsyncConfiguredSkipModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2792,7 +2792,7 @@ public class DependencyGraphExporterTests
         var directory = Directory.CreateTempSubdirectory("modular-pipelines-graph-");
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<ExecutionMutatingModule>();
             await using var pipeline = await builder.BuildAsync();
             _ = await pipeline.RunAsync();
@@ -2813,7 +2813,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Exporter_Rejects_Graph_Render_After_Execution()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ExecutionMutatingModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2828,7 +2828,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Async_Attribute_Condition_Is_Unresolved_Without_Starting_Work()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<AsyncAttributeConditionModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2848,7 +2848,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Deferred_Condition_Attribute_Is_Not_Constructed_During_Planning()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DeferredStatefulConditionModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2872,7 +2872,7 @@ public class DependencyGraphExporterTests
     public async Task Custom_Generic_Attribute_Requires_Planning_Opt_In()
     {
         _customPlanningAttributeEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<CustomGenericAttributeConditionModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2892,7 +2892,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Safe_Attribute_Skip_Remains_Definitive_With_Async_Attribute()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SafeSkipWithAsyncAttributeModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2911,7 +2911,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Safe_False_Any_Remains_Definitive_With_Deferred_Any()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SafeFalseAnyWithDeferredAnyModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2926,7 +2926,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Safe_False_Any_Group_Remains_Definitive_With_Deferred_Any()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SafeFalseAnyGroupWithDeferredAnyModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -2942,7 +2942,7 @@ public class DependencyGraphExporterTests
     public async Task Safe_False_Any_Group_Defers_When_Alternative_Is_Deferred()
     {
         _deferredGroupedConditionAttributeConstructions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SafeFalseAnyGroupWithDeferredAlternativeModule>();
         await using var pipeline = await builder.BuildAsync();
         var constructionsBeforeRender = _deferredGroupedConditionAttributeConstructions;
@@ -2963,7 +2963,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Synchronous_Skip_Short_Circuits_Before_Async_Condition()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SynchronouslySkippedBeforeAsyncModule>();
         builder.AddModule<DependentOnSynchronouslySkippedBeforeAsyncModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -2991,7 +2991,7 @@ public class DependencyGraphExporterTests
     public async Task Synchronous_Skip_Short_Circuits_After_Async_Condition()
     {
         _asyncSkipConditionEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SynchronouslySkippedAfterAsyncModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3012,7 +3012,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Rejects_Invalid_Registration_Dependency()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<InvalidDynamicDependencyModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3024,7 +3024,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Validates_Dependency_Before_Configured_Skip()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<InvalidSkippedDynamicDependencyModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3036,7 +3036,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Includes_Registered_Dynamic_Dependency()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<DynamicDependencyModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3062,7 +3062,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Preserves_Companion_Attributes_Without_Constructing_Them()
     {
         _planningCompanionAttributeConstructions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<CompanionAwareDynamicDependencyModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3083,7 +3083,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Checks_Attribute_Presence_Without_Constructing_It()
     {
         _planningPresenceAttributeConstructions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<PresenceDependencyModule>();
         builder.AddModule<AttributePresenceConsumerModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3105,7 +3105,7 @@ public class DependencyGraphExporterTests
     {
         _customDependencyAttributeConstructions = 0;
         _customDependencyPredicateEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<RuntimePredicateConsumerModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3134,7 +3134,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Defers_Custom_Inheritance_Selectors()
     {
         _customDependencySelectorConstructions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<RuntimeSelectorConsumerModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3150,7 +3150,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Uses_Explicitly_Planning_Safe_Inheritance_Selectors()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<PlanningSafeSelectorConsumerModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3165,7 +3165,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Cascades_Skipped_Dynamic_Dependency()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             SkippedModules = [nameof(DependencyModule)],
@@ -3191,7 +3191,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Does_Not_Cache_Conditions_Before_Startup_Hooks()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<StartupConditionModule>();
         builder.AddPipelineGlobalHooks<EnableStartupConditionHook>();
         await using var pipeline = await builder.BuildAsync();
@@ -3214,7 +3214,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Rejected_Render_Does_Not_Cache_Registration_Before_Startup_Hooks()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<StartupDynamicDependencyModule>();
         builder.AddPipelineGlobalHooks<EnableStartupDependencyHook>();
@@ -3243,7 +3243,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Rejected_Render_Does_Not_Freeze_Direct_Module_Configuration()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(new StartupConfiguredModule());
         builder.AddPipelineGlobalHooks<EnableStartupConfigurationHook>();
         await using var pipeline = await builder.BuildAsync();
@@ -3264,7 +3264,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Rejected_Render_Does_Not_Freeze_Factory_Module_Configuration()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new StartupConfiguredModule());
         builder.AddPipelineGlobalHooks<EnableStartupConfigurationHook>();
         await using var pipeline = await builder.BuildAsync();
@@ -3285,7 +3285,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Planning_Conditions_Use_The_Supplied_Metadata_Registry()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         await using var pipeline = await builder.BuildAsync();
         var conditionHandler = pipeline.Services.GetRequiredService<IModuleConditionHandler>();
@@ -3306,7 +3306,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Does_Not_Share_Mutable_Module_State_With_Runtime()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<MutableConfigurationStateModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3321,7 +3321,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Preserves_User_Factory_Initialization()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ =>
         {
@@ -3344,7 +3344,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Rejected_Render_Then_Run_Invokes_Registration_Receivers_Once()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<UnsafeRegistrationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3367,7 +3367,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Configures_Factory_Copy_After_Validation()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new MutableConfigurationStateModule());
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3393,7 +3393,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Does_Not_Replay_Configuration_Against_Injected_State()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<ConfigurationMutationCounter>();
         builder.AddModule<InjectedConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3418,7 +3418,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Configuration_Against_Global_State()
     {
         _globalConfigurationMutations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<GlobalConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3443,7 +3443,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Configuration_Through_Constructor_State()
     {
         _constructorConfigurationMutations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ConstructorConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3462,7 +3462,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Configuration_Through_Virtual_Override()
     {
         _globalConfigurationMutations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<VirtualConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3481,7 +3481,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Configuration_Through_Helper_Virtual_Override()
     {
         _globalConfigurationMutations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<HelperVirtualConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3500,7 +3500,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Configuration_Through_External_Constructor_State()
     {
         ExternalConfigurationMutationProbe.Reset();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ExternalConstructorConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3525,7 +3525,7 @@ public class DependencyGraphExporterTests
             Environment.SetEnvironmentVariable(
                 FrameworkConfigurationMutationModule.EnvironmentVariableName,
                 null);
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.AddModule<FrameworkConfigurationMutationModule>();
             await using var pipeline = await builder.BuildAsync();
             var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3558,7 +3558,7 @@ public class DependencyGraphExporterTests
         await Assert.That(touchesStaticState).IsTrue();
 
         using var pluginScope = PluginRegistry.BeginIsolatedScope();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<CoreApiConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3613,7 +3613,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Static_Runtime_Bound_Planning_Condition()
     {
         _staticPlanningSkipEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<StaticRuntimeBoundPlanningConditionModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3632,7 +3632,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Planning_Callback_Constructor_Mutation()
     {
         _planningCallbackConstructorMutations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ConstructorBoundPlanningConditionModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3650,7 +3650,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Rejects_Shared_Module_Owned_Holder_Without_Replaying_Constructor()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<ConfigurationMutationCounter>();
         builder.AddModule<NestedInjectedConfigurationMutationModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3671,7 +3671,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Rejects_Shared_Runtime_Bound_Planning_Condition()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<ConfigurationMutationCounter>();
         builder.AddModule<InjectedRuntimeBoundPlanningConditionModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3686,7 +3686,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Preserves_Configured_Fallback_Copy()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new ConfiguredFallbackFactoryModule("factory-only"));
         await using var pipeline = await builder.BuildAsync();
@@ -3708,7 +3708,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Compares_User_Struct_Fields()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new StructEqualityFactoryModule(includeDependency: true));
         await using var pipeline = await builder.BuildAsync();
@@ -3723,7 +3723,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Matches_User_Factory_To_Derived_Runtime_Type()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<FactoryInitializedBaseModule>(
             _ => new FactoryInitializedDerivedModule { IncludeDependency = true });
@@ -3740,7 +3740,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Factory_With_Different_Initialization()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new FactoryInitializedModule
         {
@@ -3763,7 +3763,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Factory_Replay_With_Shared_Mutable_State()
     {
         var sharedState = new List<string>();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new SharedMutableFactoryStateModule(sharedState));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3781,7 +3781,7 @@ public class DependencyGraphExporterTests
     {
         var sharedState = new List<string>();
         var state = new StructWrappedState(sharedState);
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new StructWrappedFactoryStateModule(state));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3797,7 +3797,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Selects_Planning_Copy_Override_By_Signature()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new OverloadedPlanningCopyModule());
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3810,7 +3810,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Accepts_Independent_Fieldless_State()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new FieldlessStateFactoryModule());
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -3823,7 +3823,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Preserves_Reference_Identity_Dependent_Configuration()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new ReferenceIdentityFactoryModule(DependencySentinel));
         await using var pipeline = await builder.BuildAsync();
@@ -3839,7 +3839,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Preserves_Initialized_External_Configuration()
     {
         _externalConfigurationIncludesDependency = true;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new ExternalConfigurationFactoryModule());
         await using var pipeline = await builder.BuildAsync();
@@ -3856,7 +3856,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Preserves_Configuration_That_Calls_External_Helper()
     {
         ExternalConfigurationState.IncludeDependency = true;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<ExternalHelperConfigurationModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -3873,7 +3873,7 @@ public class DependencyGraphExporterTests
     public async Task Registration_Rejects_Direct_Interface_Module_Without_Activation()
     {
         _directModuleActivations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
 
         var exception = Assert.Throws<InvalidOperationException>(
             () => builder.AddModule<DirectInterfaceModule>());
@@ -3889,7 +3889,7 @@ public class DependencyGraphExporterTests
     public async Task Registration_Validates_Direct_Module_Before_Configuration()
     {
         var runtimeModule = new StatefulDirectInterfaceModule();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         StatefulDirectInterfaceModule.InitialConfigurationCallCount = runtimeModule.ConfigurationCallCount;
 
         try
@@ -3915,7 +3915,7 @@ public class DependencyGraphExporterTests
     {
         var state = new DirectModulePlanningState();
         var runtimeModule = new ServiceBackedDirectInterfaceModule(state);
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton(state);
         var configurationReadsBeforeExport = state.ConfigurationReads;
 
@@ -3933,7 +3933,7 @@ public class DependencyGraphExporterTests
     public async Task Registration_Rejects_Direct_Interface_Singleton_Factory_Without_Activation()
     {
         _directModuleActivations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<DirectInterfaceModule>();
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -3950,7 +3950,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Accepts_Service_Provider_Owned_Factory_State()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton(new PlanningSingletonDependency
         {
             IncludeDependency = true,
@@ -3971,7 +3971,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Different_Inherited_Factory_State()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new InheritedSettingsFactoryModule(new DerivedFactorySettings
         {
@@ -3990,7 +3990,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Different_Factory_Alias_Topology()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ =>
         {
@@ -4013,7 +4013,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Different_Factory_Array_Shape()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new ArrayShapeFactoryModule(
             Interlocked.Increment(ref factoryCalls) == 1
@@ -4031,7 +4031,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Requires_Copy_For_Mutable_Factory_Collection()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new ComparerBackedFactoryModule(
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)));
@@ -4047,7 +4047,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Clones_Precreated_Module_With_NonResolvable_Constructor_State()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(new PrecreatedConfiguredModule(new PrecreatedModuleSettings
         {
@@ -4066,7 +4066,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Shared_Precreated_State_Without_Disposing_It()
     {
         var state = new PrecreatedDisposableState();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(new PrecreatedDisposableModule(state));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4096,7 +4096,7 @@ public class DependencyGraphExporterTests
             comparisons++;
             return StringComparer.Ordinal.Compare(left, right);
         });
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new CapturingComparerFactoryModule(comparer));
         await using var pipeline = await builder.BuildAsync();
@@ -4117,7 +4117,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Uses_Planning_Copy_After_Factory_Replay_Mismatch()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule(_ => new FactoryInitializedPlanningCopyModule
         {
@@ -4136,7 +4136,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Uses_Runtime_Factory_Type_Without_Replay()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<FactoryInitializedBaseModule>(_ =>
             Interlocked.Increment(ref factoryCalls) == 1
                 ? new FactoryInitializedDerivedModule()
@@ -4157,7 +4157,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Preserves_Factory_Skip_Decision_Without_Replay()
     {
         var factoryCalls = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new FactorySkipModule(
             Interlocked.Increment(ref factoryCalls) == 1));
         await using var pipeline = await builder.BuildAsync();
@@ -4179,7 +4179,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Mutable_Factory_Closure_Without_Evaluating_It()
     {
         _executions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new MutableClosureFactorySkipModule("factory-only"));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4199,7 +4199,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Rejects_ByRef_Mutable_Factory_Closure_Without_Evaluating_It()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new ByRefMutableClosureFactorySkipModule("factory-only"));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4214,7 +4214,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Mutable_Reference_Closure_Without_Evaluating_It()
     {
         _executions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new MutableReferenceClosureFactorySkipModule("factory-only"));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4235,7 +4235,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Mutable_Struct_Closure_Without_Evaluating_It()
     {
         _executions = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new MutableStructClosureFactorySkipModule("factory-only"));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4256,7 +4256,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Runtime_Bound_Factory_Skip_Condition()
     {
         RuntimeBoundFactorySkipModule? runtimeModule = null;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => runtimeModule = new RuntimeBoundFactorySkipModule(shouldSkip: true));
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4275,7 +4275,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Runtime_Bound_Method_Group_Skip_Condition()
     {
         RuntimeBoundMethodGroupFactorySkipModule? runtimeModule = null;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ =>
             runtimeModule = new RuntimeBoundMethodGroupFactorySkipModule(shouldSkip: true));
         await using var pipeline = await builder.BuildAsync();
@@ -4295,7 +4295,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Rejects_Runtime_Bound_Collection_Skip_Condition()
     {
         RuntimeBoundCollectionFactorySkipModule? runtimeModule = null;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ =>
             runtimeModule = new RuntimeBoundCollectionFactorySkipModule(shouldSkip: true));
         await using var pipeline = await builder.BuildAsync();
@@ -4315,7 +4315,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Validate_Unused_Async_Factory_Skip_Condition()
     {
         RuntimeBoundAsyncFactorySkipModule? runtimeModule = null;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ =>
             runtimeModule = new RuntimeBoundAsyncFactorySkipModule(shouldSkip: true));
         await using var pipeline = await builder.BuildAsync();
@@ -4337,7 +4337,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Disposes_Copy_When_Configuration_Initialization_Fails()
     {
         ConfigurationThrowingDisposableFactoryModule.Disposals = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule(_ => new ConfigurationThrowingDisposableFactoryModule
         {
             HasFactoryState = true,
@@ -4359,7 +4359,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Disposes_Scoped_Planning_Module_After_Each_Render()
     {
         _planningDisposals = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddTransient<ContainerOwnedPlanningModule>();
         builder.AddModule(serviceProvider =>
             serviceProvider.GetRequiredService<ContainerOwnedPlanningModule>());
@@ -4381,7 +4381,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Disposes_Indirectly_Resolved_Scoped_Planning_Module()
     {
         _planningDisposals = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddTransient<ContainerOwnedPlanningModule>();
         builder.Services.AddTransient<ContainerOwnedPlanningModuleFactory>();
         builder.AddModule(serviceProvider => serviceProvider
@@ -4403,7 +4403,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Disposes_Isolated_Copy_When_Factory_Uses_Root_Service()
     {
         _planningDisposals = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddTransient<ContainerOwnedPlanningModule>();
         builder.Services.AddSingleton<ContainerOwnedPlanningModuleFactory>();
         builder.AddModule(serviceProvider => serviceProvider
@@ -4424,7 +4424,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Accepts_Indirectly_Resolved_Container_State()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<ContainerOwnedPlanningState>();
         builder.Services.AddTransient<ContainerOwnedPlanningStateFactory>();
         builder.AddModule(serviceProvider => new ModuleWithContainerOwnedPlanningState(
@@ -4443,7 +4443,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Disposes_Scoped_Planning_Copy()
     {
         _planningDisposals = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddKeyedTransient<ContainerOwnedPlanningCopyModule>("planning");
         builder.AddModule(new ContainerOwnedPlanningCopyModule());
 
@@ -4461,7 +4461,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Disposes_Manually_Constructed_Registered_Planning_Module()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddTransient<ContainerOwnedPlanningModule>();
         builder.Services.AddSingleton<PlanningFactoryDependency>();
         builder.AddModule(serviceProvider =>
@@ -4481,7 +4481,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Uses_Isolated_Copy_When_Factory_Returns_Runtime_Singleton()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<SingletonFactoryModule>();
         builder.AddModule(serviceProvider =>
             serviceProvider.GetRequiredService<SingletonFactoryModule>());
@@ -4497,7 +4497,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Disposes_Isolated_Planning_Modules()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DisposablePlanningModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4529,7 +4529,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Aggregates_Planner_And_Scope_Cleanup_Failures()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddScoped<ThrowingPlanningScopeService>();
         builder.AddModule<DualCleanupFailureModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -4553,7 +4553,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Preserves_Discovery_And_Cleanup_Failures()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ThrowingDisposablePlanningModule>();
         builder.AddModule<CancelPlanningModule>();
         var pipeline = await builder.BuildAsync();
@@ -4582,7 +4582,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Preserves_Post_Discovery_And_Cleanup_Failures()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<ThrowingDisposablePlanningModule>();
         builder.AddModule<InvalidDynamicDependencyModule>();
         var pipeline = await builder.BuildAsync();
@@ -4607,7 +4607,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Canceled_Render_Does_Not_Activate_Or_Register_Planning_Modules()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DisposablePlanningModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4634,7 +4634,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Observes_Cancellation_After_Loading_Estimates()
     {
         using var cancellationTokenSource = new CancellationTokenSource();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton<IModuleEstimatedTimeProvider>(
             new CancelingEstimatedTimeProvider(cancellationTokenSource));
         builder.AddModule<DependencyModule>();
@@ -4650,7 +4650,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Completed_Summary_Render_Observes_An_Already_Canceled_Token()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         await using var pipeline = await builder.BuildAsync();
         var summary = await pipeline.RunAsync();
@@ -4670,7 +4670,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Default_Module_Constructor()
     {
         var state = new ConstructorMutationState();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton(state);
         builder.AddModule<ConstructorMutatingModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -4691,7 +4691,7 @@ public class DependencyGraphExporterTests
     public async Task Render_Does_Not_Replay_Factory_Module_Constructor()
     {
         var state = new ConstructorMutationState();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.Services.AddSingleton(state);
         builder.AddModule(serviceProvider => new ConstructorMutatingModule(
             serviceProvider.GetRequiredService<ConstructorMutationState>()));
@@ -4715,7 +4715,7 @@ public class DependencyGraphExporterTests
         const string typeName = "Duplicate.SummaryModule";
         var firstType = CreateDynamicSummaryModuleType("SummaryAssemblyOne", typeName);
         var secondType = CreateDynamicSummaryModuleType("SummaryAssemblyTwo", typeName);
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModules(firstType, secondType);
         await using var pipeline = await builder.BuildAsync();
         var summary = await pipeline.RunAsync();
@@ -4734,7 +4734,7 @@ public class DependencyGraphExporterTests
         const string typeName = "Duplicate.DeserializedSummaryModule";
         var firstType = CreateDynamicSummaryModuleType("DeserializedSummaryAssemblyOne", typeName);
         var secondType = CreateDynamicSummaryModuleType("DeserializedSummaryAssemblyTwo", typeName);
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModules(firstType, secondType);
         await using var pipeline = await builder.BuildAsync();
         _ = await pipeline.RunAsync();
@@ -4772,7 +4772,7 @@ public class DependencyGraphExporterTests
     public async Task RenderSummary_Reuses_Initialized_Dependency_Models()
     {
         _customDependencyPredicateEvaluations = 0;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         builder.AddModule<RuntimePredicateConsumerModule>();
         await using var pipeline = await builder.BuildAsync();
@@ -4793,7 +4793,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task RenderSummary_Matches_Deserialized_Result_By_Type_Name()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         await using var pipeline = await builder.BuildAsync();
         var module = pipeline.Services.GetServices<IModule>()
@@ -4832,7 +4832,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Uses_Fresh_Stateful_Condition_Attributes()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<SingleUseConditionModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4846,7 +4846,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Render_Can_Retry_After_Canceled_Module_Discovery()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<DependencyModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4866,7 +4866,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Dot_Escapes_Line_Breaks_Inside_Label_Values()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LineBreakCategoryModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
@@ -4879,7 +4879,7 @@ public class DependencyGraphExporterTests
     [Test]
     public async Task Mermaid_Escapes_Markdown_Fence_Content()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<MarkdownFenceCategoryModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();

--- a/test/ModularPipelines.UnitTests/Engine/PipelineLifecycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineLifecycleTests.cs
@@ -169,7 +169,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Pipeline_Disposal_Is_Idempotent()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         var pipeline = await builder.BuildAsync();
 
@@ -180,7 +180,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Reentrant_Disposal_Does_Not_Await_Itself()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<ReentrantDisposalTracker>();
         var pipeline = await builder.BuildAsync();
@@ -195,7 +195,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Cross_Thread_Reentrant_Disposal_Does_Not_Deadlock()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<CrossThreadReentrantDisposalTracker>();
         var pipeline = await builder.BuildAsync();
@@ -210,7 +210,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Non_Flowing_Cross_Thread_Reentrant_Disposal_Does_Not_Deadlock()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<NonFlowingCrossThreadReentrantDisposalTracker>();
         var pipeline = await builder.BuildAsync();
@@ -226,7 +226,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Concurrent_Disposal_Awaits_The_Shared_Task()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<BlockingDisposalTracker>();
         var pipeline = await builder.BuildAsync();
@@ -246,7 +246,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Captured_Disposal_Context_Observes_Completed_Failure()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<CapturedContextThrowingDisposalTracker>();
         var pipeline = await builder.BuildAsync();
@@ -265,7 +265,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Disposal_Aggregates_Scope_And_Host_Failures()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddScoped<ThrowingScopedDisposalTracker>();
         builder.Services.AddSingleton<ThrowingRootDisposalTracker>();
@@ -290,7 +290,7 @@ public class PipelineLifecycleTests
     public async Task Canceled_Disposal_Produces_A_Canceled_Task()
     {
         using var cancellationTokenSource = new CancellationTokenSource();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<CancelingDisposalTracker>();
         var pipeline = await builder.BuildAsync();
@@ -308,7 +308,7 @@ public class PipelineLifecycleTests
     public async Task Initialization_Failure_Disposes_The_Built_Host()
     {
         DisposalTracker? disposalTracker = null;
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton(_ => disposalTracker = new DisposalTracker());
         builder.Services.AddSingleton<IInitializer, ThrowingInitializer>();
@@ -322,7 +322,7 @@ public class PipelineLifecycleTests
     [Test]
     public async Task Initialization_Failure_Is_Preserved_When_Disposal_Also_Fails()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.AddModule<LifecycleModule>();
         builder.Services.AddSingleton<ThrowingDisposalTracker>();
         builder.Services.AddSingleton<IInitializer, ThrowingCleanupInitializer>();

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -2141,7 +2141,7 @@ public class RunReportTests
     public async Task BuilderRegistrationInvokesRunReportEnricher()
     {
         var directory = CreateTemporaryDirectory();
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Console = options.Console with { PrintLogo = false, PrintResults = false },
@@ -2847,7 +2847,7 @@ public class RunReportTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 Console = options.Console with { PrintLogo = false, PrintResults = false },
@@ -2888,7 +2888,7 @@ public class RunReportTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 Console = options.Console with { PrintLogo = false, PrintResults = false },
@@ -2929,30 +2929,27 @@ public class RunReportTests
 
         try
         {
-            PipelineRunReport failedReport;
-            using (var builder = Pipeline.CreateBuilder())
+            var builder = Pipeline.CreateBuilder();
+            builder.ConfigurePipelineOptions(options => options with
             {
-                builder.ConfigurePipelineOptions(options => options with
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
+                RunReport = options.RunReport with
                 {
-                    Console = options.Console with { PrintLogo = false, PrintResults = false },
-                    RunReport = options.RunReport with
-                    {
-                        ReportPath = reportPath,
-                        HistoryDirectory = historyPath,
-                        HistoryRetention = 2,
-                    },
-                });
-                builder.AddModule<SuccessfulModule>();
-                builder.AddRequirement(Require.That(_ => false, "requirement failed"));
+                    ReportPath = reportPath,
+                    HistoryDirectory = historyPath,
+                    HistoryRetention = 2,
+                },
+            });
+            builder.AddModule<SuccessfulModule>();
+            builder.AddRequirement(Require.That(_ => false, "requirement failed"));
 
-                await Assert.ThrowsAsync<FailedRequirementsException>(
-                    () => builder.RunAsync());
+            await Assert.ThrowsAsync<FailedRequirementsException>(
+                () => builder.RunAsync());
 
-                failedReport = RunReportJsonSerializer.Deserialize(
-                    await File.ReadAllTextAsync(reportPath))!;
-            }
+            var failedReport = RunReportJsonSerializer.Deserialize(
+                await File.ReadAllTextAsync(reportPath))!;
 
-            using var successfulBuilder = Pipeline.CreateBuilder();
+            var successfulBuilder = Pipeline.CreateBuilder();
             successfulBuilder.ConfigurePipelineOptions(options => options with
             {
                 Console = options.Console with { PrintLogo = false, PrintResults = false },
@@ -3067,7 +3064,7 @@ public class RunReportTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 ExecutionMode = ExecutionMode.StopOnFirstException,
@@ -3106,7 +3103,7 @@ public class RunReportTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 ExecutionMode = ExecutionMode.WaitForAllModules,
@@ -3147,7 +3144,7 @@ public class RunReportTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder();
+            var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
                 ExecutionMode = ExecutionMode.WaitForAllModules,
@@ -3666,7 +3663,7 @@ public class RunReportTests
     [Test]
     public async Task RunReportIncludesMaskedModuleOutputWhenEnabled()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Console = options.Console with { PrintLogo = false, PrintResults = false },
@@ -3883,7 +3880,7 @@ public class RunReportTests
         string reportPath,
         string historyPath)
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.WriteRunReport(reportPath);
         builder.ConfigurePipelineOptions(options => options with
         {
@@ -3905,7 +3902,7 @@ public class RunReportTests
 
     private static async Task<PipelineSummary> RunPipelineWithoutReportAsync(string historyPath)
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
             Console = options.Console with { PrintLogo = false, PrintResults = false },

--- a/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
@@ -31,7 +31,7 @@ public class ConfigurationSectionSecretMaskingTests
     public async Task FluentConfigurationMasksSectionValuesAndNestedLeaves()
     {
         var output = new StringBuilder();
-        using var builder = CreateBuilder(output);
+        var builder = CreateBuilder(output);
         builder.MaskConfigurationSection("Secrets");
 
         await builder.RunAsync();
@@ -49,7 +49,7 @@ public class ConfigurationSectionSecretMaskingTests
     public async Task OptionsCanMaskMultipleSections()
     {
         var output = new StringBuilder();
-        using var builder = CreateBuilder(output);
+        var builder = CreateBuilder(output);
         builder.Services.Configure<SecretMaskingOptions>(options =>
             options.MaskedConfigurationSections = ["Secrets", "ConnectionStrings", "Missing"]);
 
@@ -69,7 +69,7 @@ public class ConfigurationSectionSecretMaskingTests
     [Arguments("   ")]
     public async Task FluentConfigurationRejectsInvalidPaths(string? sectionPath)
     {
-        using var builder = TestPipelineBuilder.Create();
+        var builder = TestPipelineBuilder.Create();
 
         await Assert.That(() => builder.MaskConfigurationSection(sectionPath!))
             .Throws<ArgumentException>();

--- a/test/ModularPipelines.UnitTests/Options/PipelineOptionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Options/PipelineOptionsTests.cs
@@ -21,7 +21,7 @@ public class PipelineOptionsTests
     }
 
     [Test]
-    [Arguments(typeof(PipelineBuilderOptions))]
+    [Arguments(typeof(PipelineBuilderSettings))]
     [Arguments(typeof(PipelineOptions))]
     [Arguments(typeof(PipelineConsoleOptions))]
     [Arguments(typeof(PipelineHttpOptions))]
@@ -78,14 +78,14 @@ public class PipelineOptionsTests
     }
 
     [Test]
-    public async Task PipelineBuilderOptions_IsASealedRecord()
+    public async Task PipelineBuilderSettings_IsASealedRecord()
     {
-        var original = new PipelineBuilderOptions { ApplicationName = "original" };
+        var original = new PipelineBuilderSettings { ApplicationName = "original" };
         var updated = original with { ApplicationName = "updated" };
 
         using (Assert.Multiple())
         {
-            await Assert.That(typeof(PipelineBuilderOptions).IsSealed).IsTrue();
+            await Assert.That(typeof(PipelineBuilderSettings).IsSealed).IsTrue();
             await Assert.That(original.ApplicationName).IsEqualTo("original");
             await Assert.That(updated.ApplicationName).IsEqualTo("updated");
         }
@@ -94,7 +94,7 @@ public class PipelineOptionsTests
     [Test]
     public async Task CategoryBuilderMethodsReplaceEarlierFilters()
     {
-        using var builder = Pipeline.CreateBuilder();
+        var builder = Pipeline.CreateBuilder();
 
         builder.RunOnlyCategories("first");
         builder.RunOnlyCategories("second");

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -106,18 +106,20 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
-    public async Task ModularPipelineAssemblyLoading_IsOptIn()
+    public async Task ModularPipelineAssemblyLoading_IsBuilderSetting()
     {
-        var builder = TestPipelineBuilder.Create();
-
-        await Assert.That(builder.Options.LoadModularPipelineAssemblies).IsFalse();
-
-        builder.ConfigurePipelineOptions(options => options with
+        var defaultSettings = new PipelineBuilderSettings();
+        var optedInSettings = defaultSettings with
         {
-            LoadModularPipelineAssemblies = true,
-        });
+            LoadModularPipelinesAssemblies = true,
+        };
 
-        await Assert.That(builder.Options.LoadModularPipelineAssemblies).IsTrue();
+        using (Assert.Multiple())
+        {
+            await Assert.That(defaultSettings.LoadModularPipelinesAssemblies).IsFalse();
+            await Assert.That(optedInSettings.LoadModularPipelinesAssemblies).IsTrue();
+            await Assert.That(typeof(PipelineOptions).GetProperty("LoadModularPipelineAssemblies")).IsNull();
+        }
     }
 
     [Test]
@@ -142,7 +144,7 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
-    public async Task Environment_IsCachedAndHonorsBuilderOptions()
+    public async Task Environment_IsCachedAndHonorsBuilderSettings()
     {
         var contentRoot = Path.GetTempPath();
         var fileName = $"pipeline-environment-{Guid.NewGuid():N}.txt";
@@ -151,7 +153,7 @@ public class PipelineBuilderRegistrationTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+            var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
             {
                 ApplicationName = "ConfiguredApp",
                 EnvironmentName = "ConfiguredEnvironment",
@@ -177,7 +179,7 @@ public class PipelineBuilderRegistrationTests
     public async Task Environment_HonorsCommandLineHostConfiguration()
     {
         var contentRoot = Path.GetTempPath();
-        using var builder = Pipeline.CreateBuilder(
+        var builder = Pipeline.CreateBuilder(
         [
             "--applicationName", "CommandLineApp",
             "--environment", "CommandLineEnvironment",
@@ -198,7 +200,6 @@ public class PipelineBuilderRegistrationTests
         builder.Environment.ContentRootFileProvider = fileProvider.Object;
         builder.AddModule<TestModuleA>();
 
-        builder.Dispose();
         disposable.Verify(x => x.Dispose(), Times.Never);
 
         var pipeline = await builder.BuildAsync();
@@ -206,6 +207,16 @@ public class PipelineBuilderRegistrationTests
 
         await pipeline.DisposeAsync();
         disposable.Verify(x => x.Dispose(), Times.Once);
+    }
+
+    [Test]
+    public async Task PipelineBuilder_IsNotDisposable()
+    {
+        using (Assert.Multiple())
+        {
+            await Assert.That(typeof(IDisposable).IsAssignableFrom(typeof(PipelineBuilder))).IsFalse();
+            await Assert.That(typeof(PipelineBuilder).GetMethod(nameof(IDisposable.Dispose))).IsNull();
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
@@ -61,7 +61,7 @@ public class PipelineWorkingDirectoryTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+            var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
             {
                 WorkingDirectory = workingDirectory.FullName,
             });
@@ -106,7 +106,7 @@ public class PipelineWorkingDirectoryTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+            var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
             {
                 WorkingDirectory = pipelineDirectory.FullName,
             });
@@ -139,7 +139,7 @@ public class PipelineWorkingDirectoryTests
         try
         {
             var nestedDirectory = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "src", "Pipeline"));
-            using var builder = Pipeline.CreateBuilderFromSource(
+            var builder = Pipeline.CreateBuilder(
                 sourceFilePath: Path.Combine(nestedDirectory.FullName, "Program.cs"));
             builder.Configuration.AddJsonFile("appsettings.json");
 
@@ -156,11 +156,15 @@ public class PipelineWorkingDirectoryTests
     }
 
     [Test]
-    public async Task CreateBuilderRetainsSingleArgumentBinarySignature()
+    public async Task CreateBuilderUsesCallerFilePath()
     {
-        var method = typeof(Pipeline).GetMethod(nameof(Pipeline.CreateBuilder), [typeof(string[])]);
+        var method = typeof(Pipeline).GetMethod(
+            nameof(Pipeline.CreateBuilder),
+            [typeof(string[]), typeof(string)]);
 
-        await Assert.That(method).IsNotNull();
+        await Assert.That(method!.GetParameters()[1].GetCustomAttributesData()
+                .Select(attribute => attribute.AttributeType))
+            .Contains(typeof(System.Runtime.CompilerServices.CallerFilePathAttribute));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
@@ -156,6 +156,54 @@ public class PipelineWorkingDirectoryTests
     }
 
     [Test]
+    public async Task ExplicitContentRootOverridesInferredPipelineProject()
+    {
+        var projectDirectory = Directory.CreateTempSubdirectory("pipeline-project-");
+        var contentRoot = Directory.CreateTempSubdirectory("pipeline-content-root-");
+        await File.WriteAllTextAsync(Path.Combine(projectDirectory.FullName, "appsettings.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(projectDirectory.FullName, "Pipeline.csproj"), "<Project />");
+
+        try
+        {
+            var builder = Pipeline.CreateBuilder(
+                new PipelineBuilderSettings { ContentRootPath = contentRoot.FullName },
+                Path.Combine(projectDirectory.FullName, "Program.cs"));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(builder.WorkingDirectory).IsEqualTo(contentRoot.FullName);
+                await Assert.That(builder.Environment.ContentRootPath).IsEqualTo(contentRoot.FullName);
+            }
+        }
+        finally
+        {
+            projectDirectory.Delete(recursive: true);
+            contentRoot.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task NonInferringBuilderIgnoresPipelineDirectoryEnvironmentVariable()
+    {
+        var variableName = "MODULAR_PIPELINES_DIRECTORY";
+        var previousValue = Environment.GetEnvironmentVariable(variableName);
+        Environment.SetEnvironmentVariable(
+            variableName,
+            Path.Combine(Path.GetTempPath(), $"missing-pipeline-{Guid.NewGuid():N}"));
+
+        try
+        {
+            var builder = Pipeline.CreateBuilderWithoutProjectInference(new PipelineBuilderSettings());
+
+            await Assert.That(builder.WorkingDirectory).IsEqualTo(Environment.CurrentDirectory);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, previousValue);
+        }
+    }
+
+    [Test]
     public async Task CreateBuilderUsesCallerFilePath()
     {
         var method = typeof(Pipeline).GetMethod(

--- a/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
@@ -212,6 +212,32 @@ public class PipelineWorkingDirectoryTests
     }
 
     [Test]
+    public async Task ExplicitWorkingDirectorySkipsProjectInference()
+    {
+        var variableName = "MODULAR_PIPELINES_DIRECTORY";
+        var previousValue = Environment.GetEnvironmentVariable(variableName);
+        var workingDirectory = Directory.CreateTempSubdirectory("pipeline-working-directory-");
+        Environment.SetEnvironmentVariable(
+            variableName,
+            Path.Combine(Path.GetTempPath(), $"missing-pipeline-{Guid.NewGuid():N}"));
+
+        try
+        {
+            var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
+            {
+                WorkingDirectory = workingDirectory.FullName,
+            });
+
+            await Assert.That(builder.WorkingDirectory).IsEqualTo(workingDirectory.FullName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, previousValue);
+            workingDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task NonInferringBuilderIgnoresPipelineDirectoryEnvironmentVariable()
     {
         var variableName = "MODULAR_PIPELINES_DIRECTORY";

--- a/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
@@ -183,6 +183,35 @@ public class PipelineWorkingDirectoryTests
     }
 
     [Test]
+    public async Task HostConfiguredContentRootOverridesInferredPipelineProject()
+    {
+        var projectDirectory = Directory.CreateTempSubdirectory("pipeline-project-");
+        var contentRoot = Directory.CreateTempSubdirectory("pipeline-content-root-");
+        await File.WriteAllTextAsync(Path.Combine(projectDirectory.FullName, "Pipeline.csproj"), "<Project />");
+
+        try
+        {
+            var builder = Pipeline.CreateBuilder(
+                new PipelineBuilderSettings
+                {
+                    Args = ["--contentRoot", contentRoot.FullName],
+                },
+                Path.Combine(projectDirectory.FullName, "Program.cs"));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(builder.WorkingDirectory).IsEqualTo(contentRoot.FullName);
+                await Assert.That(builder.Environment.ContentRootPath).IsEqualTo(contentRoot.FullName);
+            }
+        }
+        finally
+        {
+            projectDirectory.Delete(recursive: true);
+            contentRoot.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task NonInferringBuilderIgnoresPipelineDirectoryEnvironmentVariable()
     {
         var variableName = "MODULAR_PIPELINES_DIRECTORY";

--- a/test/ModularPipelines.UnitTests/Requirements/RequireFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Requirements/RequireFactoryTests.cs
@@ -159,7 +159,7 @@ public class RequireFactoryTests
 
         try
         {
-            using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+            var builder = Pipeline.CreateBuilder(new PipelineBuilderSettings
             {
                 WorkingDirectory = workingDirectory.FullName,
             });


### PR DESCRIPTION
## Summary
- replace `CreateBuilderFromSource` with one caller-path-aware `Pipeline.CreateBuilder` entry point
- rename `PipelineBuilderOptions` to `PipelineBuilderSettings` and move assembly discovery into builder settings
- remove the no-op `PipelineBuilder.Dispose` contract and update consumers, tests, templates, and docs

## Validation
- CI-mode `ModularPipelines.slnx` build (0 warnings, 0 errors)
- `ModularPipelines.Tests.slnf` build (0 errors; existing fixture nullability warnings)
- focused tests: `PipelineBuilderRegistrationTests` 18/18, `PipelineOptionsTests` 19/19, `PipelineWorkingDirectoryTests` 5/5
- `ModularPipelines.Testing.slnx`, `ModularPipelines.Templates.slnx`, TrimAotSmoke, S3, Redis, and GitHub touched-project builds
- docs production build (329 documents)
- changed-file whitespace formatting and `git diff --check`

Closes #4223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pipeline setup now infers the project directory from the calling source file.
  - Added working-directory controls and optional ModularPipelines assembly loading.
  - Added a non-inferring pipeline creation option for isolated scenarios.

- **Breaking Changes**
  - Renamed `PipelineBuilderOptions` to `PipelineBuilderSettings`.
  - Removed `CreateBuilderFromSource`.
  - Pipeline builders are no longer disposable; remove `using` declarations.
  - ModularPipelines assembly loading is opt-in and disabled by default.
  - Updated module configuration to use the builder-based configuration pattern.

- **Documentation**
  - Updated Quick Start, migration, CLI, F#, and related examples for V4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->