### PR TITLE
Let modules configure a supplied builder

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -10,15 +10,17 @@ Asynchronous module predicates now consistently use `ValueTask`. The
 `ModuleConfiguration.IgnoreFailuresCondition` property and the asynchronous
 `ModuleConfigurationBuilder.WithIgnoreFailuresWhen` overload therefore accept
 `Func<IModuleContext, Exception, ValueTask<bool>>` instead of the previous
-`Task<bool>` delegate. Explicitly typed callers must migrate for v4:
+`Task<bool>` delegate. Explicitly typed callers must migrate inside their module's
+configuration hook for v4:
 
 ```csharp
-Func<IModuleContext, Exception, ValueTask<bool>> ignoreFailure =
-    (context, exception) => ValueTask.FromResult(exception is ApiValidationException);
+protected override void Configure(ModuleConfigurationBuilder module)
+{
+    Func<IModuleContext, Exception, ValueTask<bool>> ignoreFailure =
+        (context, exception) => ValueTask.FromResult(exception is ApiValidationException);
 
-ModuleConfiguration.Create()
-    .WithIgnoreFailuresWhen(ignoreFailure)
-    .Build();
+    module.WithIgnoreFailuresWhen(ignoreFailure);
+}
 ```
 
 ## CLI argument ordering

--- a/docs/docs/how-to/always-run.md
+++ b/docs/docs/how-to/always-run.md
@@ -16,8 +16,7 @@ With `WithAlwaysRun()`, a module will run regardless of whether any dependencies
 public class CleanupModule : Module<CommandResult>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithAlwaysRun()
-        ;
+        .WithAlwaysRun();
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -38,8 +37,7 @@ public class CleanupModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithAlwaysRun()
         .WithIgnoreFailures()  // Don't fail the pipeline if cleanup fails
-        .WithTimeout(TimeSpan.FromMinutes(5))
-        ;
+        .WithTimeout(TimeSpan.FromMinutes(5));
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/docs/docs/how-to/always-run.md
+++ b/docs/docs/how-to/always-run.md
@@ -15,9 +15,9 @@ With `WithAlwaysRun()`, a module will run regardless of whether any dependencies
 ```csharp
 public class CleanupModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithAlwaysRun()
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -35,11 +35,11 @@ Always run can be combined with other module behaviors:
 [DependsOn<TestModule>]
 public class CleanupModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithAlwaysRun()
         .WithIgnoreFailures()  // Don't fail the pipeline if cleanup fails
         .WithTimeout(TimeSpan.FromMinutes(5))
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/docs/docs/how-to/defining-modules.md
+++ b/docs/docs/how-to/defining-modules.md
@@ -73,8 +73,7 @@ public class MyModule : Module<FileInfo>
         .WithCategory("build")
         .DependsOn<RestoreModule>()
         .WithIgnoreFailures()
-        .WithAlwaysRun()
-        ;
+        .WithAlwaysRun();
 
     protected override async Task<FileInfo> ExecuteAsync(
         IModuleContext context, CancellationToken cancellationToken)
@@ -181,8 +180,7 @@ public class BuildModule : Module<BuildOutput>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithCategory("Build")
-        .WithTags("critical", "fast")
-        ;
+        .WithTags("critical", "fast");
 
     protected override async Task<BuildOutput> ExecuteAsync(
         IModuleContext context, CancellationToken cancellationToken)

--- a/docs/docs/how-to/defining-modules.md
+++ b/docs/docs/how-to/defining-modules.md
@@ -58,12 +58,12 @@ You only need to return that sentinel yourself when using `SyncModule<None>`.
 
 ## Configuring Module Behavior
 
-Configure module behaviors such as timeouts, retry policies, skip conditions, and hooks by overriding the `Configure()` method:
+Configure module behaviors such as timeouts, retry policies, skip conditions, and hooks by overriding the `Configure(ModuleConfigurationBuilder)` method:
 
 ```csharp
 public class MyModule : Module<FileInfo>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithTimeout(TimeSpan.FromMinutes(5))
         .WithRetry(3)
         .WithSkipWhen(_ => !File.Exists("important.json"), "important.json does not exist")
@@ -74,7 +74,7 @@ public class MyModule : Module<FileInfo>
         .DependsOn<RestoreModule>()
         .WithIgnoreFailures()
         .WithAlwaysRun()
-        .Build();
+        ;
 
     protected override async Task<FileInfo> ExecuteAsync(
         IModuleContext context, CancellationToken cancellationToken)
@@ -179,10 +179,10 @@ Or define them programmatically:
 ```csharp
 public class BuildModule : Module<BuildOutput>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithCategory("Build")
         .WithTags("critical", "fast")
-        .Build();
+        ;
 
     protected override async Task<BuildOutput> ExecuteAsync(
         IModuleContext context, CancellationToken cancellationToken)

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -182,7 +182,6 @@ public class Module2 : Module<string>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .DependsOn<Module1>()                    // Required
         .DependsOnOptional<Module3>()            // Optional
-        .DependsOnIf<Module4>(someCondition)     // Required when true
-        ;
+        .DependsOnIf<Module4>(someCondition);    // Required when true
 }
 ```

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -174,15 +174,15 @@ if (module != null)
 
 ## Fluent Dependencies
 
-Declare runtime-selected dependencies through the module's `Configure()` method:
+Declare runtime-selected dependencies through the module's `Configure(ModuleConfigurationBuilder)` method:
 
 ```csharp
 public class Module2 : Module<string>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .DependsOn<Module1>()                    // Required
         .DependsOnOptional<Module3>()            // Optional
         .DependsOnIf<Module4>(someCondition)     // Required when true
-        .Build();
+        ;
 }
 ```

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -64,8 +64,6 @@ For runtime-selected dependencies, override `Configure` and use the fluent
 configuration builder:
 
 ```fsharp
-override _.Configure() =
-    ModuleConfiguration.Create()
-        .DependsOn<BuildModule>()
-        .Build()
+override _.Configure(moduleConfiguration: ModuleConfigurationBuilder) =
+    moduleConfiguration.DependsOn<BuildModule>() |> ignore
 ```

--- a/docs/docs/how-to/ignoring-failures.md
+++ b/docs/docs/how-to/ignoring-failures.md
@@ -15,9 +15,9 @@ To always ignore failures from a module:
 ```csharp
 public class OptionalModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithIgnoreFailures()
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -33,9 +33,9 @@ To ignore only specific types of failures:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithIgnoreFailuresWhen((ctx, exception) => exception is ItemAlreadyExistsException)
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -51,7 +51,7 @@ For conditions that require async operations:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithIgnoreFailuresWhen(async (ctx, exception) =>
         {
             if (exception is HttpRequestException httpEx)
@@ -62,7 +62,7 @@ public class MyModule : Module<CommandResult>
             }
             return false;
         })
-        .Build();
+        ;
 }
 ```
 
@@ -73,11 +73,11 @@ Ignoring failures can be combined with other module behaviors:
 ```csharp
 public class ResilientModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithRetry(3)  // Try 3 times first
         .WithIgnoreFailuresWhen((ctx, ex) => ex is HttpRequestException)  // Then ignore HTTP errors
         .WithAlwaysRun()  // Run even if dependencies failed
-        .Build();
+        ;
 }
 ```
 

--- a/docs/docs/how-to/ignoring-failures.md
+++ b/docs/docs/how-to/ignoring-failures.md
@@ -16,8 +16,7 @@ To always ignore failures from a module:
 public class OptionalModule : Module<CommandResult>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithIgnoreFailures()
-        ;
+        .WithIgnoreFailures();
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -34,8 +33,7 @@ To ignore only specific types of failures:
 public class MyModule : Module<CommandResult>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithIgnoreFailuresWhen((ctx, exception) => exception is ItemAlreadyExistsException)
-        ;
+        .WithIgnoreFailuresWhen((ctx, exception) => exception is ItemAlreadyExistsException);
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -61,8 +59,7 @@ public class MyModule : Module<CommandResult>
                 return isMaintenanceMode;
             }
             return false;
-        })
-        ;
+        });
 }
 ```
 
@@ -76,8 +73,7 @@ public class ResilientModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithRetry(3)  // Try 3 times first
         .WithIgnoreFailuresWhen((ctx, ex) => ex is HttpRequestException)  // Then ignore HTTP errors
-        .WithAlwaysRun()  // Run even if dependencies failed
-        ;
+        .WithAlwaysRun(); // Run even if dependencies failed
 }
 ```
 

--- a/docs/docs/how-to/module-caching.md
+++ b/docs/docs/how-to/module-caching.md
@@ -52,10 +52,9 @@ File contents do not represent every input. Add configuration or tool versions e
 
 ```csharp
 protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithCacheKeyPart($"configuration={configurationName}")
-        .WithCacheKeyPart($"sdk={sdkVersion}")
-        .WithCacheEnvironmentVariable("TARGET_RUNTIME")
-        ;
+    .WithCacheKeyPart($"configuration={configurationName}")
+    .WithCacheKeyPart($"sdk={sdkVersion}")
+    .WithCacheEnvironmentVariable("TARGET_RUNTIME");
 ```
 
 Changing any key part or declared environment value invalidates the entry.
@@ -72,9 +71,8 @@ Use an explicit version key only when your build changes the MVID independently 
 
 ```csharp
 protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithCacheKeyPart("configuration=v1")
-        .WithCacheAssemblyVersionKey("build-module-v3")
-        ;
+    .WithCacheKeyPart("configuration=v1")
+    .WithCacheAssemblyVersionKey("build-module-v3");
 ```
 
 You must update this key whenever the module implementation changes. Reusing it after a behavior

--- a/docs/docs/how-to/module-caching.md
+++ b/docs/docs/how-to/module-caching.md
@@ -51,12 +51,11 @@ Use `--no-cache` to bypass all module cache reads and writes for one command-lin
 File contents do not represent every input. Add configuration or tool versions explicitly:
 
 ```csharp
-protected override ModuleConfiguration Configure() =>
-    ModuleConfiguration.Create()
+protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithCacheKeyPart($"configuration={configurationName}")
         .WithCacheKeyPart($"sdk={sdkVersion}")
         .WithCacheEnvironmentVariable("TARGET_RUNTIME")
-        .Build();
+        ;
 ```
 
 Changing any key part or declared environment value invalidates the entry.
@@ -72,11 +71,10 @@ cached module declared by that assembly.
 Use an explicit version key only when your build changes the MVID independently of module behavior:
 
 ```csharp
-protected override ModuleConfiguration Configure() =>
-    ModuleConfiguration.Create()
+protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithCacheKeyPart("configuration=v1")
         .WithCacheAssemblyVersionKey("build-module-v3")
-        .Build();
+        ;
 ```
 
 You must update this key whenever the module implementation changes. Reusing it after a behavior

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 6
 
 # Retries and Resilience Shields
 
-When creating modules, you can configure retries per module using the `Configure()` method.
+When creating modules, you can configure retries per module using the `Configure(ModuleConfigurationBuilder)` method.
 The standard API supports exponential backoff, jitter, and exception filtering without exposing
 the underlying resilience library.
 
@@ -18,9 +18,9 @@ The easiest way to add retries is with `WithRetry()`:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithRetry(3)  // Retry up to 3 times with exponential backoff and jitter
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -34,12 +34,12 @@ its exponential-backoff ceiling. You can set a different base delay and limit re
 exceptions:
 
 ```csharp
-protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+protected override void Configure(ModuleConfigurationBuilder module) => module
     .WithRetry(
         count: 5,
         baseDelay: TimeSpan.FromSeconds(1),
         shouldRetry: exception => exception is HttpRequestException)
-    .Build();
+    ;
 ```
 
 ### Custom Resilience Shield
@@ -49,11 +49,11 @@ For resilience features outside the standard retry API, configure a Kevlar `Shie
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithShield(
             Shield.When<HttpRequestException>()
                 .Retry(5, Backoff.Custom(i => TimeSpan.FromSeconds(i * i))))
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -69,14 +69,14 @@ If you need access to the pipeline context when building your shield:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithShield(ctx =>
         {
             var retryCount = ctx.Environment.IsCI ? 5 : 2;
             return Shield.When<Exception>()
                 .Retry(retryCount, Backoff.Custom(i => TimeSpan.FromSeconds(i)));
         })
-        .Build();
+        ;
 }
 ```
 
@@ -87,11 +87,11 @@ Retry configuration can be combined with other module behaviors:
 ```csharp
 public class ResilientModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithRetry(3)
         .WithTimeout(TimeSpan.FromMinutes(10))
         .WithIgnoreFailures()  // Don't fail the pipeline even after all retries
-        .Build();
+        ;
 }
 ```
 
@@ -121,4 +121,4 @@ builder.ConfigurePipelineOptions(options => options with
 await builder.RunAsync();
 ```
 
-This applies to all modules that don't override their retry configuration. Modules can override this default by configuring retries in `Configure()`.
+This applies to all modules that don't override their retry configuration. Modules can override this default by configuring retries in `Configure(ModuleConfigurationBuilder)`.

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -19,8 +19,7 @@ The easiest way to add retries is with `WithRetry()`:
 public class MyModule : Module<CommandResult>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithRetry(3)  // Retry up to 3 times with exponential backoff and jitter
-        ;
+        .WithRetry(3); // Retry up to 3 times with exponential backoff and jitter
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -38,8 +37,7 @@ protected override void Configure(ModuleConfigurationBuilder module) => module
     .WithRetry(
         count: 5,
         baseDelay: TimeSpan.FromSeconds(1),
-        shouldRetry: exception => exception is HttpRequestException)
-    ;
+        shouldRetry: exception => exception is HttpRequestException);
 ```
 
 ### Custom Resilience Shield
@@ -52,8 +50,7 @@ public class MyModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithShield(
             Shield.When<HttpRequestException>()
-                .Retry(5, Backoff.Custom(i => TimeSpan.FromSeconds(i * i))))
-        ;
+                .Retry(5, Backoff.Custom(i => TimeSpan.FromSeconds(i * i))));
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -75,8 +72,7 @@ public class MyModule : Module<CommandResult>
             var retryCount = ctx.Environment.IsCI ? 5 : 2;
             return Shield.When<Exception>()
                 .Retry(retryCount, Backoff.Custom(i => TimeSpan.FromSeconds(i)));
-        })
-        ;
+        });
 }
 ```
 
@@ -90,8 +86,7 @@ public class ResilientModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithRetry(3)
         .WithTimeout(TimeSpan.FromMinutes(10))
-        .WithIgnoreFailures()  // Don't fail the pipeline even after all retries
-        ;
+        .WithIgnoreFailures(); // Don't fail the pipeline even after all retries
 }
 ```
 

--- a/docs/docs/how-to/run-conditions.md
+++ b/docs/docs/how-to/run-conditions.md
@@ -83,4 +83,4 @@ environment-variable check. The `ModularPipelines.Git` package also provides
 `RunIfBranch`, `RunIfBranchStartsWith`, and `SkipIfBranch`; these stateful attributes use the same
 base classes.
 
-One-off conditions can use `Configure().WithSkipWhen(...)`.
+One-off conditions can use `Configure(ModuleConfigurationBuilder).WithSkipWhen(...)`.

--- a/docs/docs/how-to/skipping.md
+++ b/docs/docs/how-to/skipping.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 
 ## Using ModuleConfiguration
 
-The recommended way to configure module skipping is through the `Configure()` method with the fluent builder API:
+The recommended way to configure module skipping is through the `Configure(ModuleConfigurationBuilder)` method with the fluent builder API:
 
 Attribute conditions (`[SkipIf<T>]`, `[RunIfAll<T>]`, and `[RunIfAny<T>]`) remain supported.
 Attribute and fluent conditions run in the same execution pipeline after dependency waiting, so
@@ -23,11 +23,10 @@ the plan reports the module's skip decision as unknown and continues without exe
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(
             _ => Environment.GetEnvironmentVariable("SKIP_MODULE") == "true",
-            "SKIP_MODULE is true")
-        .Build();
+            "SKIP_MODULE is true");
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -43,11 +42,10 @@ When you need access to the pipeline context for your skip condition:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(
             async (ctx, _) => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main",
-            "This should only run on the main branch")
-        .Build();
+            "This should only run on the main branch");
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -63,13 +61,12 @@ For better reporting, pass the reason alongside the boolean condition:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(async (ctx, _) =>
         {
             var repositoryInfo = await ctx.Git().Information.GetInfoAsync();
             return repositoryInfo?.BranchName != "main";
-        }, "This should only run on the main branch")
-        .Build();
+        }, "This should only run on the main branch");
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -85,15 +82,14 @@ For conditions that require async operations:
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(async (_, cancellationToken) =>
         {
             var response = await HttpClient.GetAsync(
                 "https://api.example.com/should-run",
                 cancellationToken);
             return !response.IsSuccessStatusCode;
-        }, "The remote service is unavailable")
-        .Build();
+        }, "The remote service is unavailable");
 }
 ```
 
@@ -108,14 +104,13 @@ For example, this module skips cleanup for either CI builds or non-main branches
 ```csharp
 public class CleanupModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(_ => Environment.GetEnvironmentVariable("CI") == "true", "Running in CI")
         .WithSkipWhen(
             async (ctx, _) => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main",
             "Not on the main branch")
         .WithAlwaysRun()  // Run even if dependencies fail (when not skipped)
-        .WithTimeout(TimeSpan.FromMinutes(5))
-        .Build();
+        .WithTimeout(TimeSpan.FromMinutes(5));
 }
 ```
 
@@ -123,15 +118,14 @@ When every condition must match before the module is skipped, group them explici
 `WithSkipWhenAll`:
 
 ```csharp
-protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+protected override void Configure(ModuleConfigurationBuilder module) => module
     .WithSkipWhenAll(
         _ => Environment.GetEnvironmentVariable("CI") == "true"
             ? SkipDecision.Skip("Running in CI")
             : SkipDecision.DoNotSkip,
         _ => Environment.GetEnvironmentVariable("DEPLOY_ENV") != "production"
             ? SkipDecision.Skip("Not deploying to production")
-            : SkipDecision.DoNotSkip)
-    .Build();
+            : SkipDecision.DoNotSkip);
 ```
 
 Conditions inside a `WithSkipWhenAll` group use AND-to-skip semantics and combine their reasons.

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -20,7 +20,7 @@ builder.ConfigurePipelineOptions(options => options with
 });
 ```
 
-You can override the pipeline default for one module using `Configure()`. Bear in mind some build runners, like GitHub Actions, have their own timeouts, so extending past these won't help.
+You can override the pipeline default for one module using `Configure(ModuleConfigurationBuilder)`. Bear in mind some build runners, like GitHub Actions, have their own timeouts, so extending past these won't help.
 
 `AlwaysRun` teardown has a separate 30-second scheduler-progress watchdog. This prevents a
 constraint-deferred `AlwaysRun` module from waiting indefinitely for a hung active module, even
@@ -42,9 +42,9 @@ for each retry, so increase it for pipelines whose blocking modules can legitima
 ```csharp
 public class MyModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithTimeout(TimeSpan.FromSeconds(120))
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -60,11 +60,11 @@ Timeouts can be combined with other module behaviors:
 ```csharp
 public class ResilientModule : Module<CommandResult>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithTimeout(TimeSpan.FromMinutes(5))
         .WithRetry(3)  // Retry if timeout or other failure occurs
         .WithIgnoreFailures()  // Don't fail the pipeline if module times out
-        .Build();
+        ;
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -43,8 +43,7 @@ for each retry, so increase it for pipelines whose blocking modules can legitima
 public class MyModule : Module<CommandResult>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
-        .WithTimeout(TimeSpan.FromSeconds(120))
-        ;
+        .WithTimeout(TimeSpan.FromSeconds(120));
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -63,8 +62,7 @@ public class ResilientModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithTimeout(TimeSpan.FromMinutes(5))
         .WithRetry(3)  // Retry if timeout or other failure occurs
-        .WithIgnoreFailures()  // Don't fail the pipeline if module times out
-        ;
+        .WithIgnoreFailures(); // Don't fail the pipeline if module times out
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
+++ b/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
@@ -29,11 +29,10 @@ public class CreateReleaseModule : Module<Release>
         _publishSettings = publishSettings;
     }
 
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(_ => !_publishSettings.Value.ShouldPublish, "The 'ShouldPublish' flag is false")
         .WithSkipWhen(_ => string.IsNullOrEmpty(_githubSettings.Value.AdminToken), "The GitHub admin token is unavailable")
-        .WithIgnoreFailuresWhen((_, ex) => ex is ApiValidationException)
-        .Build();
+        .WithIgnoreFailuresWhen((_, ex) => ex is ApiValidationException);
 
     protected override async Task<Release> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
+++ b/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
@@ -9,9 +9,8 @@ namespace ModularPipelines.Build.Modules;
 
 public class FindProjectsModule : Module<IReadOnlyList<File>>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithAlwaysRun()
-        .Build();
+    protected override void Configure(ModuleConfigurationBuilder module) => module
+        .WithAlwaysRun();
 
     protected override Task<IReadOnlyList<File>> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Build.Modules;
 [DependsOn<GenerateReadMeModule>]
 public class FormatMarkdownModule : Module<None>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(ctx =>
         {
             if (FastFailValidation.IsComplete(ctx))
@@ -31,8 +31,7 @@ public class FormatMarkdownModule : Module<None>
 
             return SkipDecision.DoNotSkip;
         })
-        .WithAlwaysRun()
-        .Build();
+        .WithAlwaysRun();
 
     protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
+++ b/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
@@ -13,9 +13,8 @@ namespace ModularPipelines.Build.Modules;
 [DependsOn<FindProjectsModule>]
 public class GenerateReadMeModule : Module<None>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithAlwaysRun()
-        .Build();
+    protected override void Configure(ModuleConfigurationBuilder module) => module
+        .WithAlwaysRun();
 
     protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/LocalMachine/AddLocalNugetSourceModule.cs
+++ b/src/ModularPipelines.Build/Modules/LocalMachine/AddLocalNugetSourceModule.cs
@@ -23,11 +23,10 @@ public class AddLocalNugetSourceModule : Module<CommandResult>
         _localNuGetSettings = localNuGetSettings;
     }
 
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithIgnoreFailuresWhen((_, ex) =>
             ex is CommandException commandException &&
-            commandException.Result.StandardOutput.Contains("The name specified has already been added to the list of available package sources"))
-        .Build();
+            commandException.Result.StandardOutput.Contains("The name specified has already been added to the list of available package sources"));
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/PushVersionTagModule.cs
+++ b/src/ModularPipelines.Build/Modules/PushVersionTagModule.cs
@@ -28,14 +28,13 @@ public class PushVersionTagModule : Module<CommandResult>
         _gitHubSettings = gitHubSettings;
     }
 
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithIgnoreFailuresWhen((ctx, ex) =>
         {
             // Use GetAwaiter().GetResult() since dependency has completed by the time this callback runs
             var versionInformation = ((IModuleContext)ctx).GetModule<NugetVersionGeneratorModule>().GetAwaiter().GetResult();
             return ex.Message.Contains($"tag 'v{versionInformation.Value}' already exists");
-        })
-        .Build();
+        });
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -37,10 +37,9 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
 
     protected abstract string TestProjectFileName { get; }
 
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(GetSkipDecision)
-        .WithShield(Shield.Retry(0))
-        .Build();
+        .WithShield(Shield.Retry(0));
 
     protected virtual SkipDecision GetSkipDecision(IModuleContext context) => SkipDecision.DoNotSkip;
 

--- a/src/ModularPipelines.Build/Modules/UploadPackagesToNugetModule.cs
+++ b/src/ModularPipelines.Build/Modules/UploadPackagesToNugetModule.cs
@@ -28,9 +28,8 @@ public class UploadPackagesToNugetModule : Module<CommandResult[]>
         _publishSettings = publishSettings;
     }
 
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithSkipWhen(_ => !_publishSettings.Value.ShouldPublish, "The 'ShouldPublish' flag is false")
-        .Build();
+    protected override void Configure(ModuleConfigurationBuilder module) => module
+        .WithSkipWhen(_ => !_publishSettings.Value.ShouldPublish, "The 'ShouldPublish' flag is false");
 
     protected override async Task<CommandResult[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {

--- a/src/ModularPipelines/Configuration/ModuleConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfiguration.cs
@@ -15,13 +15,13 @@ namespace ModularPipelines.Configuration;
 /// of module execution including skip conditions, timeouts, retry policies, failure handling,
 /// and scheduling metadata.
 /// </para>
-/// <para>
-/// Use <see cref="Create"/> to obtain a <see cref="ModuleConfigurationBuilder"/> for fluent configuration,
-/// or use <see cref="Default"/> for a configuration with all default values.
-/// </para>
 /// </remarks>
 public sealed class ModuleConfiguration
 {
+    internal ModuleConfiguration()
+    {
+    }
+
     /// <summary>
     /// Gets the default module configuration with all properties set to their default values.
     /// </summary>
@@ -29,21 +29,7 @@ public sealed class ModuleConfiguration
     /// A <see cref="ModuleConfiguration"/> instance where all nullable properties are null
     /// and <see cref="AlwaysRun"/> is false.
     /// </value>
-    public static ModuleConfiguration Default { get; } = new();
-
-    /// <summary>
-    /// Creates a new <see cref="ModuleConfigurationBuilder"/> for fluent configuration.
-    /// </summary>
-    /// <returns>A new <see cref="ModuleConfigurationBuilder"/> instance.</returns>
-    /// <example>
-    /// <code>
-    /// var config = ModuleConfiguration.Create()
-    ///     .WithTimeout(TimeSpan.FromMinutes(5))
-    ///     .WithRetry(3)
-    ///     .Build();
-    /// </code>
-    /// </example>
-    public static ModuleConfigurationBuilder Create() => new();
+    internal static ModuleConfiguration Default { get; } = new();
 
     /// <summary>
     /// Gets the condition that determines whether the module should be skipped.

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -16,20 +16,16 @@ namespace ModularPipelines.Configuration;
 /// This builder provides a fluent API for configuring module behavior including
 /// skip conditions, timeouts, retry policies, failure handling, and scheduling metadata.
 /// </para>
-/// <para>
-/// All methods return the builder instance to support method chaining.
-/// Call <see cref="Build"/> to create the final <see cref="ModuleConfiguration"/> instance.
-/// </para>
+/// <para>All methods return the builder instance to support method chaining.</para>
 /// </remarks>
 /// <example>
 /// <code>
-/// var config = ModuleConfiguration.Create()
+/// protected override void Configure(ModuleConfigurationBuilder module) => module
 ///     .WithSkipWhen(_ => someCondition, "Configured skip condition returned true")
 ///     .WithTimeout(TimeSpan.FromMinutes(5))
 ///     .WithRetry(3)
 ///     .WithIgnoreFailures()
-///     .WithAlwaysRun()
-///     .Build();
+///     .WithAlwaysRun();
 /// </code>
 /// </example>
 public sealed class ModuleConfigurationBuilder
@@ -483,7 +479,7 @@ public sealed class ModuleConfigurationBuilder
     /// Builds the <see cref="ModuleConfiguration"/> instance with the configured settings.
     /// </summary>
     /// <returns>A new <see cref="ModuleConfiguration"/> instance.</returns>
-    public ModuleConfiguration Build()
+    internal ModuleConfiguration Build()
     {
         return new ModuleConfiguration
         {

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -42,11 +42,10 @@ namespace ModularPipelines.Modules;
 /// <code>
 /// public class ApiModule : Module&lt;ApiResult&gt;
 /// {
-///     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+///     protected override void Configure(ModuleConfigurationBuilder module) => module
 ///         .DependsOn&lt;DatabaseModule&gt;()
 ///         .DependsOnOptional&lt;CachingModule&gt;()
-///         .DependsOnIf&lt;MonitoringModule&gt;(Environment.IsProduction)
-///         .Build();
+///         .DependsOnIf&lt;MonitoringModule&gt;(Environment.IsProduction);
 ///
 ///     protected override Task&lt;ApiResult&gt; ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
 ///         =&gt; Task.FromResult(new ApiResult());
@@ -94,27 +93,27 @@ public abstract class Module<T> : IInternalModule, IPlanningModuleCopyProvider
     /// <summary>
     /// Override to configure module behaviors (skip, timeout, retry, etc.).
     /// </summary>
-    /// <returns>The module configuration.</returns>
+    /// <param name="module">The builder used to configure this module.</param>
     /// <remarks>
     /// <para>
     /// This method is called once during module activation and cached for subsequent accesses.
     /// Directly constructed modules initialize on first access.
     /// </para>
     /// <para>
-    /// Use <see cref="ModuleConfiguration.Create"/> to build a custom configuration,
-    /// or return <see cref="ModuleConfiguration.Default"/> for default behavior.
+    /// The pipeline builds and caches the final configuration after this method returns.
     /// </para>
     /// </remarks>
     /// <example>
     /// <code>
-    /// protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    /// protected override void Configure(ModuleConfigurationBuilder module) => module
     ///     .WithTimeout(TimeSpan.FromMinutes(5))
     ///     .WithRetry(3)
-    ///     .WithAlwaysRun()
-    ///     .Build();
+    ///     .WithAlwaysRun();
     /// </code>
     /// </example>
-    protected virtual ModuleConfiguration Configure() => ModuleConfiguration.Default;
+    protected virtual void Configure(ModuleConfigurationBuilder module)
+    {
+    }
 
     /// <inheritdoc />
     ModuleConfiguration IModule.Configuration => _configuration.Value;
@@ -341,10 +340,12 @@ public abstract class Module<T> : IInternalModule, IPlanningModuleCopyProvider
             : CompletionSource.Task.GetAwaiter();
     }
 
-    private ModuleConfiguration CreateConfiguration() =>
-        ModuleConfigurationAttributeAdapter.Apply(
-            GetType(),
-            Configure());
+    private ModuleConfiguration CreateConfiguration()
+    {
+        var builder = new ModuleConfigurationBuilder();
+        Configure(builder);
+        return ModuleConfigurationAttributeAdapter.Apply(GetType(), builder.Build());
+    }
 
     private Lazy<ModuleConfiguration> CreateConfigurationLazy() =>
         new(CreateConfiguration, LazyThreadSafetyMode.ExecutionAndPublication);

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -52,10 +52,8 @@ public class DistributedModuleExecutorTests
 
     private class ShortTimeoutDistributedModule : Module<SimpleResult>
     {
-        protected override ModuleConfiguration Configure() =>
-            ModuleConfiguration.Create()
-                .WithTimeout(TimeSpan.FromMilliseconds(50))
-                .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+                .WithTimeout(TimeSpan.FromMilliseconds(50));
 
         protected internal override Task<SimpleResult> ExecuteAsync(
             Context.IModuleContext context, CancellationToken cancellationToken)

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
@@ -44,9 +44,8 @@ public class DistributedWorkPublisherTests
 
     private class FluentConsumerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<DependencyModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<DependencyModule>();
 
         protected internal override Task<string> ExecuteAsync(
             Context.IModuleContext context, CancellationToken cancellationToken)
@@ -72,9 +71,8 @@ public class DistributedWorkPublisherTests
 
     private class TaggedDependencyModule : Module<DepResult>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTags("distributed")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTags("distributed");
 
         protected internal override Task<DepResult> ExecuteAsync(
             Context.IModuleContext context, CancellationToken cancellationToken)

--- a/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
+++ b/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
@@ -34,11 +34,8 @@ type DependentModule() =
 type ConfiguredDependentModule() =
     inherit Module<string>()
 
-    override _.Configure() =
-        ModuleConfiguration
-            .Create()
-            .DependsOn<DependencyModule>()
-            .Build()
+    override _.Configure(moduleConfiguration: ModuleConfigurationBuilder) =
+        moduleConfiguration.DependsOn<DependencyModule>() |> ignore
 
     override _.ExecuteAsync(
         context: IModuleContext,

--- a/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
@@ -33,11 +33,10 @@ public class GitHubMarkdownSummaryGeneratorTests
 
     private sealed class SingleUseSkipConditionModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => Interlocked.Increment(ref _skipConditionEvaluations) == 1
                 ? SkipDecision.DoNotSkip
-                : throw new InvalidOperationException("Skip condition evaluated twice"))
-            .Build();
+                : throw new InvalidOperationException("Skip condition evaluated twice"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.Testing.UnitTests/ModuleTesterTests.cs
+++ b/test/ModularPipelines.Testing.UnitTests/ModuleTesterTests.cs
@@ -482,9 +482,8 @@ public class ModuleTesterTests
 
     public sealed class DependentModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<DependencyModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<DependencyModule>();
 
         protected override async Task<string> ExecuteAsync(
             IModuleContext context,
@@ -578,9 +577,8 @@ public class ModuleTesterTests
 
     public sealed class SkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("not needed"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("not needed"));
 
         protected override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -780,9 +778,8 @@ public class ModuleTesterTests
 
     public sealed class CancellableAlwaysRunModule(TaskCompletionSource started) : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected override async Task<string> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -157,9 +157,8 @@ internal sealed class VerificationModule(
 
 internal sealed class IgnoredValueModule : Module<int>
 {
-    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithCategory("ignored")
-        .Build();
+    protected override void Configure(ModuleConfigurationBuilder module) => module
+        .WithCategory("ignored");
 
     protected override Task<int> ExecuteAsync(
         IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Artifacts/ArtifactContractTests.cs
@@ -191,9 +191,8 @@ public class ArtifactContractTests
     [ConsumesArtifact(typeof(DeclaredProducerModule), "missing-output")]
     private sealed class ConfiguredSkippedInvalidArtifactConsumerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("consumer skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("consumer skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -298,9 +297,8 @@ public class ArtifactContractTests
     {
         public static bool IsReady { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCacheKeyPart("local-producer-v1")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCacheKeyPart("local-producer-v1");
 
         protected internal override async Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -318,11 +316,10 @@ public class ArtifactContractTests
     {
         public static bool ShouldSkip { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => ShouldSkip
                 ? SkipDecision.Skip("mutable condition requested a skip")
-                : SkipDecision.DoNotSkip)
-            .Build();
+                : SkipDecision.DoNotSkip);
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -336,11 +333,10 @@ public class ArtifactContractTests
     {
         public static bool ShouldSkip { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => ShouldSkip
                 ? SkipDecision.Skip("mutable consumer skipped")
-                : SkipDecision.DoNotSkip)
-            .Build();
+                : SkipDecision.DoNotSkip);
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -432,11 +428,10 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => LocalProducerModule.IsReady
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("producer is not ready"))
-            .Build();
+                : SkipDecision.Skip("producer is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -467,11 +462,10 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => ProducerStateIntermediateModule.IsReady
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("producer path is not ready"))
-            .Build();
+                : SkipDecision.Skip("producer path is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -500,11 +494,10 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => DependencyStateSourceModule.IsReady
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("shared dependency state is not ready"))
-            .Build();
+                : SkipDecision.Skip("shared dependency state is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -520,11 +513,10 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => DependencyStateSourceModule.IsReady
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("dependency state is not ready"))
-            .Build();
+                : SkipDecision.Skip("dependency state is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -683,9 +675,8 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("consumer skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("consumer skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -746,9 +737,8 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -762,9 +752,8 @@ public class ArtifactContractTests
     [ProducesArtifact("skipped-runtime", MissingRuntimeFile)]
     private sealed class SkippedArtifactProducerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("producer skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("producer skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -793,9 +782,8 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("consumer skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("consumer skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -814,13 +802,12 @@ public class ArtifactContractTests
 
         public static int SkipEvaluations;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ =>
             {
                 Interlocked.Increment(ref SkipEvaluations);
                 return SkipDecision.Skip("consumer skipped");
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -849,9 +836,8 @@ public class ArtifactContractTests
 
     private sealed class SkippedArtifactBlockerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("blocker skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("blocker skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -863,9 +849,8 @@ public class ArtifactContractTests
     [ProducesArtifact("dependency-ordered", MissingRuntimeFile)]
     private sealed class DependencyOrderedSkippedArtifactProducerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("producer skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("producer skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -909,9 +894,8 @@ public class ArtifactContractTests
 
     private sealed class HistoryBackedSkippedDependencyModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("history-backed dependency skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("history-backed dependency skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -950,11 +934,10 @@ public class ArtifactContractTests
     {
         public static bool Executed { get; set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => ArtifactConsumerStateDependencyModule.IsReady
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("dependency state is not ready"))
-            .Build();
+                : SkipDecision.Skip("dependency state is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -970,11 +953,10 @@ public class ArtifactContractTests
     [ConsumesArtifact(typeof(DeclaredProducerModule), "missing-output")]
     private sealed class DependencyStateInvalidArtifactConsumerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => ArtifactConsumerStateDependencyModule.IsReady
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("dependency state is not ready"))
-            .Build();
+                : SkipDecision.Skip("dependency state is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -1077,9 +1059,8 @@ public class ArtifactContractTests
     [ProducesArtifact("failed-runtime", FailedRuntimeFile)]
     private sealed class IgnoredFailureArtifactProducerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
@@ -83,9 +83,8 @@ public class LifecycleEventIntegrationTests : TestBase
     [LogSkipped]
     public class SkippingModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Test skip reason"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Test skip reason"));
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleMetadataRegistryTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleMetadataRegistryTests.cs
@@ -21,7 +21,7 @@ public class ModuleMetadataRegistryTests
     {
         public Type ResultType => typeof(string);
 
-        public ModuleConfiguration Configuration { get; } = ModuleConfiguration.Create()
+        public ModuleConfiguration Configuration { get; } = new ModuleConfigurationBuilder()
             .WithTags("direct-tag")
             .WithCategory("direct-category")
             .Build();

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -147,11 +147,9 @@ public class ModuleCacheTests
         public const string AssemblyVersionKey = "stable-build-module-v3";
         public const string KeyPart = "configuration-value";
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
                 .WithCacheKeyPart(KeyPart)
-                .WithCacheAssemblyVersionKey(AssemblyVersionKey)
-                .Build();
+                .WithCacheAssemblyVersionKey(AssemblyVersionKey);
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -181,10 +179,8 @@ public class ModuleCacheTests
             return dependency.Value.GetType().FullName!;
         }
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
-                .WithCacheKeyPart("runtime-typed-dependency-v1")
-                .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+                .WithCacheKeyPart("runtime-typed-dependency-v1");
     }
 
     private sealed class RuntimeTypedCachedResultModule : Module<object>
@@ -199,10 +195,8 @@ public class ModuleCacheTests
             return Task.FromResult<object>(1);
         }
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
-                .WithCacheKeyPart("runtime-typed-result-v1")
-                .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+                .WithCacheKeyPart("runtime-typed-result-v1");
     }
 
     private sealed class EnvironmentCachedModule : Module<string?>
@@ -220,10 +214,8 @@ public class ModuleCacheTests
             return Task.FromResult(Environment.GetEnvironmentVariable(EnvironmentVariableName));
         }
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
-                .WithCacheEnvironmentVariable(EnvironmentVariableName)
-                .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+                .WithCacheEnvironmentVariable(EnvironmentVariableName);
     }
 
     private sealed class UncachedModule : Module<string>
@@ -310,10 +302,8 @@ public class ModuleCacheTests
                     : null);
         }
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
-                .WithCacheKeyPart("result-transform-v1")
-                .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+                .WithCacheKeyPart("result-transform-v1");
     }
 
     [ModularPipelines.Attributes.DependsOn<ResultTransformingCachedModule>]
@@ -691,13 +681,11 @@ public class ModuleCacheTests
             return Task.FromResult<string>("result");
         }
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
                 .WithCacheKeyPart("skippable-v1")
                 .WithSkipWhen(_ => ShouldSkip
                     ? SkipDecision.Skip("gate closed")
-                    : SkipDecision.DoNotSkip)
-                .Build();
+                    : SkipDecision.DoNotSkip);
     }
 
     [CacheInputs("empty-directory-input.txt")]
@@ -745,10 +733,8 @@ public class ModuleCacheTests
             return $"dependent:{dependency.ValueOrDefault}";
         }
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
-                .WithCacheKeyPart("dependent-v1")
-                .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+                .WithCacheKeyPart("dependent-v1");
     }
 
     [Test]
@@ -1166,7 +1152,7 @@ public class ModuleCacheTests
     [Test]
     public async Task FluentCacheInputsArePreserved()
     {
-        var configuration = ModularPipelines.Configuration.ModuleConfiguration.Create()
+        var configuration = new ModularPipelines.Configuration.ModuleConfigurationBuilder()
             .WithCacheKeyPart("configuration=v1")
             .WithCacheEnvironmentVariable("CI")
             .WithCacheAssemblyVersionKey("build-module-v3")
@@ -1185,7 +1171,7 @@ public class ModuleCacheTests
     public async Task CacheAssemblyVersionKeyRejectsWhitespace()
     {
         var exception = Assert.Throws<ArgumentException>(() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
+            new ModularPipelines.Configuration.ModuleConfigurationBuilder()
                 .WithCacheAssemblyVersionKey(" "));
 
         await Assert.That(exception.ParamName).IsEqualTo("value");

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -92,9 +92,8 @@ public class PipelineCommandLineTests
 
     private sealed class ConfiguredCategoryModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCategory("configured-category")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCategory("configured-category");
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -104,9 +103,8 @@ public class PipelineCommandLineTests
 
     private sealed class CacheCandidateModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCacheKeyPart("plan-v1")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCacheKeyPart("plan-v1");
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -135,7 +133,7 @@ public class PipelineCommandLineTests
 
     private sealed class ThrowingConfigurationModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() =>
+        protected override void Configure(ModuleConfigurationBuilder module) =>
             throw new InvalidOperationException("Help must not read module configuration.");
 
         protected internal override Task<string> ExecuteAsync(
@@ -166,13 +164,12 @@ public class PipelineCommandLineTests
     [ModularPipelines.Attributes.DependsOn<DependencyModule>]
     private sealed class ResultDependentSkipModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (context, _) =>
             {
                 await context.GetModule<DependencyModule>();
                 return SkipDecision.Skip("dependency result matched");
-            })
-            .Build();
+            });
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -183,28 +180,26 @@ public class PipelineCommandLineTests
     [ModularPipelines.Attributes.DependsOn<DependencyModule>]
     private sealed class UnknownThenSkippedModule : DryRunModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (context, _) =>
             {
                 await context.GetModule<DependencyModule>();
                 return SkipDecision.DoNotSkip;
             })
-            .WithSkipWhen(_ => SkipDecision.Skip("later condition"))
-            .Build();
+            .WithSkipWhen(_ => SkipDecision.Skip("later condition"));
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyModule>]
     private sealed class UnknownAndDoNotSkipModule : DryRunModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhenAll(
                 async (context, _) =>
                 {
                     await context.GetModule<DependencyModule>();
                     return SkipDecision.Skip("result matched");
                 },
-                (_, _) => ValueTask.FromResult(SkipDecision.DoNotSkip))
-            .Build();
+                (_, _) => ValueTask.FromResult(SkipDecision.DoNotSkip));
     }
 
     [ModularPipelines.Attributes.DependsOn<ResultDependentSkipModule>]
@@ -279,10 +274,9 @@ public class PipelineCommandLineTests
 
     private sealed class FluentlySkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithCategory("selected")
-            .WithSkipWhen(_ => SkipDecision.Skip("fluent skip"))
-            .Build();
+            .WithSkipWhen(_ => SkipDecision.Skip("fluent skip"));
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -292,10 +286,9 @@ public class PipelineCommandLineTests
 
     private sealed class SkippedDependencyModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithCategory("selected")
-            .WithSkipWhen(_ => SkipDecision.Skip("dependency unavailable"))
-            .Build();
+            .WithSkipWhen(_ => SkipDecision.Skip("dependency unavailable"));
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -306,9 +299,8 @@ public class PipelineCommandLineTests
     [ModuleCategory("excluded")]
     private sealed class ExcludedSkippedDependencyModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("dependency unavailable"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("dependency unavailable"));
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -319,9 +311,8 @@ public class PipelineCommandLineTests
     [ModularPipelines.Attributes.DependsOn<SkippedDependencyModule>]
     private sealed class DependentOnSkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCategory("selected")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCategory("selected");
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -332,13 +323,12 @@ public class PipelineCommandLineTests
     [ModularPipelines.Attributes.DependsOn<SkippedDependencyModule>]
     private sealed class ResultDependentOnSkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (context, _) =>
             {
                 await context.GetModule<SkippedDependencyModule>();
                 return SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -420,9 +410,8 @@ public class PipelineCommandLineTests
 
     private sealed class FirstLockedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithNotInParallel("shared-plan-lock")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithNotInParallel("shared-plan-lock");
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -432,9 +421,8 @@ public class PipelineCommandLineTests
 
     private sealed class SecondLockedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithNotInParallel("shared-plan-lock")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithNotInParallel("shared-plan-lock");
 
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
@@ -473,9 +461,8 @@ public class PipelineCommandLineTests
 
     private sealed class SecondHighPriorityModule : DryRunModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithPriority(ModulePriority.High)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithPriority(ModulePriority.High);
     }
 
     [ExecutionHint(ExecutionType.CpuIntensive)]
@@ -608,16 +595,15 @@ public class PipelineCommandLineTests
 
     private sealed class RegistrationOnlyOptionalSkipModule : DryRunModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(context => context.GetModuleIfRegistered<MissingOptionalModule>() is null
                 ? SkipDecision.Skip("optional module absent")
-                : SkipDecision.DoNotSkip)
-            .Build();
+                : SkipDecision.DoNotSkip);
     }
 
     private sealed class OptionalResultDependentSkipModule : DryRunModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (context, _) =>
             {
                 var dependency = context.GetModuleIfRegistered<DependencyModule>();
@@ -628,8 +614,7 @@ public class PipelineCommandLineTests
 
                 await dependency;
                 return SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
     }
 
     [ModularPipelines.Attributes.DependsOn<SkippedCycleBModule>]

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -98,7 +98,7 @@ public class ModuleConfigurationTests
     [Arguments(false, null)]
     public async Task WithSkipWhen_BooleanCondition_MapsDecision(bool shouldSkip, string? expectedReason)
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen(_ => shouldSkip, "Skip reason")
             .Build();
 
@@ -116,7 +116,7 @@ public class ModuleConfigurationTests
     {
         using var cancellationTokenSource = new CancellationTokenSource();
         CancellationToken? receivedToken = null;
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen((_, cancellationToken) =>
             {
                 receivedToken = cancellationToken;

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -65,7 +65,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task Create_ReturnsBuilder()
     {
-        var builder = ModuleConfiguration.Create();
+        var builder = new ModuleConfigurationBuilder();
 
         await Assert.That(builder).IsNotNull();
         await Assert.That(builder).IsTypeOf<ModuleConfigurationBuilder>();
@@ -154,7 +154,7 @@ public class ModuleConfigurationTests
     public async Task WithSkipWhen_RepeatedCalls_OrComposeAndShortCircuit()
     {
         var evaluatedConditions = new List<string>();
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen(_ =>
             {
                 evaluatedConditions.Add("first");
@@ -180,7 +180,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithSkipWhen_RepeatedCalls_SkipWhenLaterConditionMatches()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen(_ => SkipDecision.DoNotSkip)
             .WithSkipWhen(_ => SkipDecision.Skip("Second reason"))
             .Build();
@@ -200,7 +200,7 @@ public class ModuleConfigurationTests
         var context = Mock.Of<IModuleContext>();
         var expectedDecision = SkipDecision.Skip("Test reason");
 
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen(receivedContext =>
                 ReferenceEquals(receivedContext, context) ? expectedDecision : SkipDecision.DoNotSkip)
             .Build();
@@ -219,7 +219,7 @@ public class ModuleConfigurationTests
     {
         var expectedDecision = SkipDecision.Skip("Async reason");
 
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen(async (_, _) =>
             {
                 await Task.Delay(1).ConfigureAwait(false);
@@ -242,7 +242,7 @@ public class ModuleConfigurationTests
     {
         using var cancellationTokenSource = new CancellationTokenSource();
         CancellationToken? receivedToken = null;
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen((_, cancellationToken) =>
             {
                 receivedToken = cancellationToken;
@@ -258,7 +258,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithSkipWhenAll_AllConditionsSkip_CombinesReasons()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhenAll(
                 _ => SkipDecision.Skip("First reason"),
                 _ => SkipDecision.Skip("Second reason"))
@@ -277,7 +277,7 @@ public class ModuleConfigurationTests
     public async Task WithSkipWhenAll_StopsWhenConditionDoesNotSkip()
     {
         var evaluatedConditions = new List<string>();
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhenAll(
                 _ =>
                 {
@@ -307,7 +307,7 @@ public class ModuleConfigurationTests
         [
             (_, _) => ValueTask.FromResult(SkipDecision.Skip("Original reason")),
         ];
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhenAll(conditions)
             .Build();
 
@@ -327,7 +327,7 @@ public class ModuleConfigurationTests
     [Test]
     public void WithSkipWhenAll_RejectsEmptyGroups()
     {
-        var builder = ModuleConfiguration.Create();
+        var builder = new ModuleConfigurationBuilder();
 
         Assert.Throws<ArgumentException>(() =>
             builder.WithSkipWhenAll(Array.Empty<Func<IModuleContext, SkipDecision>>()));
@@ -336,7 +336,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task Build_SnapshotsSkipConditions()
     {
-        var builder = ModuleConfiguration.Create()
+        var builder = new ModuleConfigurationBuilder()
             .WithSkipWhen(_ => SkipDecision.DoNotSkip);
         var firstConfig = builder.Build();
 
@@ -363,7 +363,7 @@ public class ModuleConfigurationTests
     {
         var timeout = TimeSpan.FromMinutes(5);
 
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithTimeout(timeout)
             .Build();
 
@@ -377,7 +377,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithRetry_UsesDefaultBaseDelay()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithRetry(3)
             .Build();
 
@@ -397,7 +397,7 @@ public class ModuleConfigurationTests
         var baseDelay = TimeSpan.FromSeconds(2);
         Func<Exception, bool> shouldRetry = exception => exception is TimeoutException;
 
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithRetry(5, baseDelay, shouldRetry)
             .Build();
 
@@ -414,9 +414,9 @@ public class ModuleConfigurationTests
     public async Task WithRetry_RejectsNegativeValues()
     {
         var countException = Assert.Throws<ArgumentOutOfRangeException>(
-            () => ModuleConfiguration.Create().WithRetry(-1));
+            () => new ModuleConfigurationBuilder().WithRetry(-1));
         var delayException = Assert.Throws<ArgumentOutOfRangeException>(
-            () => ModuleConfiguration.Create().WithRetry(1, TimeSpan.FromMilliseconds(-1)));
+            () => new ModuleConfigurationBuilder().WithRetry(1, TimeSpan.FromMilliseconds(-1)));
 
         using (Assert.Multiple())
         {
@@ -430,7 +430,7 @@ public class ModuleConfigurationTests
     {
         var shield = Shield.Retry(0);
 
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithShield(shield)
             .Build();
 
@@ -447,7 +447,7 @@ public class ModuleConfigurationTests
     {
         var shield = Shield.Retry(0);
 
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithShield(_ => shield)
             .Build();
 
@@ -530,7 +530,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithIgnoreFailures_Always_SetsIgnoreFailuresCondition()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithIgnoreFailures()
             .Build();
 
@@ -545,7 +545,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithIgnoreFailuresWhen_SyncCondition_SetsIgnoreFailuresCondition()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithIgnoreFailuresWhen((ctx, ex) => ex.Message == "ignore")
             .Build();
 
@@ -563,7 +563,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithIgnoreFailuresWhen_AsyncCondition_SetsIgnoreFailuresCondition()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithIgnoreFailuresWhen(async (ctx, ex) =>
             {
                 await Task.Delay(1).ConfigureAwait(false);
@@ -587,7 +587,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task WithAlwaysRun_SetsAlwaysRun()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithAlwaysRun()
             .Build();
 
@@ -601,7 +601,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task Builder_Configures_Scheduling_Metadata_And_Dependencies()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithNotInParallel("database")
             .WithPriority(ModulePriority.Critical)
             .WithExecutionHint(ExecutionType.IoIntensive)
@@ -625,7 +625,7 @@ public class ModuleConfigurationTests
     [Test]
     public async Task Builder_FluentChaining_AllMethodsChain()
     {
-        var config = ModuleConfiguration.Create()
+        var config = new ModuleConfigurationBuilder()
             .WithSkipWhen(_ => SkipDecision.DoNotSkip)
             .WithTimeout(TimeSpan.FromMinutes(1))
             .WithRetry(3)

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
@@ -161,13 +161,15 @@ public class ModuleConfigureTests
     {
         const System.Reflection.BindingFlags publicStatic =
             System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static;
+        const System.Reflection.BindingFlags publicInstance =
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance;
 
         using (Assert.Multiple())
         {
             await Assert.That(typeof(ModuleConfiguration).GetConstructors()).IsEmpty();
             await Assert.That(typeof(ModuleConfiguration).GetProperty("Default", publicStatic)).IsNull();
             await Assert.That(typeof(ModuleConfiguration).GetMethod("Create", publicStatic)).IsNull();
-            await Assert.That(typeof(ModuleConfigurationBuilder).GetMethod("Build", publicStatic)).IsNull();
+            await Assert.That(typeof(ModuleConfigurationBuilder).GetMethod("Build", publicInstance)).IsNull();
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
@@ -15,12 +15,10 @@ public class ModuleConfigureTests
     {
         public int ConfigureCount { get; private set; }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             ConfigureCount++;
-            return ModuleConfiguration.Create()
-                .WithTags("cached-tag")
-                .Build();
+            module.WithTags("cached-tag");
         }
 
         protected internal override Task<string> ExecuteAsync(
@@ -37,10 +35,9 @@ public class ModuleConfigureTests
 
     private class ConfiguredModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromSeconds(60))
-            .WithAlwaysRun()
-            .Build();
+            .WithAlwaysRun();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("test");
@@ -54,13 +51,12 @@ public class ModuleConfigureTests
     [ModularPipelines.Attributes.DependsOn<TestModule>]
     private class UnifiedConfigurationModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithNotInParallel("fluent-lock")
             .WithPriority(ModulePriority.Critical)
             .WithExecutionHint(ExecutionType.IoIntensive)
             .WithTags("fluent-tag")
-            .WithCategory("fluent-category")
-            .Build();
+            .WithCategory("fluent-category");
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("test");
@@ -69,21 +65,25 @@ public class ModuleConfigureTests
     [ModularPipelines.Attributes.DependsOn<TestModule>]
     private class RequiredAndOptionalDependencyModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnOptional<TestModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) =>
+            module.DependsOnOptional<TestModule>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("test");
     }
 
     [Test]
-    public async Task Module_DefaultConfiguration_ReturnsDefault()
+    public async Task Module_DefaultConfiguration_HasDefaultValues()
     {
         var module = new TestModule();
         var config = ((IModule) module).Configuration;
 
-        await Assert.That(config).IsSameReferenceAs(ModuleConfiguration.Default);
+        using (Assert.Multiple())
+        {
+            await Assert.That(config.Timeout).IsNull();
+            await Assert.That(config.AlwaysRun).IsFalse();
+            await Assert.That(config.Dependencies).IsEmpty();
+        }
     }
 
     [Test]
@@ -154,5 +154,20 @@ public class ModuleConfigureTests
 
         await Assert.That(dependency.Kind).IsEqualTo(DependencyType.Required);
         await Assert.That(dependency.IsOptional).IsFalse();
+    }
+
+    [Test]
+    public async Task ConfigurationConstructionApisAreNotPublic()
+    {
+        const System.Reflection.BindingFlags publicStatic =
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(typeof(ModuleConfiguration).GetConstructors()).IsEmpty();
+            await Assert.That(typeof(ModuleConfiguration).GetProperty("Default", publicStatic)).IsNull();
+            await Assert.That(typeof(ModuleConfiguration).GetMethod("Create", publicStatic)).IsNull();
+            await Assert.That(typeof(ModuleConfigurationBuilder).GetMethod("Build", publicStatic)).IsNull();
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Configuration/UnifiedModuleConfigurationIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/UnifiedModuleConfigurationIntegrationTests.cs
@@ -25,14 +25,13 @@ public class UnifiedModuleConfigurationIntegrationTests
 
     private sealed class ConfiguredModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .DependsOn<DependencyModule>()
             .WithTags("configured")
             .WithCategory("configured-category")
             .WithNotInParallel("configured-lock")
             .WithPriority(ModulePriority.High)
-            .WithExecutionHint(ExecutionType.IoIntensive)
-            .Build();
+            .WithExecutionHint(ExecutionType.IoIntensive);
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -54,9 +53,8 @@ public class UnifiedModuleConfigurationIntegrationTests
 
     private sealed class FailingTaggedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTags("failing")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTags("failing");
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => throw new InvalidOperationException("Expected test failure");
@@ -74,9 +72,8 @@ public class UnifiedModuleConfigurationIntegrationTests
 
     private sealed class SelfDependentModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<SelfDependentModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<SelfDependentModule>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("self-dependent");
@@ -84,9 +81,8 @@ public class UnifiedModuleConfigurationIntegrationTests
 
     private sealed class CircularDependencyModuleA : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<CircularDependencyModuleB>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<CircularDependencyModuleB>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("a");
@@ -94,9 +90,8 @@ public class UnifiedModuleConfigurationIntegrationTests
 
     private sealed class CircularDependencyModuleB : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<CircularDependencyModuleA>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<CircularDependencyModuleA>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("b");

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -87,9 +87,8 @@ public class CategoryFilterDependencyTests : TestBase
 
     private class FluentlySkippedModule : SimpleTestModule<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Fluent skip"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Fluent skip"));
 
         protected override string Result => throw new InvalidOperationException("A fluently skipped module must not execute");
     }

--- a/test/ModularPipelines.UnitTests/Dependencies/FlexibleDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/FlexibleDependencyIntegrationTests.cs
@@ -516,9 +516,8 @@ public class FlexibleDependencyIntegrationTests : TestBase
 
     private class ModuleWithConfiguredTags : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTags("database", "configured-tag")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTags("database", "configured-tag");
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -530,9 +529,8 @@ public class FlexibleDependencyIntegrationTests : TestBase
 
     private class ModuleWithConfiguredCategory : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCategory("infrastructure")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCategory("infrastructure");
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Dependencies/FluentDependencyConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/FluentDependencyConfigurationTests.cs
@@ -43,9 +43,8 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithProgrammaticDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<BaseModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<BaseModule>();
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -59,9 +58,8 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithOptionalDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnOptional<OptionalDependencyModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOnOptional<OptionalDependencyModule>();
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -75,9 +73,8 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithActiveConditionalDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnIf<ConditionalModule>(true)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOnIf<ConditionalModule>(true);
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -91,9 +88,8 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithInactiveConditionalDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnIf<ConditionalModule>(false)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOnIf<ConditionalModule>(false);
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -108,9 +104,8 @@ public class FluentDependencyConfigurationTests : TestBase
     [ModularPipelines.Attributes.DependsOn<BaseModule>]
     private class ModuleWithBothAttributeAndProgrammaticDependencies : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnOptional<OptionalDependencyModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOnOptional<OptionalDependencyModule>();
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -124,10 +119,9 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithChainedDependencies : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .DependsOn<BaseModule>()
-            .DependsOnOptional<OptionalDependencyModule>()
-            .Build();
+            .DependsOnOptional<OptionalDependencyModule>();
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -141,9 +135,8 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithMissingRequiredDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<BaseModule>() // BaseModule not registered
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) =>
+            module.DependsOn<BaseModule>(); // BaseModule not registered
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -157,9 +150,8 @@ public class FluentDependencyConfigurationTests : TestBase
     /// </summary>
     private class ModuleWithTypeDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn(typeof(BaseModule))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn(typeof(BaseModule));
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Dependencies/ModuleDependencyResolverTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/ModuleDependencyResolverTests.cs
@@ -19,7 +19,7 @@ public class ModuleDependencyResolverTests
     {
         public Type ResultType => typeof(string);
 
-        public ModuleConfiguration Configuration { get; } = ModuleConfiguration.Create()
+        public ModuleConfiguration Configuration { get; } = new ModuleConfigurationBuilder()
             .DependsOnOptional<DependencyModule>()
             .Build();
     }

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -528,7 +528,6 @@ public class DependencyGraphExporterTests
             {
                 throw new InvalidOperationException("Mutable configuration state was shared.");
             }
-
         }
 
         protected internal override Task<string?> ExecuteAsync(

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -251,12 +251,11 @@ public class DependencyGraphExporterTests
         protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
             new OptionalLookupPlanningSkipModule();
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(context =>
                 context.GetModuleIfRegistered<OptionalPlanningDependencyModule>() is null
                     ? SkipDecision.DoNotSkip
-                    : SkipDecision.Skip("Runtime dependency was exposed during planning"))
-            .Build();
+                    : SkipDecision.Skip("Runtime dependency was exposed during planning"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -352,14 +351,13 @@ public class DependencyGraphExporterTests
     [ConsumesArtifact(typeof(HistoricalArtifactProducerModule), "graph-output")]
     private sealed class AsyncHistoricalArtifactConsumerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (_, _) =>
             {
                 Interlocked.Increment(ref _asyncSkipConditionEvaluations);
                 await Task.Yield();
                 return SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -372,9 +370,8 @@ public class DependencyGraphExporterTests
     [ConsumesArtifact(typeof(HistoricalArtifactProducerModule), "graph-output")]
     private sealed class SynchronouslySkippedArtifactConsumerModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("consumer is synchronously skipped"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("consumer is synchronously skipped"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -397,9 +394,8 @@ public class DependencyGraphExporterTests
     [AddRegistrationDependency(typeof(UnregisteredModule))]
     private sealed class InvalidSkippedDynamicDependencyModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("configured skip"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("configured skip"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -507,9 +503,8 @@ public class DependencyGraphExporterTests
 
     private sealed class PlanningCategoryModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCategory("planning")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCategory("planning");
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -526,7 +521,7 @@ public class DependencyGraphExporterTests
         protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
             new MutableConfigurationStateModule();
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             _configurationCalls.Add("configured");
             if (_configurationCalls.Count > 1)
@@ -534,7 +529,6 @@ public class DependencyGraphExporterTests
                 throw new InvalidOperationException("Mutable configuration state was shared.");
             }
 
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -552,12 +546,11 @@ public class DependencyGraphExporterTests
 
     private sealed class GlobalConfigurationMutationModule : Module<int>
     {
-        protected override ModuleConfiguration Configure() => CreateConfiguration();
+        protected override void Configure(ModuleConfigurationBuilder module) => CreateConfiguration();
 
-        private static ModuleConfiguration CreateConfiguration()
+        private static void CreateConfiguration()
         {
             Interlocked.Increment(ref _globalConfigurationMutations);
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -568,10 +561,9 @@ public class DependencyGraphExporterTests
 
     private sealed class ConstructorConfigurationMutationModule : Module<int>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             _ = new ConfigurationMutationProbe();
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -582,10 +574,9 @@ public class DependencyGraphExporterTests
 
     private sealed class ExternalConstructorConfigurationMutationModule : Module<int>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             _ = new ExternalConfigurationMutationProbe();
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -596,19 +587,19 @@ public class DependencyGraphExporterTests
 
     private abstract class VirtualConfigurationMutationBaseModule : Module<int>
     {
-        protected override ModuleConfiguration Configure() => CreateConfiguration();
+        protected override void Configure(ModuleConfigurationBuilder module) => CreateConfiguration();
 
-        protected virtual ModuleConfiguration CreateConfiguration() =>
-            ModuleConfiguration.Default;
+        protected virtual void CreateConfiguration()
+        {
+        }
     }
 
     private sealed class VirtualConfigurationMutationModule
         : VirtualConfigurationMutationBaseModule
     {
-        protected override ModuleConfiguration CreateConfiguration()
+        protected override void CreateConfiguration()
         {
             Interlocked.Increment(ref _globalConfigurationMutations);
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -619,16 +610,16 @@ public class DependencyGraphExporterTests
 
     private class VirtualConfigurationHelper
     {
-        public virtual ModuleConfiguration CreateConfiguration() =>
-            ModuleConfiguration.Default;
+        public virtual void CreateConfiguration()
+        {
+        }
     }
 
     private sealed class StatefulVirtualConfigurationHelper : VirtualConfigurationHelper
     {
-        public override ModuleConfiguration CreateConfiguration()
+        public override void CreateConfiguration()
         {
             Interlocked.Increment(ref _globalConfigurationMutations);
-            return ModuleConfiguration.Default;
         }
     }
 
@@ -637,7 +628,7 @@ public class DependencyGraphExporterTests
         private readonly VirtualConfigurationHelper _helper =
             new StatefulVirtualConfigurationHelper();
 
-        protected override ModuleConfiguration Configure() =>
+        protected override void Configure(ModuleConfigurationBuilder module) =>
             _helper.CreateConfiguration();
 
         protected internal override Task<int> ExecuteAsync(
@@ -656,13 +647,12 @@ public class DependencyGraphExporterTests
     {
         public const string EnvironmentVariableName = "MODULAR_PIPELINES_GRAPH_PLANNING_TEST";
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var currentValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
             Environment.SetEnvironmentVariable(
                 EnvironmentVariableName,
                 currentValue is null ? "configured" : currentValue + "-configured");
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -675,10 +665,9 @@ public class DependencyGraphExporterTests
     {
         private readonly PlanningMutationPlugin _plugin = new();
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             PluginRegistry.Register(_plugin);
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -707,9 +696,8 @@ public class DependencyGraphExporterTests
 
     private sealed class StaticRuntimeBoundPlanningConditionModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(EvaluatePlanningSkip)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(EvaluatePlanningSkip);
 
         private static SkipDecision EvaluatePlanningSkip(IModuleContext context) =>
             Interlocked.Increment(ref _staticPlanningSkipEvaluations) == 1
@@ -724,9 +712,8 @@ public class DependencyGraphExporterTests
 
     private sealed class ConstructorBoundPlanningConditionModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(EvaluatePlanningSkip)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(EvaluatePlanningSkip);
 
         private static SkipDecision EvaluatePlanningSkip(IModuleContext context)
         {
@@ -749,10 +736,9 @@ public class DependencyGraphExporterTests
     private sealed class InjectedConfigurationMutationModule(ConfigurationMutationCounter counter)
         : Module<int>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             counter.Count++;
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -773,10 +759,9 @@ public class DependencyGraphExporterTests
             counter.Activations++;
         }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             _holder.Counter.Count++;
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<int> ExecuteAsync(
@@ -790,11 +775,10 @@ public class DependencyGraphExporterTests
     {
         private int _planningEvaluations;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => ++_planningEvaluations == 1
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("runtime state changed"))
-            .Build();
+                : SkipDecision.Skip("runtime state changed"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -808,16 +792,13 @@ public class DependencyGraphExporterTests
 
         public int ConfigurationCallCount => _configurationCallCount;
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             _configurationCallCount++;
-            var builder = ModuleConfiguration.Create();
             if (_configurationCallCount == 1)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -830,15 +811,12 @@ public class DependencyGraphExporterTests
     {
         public bool IncludeDependency { get; init; }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -851,15 +829,12 @@ public class DependencyGraphExporterTests
     {
         public bool IncludeDependency { get; init; }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
@@ -873,10 +848,9 @@ public class DependencyGraphExporterTests
 
     private sealed class SharedMutableFactoryStateModule(List<string> state) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             state.Add("configured");
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -889,10 +863,9 @@ public class DependencyGraphExporterTests
 
     private sealed class StructWrappedFactoryStateModule(StructWrappedState state) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             state.Values.Add("configured");
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -954,15 +927,12 @@ public class DependencyGraphExporterTests
         {
         }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (ReferenceEquals(state, DependencySentinel))
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -973,15 +943,12 @@ public class DependencyGraphExporterTests
 
     private sealed class ExternalConfigurationFactoryModule : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (_externalConfigurationIncludesDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1051,15 +1018,12 @@ public class DependencyGraphExporterTests
     private sealed class ServiceBackedFactoryModule(PlanningSingletonDependency dependency)
         : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (dependency.IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1081,15 +1045,12 @@ public class DependencyGraphExporterTests
     private sealed class InheritedSettingsFactoryModule(DerivedFactorySettings settings)
         : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (settings.IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1106,15 +1067,12 @@ public class DependencyGraphExporterTests
     private sealed class AliasTopologyFactoryModule(AliasState first, AliasState second)
         : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (ReferenceEquals(first, second) && first.IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1125,17 +1083,14 @@ public class DependencyGraphExporterTests
 
     private sealed class ArrayShapeFactoryModule(Array state) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (state.Rank == 2
                 && state.GetLength(0) == 1
                 && state.GetLowerBound(0) == 0)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1146,15 +1101,12 @@ public class DependencyGraphExporterTests
 
     private sealed class ComparerBackedFactoryModule(HashSet<string> values) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (values.Comparer.Equals("dependency", "DEPENDENCY"))
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1170,15 +1122,12 @@ public class DependencyGraphExporterTests
 
     private sealed class PrecreatedConfiguredModule(PrecreatedModuleSettings settings) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (settings.IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
@@ -1216,15 +1165,12 @@ public class DependencyGraphExporterTests
 
     private sealed class CapturingComparerFactoryModule(IComparer<string> comparer) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (comparer.Compare("dependency", "other") < 0)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1245,15 +1191,12 @@ public class DependencyGraphExporterTests
     {
         public bool IncludeDependency { get; init; }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1298,15 +1241,12 @@ public class DependencyGraphExporterTests
     {
         private readonly SelectiveEqualityState _state = new(includeDependency);
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (_state.IncludeDependency)
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1442,11 +1382,10 @@ public class DependencyGraphExporterTests
 
     private sealed class StartupConfiguredModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => _startupConfigurationEnabled
                 ? SkipDecision.DoNotSkip
-                : SkipDecision.Skip("startup configuration is not ready"))
-            .Build();
+                : SkipDecision.Skip("startup configuration is not ready"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -1459,14 +1398,12 @@ public class DependencyGraphExporterTests
 
     private sealed class FactorySkipModule(bool shouldSkip) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var capturedDecision = shouldSkip
                 ? SkipDecision.Skip("factory requested a skip")
                 : SkipDecision.DoNotSkip;
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(_ => capturedDecision)
-                .Build();
+            module.WithSkipWhen(_ => capturedDecision);
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1477,14 +1414,12 @@ public class DependencyGraphExporterTests
 
     private sealed class MutableClosureFactorySkipModule(string factoryValue) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var evaluations = 0;
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(_ => ++evaluations == 1
+            module.WithSkipWhen(_ => ++evaluations == 1
                     ? SkipDecision.Skip("first evaluation")
-                    : SkipDecision.DoNotSkip)
-                .Build();
+                    : SkipDecision.DoNotSkip);
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1537,13 +1472,11 @@ public class DependencyGraphExporterTests
 
     private sealed class MutableReferenceClosureFactorySkipModule(string factoryValue) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var decisions = new Queue<SkipDecision>(
                 [SkipDecision.Skip("first evaluation"), SkipDecision.DoNotSkip]);
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(_ => decisions.Dequeue())
-                .Build();
+            module.WithSkipWhen(_ => decisions.Dequeue());
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1566,12 +1499,10 @@ public class DependencyGraphExporterTests
 
     private sealed class MutableStructClosureFactorySkipModule(string factoryValue) : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var counter = new MutablePlanningCounter();
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(_ => counter.NextDecision())
-                .Build();
+            module.WithSkipWhen(_ => counter.NextDecision());
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1587,15 +1518,14 @@ public class DependencyGraphExporterTests
     {
         public int PlanningEvaluations { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ =>
             {
                 PlanningEvaluations++;
                 return shouldSkip
                     ? SkipDecision.Skip("factory requested a skip")
                     : SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -1607,12 +1537,10 @@ public class DependencyGraphExporterTests
     {
         public int PlanningEvaluations { get; private set; }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var target = new RuntimeBoundSkipTarget(this, shouldSkip);
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(target.ShouldSkip)
-                .Build();
+            module.WithSkipWhen(target.ShouldSkip);
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1638,12 +1566,10 @@ public class DependencyGraphExporterTests
     {
         public int PlanningEvaluations { get; private set; }
 
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var target = new RuntimeBoundCollectionSkipTarget([this], shouldSkip);
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(target.ShouldSkip)
-                .Build();
+            module.WithSkipWhen(target.ShouldSkip);
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1669,7 +1595,7 @@ public class DependencyGraphExporterTests
     {
         public int PlanningEvaluations { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (_, _) =>
             {
                 PlanningEvaluations++;
@@ -1677,8 +1603,7 @@ public class DependencyGraphExporterTests
                 return shouldSkip
                     ? SkipDecision.Skip("factory requested a skip")
                     : SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -1697,9 +1622,13 @@ public class DependencyGraphExporterTests
 
         public void Dispose() => Interlocked.Increment(ref Disposals);
 
-        protected override ModuleConfiguration Configure() => HasFactoryState
-            ? ModuleConfiguration.Default
-            : throw new InvalidOperationException("Factory state is unavailable.");
+        protected override void Configure(ModuleConfigurationBuilder module)
+        {
+            if (!HasFactoryState)
+            {
+                throw new InvalidOperationException("Factory state is unavailable.");
+            }
+        }
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -1726,16 +1655,10 @@ public class DependencyGraphExporterTests
 
     private sealed class ByRefMutableClosureFactorySkipModule(string factoryValue) : Module<string>
     {
-        private readonly ModuleConfiguration _configuration = CreateConfiguration();
-
-        protected override ModuleConfiguration Configure() => _configuration;
-
-        private static ModuleConfiguration CreateConfiguration()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             var evaluations = 0;
-            return ModuleConfiguration.Create()
-                .WithSkipWhen(_ => NextDecision(ref evaluations))
-                .Build();
+            module.WithSkipWhen(_ => NextDecision(ref evaluations));
         }
 
         private static SkipDecision NextDecision(ref int evaluations) =>
@@ -1911,14 +1834,12 @@ public class DependencyGraphExporterTests
 
     private sealed class SingleUseConfigurationFactoryModule : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
             if (Interlocked.Increment(ref _singleUseConfigurationCalls) != 1)
             {
                 throw new InvalidOperationException("Configuration was replayed.");
             }
-
-            return ModuleConfiguration.Default;
         }
 
         protected internal override Task<string?> ExecuteAsync(
@@ -1983,9 +1904,8 @@ public class DependencyGraphExporterTests
 
     private sealed class ConfiguredSkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("configured skip"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("configured skip"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -2005,13 +1925,12 @@ public class DependencyGraphExporterTests
     [ModularPipelines.Attributes.DependsOn<DependencyModule>]
     private sealed class ResultDependentConfiguredSkipModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (context, _) =>
             {
                 await context.GetModule<DependencyModule>();
                 return SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -2021,14 +1940,13 @@ public class DependencyGraphExporterTests
 
     private sealed class AsyncConfiguredSkipModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (_, cancellationToken) =>
             {
                 Interlocked.Increment(ref _asyncSkipConditionEvaluations);
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 return SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -2038,15 +1956,14 @@ public class DependencyGraphExporterTests
 
     private sealed class SynchronouslySkippedBeforeAsyncModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(_ => SkipDecision.Skip("synchronous short circuit"))
             .WithSkipWhen(async (_, _) =>
             {
                 Interlocked.Increment(ref _asyncSkipConditionEvaluations);
                 await Task.Yield();
                 return SkipDecision.DoNotSkip;
-            })
-            .Build();
+            });
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -2056,15 +1973,14 @@ public class DependencyGraphExporterTests
 
     private sealed class SynchronouslySkippedAfterAsyncModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithSkipWhen(async (_, _) =>
             {
                 Interlocked.Increment(ref _asyncSkipConditionEvaluations);
                 await Task.Yield();
                 return SkipDecision.DoNotSkip;
             })
-            .WithSkipWhen(_ => SkipDecision.Skip("synchronous short circuit"))
-            .Build();
+            .WithSkipWhen(_ => SkipDecision.Skip("synchronous short circuit"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
@@ -2467,15 +2383,12 @@ public class DependencyGraphExporterTests
 
     private sealed class ExternalHelperConfigurationModule : Module<string>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            var builder = ModuleConfiguration.Create();
             if (ExternalConfigurationState.ShouldIncludeDependency())
             {
-                builder.DependsOn<DependencyModule>();
+                module.DependsOn<DependencyModule>();
             }
-
-            return builder.Build();
         }
 
         protected internal override Task<string?> ExecuteAsync(

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -482,11 +482,9 @@ public class AlwaysRunHandlerTests
 
     private abstract class AlwaysRunTestModule : Module<bool>
     {
-        protected override ModuleConfiguration Configure()
+        protected override void Configure(ModuleConfigurationBuilder module)
         {
-            return ModuleConfiguration.Create()
-                .WithAlwaysRun()
-                .Build();
+            module.WithAlwaysRun();
         }
 
         protected internal override Task<bool> ExecuteAsync(

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -514,9 +514,7 @@ public class ParallelLimitHandlerTests
 
     private sealed class AlwaysRunTestModule : TestModule
     {
-        protected override ModuleConfiguration Configure() =>
-            ModuleConfiguration.Create()
-                .WithAlwaysRun()
-                .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+                .WithAlwaysRun();
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -229,9 +229,8 @@ public class GeneratedModuleMetadataTests
 
     private sealed class GeneratedAlwaysRunModule : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -79,16 +79,14 @@ public class ModuleExecutionPipelineTests
 
     private sealed class IgnoredTimeoutExceptionModule : TimeoutExceptionModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
     }
 
     private sealed class ElapsedCancellationModule : Module<int>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromMilliseconds(5))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromMilliseconds(5));
 
         protected internal override Task<int> ExecuteAsync(
             IModuleContext context,
@@ -100,9 +98,8 @@ public class ModuleExecutionPipelineTests
 
     private sealed class IgnoredCancellationModule : Module<int>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected internal override Task<int> ExecuteAsync(
             IModuleContext context,
@@ -114,9 +111,8 @@ public class ModuleExecutionPipelineTests
 
     private sealed class AlwaysRunTimeoutExceptionModule : Module<int>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override Task<int> ExecuteAsync(
             IModuleContext context,
@@ -130,10 +126,9 @@ public class ModuleExecutionPipelineTests
 
     private sealed class AlwaysRunElapsedCancellationModule : Module<int>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithAlwaysRun()
-            .WithTimeout(TimeSpan.FromMilliseconds(5))
-            .Build();
+            .WithTimeout(TimeSpan.FromMilliseconds(5));
 
         protected internal override Task<int> ExecuteAsync(
             IModuleContext context,
@@ -293,10 +288,8 @@ public class ModuleExecutionPipelineTests
 
     private sealed class CachedSuccessfulModule : SuccessfulModule
     {
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
-            ModularPipelines.Configuration.ModuleConfiguration.Create()
-                .WithCacheKeyPart("v1")
-                .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+                .WithCacheKeyPart("v1");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -46,10 +46,8 @@ public class ModuleExecutorLoggingTests
 
     private class QueuedAlwaysRunModule : Module<bool>
     {
-        protected override ModuleConfiguration Configure() =>
-            ModuleConfiguration.Create()
-                .WithAlwaysRun()
-                .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+                .WithAlwaysRun();
 
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
@@ -44,9 +44,8 @@ public class PipelineProgressTests
     [ModularPipelines.Attributes.DependsOn<Module1>]
     private class Module4 : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Testing"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Testing"));
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -58,9 +57,8 @@ public class PipelineProgressTests
     [ModularPipelines.Attributes.DependsOn<Module1>]
     private class Module5 : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -68,9 +68,8 @@ public class RunReportTests
 
     private sealed class SkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("report skip reason"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("report skip reason"));
 
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Execution/AlwaysRunTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/AlwaysRunTests.cs
@@ -22,9 +22,8 @@ public class AlwaysRunTests : TestBase
     [ModularPipelines.Attributes.DependsOn<MyModule1>]
     public class MyModule2 : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -36,9 +35,8 @@ public class AlwaysRunTests : TestBase
     [ModularPipelines.Attributes.DependsOn<MyModule2>]
     public class MyModule3 : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -50,9 +48,8 @@ public class AlwaysRunTests : TestBase
     [ModularPipelines.Attributes.DependsOn<MyModule3>]
     public class MyModule4 : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -64,9 +61,8 @@ public class AlwaysRunTests : TestBase
     [ModularPipelines.Attributes.DependsOn<MyModule1>]
     public class SuccessfulAlwaysRunModule : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Execution/ComposableModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ComposableModuleTests.cs
@@ -22,9 +22,8 @@ public class ComposableModuleTests
     /// </summary>
     private class AlwaysSkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Skipped via composition"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Skipped via composition"));
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -38,9 +37,8 @@ public class ComposableModuleTests
     /// </summary>
     private class NeverSkippedModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.DoNotSkip)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.DoNotSkip);
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -54,9 +52,8 @@ public class ComposableModuleTests
     /// </summary>
     private class TimeoutableModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromSeconds(5))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromSeconds(5));
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -73,10 +70,9 @@ public class ComposableModuleTests
         public static bool BeforeHookCalled { get; private set; }
         public static bool AfterHookCalled { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromMinutes(1))
-            .WithSkipWhen(_ => SkipDecision.DoNotSkip)
-            .Build();
+            .WithSkipWhen(_ => SkipDecision.DoNotSkip);
 
         protected internal override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -113,9 +109,8 @@ public class ComposableModuleTests
     /// </summary>
     private class AlwaysRunModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -43,9 +43,8 @@ public class EngineCancellationTokenTests : TestBase
     {
         protected override bool Result => true;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
     }
 
     [ModularPipelines.Attributes.DependsOn<AlwaysRunBarrierModule>]
@@ -69,9 +68,8 @@ public class EngineCancellationTokenTests : TestBase
     {
         private readonly TaskCompletionSource<bool> _taskCompletionSource = new();
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromSeconds(10))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromSeconds(10));
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -194,9 +192,8 @@ public class EngineCancellationTokenTests : TestBase
 
     private class AwaitingTerminatedModule : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithAlwaysRun()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun();
 
         protected internal override async Task<bool> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Execution/IgnoredFailureTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/IgnoredFailureTests.cs
@@ -15,9 +15,8 @@ public class IgnoredFailureTests : TestBase
 {
     private class IgnoredFailureModule : Module<CommandResult>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
@@ -61,9 +61,8 @@ public class ModuleHistoryTests
 
     private class SkipFromMethod : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Testing"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Testing"));
 
         protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -14,9 +14,8 @@ public class ModuleTimeoutTests : TestBase
     {
         private static readonly TaskCompletionSource<bool> _taskCompletionSource = new();
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromSeconds(1))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromSeconds(1));
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -27,9 +26,8 @@ public class ModuleTimeoutTests : TestBase
 
     private class Module_NotUsingCancellationToken : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromSeconds(1))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromSeconds(1));
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
@@ -189,9 +189,8 @@ public class NewRunConditionAttributeTests : TestBase
     {
         protected override bool Result => true;
 
-        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() => ModularPipelines.Configuration.ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Fluent condition"))
-            .Build();
+        protected override void Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Fluent condition"));
     }
 
     private class CancelDuringEvaluation : IRunCondition

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -77,12 +77,11 @@ public class RetryTests : TestBase
     {
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithRetry(
                 DefaultRetryCount,
                 TimeSpan.Zero,
-                exception => exception is RetryableTestException)
-            .Build();
+                exception => exception is RetryableTestException);
 
         protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -98,12 +97,11 @@ public class RetryTests : TestBase
     {
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithRetry(
                 DefaultRetryCount,
                 TimeSpan.Zero,
-                exception => exception is RetryableTestException)
-            .Build();
+                exception => exception is RetryableTestException);
 
         protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -116,11 +114,10 @@ public class RetryTests : TestBase
     {
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithShield(Shield
                 .When<Exception>()
-                .Retry(DefaultRetryCount, Backoff.None))
-            .Build();
+                .Retry(DefaultRetryCount, Backoff.None));
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -140,12 +137,11 @@ public class RetryTests : TestBase
     {
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
             .WithShield(Shield
                 .When<Exception>()
-                .Retry(DefaultRetryCount, Backoff.Constant(TimeSpan.FromMilliseconds(RetryDelayMs))))
-            .Build();
+                .Retry(DefaultRetryCount, Backoff.Constant(TimeSpan.FromMilliseconds(RetryDelayMs))));
 
         protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -158,10 +154,9 @@ public class RetryTests : TestBase
     {
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
-            .WithRetry(DefaultRetryCount, TimeSpan.Zero)
-            .Build();
+            .WithRetry(DefaultRetryCount, TimeSpan.Zero);
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -303,10 +298,9 @@ public class RetryTests : TestBase
 
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromMilliseconds(50))
-            .WithRetry(DefaultRetryCount, TimeSpan.FromMinutes(1))
-            .Build();
+            .WithRetry(DefaultRetryCount, TimeSpan.FromMinutes(1));
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -325,7 +319,7 @@ public class RetryTests : TestBase
         internal int ExecutionCount;
         internal int ObservedTimeoutCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromMilliseconds(50))
             .WithShield(Shield
                 .When<ModuleTimeoutException>(_ =>
@@ -333,8 +327,7 @@ public class RetryTests : TestBase
                     ObservedTimeoutCount++;
                     return true;
                 })
-                .Retry(DefaultRetryCount, Backoff.None))
-            .Build();
+                .Retry(DefaultRetryCount, Backoff.None));
 
         protected internal override async Task<bool> ExecuteAsync(
             IModuleContext context,
@@ -356,10 +349,9 @@ public class RetryTests : TestBase
 
         internal int ExecutionCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithTimeout(TimeSpan.FromSeconds(2))
-            .WithRetry(1, TimeSpan.FromMilliseconds(250))
-            .Build();
+            .WithRetry(1, TimeSpan.FromMilliseconds(250));
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Execution/RunnableCategoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RunnableCategoryTests.cs
@@ -47,9 +47,8 @@ public class RunnableCategoryTests : TestBase
 
     private class ConfiguredCategoryModule : SimpleTestModule<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithCategory("Run1")
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithCategory("Run1");
 
         protected override bool Result => true;
     }

--- a/test/ModularPipelines.UnitTests/Execution/SkippedModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/SkippedModuleTests.cs
@@ -13,9 +13,8 @@ public class SkippedModuleTests : TestBase
 {
     private class SkippedModule : Module<CommandResult>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Testing purposes"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Testing purposes"));
 
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Execution/SubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/SubModuleTests.cs
@@ -168,9 +168,8 @@ public class SubModuleTests : TestBase
         public int _twoCount;
         public int _threeCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithShield(Shield.When<Exception>().Retry(3, Backoff.None))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithShield(Shield.When<Exception>().Retry(3, Backoff.None));
 
         protected internal override async Task<string[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -205,9 +204,8 @@ public class SubModuleTests : TestBase
         public int _twoCount;
         public int _threeCount;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithShield(Shield.When<Exception>().Retry(3, Backoff.None))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithShield(Shield.When<Exception>().Retry(3, Backoff.None));
 
         protected internal override async Task<string[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksTests.cs
+++ b/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksTests.cs
@@ -77,9 +77,8 @@ public class DirectModuleHooksTests : TestBase
         public List<string> HooksCalled { get; } = [];
         public SkipDecision? ReceivedSkipDecision { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Test skip reason"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Test skip reason"));
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -139,9 +138,8 @@ public class DirectModuleHooksTests : TestBase
         public ModuleResult<string>? ReceivedAfterResult { get; private set; }
         public bool AfterHookCancellationRequested { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -175,8 +173,9 @@ public class DirectModuleHooksTests : TestBase
 
     private class NonIgnoredFailingHookTrackingModule : FailingHookTrackingModule
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module)
+        {
+        }
     }
 
     /// <summary>
@@ -186,9 +185,8 @@ public class DirectModuleHooksTests : TestBase
     {
         public List<string> HooksCalled { get; } = [];
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithIgnoreFailures()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithIgnoreFailures();
 
         protected override Task OnBeforeExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Modules/SyncModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/SyncModuleTests.cs
@@ -225,9 +225,8 @@ public class SyncModuleTests : TestBase
         public bool SkippedHookCalled { get; private set; }
         public SkipDecision? CapturedSkipDecision { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("Always skip"))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(_ => SkipDecision.Skip("Always skip"));
 
         protected override Task OnSkippedAsync(
             IModuleContext context,
@@ -365,9 +364,8 @@ public class SyncModuleTests : TestBase
 
     public class SyncModuleWithTimeout : SyncModule<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromMinutes(5))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromMinutes(5));
 
         protected override string Execute(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -388,9 +386,8 @@ public class SyncModuleTests : TestBase
     {
         public int ExecutionCount { get; private set; }
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithRetry(3, TimeSpan.Zero)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithRetry(3, TimeSpan.Zero);
 
         protected override string Execute(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
@@ -169,9 +169,8 @@ public class TelemetryIntegrationTests
     {
         private int _attempts;
 
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithRetry(2, TimeSpan.Zero)
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithRetry(2, TimeSpan.Zero);
 
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,
@@ -185,9 +184,8 @@ public class TelemetryIntegrationTests
 
     private sealed class TimedOutModule : Module<bool>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithTimeout(TimeSpan.FromMilliseconds(10))
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithTimeout(TimeSpan.FromMilliseconds(10));
 
         protected internal override async Task<bool> ExecuteAsync(
             IModuleContext context,

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -107,9 +107,8 @@ public class ValidationTests
 
     private class ModuleWithFluentMissingDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<FluentMissingDependencyModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<FluentMissingDependencyModule>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("success");
@@ -123,9 +122,8 @@ public class ValidationTests
     [RunIfAll<NeverRun>]
     private class ExecutionSkippedModuleWithFluentMissingDependency : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<FluentMissingDependencyModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<FluentMissingDependencyModule>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("success");
@@ -133,9 +131,8 @@ public class ValidationTests
 
     private class FluentSelfReferencingModule : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<FluentSelfReferencingModule>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<FluentSelfReferencingModule>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("self");
@@ -143,9 +140,8 @@ public class ValidationTests
 
     private class FluentCycleModuleA : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<FluentCycleModuleB>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<FluentCycleModuleB>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("a");
@@ -153,9 +149,8 @@ public class ValidationTests
 
     private class FluentCycleModuleB : Module<string>
     {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<FluentCycleModuleA>()
-            .Build();
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .DependsOn<FluentCycleModuleA>();
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string>("b");


### PR DESCRIPTION
Closes #4215

## Summary
- replace `Configure() : ModuleConfiguration` with `Configure(ModuleConfigurationBuilder)`
- let the module runtime own the single terminal `Build()` call
- hide direct `ModuleConfiguration` construction and builder finalization APIs
- migrate C#, F#, build modules, tests, and current documentation

## Validation
- `ModularPipelines.Tests.slnf` Release build
- `ModularPipelines.slnx` Release build
- GitHub integration solution Release build
- Testing integration solution Release build
- Distributed unit-test project Release build
- Trim/AOT smoke project Release build
- `ModuleConfigureTests`: 7 passed
- `ModuleConfigurationTests`: 35 passed
- `DependencyGraphExporterTests`: 124 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module configuration now uses a streamlined fluent builder API for dependencies, timeouts, retries, skipping, tags, categories, and failure handling.
  * Configuration construction details are no longer exposed through the public API.

* **Documentation**
  * Updated configuration guides and examples to reflect the builder-based approach.

* **Tests**
  * Updated tests and fixtures to validate the new configuration workflow while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->