### PR TITLE
Clarify failure modes and execution hints

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -1,5 +1,22 @@
 # ModularPipelines V4 Release Notes
 
+## Failure modes and execution hints
+
+Pipeline failure behavior now uses `FailureMode` instead of `ExecutionMode`:
+
+- `ExecutionMode.StopOnFirstException` is now `FailureMode.FailFast`.
+- `ExecutionMode.WaitForAllModules` is now `FailureMode.ContinueOnFailure`.
+- `PipelineOptions.ExecutionMode` is now `PipelineOptions.FailureMode`.
+
+Module resource classification now uses `ExecutionHint` instead of `ExecutionType`:
+
+- `ExecutionType.CpuIntensive` is now `ExecutionHint.CpuBound`.
+- `ExecutionType.IoIntensive` is now `ExecutionHint.IoBound`.
+- `ModuleConfiguration.ExecutionType` is now `ModuleConfiguration.ExecutionHint`.
+- `WithExecutionHint(ExecutionType)` now accepts `ExecutionHint`.
+
+The `[ExecutionHint(...)]` attribute syntax is unchanged.
+
 ## Module condition predicates
 
 `WithSkipWhen` now has boolean predicate overloads that accept a skip reason. Use

--- a/docs/docs/how-to/defining-modules.md
+++ b/docs/docs/how-to/defining-modules.md
@@ -68,7 +68,7 @@ public class MyModule : Module<FileInfo>
         .WithRetry(3)
         .WithSkipWhen(_ => !File.Exists("important.json"), "important.json does not exist")
         .WithPriority(ModulePriority.High)
-        .WithExecutionHint(ExecutionType.IoIntensive)
+        .WithExecutionHint(ExecutionHint.IoBound)
         .WithTags("build", "critical")
         .WithCategory("build")
         .DependsOn<RestoreModule>()
@@ -96,7 +96,7 @@ public class MyModule : Module<FileInfo>
 | `.WithAlwaysRun()` | Run even if the pipeline has failed |
 | `.WithNotInParallel(...)` | Prevent parallel execution globally or for matching constraint keys |
 | `.WithPriority(ModulePriority)` | Set scheduler priority |
-| `.WithExecutionHint(ExecutionType)` | Select CPU, I/O, or default concurrency limits |
+| `.WithExecutionHint(ExecutionHint)` | Select CPU-bound, I/O-bound, or default concurrency limits |
 | `.WithTags(...)` | Add tags used by metadata-based dependencies |
 | `.WithCategory(string)` | Set the module category |
 | `.DependsOn<TModule>()` | Add a required dependency |

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -98,8 +98,8 @@ var builder = Pipeline.CreateBuilder(args);
 
 builder.ConfigurePipelineOptions(options => options with
 {
-    // Execution mode
-    ExecutionMode = ExecutionMode.StopOnFirstException,
+    // Failure mode
+    FailureMode = FailureMode.FailFast,
 
     // Category filtering
     RunOnlyCategories = ["Build", "Test"],
@@ -129,7 +129,7 @@ The pipeline follows a two-step build-then-run pattern:
 var builder = Pipeline.CreateBuilder(args);
 builder.ConfigurePipelineOptions(options => options with
 {
-    ExecutionMode = ExecutionMode.WaitForAllModules,
+    FailureMode = FailureMode.ContinueOnFailure,
     ThrowOnPipelineFailure = false,
 });
 builder.AddModule<MyModule>();
@@ -147,7 +147,7 @@ if (summary.Status == ModularPipelines.Enums.ModuleStatus.Failed)
 }
 ```
 
-Use `WaitForAllModules` with `ThrowOnPipelineFailure = false` when you need to inspect
+Use `ContinueOnFailure` with `ThrowOnPipelineFailure = false` when you need to inspect
 the returned summary after a module fails. Fail-fast mode rethrows the module exception.
 
 `BuildAsync()` always validates the pipeline configuration before returning:
@@ -211,7 +211,7 @@ builder.Configuration
 // Options
 builder.ConfigurePipelineOptions(options => options with
 {
-    ExecutionMode = ExecutionMode.StopOnFirstException,
+    FailureMode = FailureMode.FailFast,
     IgnoreCategories = ["Experimental"],
 });
 
@@ -273,7 +273,7 @@ await builder
     .AddModule<Module2>()
     .ConfigurePipelineOptions(options => options with
     {
-        ExecutionMode = ExecutionMode.StopOnFirstException,
+        FailureMode = FailureMode.FailFast,
     })
     .RunAsync();
 ```

--- a/docs/docs/how-to/pipeline-modes.md
+++ b/docs/docs/how-to/pipeline-modes.md
@@ -1,16 +1,19 @@
 ---
-title: Pipeline Execution Modes
+title: Pipeline Failure Modes
 ---
 
-# Pipeline Execution Modes
+# Pipeline Failure Modes
 
-A pipeline has two execution modes:
-- StopOnFirstException
-- WaitForAllModules
+A pipeline has two failure modes:
 
-By default, a pipeline will use `StopOnFirstException`. This means as soon as any module throws an exception, the pipeline is considered fail and will terminate. This is for fast feedback.
+- FailFast
+- ContinueOnFailure
 
-If you want to run every module regardless, you can switch to `WaitForAllModules`, and the pipeline won't terminate until all modules have finished executing.
+By default, a pipeline uses `FailFast`. As soon as any module throws an exception,
+the pipeline fails and terminates for fast feedback.
+
+Use `ContinueOnFailure` to let independent modules finish before the pipeline evaluates
+failures. Modules whose required dependencies fail still do not run.
 
 ## Example
 
@@ -24,7 +27,7 @@ builder
 
 builder.ConfigurePipelineOptions(options => options with
 {
-    ExecutionMode = ExecutionMode.WaitForAllModules,
+    FailureMode = FailureMode.ContinueOnFailure,
 });
 
 await builder.RunAsync();

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunGeneratedOptionsUnitTestsModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunGeneratedOptionsUnitTestsModule.cs
@@ -5,7 +5,7 @@ using ModularPipelines.Enums;
 
 namespace ModularPipelines.Build.Modules.UnitTests;
 
-[ExecutionHint(ExecutionType.CpuIntensive)]
+[ExecutionHint(ExecutionHint.CpuBound)]
 [DependsOn<RunCoreUnitTestsModule>]
 public abstract class RunGeneratedOptionsUnitTestsModule(
     IOptions<PipelineSettings> pipelineSettings)

--- a/src/ModularPipelines.Examples/Program.cs
+++ b/src/ModularPipelines.Examples/Program.cs
@@ -17,7 +17,7 @@ builder.Configuration
 
 builder.ConfigurePipelineOptions(options => options with
 {
-    ExecutionMode = ExecutionMode.StopOnFirstException,
+    FailureMode = FailureMode.FailFast,
 });
 
 builder

--- a/src/ModularPipelines/Attributes/ExecutionHintAttribute.cs
+++ b/src/ModularPipelines/Attributes/ExecutionHintAttribute.cs
@@ -8,13 +8,13 @@ namespace ModularPipelines.Attributes;
 /// </summary>
 /// <example>
 /// <code>
-/// [ExecutionHint(ExecutionType.CpuIntensive)]
+/// [ExecutionHint(ExecutionHint.CpuBound)]
 /// public class CompilationModule : Module&lt;BuildResult&gt;
 /// {
 ///     // Limited by ConcurrencyOptions.MaxCpuIntensiveModules
 /// }
 ///
-/// [ExecutionHint(ExecutionType.IoIntensive)]
+/// [ExecutionHint(ExecutionHint.IoBound)]
 /// public class DownloadDependenciesModule : Module&lt;DownloadResult&gt;
 /// {
 ///     // Limited by ConcurrencyOptions.MaxIoIntensiveModules
@@ -25,16 +25,16 @@ namespace ModularPipelines.Attributes;
 public class ExecutionHintAttribute : Attribute
 {
     /// <summary>
-    /// Gets the execution type hint for the module.
+    /// Gets the execution hint for the module.
     /// </summary>
-    public ExecutionType ExecutionType { get; }
+    public ExecutionHint ExecutionHint { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExecutionHintAttribute"/> class.
     /// </summary>
-    /// <param name="executionType">The execution type hint for the module.</param>
-    public ExecutionHintAttribute(ExecutionType executionType)
+    /// <param name="executionHint">The execution hint for the module.</param>
+    public ExecutionHintAttribute(ExecutionHint executionHint)
     {
-        ExecutionType = executionType;
+        ExecutionHint = executionHint;
     }
 }

--- a/src/ModularPipelines/Configuration/ModuleConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfiguration.cs
@@ -85,9 +85,9 @@ public sealed class ModuleConfiguration
     public ModulePriority? Priority { get; init; }
 
     /// <summary>
-    /// Gets the resource-usage hint, or <see langword="null"/> to use the default execution type.
+    /// Gets the resource-usage hint, or <see langword="null"/> to use the default execution hint.
     /// </summary>
-    public ExecutionType? ExecutionType { get; init; }
+    public ExecutionHint? ExecutionHint { get; init; }
 
     /// <summary>
     /// Gets module tags used by metadata-based dependency selection.

--- a/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
@@ -46,7 +46,7 @@ internal static class ModuleConfigurationAttributeAdapter
             ParallelConstraintKeys = configured.ParallelConstraintKeys
                 ?? notInParallel?.ConstraintKeys.ToArray(),
             Priority = configured.Priority ?? priority?.Priority,
-            ExecutionType = configured.ExecutionType ?? executionHint?.ExecutionType,
+            ExecutionHint = configured.ExecutionHint ?? executionHint?.ExecutionHint,
             Tags = tags,
             Category = category,
             CacheInputPatterns = cacheInputPatterns,
@@ -104,7 +104,7 @@ internal static class ModuleConfigurationAttributeAdapter
                && notInParallel is null
                && configured.Priority is null
                && priority is null
-               && configured.ExecutionType is null
+               && configured.ExecutionHint is null
                && executionHint is null
                && tags.Count == 0
                && category is null

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -46,7 +46,7 @@ public sealed class ModuleConfigurationBuilder
     private bool _hasAsyncSkipCondition;
     private string[]? _parallelConstraintKeys;
     private ModulePriority? _priority;
-    private ExecutionType? _executionType;
+    private ExecutionHint? _executionHint;
     private string? _category;
 
     #region WithSkipWhen Overloads
@@ -254,9 +254,9 @@ public sealed class ModuleConfigurationBuilder
     /// Sets the module resource-usage hint.
     /// </summary>
     /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder WithExecutionHint(ExecutionType executionType)
+    public ModuleConfigurationBuilder WithExecutionHint(ExecutionHint executionHint)
     {
-        _executionType = executionType;
+        _executionHint = executionHint;
         return this;
     }
 
@@ -493,7 +493,7 @@ public sealed class ModuleConfigurationBuilder
             AlwaysRun = _alwaysRun,
             ParallelConstraintKeys = _parallelConstraintKeys,
             Priority = _priority,
-            ExecutionType = _executionType,
+            ExecutionHint = _executionHint,
             Tags = new HashSet<string>(_tags, StringComparer.OrdinalIgnoreCase),
             Category = _category,
             CacheKeyParts = [.. _cacheKeyParts],

--- a/src/ModularPipelines/Engine/Execution/IParallelLimitHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/IParallelLimitHandler.cs
@@ -3,7 +3,7 @@ namespace ModularPipelines.Engine.Execution;
 /// <summary>
 /// Responsible for managing parallel execution limits.
 /// Handles both custom parallel limiters (via ParallelLimiterAttribute) and
-/// execution type limits (CPU-intensive, IO-intensive).
+/// execution hint limits (CPU-bound, I/O-bound).
 /// </summary>
 internal interface IParallelLimitHandler
 {
@@ -16,10 +16,10 @@ internal interface IParallelLimitHandler
     Task<IDisposable> AcquireParallelLimitAsync(Type moduleType, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Acquires an execution type limit semaphore for the specified module state.
+    /// Acquires an execution hint limit semaphore for the specified module state.
     /// </summary>
-    /// <param name="moduleState">The module state containing execution type information.</param>
+    /// <param name="moduleState">The module state containing execution hint information.</param>
     /// <param name="cancellationToken">The token that cancels waiting for a slot.</param>
     /// <returns>A disposable that releases the semaphore when disposed.</returns>
-    Task<IDisposable> AcquireExecutionTypeLimitAsync(ModuleState moduleState, CancellationToken cancellationToken);
+    Task<IDisposable> AcquireExecutionHintLimitAsync(ModuleState moduleState, CancellationToken cancellationToken);
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -178,8 +178,8 @@ internal class ModuleRunner : IModuleRunner
                 using var semaphoreHandle = await _parallelLimitHandler
                     .AcquireParallelLimitAsync(moduleType, limiterCancellationToken)
                     .ConfigureAwait(false);
-                using var executionTypeHandle = await _parallelLimitHandler
-                    .AcquireExecutionTypeLimitAsync(moduleState, limiterCancellationToken)
+                using var executionHintHandle = await _parallelLimitHandler
+                    .AcquireExecutionHintLimitAsync(moduleState, limiterCancellationToken)
                     .ConfigureAwait(false);
 
                 // Check constraints again after acquiring execution slots. Keeping the module queued
@@ -217,7 +217,7 @@ internal class ModuleRunner : IModuleRunner
                     handledException,
                     cancellationToken);
 
-                if (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
+                if (_pipelineOptions.Value.FailureMode == FailureMode.FailFast)
                 {
                     if (ReferenceEquals(handledException, ex))
                     {

--- a/src/ModularPipelines/Engine/Execution/ParallelLimitHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/ParallelLimitHandler.cs
@@ -48,20 +48,20 @@ internal class ParallelLimitHandler : IParallelLimitHandler
     }
 
     /// <inheritdoc />
-    public async Task<IDisposable> AcquireExecutionTypeLimitAsync(
+    public async Task<IDisposable> AcquireExecutionHintLimitAsync(
         ModuleState moduleState,
         CancellationToken cancellationToken)
     {
-        var executionTypeLock = _parallelLimitProvider.GetExecutionTypeLock(moduleState.ExecutionType);
+        var executionHintLock = _parallelLimitProvider.GetExecutionHintLock(moduleState.ExecutionHint);
 
-        if (executionTypeLock != null)
+        if (executionHintLock != null)
         {
             _logger.LogDebug(
-                "Module {ModuleName} waiting for {ExecutionType} execution slot",
+                "Module {ModuleName} waiting for {ExecutionHint} execution slot",
                 moduleState.ModuleType.Name,
-                moduleState.ExecutionType);
+                moduleState.ExecutionHint);
 
-            return await executionTypeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return await executionHintLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
         return NoOpDisposable.Instance;

--- a/src/ModularPipelines/Engine/Executors/PipelineExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineExecutor.cs
@@ -64,7 +64,7 @@ internal class PipelineExecutor : IPipelineExecutor
 
         // Wait-for-all may return a failed summary when configured not to throw.
         // Fail-fast retains its existing behavior and always surfaces the original.
-        if (_options.Value.ExecutionMode == ExecutionMode.StopOnFirstException
+        if (_options.Value.FailureMode == FailureMode.FailFast
             || _options.Value.ThrowOnPipelineFailure)
         {
             _exceptionRethrowService.ThrowOriginalExceptionIfPresent();

--- a/src/ModularPipelines/Engine/IMetricsCollector.cs
+++ b/src/ModularPipelines/Engine/IMetricsCollector.cs
@@ -21,12 +21,12 @@ internal interface IMetricsCollector
     /// <summary>
     /// Registers a module before dependency scheduling begins.
     /// </summary>
-    void RecordModuleInitialized(Type moduleType, ModulePriority priority, ExecutionType executionType);
+    void RecordModuleInitialized(Type moduleType, ModulePriority priority, ExecutionHint executionHint);
 
     /// <summary>
     /// Records when a module becomes ready (all dependencies satisfied).
     /// </summary>
-    void RecordModuleReady(Type moduleType, DateTimeOffset time, ModulePriority priority, ExecutionType executionType);
+    void RecordModuleReady(Type moduleType, DateTimeOffset time, ModulePriority priority, ExecutionHint executionHint);
 
     /// <summary>
     /// Records when a module is queued for execution.

--- a/src/ModularPipelines/Engine/MetricsCollector.cs
+++ b/src/ModularPipelines/Engine/MetricsCollector.cs
@@ -20,19 +20,19 @@ internal class MetricsCollector : IMetricsCollector
 
     public DateTimeOffset? GetPipelineStartTime() => _pipelineStartTime;
 
-    public void RecordModuleInitialized(Type moduleType, ModulePriority priority, ExecutionType executionType)
+    public void RecordModuleInitialized(Type moduleType, ModulePriority priority, ExecutionHint executionHint)
     {
         var data = _moduleMetrics.GetOrAdd(moduleType, _ => new ModuleMetricsData { ModuleType = moduleType });
         data.Priority = priority;
-        data.ExecutionType = executionType;
+        data.ExecutionHint = executionHint;
     }
 
-    public void RecordModuleReady(Type moduleType, DateTimeOffset time, ModulePriority priority, ExecutionType executionType)
+    public void RecordModuleReady(Type moduleType, DateTimeOffset time, ModulePriority priority, ExecutionHint executionHint)
     {
         var data = _moduleMetrics.GetOrAdd(moduleType, _ => new ModuleMetricsData { ModuleType = moduleType });
         data.ReadyTime = time;
         data.Priority = priority;
-        data.ExecutionType = executionType;
+        data.ExecutionHint = executionHint;
     }
 
     public void RecordModuleQueued(Type moduleType, DateTimeOffset time)
@@ -163,7 +163,7 @@ internal class MetricsCollector : IMetricsCollector
                 ModuleTypeName = ModuleTypeIdentifier.Get(data.ModuleType),
                 RuntimeModuleTypeName = ModuleTypeIdentifier.GetRuntime(data.ModuleType),
                 Priority = data.Priority,
-                ExecutionType = data.ExecutionType,
+                ExecutionHint = data.ExecutionHint,
                 ReadyTime = data.ReadyTime,
                 QueuedTime = data.QueuedTime,
                 StartTime = data.StartTime,
@@ -210,7 +210,7 @@ internal class MetricsCollector : IMetricsCollector
     {
         public required Type ModuleType { get; init; }
         public ModulePriority Priority { get; set; }
-        public ExecutionType ExecutionType { get; set; }
+        public ExecutionHint ExecutionHint { get; set; }
         public DateTimeOffset? ReadyTime { get; set; }
         public DateTimeOffset? QueuedTime { get; set; }
         public DateTimeOffset? StartTime { get; set; }

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -828,7 +828,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             exception,
             wasLogged: true);
 
-        if (moduleContext.Services.Options.ExecutionMode == ExecutionMode.StopOnFirstException)
+        if (moduleContext.Services.Options.FailureMode == FailureMode.FailFast)
         {
             logger.LogDebug("Module failed. Cancelling the pipeline");
             _engineCancellationToken.CancelWithException(moduleFailedException);

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -269,7 +269,7 @@ internal class ModuleExecutor : IModuleExecutor
                     {
                         await _moduleRunner.ExecuteAsync(moduleState, scheduler, ct).ConfigureAwait(false);
                     }
-                    catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
+                    catch (Exception ex) when (_pipelineOptions.Value.FailureMode == FailureMode.FailFast)
                     {
                         var failedModuleType = FindFailedModuleType(ex) ?? moduleState.ModuleType;
                         var pipelineException = GetPipelineException(ex);
@@ -309,7 +309,7 @@ internal class ModuleExecutor : IModuleExecutor
         }
         catch (OperationCanceledException) when (firstFailure != null)
         {
-            // Expected when we cancelled due to StopOnFirstException
+            // Expected when we cancelled due to FailFast
         }
 
         return firstFailure;
@@ -412,7 +412,7 @@ internal class ModuleExecutor : IModuleExecutor
 
         _logger.LogError(
             exception,
-            "Module worker failed but remaining modules will continue due to ExecutionMode.WaitForAllModules");
+            "Module worker failed but remaining modules will continue due to FailureMode.ContinueOnFailure");
     }
 
     private void TryMarkModuleFailed(

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -122,7 +122,7 @@ internal class ModuleScheduler : IModuleScheduler
             _metricsCollector.RecordModuleInitialized(
                 state.ModuleType,
                 state.Priority,
-                state.ExecutionType);
+                state.ExecutionHint);
         }
 
         foreach (var state in _moduleStates.Values)
@@ -303,15 +303,15 @@ internal class ModuleScheduler : IModuleScheduler
                 state.Priority);
         }
 
-        var executionType = configuration.ExecutionType
-                            ?? moduleType.GetCustomAttribute<ExecutionHintAttribute>(inherit: true)?.ExecutionType;
-        if (executionType is { } moduleExecutionType)
+        var executionHint = configuration.ExecutionHint
+                            ?? moduleType.GetCustomAttribute<ExecutionHintAttribute>(inherit: true)?.ExecutionHint;
+        if (executionHint is { } moduleExecutionHint)
         {
-            state.ExecutionType = moduleExecutionType;
+            state.ExecutionHint = moduleExecutionHint;
             _logger.LogDebug(
-                "Module {ModuleName} has execution type: {ExecutionType}",
+                "Module {ModuleName} has execution hint: {ExecutionHint}",
                 moduleType.Name,
-                state.ExecutionType);
+                state.ExecutionHint);
         }
     }
 
@@ -524,7 +524,7 @@ internal class ModuleScheduler : IModuleScheduler
         // This prevents LockRecursionException if metrics collector or constraint
         // evaluator callbacks try to access scheduler state
         List<ModuleState> modulesToQueue;
-        List<(Type ModuleType, DateTimeOffset ReadyTime, ModulePriority Priority, ExecutionType ExecutionType, DateTimeOffset QueuedTime)> metricsData;
+        List<(Type ModuleType, DateTimeOffset ReadyTime, ModulePriority Priority, ExecutionHint ExecutionHint, DateTimeOffset QueuedTime)> metricsData;
 
         _stateLock.EnterWriteLock();
         try
@@ -545,7 +545,7 @@ internal class ModuleScheduler : IModuleScheduler
             }
 
             modulesToQueue = new List<ModuleState>();
-            metricsData = new List<(Type, DateTimeOffset, ModulePriority, ExecutionType, DateTimeOffset)>();
+            metricsData = new List<(Type, DateTimeOffset, ModulePriority, ExecutionHint, DateTimeOffset)>();
 
             foreach (var moduleState in potentiallyReadyModules)
             {
@@ -559,7 +559,7 @@ internal class ModuleScheduler : IModuleScheduler
                 moduleState.ReadyTime ??= now;
 
                 // Collect metrics data for recording outside lock
-                metricsData.Add((moduleState.ModuleType, moduleState.ReadyTime.Value, moduleState.Priority, moduleState.ExecutionType, now));
+                metricsData.Add((moduleState.ModuleType, moduleState.ReadyTime.Value, moduleState.Priority, moduleState.ExecutionHint, now));
 
                 _stateCounters.Transition(moduleState.State, ModuleExecutionState.Queued);
                 moduleState.State = ModuleExecutionState.Queued;
@@ -578,9 +578,9 @@ internal class ModuleScheduler : IModuleScheduler
         }
 
         // Record metrics outside lock to prevent lock recursion
-        foreach (var (moduleType, readyTime, priority, executionType, queuedTime) in metricsData)
+        foreach (var (moduleType, readyTime, priority, executionHint, queuedTime) in metricsData)
         {
-            _metricsCollector.RecordModuleReady(moduleType, readyTime, priority, executionType);
+            _metricsCollector.RecordModuleReady(moduleType, readyTime, priority, executionHint);
             _metricsCollector.RecordModuleQueued(moduleType, queuedTime);
         }
 

--- a/src/ModularPipelines/Engine/ModuleState.cs
+++ b/src/ModularPipelines/Engine/ModuleState.cs
@@ -139,9 +139,9 @@ internal class ModuleState
     public ModulePriority Priority { get; set; } = ModulePriority.Normal;
 
     /// <summary>
-    /// Gets or sets the execution type hint for resource-based throttling.
+    /// Gets or sets the resource-usage hint for throttling.
     /// </summary>
-    public ExecutionType ExecutionType { get; set; } = ExecutionType.Default;
+    public ExecutionHint ExecutionHint { get; set; } = ExecutionHint.Default;
 
     /// <summary>
     /// Gets or sets when all dependencies were satisfied and the module became ready.

--- a/src/ModularPipelines/Engine/PipelinePlanner.cs
+++ b/src/ModularPipelines/Engine/PipelinePlanner.cs
@@ -497,7 +497,7 @@ internal sealed class PipelinePlanner
 
     private static SchedulingProfile CreateSchedulingProfile(PipelinePlanModule plannedModule) => new(
         GetConstraintKeys(plannedModule.Module),
-        GetExecutionType(plannedModule.Module),
+        GetExecutionHint(plannedModule.Module),
         plannedModule.ShouldSkip ? null : GetParallelLimiter(plannedModule.Module));
 
     private static IReadOnlyCollection<string>? GetConstraintKeys(IModule module)
@@ -526,14 +526,14 @@ internal sealed class PipelinePlanner
         return dependencyModels;
     }
 
-    private static ExecutionType GetExecutionType(IModule module) =>
-        module.Configuration.ExecutionType
+    private static ExecutionHint GetExecutionHint(IModule module) =>
+        module.Configuration.ExecutionHint
         ?? module.GetType()
             .GetCustomAttributes(typeof(ExecutionHintAttribute), inherit: true)
             .Cast<ExecutionHintAttribute>()
             .FirstOrDefault()
-            ?.ExecutionType
-        ?? ExecutionType.Default;
+            ?.ExecutionHint
+        ?? ExecutionHint.Default;
 
     private static ModulePriority GetPriority(IModule module) =>
         module.Configuration.Priority
@@ -686,15 +686,15 @@ internal sealed class PipelinePlanner
                 var activeModules = scheduledModules
                     .Where(module => module.ExecutionStart <= checkpoint && module.Finish > checkpoint)
                     .ToArray();
-                var executionTypeLimit = GetExecutionTypeLimit(profile.ExecutionType, concurrency);
-                if (executionTypeLimit is { } limit)
+                var executionHintLimit = GetExecutionHintLimit(profile.ExecutionHint, concurrency);
+                if (executionHintLimit is { } limit)
                 {
                     blockedUntil = Max(
                         blockedUntil,
                         GetCapacityBlocker(
                             activeModules,
                             limit,
-                            module => module.Profile.ExecutionType == profile.ExecutionType));
+                            module => module.Profile.ExecutionHint == profile.ExecutionHint));
                 }
 
                 if (blockedUntil > checkpoint)
@@ -769,13 +769,13 @@ internal sealed class PipelinePlanner
             : TimeSpan.Zero;
     }
 
-    private static int? GetExecutionTypeLimit(
-        ExecutionType executionType,
+    private static int? GetExecutionHintLimit(
+        ExecutionHint executionHint,
         ConcurrencyOptions concurrency) =>
-        executionType switch
+        executionHint switch
         {
-            ExecutionType.CpuIntensive => concurrency.MaxCpuIntensiveModules,
-            ExecutionType.IoIntensive => concurrency.MaxIoIntensiveModules,
+            ExecutionHint.CpuBound => concurrency.MaxCpuIntensiveModules,
+            ExecutionHint.IoBound => concurrency.MaxIoIntensiveModules,
             _ => null,
         };
 
@@ -801,7 +801,7 @@ internal sealed class PipelinePlanner
 
     private sealed record SchedulingProfile(
         IReadOnlyCollection<string>? ConstraintKeys,
-        ExecutionType ExecutionType,
+        ExecutionHint ExecutionHint,
         ParallelLimiterProfile? ParallelLimiter);
 
     private sealed record ParallelLimiterProfile(Type Type, int Limit);

--- a/src/ModularPipelines/Enums/ExecutionHint.cs
+++ b/src/ModularPipelines/Enums/ExecutionHint.cs
@@ -6,23 +6,23 @@ namespace ModularPipelines.Enums;
 /// Hints about the resource usage characteristics of a module.
 /// Used by the scheduler to apply appropriate concurrency limits.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ExecutionType>))]
-public enum ExecutionType
+[JsonConverter(typeof(JsonStringEnumConverter<ExecutionHint>))]
+public enum ExecutionHint
 {
     /// <summary>
-    /// Default execution type. No specific resource constraints applied.
+    /// Default execution hint. No specific resource constraints applied.
     /// </summary>
     Default = 0,
 
     /// <summary>
-    /// CPU-intensive module. Performs heavy computation.
+    /// CPU-bound module. Performs heavy computation.
     /// Limited by <see cref="Options.ConcurrencyOptions.MaxCpuIntensiveModules"/>.
     /// </summary>
-    CpuIntensive = 1,
+    CpuBound = 1,
 
     /// <summary>
-    /// I/O-intensive module. Performs network calls, file operations, or database queries.
+    /// I/O-bound module. Performs network calls, file operations, or database queries.
     /// Limited by <see cref="Options.ConcurrencyOptions.MaxIoIntensiveModules"/>.
     /// </summary>
-    IoIntensive = 2,
+    IoBound = 2,
 }

--- a/src/ModularPipelines/Helpers/IParallelLimitProvider.cs
+++ b/src/ModularPipelines/Helpers/IParallelLimitProvider.cs
@@ -15,8 +15,8 @@ internal interface IParallelLimitProvider
     int GetMaxDegreeOfParallelism();
 
     /// <summary>
-    /// Gets a semaphore lock for execution type throttling (CPU or IO intensive).
-    /// Returns null if no limit is configured for the execution type.
+    /// Gets a semaphore lock for execution hint throttling (CPU-bound or I/O-bound).
+    /// Returns null if no limit is configured for the execution hint.
     /// </summary>
-    AsyncSemaphore? GetExecutionTypeLock(ExecutionType executionType);
+    AsyncSemaphore? GetExecutionHintLock(ExecutionHint executionHint);
 }

--- a/src/ModularPipelines/Helpers/ParallelLimitProvider.cs
+++ b/src/ModularPipelines/Helpers/ParallelLimitProvider.cs
@@ -52,12 +52,12 @@ internal class ParallelLimitProvider : IParallelLimitProvider
         return _concurrencyOptions.MaxParallelism;
     }
 
-    public AsyncSemaphore? GetExecutionTypeLock(ExecutionType executionType)
+    public AsyncSemaphore? GetExecutionHintLock(ExecutionHint executionHint)
     {
-        return executionType switch
+        return executionHint switch
         {
-            ExecutionType.CpuIntensive => _cpuIntensiveLock.Value,
-            ExecutionType.IoIntensive => _ioIntensiveLock.Value,
+            ExecutionHint.CpuBound => _cpuIntensiveLock.Value,
+            ExecutionHint.IoBound => _ioIntensiveLock.Value,
             _ => null,
         };
     }

--- a/src/ModularPipelines/Models/ModuleTimeline.cs
+++ b/src/ModularPipelines/Models/ModuleTimeline.cs
@@ -32,10 +32,10 @@ public record ModuleTimeline
     public ModulePriority Priority { get; init; }
 
     /// <summary>
-    /// Gets the execution type hint of the module.
+    /// Gets the resource-usage hint of the module.
     /// </summary>
     [JsonInclude]
-    public ExecutionType ExecutionType { get; init; }
+    public ExecutionHint ExecutionHint { get; init; }
 
     /// <summary>
     /// Gets when all dependencies were satisfied and the module became ready to execute.

--- a/src/ModularPipelines/Options/ConcurrencyOptions.cs
+++ b/src/ModularPipelines/Options/ConcurrencyOptions.cs
@@ -32,16 +32,16 @@ public record ConcurrencyOptions
     public int MaxParallelism { get; init; } = Environment.ProcessorCount * ConcurrencyConstants.ParallelismMultiplier;
 
     /// <summary>
-    /// Gets the maximum number of CPU-intensive modules that can execute concurrently.
-    /// Only applies to modules decorated with <c>[ExecutionHint(ExecutionType.CpuIntensive)]</c>.
+    /// Gets the maximum number of CPU-bound modules that can execute concurrently.
+    /// Only applies to modules decorated with <c>[ExecutionHint(ExecutionHint.CpuBound)]</c>.
     /// Default: <c>Environment.ProcessorCount</c>.
     /// Set to <c>null</c> to use <see cref="MaxParallelism"/> instead.
     /// </summary>
     public int? MaxCpuIntensiveModules { get; init; } = Environment.ProcessorCount;
 
     /// <summary>
-    /// Gets the maximum number of I/O-intensive modules that can execute concurrently.
-    /// Only applies to modules decorated with <c>[ExecutionHint(ExecutionType.IoIntensive)]</c>.
+    /// Gets the maximum number of I/O-bound modules that can execute concurrently.
+    /// Only applies to modules decorated with <c>[ExecutionHint(ExecutionHint.IoBound)]</c>.
     /// Default: <c>null</c> (unlimited, bounded only by <see cref="MaxParallelism"/>).
     /// </summary>
     public int? MaxIoIntensiveModules { get; init; }

--- a/src/ModularPipelines/Options/FailureMode.cs
+++ b/src/ModularPipelines/Options/FailureMode.cs
@@ -3,15 +3,15 @@ namespace ModularPipelines.Options;
 /// <summary>
 /// Defines how the pipeline should behave when module execution encounters exceptions.
 /// </summary>
-public enum ExecutionMode
+public enum FailureMode
 {
     /// <summary>
     /// Stop pipeline execution immediately when the first exception occurs.
     /// </summary>
-    StopOnFirstException,
+    FailFast,
 
     /// <summary>
-    /// Continue running all modules and wait for all to complete before evaluating failures.
+    /// Continue running independent modules before evaluating failures.
     /// </summary>
-    WaitForAllModules,
+    ContinueOnFailure,
 }

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -83,9 +83,9 @@ public record PipelineOptions
     public bool DisableModuleCache { get; init; }
 
     /// <summary>
-    /// Gets the execution mode that determines how the pipeline handles failures.
+    /// Gets how the pipeline responds to module failures.
     /// </summary>
-    public ExecutionMode ExecutionMode { get; init; } = ExecutionMode.StopOnFirstException;
+    public FailureMode FailureMode { get; init; } = FailureMode.FailFast;
 
     /// <summary>
     /// Gets the default per-attempt timeout for modules that do not configure their own timeout.

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -17,7 +17,7 @@ public static class Pipeline
     /// builder.AddModule&lt;BuildModule&gt;();
     /// builder.ConfigurePipelineOptions(options => options with
     /// {
-    ///     ExecutionMode = ExecutionMode.StopOnFirstException,
+    ///     FailureMode = FailureMode.FailFast,
     /// });
     ///
     /// var pipeline = await builder.BuildAsync();

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -44,7 +44,7 @@ public static class CurrentApiSnippets
         var builder = Pipeline.CreateBuilder(args);
         builder.ConfigurePipelineOptions(options => options with
         {
-            ExecutionMode = ExecutionMode.WaitForAllModules,
+            FailureMode = FailureMode.ContinueOnFailure,
             ThrowOnPipelineFailure = false,
         });
         builder.AddModule<BuildModule>();

--- a/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
@@ -132,7 +132,7 @@ public class LifecycleEventIntegrationTests : TestBase
                 .AddModule<FailingModule>()
                 .ConfigurePipelineOptions((_, options) => options with
                 {
-                    ExecutionMode = ExecutionMode.WaitForAllModules,
+                    FailureMode = FailureMode.ContinueOnFailure,
                 })
                 .RunAsync();
         }

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -465,22 +465,22 @@ public class PipelineCommandLineTests
             .WithPriority(ModulePriority.High);
     }
 
-    [ExecutionHint(ExecutionType.CpuIntensive)]
+    [ExecutionHint(ExecutionHint.CpuBound)]
     private sealed class FirstCpuModule : DryRunModule
     {
     }
 
-    [ExecutionHint(ExecutionType.CpuIntensive)]
+    [ExecutionHint(ExecutionHint.CpuBound)]
     private sealed class SecondCpuModule : DryRunModule
     {
     }
 
-    [ExecutionHint(ExecutionType.IoIntensive)]
+    [ExecutionHint(ExecutionHint.IoBound)]
     private sealed class FirstIoModule : DryRunModule
     {
     }
 
-    [ExecutionHint(ExecutionType.IoIntensive)]
+    [ExecutionHint(ExecutionHint.IoBound)]
     private sealed class SecondIoModule : DryRunModule
     {
     }
@@ -522,13 +522,13 @@ public class PipelineCommandLineTests
     }
 
     [Priority(ModulePriority.Critical)]
-    [ExecutionHint(ExecutionType.CpuIntensive)]
+    [ExecutionHint(ExecutionHint.CpuBound)]
     private sealed class CpuHolderModule : DryRunModule
     {
     }
 
     [Priority(ModulePriority.High)]
-    [ExecutionHint(ExecutionType.CpuIntensive)]
+    [ExecutionHint(ExecutionHint.CpuBound)]
     [ModularPipelines.Attributes.ParallelLimiter<SingleModuleLimit>]
     private sealed class CpuAndLimiterWaiterModule : DryRunModule
     {
@@ -1122,7 +1122,7 @@ public class PipelineCommandLineTests
     }
 
     [Test]
-    public async Task PlanAsyncAppliesExecutionTypeLimitsInEstimate()
+    public async Task PlanAsyncAppliesExecutionHintLimitsInEstimate()
     {
         using var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
@@ -1181,7 +1181,7 @@ public class PipelineCommandLineTests
     }
 
     [Test]
-    public async Task PlanAsyncModelsLimiterAcquisitionBeforeExecutionTypeWait()
+    public async Task PlanAsyncModelsLimiterAcquisitionBeforeExecutionHintWait()
     {
         using var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -604,7 +604,7 @@ public class ModuleConfigurationTests
         var config = new ModuleConfigurationBuilder()
             .WithNotInParallel("database")
             .WithPriority(ModulePriority.Critical)
-            .WithExecutionHint(ExecutionType.IoIntensive)
+            .WithExecutionHint(ExecutionHint.IoBound)
             .WithTags("deploy", "production")
             .WithCategory("release")
             .DependsOn<DependencyModule>()
@@ -614,7 +614,7 @@ public class ModuleConfigurationTests
         {
             await Assert.That(config.ParallelConstraintKeys).IsEquivalentTo(new[] { "database" });
             await Assert.That(config.Priority).IsEqualTo(ModulePriority.Critical);
-            await Assert.That(config.ExecutionType).IsEqualTo(ExecutionType.IoIntensive);
+            await Assert.That(config.ExecutionHint).IsEqualTo(ExecutionHint.IoBound);
             await Assert.That(config.Tags).IsEquivalentTo(new[] { "deploy", "production" });
             await Assert.That(config.Category).IsEqualTo("release");
             await Assert.That(config.Dependencies.Select(dependency => dependency.ModuleType))
@@ -633,7 +633,7 @@ public class ModuleConfigurationTests
             .WithAlwaysRun()
             .WithNotInParallel("shared")
             .WithPriority(ModulePriority.High)
-            .WithExecutionHint(ExecutionType.CpuIntensive)
+            .WithExecutionHint(ExecutionHint.CpuBound)
             .WithTags("build")
             .WithCategory("ci")
             .DependsOnOptional<DependencyModule>()
@@ -648,7 +648,7 @@ public class ModuleConfigurationTests
             await Assert.That(config.AlwaysRun).IsTrue();
             await Assert.That(config.ParallelConstraintKeys).IsEquivalentTo(new[] { "shared" });
             await Assert.That(config.Priority).IsEqualTo(ModulePriority.High);
-            await Assert.That(config.ExecutionType).IsEqualTo(ExecutionType.CpuIntensive);
+            await Assert.That(config.ExecutionHint).IsEqualTo(ExecutionHint.CpuBound);
             await Assert.That(config.Tags).Contains("build");
             await Assert.That(config.Category).IsEqualTo("ci");
             await Assert.That(config.Dependencies).HasSingleItem();

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
@@ -45,7 +45,7 @@ public class ModuleConfigureTests
 
     [ModularPipelines.Attributes.NotInParallel("attribute-lock")]
     [Priority(ModulePriority.High)]
-    [ExecutionHint(ExecutionType.CpuIntensive)]
+    [ExecutionHint(ExecutionHint.CpuBound)]
     [ModuleTag("attribute-tag")]
     [ModuleCategory("attribute-category")]
     [ModularPipelines.Attributes.DependsOn<TestModule>]
@@ -54,7 +54,7 @@ public class ModuleConfigureTests
         protected override void Configure(ModuleConfigurationBuilder module) => module
             .WithNotInParallel("fluent-lock")
             .WithPriority(ModulePriority.Critical)
-            .WithExecutionHint(ExecutionType.IoIntensive)
+            .WithExecutionHint(ExecutionHint.IoBound)
             .WithTags("fluent-tag")
             .WithCategory("fluent-category");
 
@@ -139,7 +139,7 @@ public class ModuleConfigureTests
         {
             await Assert.That(config.ParallelConstraintKeys).IsEquivalentTo(new[] { "fluent-lock" });
             await Assert.That(config.Priority).IsEqualTo(ModulePriority.Critical);
-            await Assert.That(config.ExecutionType).IsEqualTo(ExecutionType.IoIntensive);
+            await Assert.That(config.ExecutionHint).IsEqualTo(ExecutionHint.IoBound);
             await Assert.That(config.Tags).IsEquivalentTo(new[] { "attribute-tag", "fluent-tag" });
             await Assert.That(config.Category).IsEqualTo("fluent-category");
             await Assert.That(config.Dependencies.Select(dependency => dependency.ModuleType))

--- a/test/ModularPipelines.UnitTests/Configuration/UnifiedModuleConfigurationIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/UnifiedModuleConfigurationIntegrationTests.cs
@@ -31,7 +31,7 @@ public class UnifiedModuleConfigurationIntegrationTests
             .WithCategory("configured-category")
             .WithNotInParallel("configured-lock")
             .WithPriority(ModulePriority.High)
-            .WithExecutionHint(ExecutionType.IoIntensive);
+            .WithExecutionHint(ExecutionHint.IoBound);
 
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -124,10 +124,10 @@ public class DocumentationSnippetTests
             .ConfigureAwait(false);
 
         await Assert.That(pipelineHost).Contains("ModuleStatus.Failed");
-        await Assert.That(pipelineHost).Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
+        await Assert.That(pipelineHost).Contains("FailureMode = FailureMode.ContinueOnFailure");
         await Assert.That(pipelineHost).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(versionedPipelineHost)
-            .Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
+            .Contains("FailureMode = FailureMode.ContinueOnFailure");
         await Assert.That(versionedPipelineHost).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("ModuleStatus.Succeeded");
@@ -135,7 +135,7 @@ public class DocumentationSnippetTests
         await Assert.That(azure).Contains(".Value.");
 
         await Assert.That(compiledFixture).Contains("ModuleStatus.Failed");
-        await Assert.That(compiledFixture).Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
+        await Assert.That(compiledFixture).Contains("FailureMode = FailureMode.ContinueOnFailure");
         await Assert.That(compiledFixture).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(compiledFixture).Contains("ModuleStatus.Succeeded");
         await Assert.That(compiledFixture).Contains("buildResult.Value.OutputPath");

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -127,7 +127,7 @@ public class DocumentationSnippetTests
         await Assert.That(pipelineHost).Contains("FailureMode = FailureMode.ContinueOnFailure");
         await Assert.That(pipelineHost).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(versionedPipelineHost)
-            .Contains("FailureMode = FailureMode.ContinueOnFailure");
+            .Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
         await Assert.That(versionedPipelineHost).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("ModuleStatus.Succeeded");

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -38,7 +38,7 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
-    public async Task AcquireExecutionTypeLimitAsync_CancelsWhileWaiting()
+    public async Task AcquireExecutionHintLimitAsync_CancelsWhileWaiting()
     {
         var handler = CreateHandler(new PipelineOptions
         {
@@ -49,18 +49,18 @@ public class ParallelLimitHandlerTests
         });
         var firstState = new ModuleState(new TestModule(), typeof(TestModule))
         {
-            ExecutionType = ExecutionType.CpuIntensive,
+            ExecutionHint = ExecutionHint.CpuBound,
         };
         var secondState = new ModuleState(new TestModule(), typeof(TestModule))
         {
-            ExecutionType = ExecutionType.CpuIntensive,
+            ExecutionHint = ExecutionHint.CpuBound,
         };
-        using var heldSlot = await handler.AcquireExecutionTypeLimitAsync(
+        using var heldSlot = await handler.AcquireExecutionHintLimitAsync(
             firstState,
             CancellationToken.None);
         using var cancellationTokenSource = new CancellationTokenSource();
 
-        var waitingTask = handler.AcquireExecutionTypeLimitAsync(
+        var waitingTask = handler.AcquireExecutionHintLimitAsync(
             secondState,
             cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
@@ -80,7 +80,7 @@ public class ParallelLimitHandlerTests
             .Callback(() => limitWaitObserved.TrySetResult())
             .Returns(releaseLimitWait.Task);
         parallelLimitHandler
-            .Setup(x => x.AcquireExecutionTypeLimitAsync(It.IsAny<ModuleState>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.AcquireExecutionHintLimitAsync(It.IsAny<ModuleState>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Mock.Of<IDisposable>());
         var receiver = new Mock<IModuleEventReceiver>();
         receiver
@@ -133,7 +133,7 @@ public class ParallelLimitHandlerTests
             .Callback<Type, CancellationToken>((_, token) => observedTokens.Add(token))
             .ReturnsAsync(Mock.Of<IDisposable>());
         parallelLimitHandler
-            .Setup(x => x.AcquireExecutionTypeLimitAsync(
+            .Setup(x => x.AcquireExecutionHintLimitAsync(
                 It.IsAny<ModuleState>(),
                 It.IsAny<CancellationToken>()))
             .Callback<ModuleState, CancellationToken>((_, token) => observedTokens.Add(token))

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -203,13 +203,13 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_SurfacesAllConcurrentWorkerFaults()
+    public async Task FailFast_SurfacesAllConcurrentWorkerFaults()
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
         var workersStarted = 0;
         var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var executor = CreateStopOnFirstExceptionExecutor(
+        var executor = CreateFailFastExecutor(
             faultingModule,
             laterModule,
             async (moduleState, _, _) =>
@@ -231,12 +231,12 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_DoesNotDuplicateSharedWorkerFault()
+    public async Task FailFast_DoesNotDuplicateSharedWorkerFault()
     {
         var sharedException = new InvalidOperationException("Shared failure");
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
-        var executor = CreateStopOnFirstExceptionExecutor(
+        var executor = CreateFailFastExecutor(
             faultingModule,
             laterModule,
             (_, _, _) => Task.FromException(sharedException));
@@ -249,7 +249,7 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_LateStartsQueuedAlwaysRunModule()
+    public async Task FailFast_LateStartsQueuedAlwaysRunModule()
     {
         var faultingModule = new FaultingModule();
         var alwaysRunModule = new QueuedAlwaysRunModule();
@@ -315,7 +315,7 @@ public class ModuleExecutorLoggingTests
 
         var pipelineOptions = Microsoft.Extensions.Options.Options.Create(new PipelineOptions
         {
-            ExecutionMode = ExecutionMode.StopOnFirstException,
+            FailureMode = FailureMode.FailFast,
         });
         var alwaysRunHandler = new AlwaysRunHandler(
             moduleRunner.Object,
@@ -357,13 +357,13 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_IgnoresWorkerCancellation()
+    public async Task FailFast_IgnoresWorkerCancellation()
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
         var workersStarted = 0;
         var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var executor = CreateStopOnFirstExceptionExecutor(
+        var executor = CreateFailFastExecutor(
             faultingModule,
             laterModule,
             async (moduleState, _, cancellationToken) =>
@@ -391,7 +391,7 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_SurfacesIndependentWorkerCancellation()
+    public async Task FailFast_SurfacesIndependentWorkerCancellation()
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
@@ -399,7 +399,7 @@ public class ModuleExecutorLoggingTests
         var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var failFastCancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var independentCancellationToken = new CancellationToken(canceled: true);
-        var executor = CreateStopOnFirstExceptionExecutor(
+        var executor = CreateFailFastExecutor(
             faultingModule,
             laterModule,
             async (moduleState, _, cancellationToken) =>
@@ -430,7 +430,7 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task WaitForAllModules_WorkerFault_DoesNotStopRemainingModules()
+    public async Task ContinueOnFailure_WorkerFault_DoesNotStopRemainingModules()
     {
         var dependencyRegistry = new ModuleDependencyRegistry();
         var metadataRegistry = new ModuleMetadataRegistry(new ModuleAttributeEventService());
@@ -493,7 +493,7 @@ public class ModuleExecutorLoggingTests
             secondaryExceptionContainer.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
             }),
             Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
 
@@ -513,7 +513,7 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task WaitForAllModules_RecoveryFault_DoesNotStopRemainingModules()
+    public async Task ContinueOnFailure_RecoveryFault_DoesNotStopRemainingModules()
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
@@ -577,7 +577,7 @@ public class ModuleExecutorLoggingTests
             secondaryExceptionContainer.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
             }),
             Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
 
@@ -684,7 +684,7 @@ public class ModuleExecutorLoggingTests
         }
     }
 
-    private static ModuleExecutor CreateStopOnFirstExceptionExecutor(
+    private static ModuleExecutor CreateFailFastExecutor(
         FaultingModule faultingModule,
         LaterModule laterModule,
         Func<ModuleState, IModuleScheduler, CancellationToken, Task> executeModule)
@@ -738,7 +738,7 @@ public class ModuleExecutorLoggingTests
             new SecondaryExceptionContainer(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ExecutionMode = ExecutionMode.StopOnFirstException,
+                FailureMode = FailureMode.FailFast,
             }),
             Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
     }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerConfigurationTests.cs
@@ -17,7 +17,7 @@ public class ModuleSchedulerConfigurationTests
 {
     [ModularPipelines.Attributes.NotInParallel("direct-lock")]
     [Priority(ModulePriority.Critical)]
-    [ExecutionHint(ExecutionType.IoIntensive)]
+    [ExecutionHint(ExecutionHint.IoBound)]
     private sealed class DirectAttributedModule : IModule
     {
         public Type ResultType => typeof(string);
@@ -37,11 +37,11 @@ public class ModuleSchedulerConfigurationTests
         await Assert.That(state).IsNotNull();
         await Assert.That(state!.RequiredLockKeys).IsEquivalentTo(["direct-lock"]);
         await Assert.That(state.Priority).IsEqualTo(ModulePriority.Critical);
-        await Assert.That(state.ExecutionType).IsEqualTo(ExecutionType.IoIntensive);
+        await Assert.That(state.ExecutionHint).IsEqualTo(ExecutionHint.IoBound);
         metricsCollector.Verify(x => x.RecordModuleInitialized(
             typeof(DirectAttributedModule),
             ModulePriority.Critical,
-            ExecutionType.IoIntensive), Times.Once);
+            ExecutionHint.IoBound), Times.Once);
     }
 
     private static ModuleScheduler CreateScheduler(IMetricsCollector metricsCollector)

--- a/test/ModularPipelines.UnitTests/Engine/PipelineExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineExecutorTests.cs
@@ -11,7 +11,7 @@ namespace ModularPipelines.UnitTests.Engine;
 public class PipelineExecutorTests
 {
     [Test]
-    public async Task WaitForAllModules_Does_Not_Throw_Secondary_Exceptions_When_Throwing_Is_Disabled()
+    public async Task ContinueOnFailure_Does_Not_Throw_Secondary_Exceptions_When_Throwing_Is_Disabled()
     {
         var secondaryExceptions = new Mock<ISecondaryExceptionContainer>();
         var exceptionRethrowService = new Mock<IExceptionRethrowService>();
@@ -20,7 +20,7 @@ public class PipelineExecutorTests
             exceptionRethrowService.Object,
             new PipelineOptions
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
                 ThrowOnPipelineFailure = false,
             });
 
@@ -32,7 +32,7 @@ public class PipelineExecutorTests
     }
 
     [Test]
-    public async Task WaitForAllModules_Throws_Stored_Exceptions_When_Throwing_Is_Enabled()
+    public async Task ContinueOnFailure_Throws_Stored_Exceptions_When_Throwing_Is_Enabled()
     {
         var secondaryExceptions = new Mock<ISecondaryExceptionContainer>();
         var exceptionRethrowService = new Mock<IExceptionRethrowService>();
@@ -41,7 +41,7 @@ public class PipelineExecutorTests
             exceptionRethrowService.Object,
             new PipelineOptions
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
                 ThrowOnPipelineFailure = true,
             });
 

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -3070,7 +3070,7 @@ public class RunReportTests
             using var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
-                ExecutionMode = ExecutionMode.StopOnFirstException,
+                FailureMode = FailureMode.FailFast,
                 ThrowOnPipelineFailure = false,
                 Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
@@ -3109,7 +3109,7 @@ public class RunReportTests
             using var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
                 ThrowOnPipelineFailure = false,
                 Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
@@ -3150,7 +3150,7 @@ public class RunReportTests
             using var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
                 ThrowOnPipelineFailure = false,
                 Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
@@ -3887,7 +3887,7 @@ public class RunReportTests
         builder.WriteRunReport(reportPath);
         builder.ConfigurePipelineOptions(options => options with
         {
-            ExecutionMode = ExecutionMode.WaitForAllModules,
+            FailureMode = FailureMode.ContinueOnFailure,
             ThrowOnPipelineFailure = false,
             Console = options.Console with { PrintLogo = false, PrintResults = false },
             RunReport = options.RunReport with

--- a/test/ModularPipelines.UnitTests/Execution/AlwaysRunTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/AlwaysRunTests.cs
@@ -108,12 +108,12 @@ public class AlwaysRunTests : TestBase
     }
 
     [Test]
-    public async Task WaitForAllModules_Returns_Summary_When_AlwaysRun_Dependency_Fails()
+    public async Task ContinueOnFailure_Returns_Summary_When_AlwaysRun_Dependency_Fails()
     {
         var host = await TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
                 ThrowOnPipelineFailure = false,
             })
             .AddModule<MyModule1>()
@@ -134,12 +134,12 @@ public class AlwaysRunTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_Preserves_Primary_Failure_With_AlwaysRun_Dependency()
+    public async Task FailFast_Preserves_Primary_Failure_With_AlwaysRun_Dependency()
     {
         var host = await TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
             {
-                ExecutionMode = ExecutionMode.StopOnFirstException,
+                FailureMode = FailureMode.FailFast,
                 ThrowOnPipelineFailure = true,
             })
             .AddModule<MyModule1>()

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -436,7 +436,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_Reports_DependencyFailed_For_Dependent_Module()
+    public async Task FailFast_Reports_DependencyFailed_For_Dependent_Module()
     {
         var builder = TestPipelineBuilder.Create()
             .AddModule<BadModule>()
@@ -465,7 +465,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_Reports_DependencyFailed_When_ReadyHookThrows()
+    public async Task FailFast_Reports_DependencyFailed_When_ReadyHookThrows()
     {
         var builder = TestPipelineBuilder.Create()
             .AddModule<ReadyHookFailingModule>()
@@ -491,7 +491,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_Preserves_Raw_ReadyHook_Failure_When_Dependent_Reports_First()
+    public async Task FailFast_Preserves_Raw_ReadyHook_Failure_When_Dependent_Reports_First()
     {
         var builder = TestPipelineBuilder.Create()
             .ConfigureServices(services =>
@@ -582,7 +582,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_Wraps_Independent_ReadyHook_Cancellation_For_Dependents()
+    public async Task FailFast_Wraps_Independent_ReadyHook_Cancellation_For_Dependents()
     {
         var builder = TestPipelineBuilder.Create()
             .ConfigureServices(services =>
@@ -621,7 +621,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_DoesNotPropagateDependencyFailureAcrossAlwaysRunModule()
+    public async Task FailFast_DoesNotPropagateDependencyFailureAcrossAlwaysRunModule()
     {
         var builder = TestPipelineBuilder.Create()
             .AddModule<BadModule>()
@@ -650,12 +650,12 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task WaitForAllModules_Reports_DependencyFailed_For_Dependent_Module()
+    public async Task ContinueOnFailure_Reports_DependencyFailed_For_Dependent_Module()
     {
         var builder = TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
             })
             .AddModule<BadModule>()
             .AddModule<Module1>();
@@ -834,7 +834,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task StopOnFirstException_PendingModuleAwaiterReturnsTerminatedResult()
+    public async Task FailFast_PendingModuleAwaiterReturnsTerminatedResult()
     {
         var builder = TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
@@ -872,14 +872,14 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task WaitForAllModules_Allows_InFlight_And_Pending_Modules_To_Complete()
+    public async Task ContinueOnFailure_Allows_InFlight_And_Pending_Modules_To_Complete()
     {
         PeerModuleStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var builder = TestPipelineBuilder.Create()
             .ConfigurePipelineOptions((_, options) => options with
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
             })
             .AddModule<WaitForAllFailingModule>()
             .AddModule<WaitForAllCompletingModule>()
@@ -900,14 +900,14 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task WaitForAllModules_Preserves_Original_Failure()
+    public async Task ContinueOnFailure_Preserves_Original_Failure()
     {
         PeerModuleStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var builder = TestPipelineBuilder.Create()
             .ConfigurePipelineOptions((_, options) => options with
             {
-                ExecutionMode = ExecutionMode.WaitForAllModules,
+                FailureMode = FailureMode.ContinueOnFailure,
                 ThrowOnPipelineFailure = true,
             })
             .AddModule<WaitForAllFailingModule>()

--- a/test/ModularPipelines.UnitTests/Execution/ExecutionHintTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ExecutionHintTests.cs
@@ -14,8 +14,8 @@ public class ExecutionHintTests : TestBase
     private static readonly ConcurrentBag<string> CpuViolations = new();
     private static int _maxCpuConcurrency = 0;
 
-    [ExecutionHint(ExecutionType.CpuIntensive)]
-    public class CpuIntensiveModule1 : Module<string>
+    [ExecutionHint(ExecutionHint.CpuBound)]
+    public class CpuBoundModule1 : Module<string>
     {
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -33,7 +33,7 @@ public class ExecutionHintTests : TestBase
             // Record violation if more than allowed
             if (CpuModulesExecuting.Count > 2)
             {
-                CpuViolations.Add($"{moduleName}: {CpuModulesExecuting.Count} concurrent CPU-intensive modules");
+                CpuViolations.Add($"{moduleName}: {CpuModulesExecuting.Count} concurrent CPU-bound modules");
             }
 
             CpuModulesExecuting.TryTake(out _);
@@ -41,8 +41,8 @@ public class ExecutionHintTests : TestBase
         }
     }
 
-    [ExecutionHint(ExecutionType.CpuIntensive)]
-    public class CpuIntensiveModule2 : Module<string>
+    [ExecutionHint(ExecutionHint.CpuBound)]
+    public class CpuBoundModule2 : Module<string>
     {
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -62,8 +62,8 @@ public class ExecutionHintTests : TestBase
         }
     }
 
-    [ExecutionHint(ExecutionType.CpuIntensive)]
-    public class CpuIntensiveModule3 : Module<string>
+    [ExecutionHint(ExecutionHint.CpuBound)]
+    public class CpuBoundModule3 : Module<string>
     {
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -83,18 +83,18 @@ public class ExecutionHintTests : TestBase
         }
     }
 
-    [ExecutionHint(ExecutionType.IoIntensive)]
-    public class IoIntensiveModule : Module<string>
+    [ExecutionHint(ExecutionHint.IoBound)]
+    public class IoBoundModule : Module<string>
     {
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(10, cancellationToken);
-            return "IoIntensive";
+            return "IoBound";
         }
     }
 
-    [ExecutionHint(ExecutionType.Default)]
-    public class DefaultExecutionTypeModule : Module<string>
+    [ExecutionHint(ExecutionHint.Default)]
+    public class DefaultExecutionHintModule : Module<string>
     {
         protected internal override Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -122,14 +122,14 @@ public class ExecutionHintTests : TestBase
     public async Task ExecutionHintAttribute_CanBeAppliedToModule()
     {
         var result = await TestPipelineBuilder.Create()
-            .AddModule<CpuIntensiveModule1>()
+            .AddModule<CpuBoundModule1>()
             .RunAsync();
 
         await Assert.That(result.Status).IsEqualTo(ModuleStatus.Succeeded);
     }
 
     [Test]
-    public async Task ModulesWithoutExecutionHint_UseDefaultType()
+    public async Task ModulesWithoutExecutionHint_UseDefaultHint()
     {
         var result = await TestPipelineBuilder.Create()
             .AddModule<NoHintModule>()
@@ -139,12 +139,12 @@ public class ExecutionHintTests : TestBase
     }
 
     [Test]
-    public async Task AllExecutionTypes_ExecuteSuccessfully()
+    public async Task AllExecutionHints_ExecuteSuccessfully()
     {
         var result = await TestPipelineBuilder.Create()
-            .AddModule<CpuIntensiveModule1>()
-            .AddModule<IoIntensiveModule>()
-            .AddModule<DefaultExecutionTypeModule>()
+            .AddModule<CpuBoundModule1>()
+            .AddModule<IoBoundModule>()
+            .AddModule<DefaultExecutionHintModule>()
             .AddModule<NoHintModule>()
             .RunAsync();
 
@@ -152,13 +152,13 @@ public class ExecutionHintTests : TestBase
     }
 
     [Test]
-    public async Task CpuIntensiveModules_AreThrottled()
+    public async Task CpuBoundModules_AreThrottled()
     {
-        // Set max CPU-intensive modules to 2
+        // Set max CPU-bound modules to 2
         var result = await TestPipelineBuilder.Create()
-            .AddModule<CpuIntensiveModule1>()
-            .AddModule<CpuIntensiveModule2>()
-            .AddModule<CpuIntensiveModule3>()
+            .AddModule<CpuBoundModule1>()
+            .AddModule<CpuBoundModule2>()
+            .AddModule<CpuBoundModule3>()
             .ConfigurePipelineOptions((_, options) => options with
             {
                 Concurrency = options.Concurrency with { MaxCpuIntensiveModules = 2 },

--- a/test/ModularPipelines.UnitTests/Execution/FailedPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/FailedPipelineTests.cs
@@ -38,14 +38,14 @@ public class FailedPipelineTests : TestBase
     }
 
     [Test]
-    [Arguments(ExecutionMode.StopOnFirstException)]
-    [Arguments(ExecutionMode.WaitForAllModules)]
-    public async Task Given_Failing_Module_With_Dependent_Module_When_Fail_Fast_Then_Failures_Propagate(ExecutionMode executionMode)
+    [Arguments(FailureMode.FailFast)]
+    [Arguments(FailureMode.ContinueOnFailure)]
+    public async Task Given_Failing_Module_With_Dependent_Module_Then_Failures_Propagate(FailureMode failureMode)
     {
         await Assert.That(async () => await TestPipelineBuilder.Create()
                 .ConfigurePipelineOptions((_, options) => options with
                 {
-                    ExecutionMode = executionMode,
+                    FailureMode = failureMode,
                     ThrowOnPipelineFailure = true,
                 })
                 .AddModule<Module1>()
@@ -56,14 +56,14 @@ public class FailedPipelineTests : TestBase
     }
 
     [Test]
-    [Arguments(ExecutionMode.StopOnFirstException)]
-    [Arguments(ExecutionMode.WaitForAllModules)]
-    public async Task Given_Failing_Module_When_Fail_Fast_Then_Failures_Propagate(ExecutionMode executionMode)
+    [Arguments(FailureMode.FailFast)]
+    [Arguments(FailureMode.ContinueOnFailure)]
+    public async Task Given_Failing_Module_Then_Failures_Propagate(FailureMode failureMode)
     {
         await Assert.That(async () => await TestPipelineBuilder.Create()
                 .ConfigurePipelineOptions((_, options) => options with
                 {
-                    ExecutionMode = executionMode,
+                    FailureMode = failureMode,
                     ThrowOnPipelineFailure = true,
                 })
                 .AddModule<Module1>()
@@ -73,14 +73,14 @@ public class FailedPipelineTests : TestBase
     }
 
     [Test]
-    [Arguments(ExecutionMode.StopOnFirstException)]
-    [Arguments(ExecutionMode.WaitForAllModules)]
-    public async Task Given_No_Failing_Module_Then_No_Exceptions(ExecutionMode executionMode)
+    [Arguments(FailureMode.FailFast)]
+    [Arguments(FailureMode.ContinueOnFailure)]
+    public async Task Given_No_Failing_Module_Then_No_Exceptions(FailureMode failureMode)
     {
         var pipelineSummary = await TestPipelineBuilder.Create()
                 .ConfigurePipelineOptions((_, options) => options with
                 {
-                    ExecutionMode = executionMode,
+                    FailureMode = failureMode,
                 })
                 .AddModule<Module1>()
                 .AddModule<Module3>()


### PR DESCRIPTION
Closes #4241

## Summary
- rename pipeline ExecutionMode to FailureMode, with FailFast and ContinueOnFailure
- rename module ExecutionType to ExecutionHint, with CpuBound and IoBound
- align configuration, scheduler metrics, planner throttling, tests, examples, current docs, and v4 migration notes
- keep historical v3 documentation unchanged

## Validation
- static API audit found no old identifiers outside historical v3 migration/versioned docs
- git diff --check passed
- C# compiler probe confirmed [ExecutionHint(ExecutionHint.CpuBound)] resolves to ExecutionHintAttribute

## Local validation limit
- guarded ModularPipelines.slnx Release build crossed the fixed 2 GB process-tree limit (2064 MB)
- guarded core-project Release build also crossed the fixed 2 GB limit (2058 MB)
- per repository policy, limits were not raised and builds were not retried; CI owns compilation validation