### PR TITLE
Quarantine generated metadata APIs

### DIFF
--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -53,6 +53,20 @@ These APIs remain available to JIT-compiled applications and carry trim/AOT
 annotations where appropriate. Tool integration packages are not AOT-certified unless
 their package explicitly declares `IsAotCompatible`.
 
+## Integrate another source generator
+
+Third-party generators that emit command-option or secret metadata should register it
+from a module initializer through `ModularPipelines.Generated.RuntimeMetadataRegistry`.
+This is the supported entry point for generator cooperation. Its model types also live
+in `ModularPipelines.Generated`; they are public so generated code in consumer
+assemblies can call them, but hidden from normal IntelliSense with
+`EditorBrowsableState.Never`.
+
+Use `RuntimeMetadataRegistry.CurrentCommandMetadataSchemaVersion` when calling
+`RegisterCommandOptions`. Register secret accessors with `RegisterSecrets` for every
+generated options type, including types with no secret properties, so trimmed builds
+do not need reflection fallback.
+
 ## Validate an application
 
 Enable the analyzers and publish for a concrete runtime identifier:

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -1215,11 +1215,11 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         var requiresGeneratedMetadataLiteral = requiresGeneratedMetadata ? "true" : "false";
         AppendAssemblyRegistration(
             sb,
-            "global::ModularPipelines.Helpers.Internal.GeneratedCommandMetadata",
+            "global::ModularPipelines.Generated.GeneratedCommandMetadata",
             requiresGeneratedMetadataLiteral);
         AppendAssemblyRegistration(
             sb,
-            "global::ModularPipelines.Engine.GeneratedSecretMetadata",
+            "global::ModularPipelines.Generated.GeneratedSecretMetadata",
             requiresGeneratedMetadataLiteral);
         AppendStringRegistration(
             sb,
@@ -1254,11 +1254,11 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         var requiresGeneratedMetadataLiteral = requiresGeneratedMetadata ? "true" : "false";
         AppendAssemblyRegistration(
             sb,
-            "global::ModularPipelines.Helpers.Internal.GeneratedCommandMetadata",
+            "global::ModularPipelines.Generated.GeneratedCommandMetadata",
             requiresGeneratedMetadataLiteral);
         AppendAssemblyRegistration(
             sb,
-            "global::ModularPipelines.Engine.GeneratedSecretMetadata",
+            "global::ModularPipelines.Generated.GeneratedSecretMetadata",
             requiresGeneratedMetadataLiteral);
         AppendStringRegistration(
             sb,
@@ -1308,7 +1308,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             sb,
             "RegisterCoveredTypeNames",
             uniqueItems.Where(item => item.IsCommandOptions),
-            "global::ModularPipelines.Helpers.Internal.GeneratedCommandMetadata");
+            "global::ModularPipelines.Generated.GeneratedCommandMetadata");
         AppendTypeNameRegistration(
             sb,
             "RegisterCoveredTypeNames",
@@ -1383,7 +1383,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         StringBuilder sb,
         string methodName,
         IEnumerable<TypeMetadata> items,
-        string registryType = "global::ModularPipelines.Engine.GeneratedSecretMetadata")
+        string registryType = "global::ModularPipelines.Generated.GeneratedSecretMetadata")
     {
         AppendStringRegistration(
             sb,
@@ -1400,7 +1400,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         foreach (var assemblyGroup in items.GroupBy(static item => item.AssemblyIdentity, StringComparer.Ordinal))
         {
             sb.AppendLine(
-                $"        global::ModularPipelines.Engine.GeneratedSecretMetadata.{methodName}(");
+                $"        global::ModularPipelines.Generated.GeneratedSecretMetadata.{methodName}(");
             sb.AppendLine("            assembly,");
             sb.AppendLine($"            {Literal(assemblyGroup.Key)},");
             sb.AppendLine("            new string[]");
@@ -1418,7 +1418,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         StringBuilder sb,
         string methodName,
         IEnumerable<string> values,
-        string registryType = "global::ModularPipelines.Engine.GeneratedSecretMetadata")
+        string registryType = "global::ModularPipelines.Generated.GeneratedSecretMetadata")
     {
         var valueList = values.ToList();
         if (valueList.Count == 0)
@@ -1487,14 +1487,14 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
     private static void AppendCommandRegistration(StringBuilder sb, TypeMetadata item)
     {
         var registrationMethod = item.IsExternal ? "RegisterExternal" : "Register";
-        sb.AppendLine($"        global::ModularPipelines.Helpers.Internal.GeneratedCommandMetadata.{registrationMethod}(");
+        sb.AppendLine($"        global::ModularPipelines.Generated.GeneratedCommandMetadata.{registrationMethod}(");
         if (item.IsExternal)
         {
             sb.AppendLine("            assembly,");
         }
 
         sb.AppendLine($"            typeof({item.TypeName}),");
-        sb.AppendLine("            new global::ModularPipelines.Helpers.Internal.PropertyCommandLinePart[]");
+        sb.AppendLine("            new global::ModularPipelines.Generated.PropertyCommandLinePart[]");
         sb.AppendLine("            {");
 
         foreach (var property in item.CommandMetadata.Properties)
@@ -1503,7 +1503,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             switch (property.Kind)
             {
                 case PropertyKind.Argument:
-                    sb.AppendLine("                new global::ModularPipelines.Helpers.Internal.ArgumentPart(");
+                    sb.AppendLine("                new global::ModularPipelines.Generated.ArgumentPart(");
                     sb.AppendLine($"                    {Literal(property.Name)}, {getter},");
                     sb.AppendLine($"                    new global::ModularPipelines.Attributes.CliArgumentAttribute({property.FirstInt})");
                     sb.AppendLine("                    {");
@@ -1515,7 +1515,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, HasExplicitPosition = {BooleanLiteral(property.HasExplicitArgumentPosition)} }},");
                     break;
                 case PropertyKind.Flag:
-                    sb.AppendLine("                new global::ModularPipelines.Helpers.Internal.FlagPart(");
+                    sb.AppendLine("                new global::ModularPipelines.Generated.FlagPart(");
                     sb.AppendLine($"                    {Literal(property.Name)}, {getter},");
                     sb.AppendLine($"                    new global::ModularPipelines.Attributes.CliFlagAttribute({Literal(property.PrimaryValue!)})");
                     sb.AppendLine("                    {");
@@ -1525,7 +1525,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, IsSupportedPropertyType = {BooleanLiteral(property.IsSupportedPropertyType)} }},");
                     break;
                 case PropertyKind.Option:
-                    sb.AppendLine("                new global::ModularPipelines.Helpers.Internal.OptionPart(");
+                    sb.AppendLine("                new global::ModularPipelines.Generated.OptionPart(");
                     sb.AppendLine($"                    {Literal(property.Name)}, {getter},");
                     sb.AppendLine($"                    new global::ModularPipelines.Attributes.CliOptionAttribute({Literal(property.PrimaryValue!)})");
                     sb.AppendLine("                    {");
@@ -1555,21 +1555,21 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         {
             if (item.UseTypeForEmptySecretCoverage)
             {
-                sb.AppendLine($"        global::ModularPipelines.Engine.GeneratedSecretMetadata.RegisterExternal(assembly, typeof({item.TypeName}));");
+                sb.AppendLine($"        global::ModularPipelines.Generated.GeneratedSecretMetadata.RegisterExternal(assembly, typeof({item.TypeName}));");
             }
 
             return;
         }
 
         var registrationMethod = item.IsExternal ? "RegisterExternal" : "Register";
-        sb.AppendLine($"        global::ModularPipelines.Engine.GeneratedSecretMetadata.{registrationMethod}(");
+        sb.AppendLine($"        global::ModularPipelines.Generated.GeneratedSecretMetadata.{registrationMethod}(");
         if (item.IsExternal)
         {
             sb.AppendLine("            assembly,");
         }
 
         sb.AppendLine($"            typeof({item.TypeName}),");
-        sb.AppendLine("            new global::ModularPipelines.Engine.SecretPropertyAccessor[]");
+        sb.AppendLine("            new global::ModularPipelines.Generated.SecretPropertyAccessor[]");
         sb.AppendLine("            {");
 
         foreach (var property in item.SecretMetadata.Properties)

--- a/src/ModularPipelines.SourceGenerator/GeneratedOptionsRegistrationAnalyzer.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratedOptionsRegistrationAnalyzer.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.SourceGenerator;
 public sealed class GeneratedOptionsRegistrationAnalyzer : DiagnosticAnalyzer
 {
     private const string RuntimeMetadataRegistryFullName =
-        "ModularPipelines.Metadata.RuntimeMetadataRegistry";
+        "ModularPipelines.Generated.RuntimeMetadataRegistry";
 
     [Flags]
     private enum MetadataCoverage

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -578,7 +578,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
 
         foreach (var module in modules)
         {
-            builder.AppendLine("        global::ModularPipelines.Engine.Attributes.GeneratedModuleEventMetadata.Register(");
+            builder.AppendLine("        global::ModularPipelines.Generated.GeneratedModuleEventMetadata.Register(");
             builder.AppendLine($"            typeof({module.TypeName}),");
             if (module.Attributes.IsEmpty)
             {

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -719,15 +719,15 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         sb.AppendLine("    [global::System.Runtime.CompilerServices.ModuleInitializer]");
         sb.AppendLine("    internal static void Register()");
         sb.AppendLine("    {");
-        sb.AppendLine("        global::ModularPipelines.Engine.GeneratedModuleMetadata.Register(");
+        sb.AppendLine("        global::ModularPipelines.Generated.GeneratedModuleMetadata.Register(");
         sb.AppendLine($"            typeof({registrationTypeName}).Assembly,");
-        sb.AppendLine("            new global::ModularPipelines.Engine.GeneratedModuleRegistration[]");
+        sb.AppendLine("            new global::ModularPipelines.Generated.GeneratedModuleRegistration[]");
         sb.AppendLine("            {");
 
         foreach (var module in emittedModules)
         {
-            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{GetRegistrationTypeArguments(module.TypeName, module.ResultTypeName)}>(");
-            sb.AppendLine("                    new global::ModularPipelines.Engine.ModuleDependencyMetadata[]");
+            sb.AppendLine($"                global::ModularPipelines.Generated.GeneratedModuleMetadata.CreateRegistration<{GetRegistrationTypeArguments(module.TypeName, module.ResultTypeName)}>(");
+            sb.AppendLine("                    new global::ModularPipelines.Generated.ModuleDependencyMetadata[]");
             sb.AppendLine("                    {");
 
             foreach (var dependency in module.Dependencies)
@@ -740,8 +740,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         foreach (var dependency in closedGenericDependencies)
         {
-            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{GetRegistrationTypeArguments(dependency.TypeName, dependency.ResultTypeName)}>(");
-            sb.AppendLine("                    global::System.Array.Empty<global::ModularPipelines.Engine.ModuleDependencyMetadata>(),");
+            sb.AppendLine($"                global::ModularPipelines.Generated.GeneratedModuleMetadata.CreateRegistration<{GetRegistrationTypeArguments(dependency.TypeName, dependency.ResultTypeName)}>(");
+            sb.AppendLine("                    global::System.Array.Empty<global::ModularPipelines.Generated.ModuleDependencyMetadata>(),");
             sb.AppendLine("                    dependenciesComplete: false),");
         }
 

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -20,6 +20,8 @@ using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Testing;
 
 /// <summary>

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -3,6 +3,8 @@ using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Console;
 
 /// <summary>

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -1,10 +1,9 @@
 using ModularPipelines.Attributes;
 using ModularPipelines.Engine;
+using ModularPipelines.Generated;
 using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Context;
 

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -4,6 +4,8 @@ using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Context;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -3,6 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine;
 
 internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -1,9 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using ModularPipelines.Modules;
-
 using ModularPipelines.Generated;
+using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine;
 

--- a/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
+++ b/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 using ModularPipelines.Attributes.Events;
 using ModularPipelines.Exceptions;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine.Attributes;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -6,6 +6,8 @@ using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine.Execution;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -2,11 +2,10 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Exceptions;
+using ModularPipelines.Generated;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine.Execution;
 

--- a/src/ModularPipelines/Engine/Execution/ExecutionContextFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ExecutionContextFactory.cs
@@ -1,10 +1,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
+using ModularPipelines.Generated;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine.Execution;
 

--- a/src/ModularPipelines/Engine/Execution/ExecutionContextFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ExecutionContextFactory.cs
@@ -4,6 +4,8 @@ using System.Linq.Expressions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine.Execution;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
@@ -5,6 +5,8 @@ using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine.Execution;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
@@ -1,11 +1,10 @@
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine.Executors;
+using ModularPipelines.Generated;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine.Execution;
 

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -13,14 +13,13 @@ using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Executors;
 using ModularPipelines.Events;
 using ModularPipelines.Exceptions;
+using ModularPipelines.Generated;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.Tracing;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine.Execution;
 

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -20,6 +20,8 @@ using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.Tracing;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine.Execution;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -10,11 +10,10 @@ using ModularPipelines.Distributed.Configuration;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
+using ModularPipelines.Generated;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine.Executors;
 

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -14,6 +14,8 @@ using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine.Executors;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/ModuleAutoRegistrar.cs
+++ b/src/ModularPipelines/Engine/ModuleAutoRegistrar.cs
@@ -1,8 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Extensions;
-using ModularPipelines.Modules;
-
 using ModularPipelines.Generated;
+using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine;
 

--- a/src/ModularPipelines/Engine/ModuleAutoRegistrar.cs
+++ b/src/ModularPipelines/Engine/ModuleAutoRegistrar.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
+++ b/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
@@ -9,6 +9,8 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
+++ b/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
@@ -6,10 +6,9 @@ using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
+using ModularPipelines.Generated;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine;
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -12,6 +12,8 @@ using ModularPipelines.Exceptions;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Engine;
 
 /// <summary>

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -9,10 +9,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Exceptions;
+using ModularPipelines.Generated;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Engine;
 

--- a/src/ModularPipelines/Exceptions/MissingCommandMetadataException.cs
+++ b/src/ModularPipelines/Exceptions/MissingCommandMetadataException.cs
@@ -15,7 +15,7 @@ public sealed class MissingCommandMetadataException : InvalidOperationException
             "ModularPipelines.SourceGenerator is referenced and make the options type, " +
             "its containing types, and CLI-attributed properties accessible and non-generic. " +
             "Generators that emit entire types must register static accessors through " +
-            "ModularPipelines.Metadata.RuntimeMetadataRegistry from a module initializer.")
+            "ModularPipelines.Generated.RuntimeMetadataRegistry from a module initializer.")
     {
         OptionsType = optionsType;
     }

--- a/src/ModularPipelines/Exceptions/MissingSecretMetadataException.cs
+++ b/src/ModularPipelines/Exceptions/MissingSecretMetadataException.cs
@@ -15,7 +15,7 @@ public sealed class MissingSecretMetadataException : InvalidOperationException
             $"'{objectType.Assembly.GetName().Name}'. Ensure ModularPipelines.SourceGenerator is " +
             "referenced and make SecretValue-attributed types and properties accessible and non-generic. " +
             "Generators that emit entire types must register static accessors through " +
-            "ModularPipelines.Metadata.RuntimeMetadataRegistry from a module initializer.")
+            "ModularPipelines.Generated.RuntimeMetadataRegistry from a module initializer.")
     {
         ObjectType = objectType;
     }

--- a/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,8 @@ using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
 using ModularPipelines.Requirements;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Extensions;
 
 /// <summary>

--- a/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
@@ -3,11 +3,10 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.DependencyInjection;
 using ModularPipelines.Engine;
+using ModularPipelines.Generated;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
 using ModularPipelines.Requirements;
-
-using ModularPipelines.Generated;
 
 namespace ModularPipelines.Extensions;
 

--- a/src/ModularPipelines/Generated/GeneratedCommandMetadata.cs
+++ b/src/ModularPipelines/Generated/GeneratedCommandMetadata.cs
@@ -3,11 +3,12 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-namespace ModularPipelines.Helpers.Internal;
+namespace ModularPipelines.Generated;
 
 /// <summary>
 /// Stores command models emitted by ModularPipelines.SourceGenerator.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class GeneratedCommandMetadata
 {
     internal const int CurrentSchemaVersion = 3;

--- a/src/ModularPipelines/Generated/GeneratedModuleEventMetadata.cs
+++ b/src/ModularPipelines/Generated/GeneratedModuleEventMetadata.cs
@@ -1,11 +1,12 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
 
-namespace ModularPipelines.Engine.Attributes;
+namespace ModularPipelines.Generated;
 
 /// <summary>
 /// Stores module attribute factories emitted by ModularPipelines.SourceGenerator.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class GeneratedModuleEventMetadata
 {
     private static readonly ConcurrentDictionary<Type, AttributeMetadata> Factories = new();

--- a/src/ModularPipelines/Generated/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Generated/GeneratedModuleMetadata.cs
@@ -5,18 +5,20 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
+using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Extensions;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
-namespace ModularPipelines.Engine;
+namespace ModularPipelines.Generated;
 
 /// <summary>
 /// Stores module discovery, registration, and dependency metadata emitted by
 /// <c>ModularPipelines.SourceGenerator</c>.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class GeneratedModuleMetadata
 {
     private static readonly object RegistrationLock = new();

--- a/src/ModularPipelines/Generated/GeneratedSecretMetadata.cs
+++ b/src/ModularPipelines/Generated/GeneratedSecretMetadata.cs
@@ -5,11 +5,12 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 
-namespace ModularPipelines.Engine;
+namespace ModularPipelines.Generated;
 
 /// <summary>
 /// Stores secret-property accessors emitted by ModularPipelines.SourceGenerator.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class GeneratedSecretMetadata
 {
     private static readonly ConditionalWeakTable<Type, SecretMetadata> Accessors = [];
@@ -425,6 +426,7 @@ public static class GeneratedSecretMetadata
 /// <summary>
 /// Provides direct access to a property marked with SecretValueAttribute.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed record SecretPropertyAccessor(
     string PropertyName,
     Func<object, object?> Getter,

--- a/src/ModularPipelines/Generated/IncompleteRuntimeMetadataAttribute.cs
+++ b/src/ModularPipelines/Generated/IncompleteRuntimeMetadataAttribute.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace ModularPipelines.Generated;
 
 /// <summary>
@@ -7,6 +9,7 @@ namespace ModularPipelines.Generated;
 /// Public so generated assembly-level markers can share one type across project boundaries.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed class IncompleteRuntimeMetadataAttribute(string metadataName) : Attribute
 {
     /// <summary>

--- a/src/ModularPipelines/Generated/PropertyCommandLinePart.cs
+++ b/src/ModularPipelines/Generated/PropertyCommandLinePart.cs
@@ -1,11 +1,12 @@
 using System.ComponentModel;
 using ModularPipelines.Attributes;
 
-namespace ModularPipelines.Helpers.Internal;
+namespace ModularPipelines.Generated;
 
 /// <summary>
 /// Representation of a command line part tied to a property.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public abstract record PropertyCommandLinePart(string PropertyName, Func<object, object?> Getter)
 {
     /// <summary>
@@ -27,6 +28,7 @@ public abstract record PropertyCommandLinePart(string PropertyName, Func<object,
 /// <summary>
 /// Representation of a positional argument.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed record ArgumentPart(
     string PropertyName,
     Func<object, object?> Getter,
@@ -44,6 +46,7 @@ public sealed record ArgumentPart(
 /// <summary>
 /// Representation of a boolean flag.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed record FlagPart(
     string PropertyName,
     Func<object, object?> Getter,
@@ -56,6 +59,7 @@ public sealed record FlagPart(
 /// <summary>
 /// Representation of an option with a value.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed record OptionPart(
     string PropertyName,
     Func<object, object?> Getter,

--- a/src/ModularPipelines/Generated/RuntimeMetadataRegistry.cs
+++ b/src/ModularPipelines/Generated/RuntimeMetadataRegistry.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel;
-using ModularPipelines.Engine;
-using ModularPipelines.Helpers.Internal;
 
-namespace ModularPipelines.Metadata;
+namespace ModularPipelines.Generated;
 
 /// <summary>
 /// Accepts AOT-safe runtime metadata emitted by cooperating source generators.
@@ -12,7 +10,7 @@ namespace ModularPipelines.Metadata;
 /// registers static property accessors here. This avoids runtime type discovery and reflection,
 /// which are unavailable after Native AOT trimming.
 /// </remarks>
-[EditorBrowsable(EditorBrowsableState.Advanced)]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class RuntimeMetadataRegistry
 {
     /// <summary>

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -3,9 +3,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using ModularPipelines.Attributes;
-using ModularPipelines.Models;
-
 using ModularPipelines.Generated;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Helpers.Internal;
 

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Models;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Helpers.Internal;
 
 /// <inheritdoc/>

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -5,6 +5,8 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Helpers.Internal;
 
 /// <inheritdoc/>

--- a/src/ModularPipelines/Helpers/Internal/ICommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/ICommandArgumentBuilder.cs
@@ -1,9 +1,11 @@
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Helpers.Internal;
 
 /// <summary>
 /// Service that builds a string argument list from a command model and an options object instance.
 /// </summary>
-public interface ICommandArgumentBuilder
+internal interface ICommandArgumentBuilder
 {
     /// <summary>
     /// Builds the list of arguments based on the values in an options object.

--- a/src/ModularPipelines/Helpers/Internal/ICommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/ICommandModelProvider.cs
@@ -1,9 +1,11 @@
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Helpers.Internal;
 
 /// <summary>
 /// Service for creating a command model from an options object's type.
 /// </summary>
-public interface ICommandModelProvider
+internal interface ICommandModelProvider
 {
     /// <summary>
     /// Gets a cached, structured command model by reflecting over the attributes of an options type.

--- a/src/ModularPipelines/Helpers/Internal/ICommandPartsProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/ICommandPartsProvider.cs
@@ -5,7 +5,7 @@ namespace ModularPipelines.Helpers.Internal;
 /// Command parts are determined from CliSubCommand or CliCommandAlias attributes,
 /// or from the CommandParts property on CommandLineToolOptions.
 /// </summary>
-public interface ICommandPartsProvider
+internal interface ICommandPartsProvider
 {
     /// <summary>
     /// Gets the raw command parts (subcommands) from an options object.

--- a/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.Logging;
 
 /// <summary>

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class GeneratedOptionsRegistrationAnalyzerTests
             }
         }
 
-        namespace ModularPipelines.Metadata
+        namespace ModularPipelines.Generated
         {
             public static class RuntimeMetadataRegistry
             {
@@ -118,7 +118,7 @@ public class GeneratedOptionsRegistrationAnalyzerTests
             new PeerSourceGenerator(
                 "PeerCommandOptions.cs",
                 """
-                using ModularPipelines.Metadata;
+                using ModularPipelines.Generated;
                 using ModularPipelines.Options;
 
                 public sealed class PeerCommandOptions : CommandLineToolOptions;
@@ -156,7 +156,7 @@ public class GeneratedOptionsRegistrationAnalyzerTests
             new PeerSourceGenerator(
                 "LegacyPeerCommandOptions.cs",
                 """
-                using ModularPipelines.Metadata;
+                using ModularPipelines.Generated;
                 using ModularPipelines.Options;
 
                 public sealed class LegacyPeerCommandOptions : CommandLineToolOptions;
@@ -198,7 +198,7 @@ public class GeneratedOptionsRegistrationAnalyzerTests
             new PeerSourceGenerator(
                 "StalePeerCommandOptions.cs",
                 """
-                using ModularPipelines.Metadata;
+                using ModularPipelines.Generated;
                 using ModularPipelines.Options;
 
                 public sealed class StalePeerCommandOptions : CommandLineToolOptions;

--- a/test/ModularPipelines.TestHelpers/GeneratedOptionsSmokeTestHarness.cs
+++ b/test/ModularPipelines.TestHelpers/GeneratedOptionsSmokeTestHarness.cs
@@ -7,6 +7,8 @@ using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.TestHelpers;
 
 /// <summary>

--- a/test/ModularPipelines.UnitTests/Api/GeneratedMetadataApiTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/GeneratedMetadataApiTests.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using System.Reflection;
+using ModularPipelines.Generated;
+
+namespace ModularPipelines.UnitTests.Api;
+
+public class GeneratedMetadataApiTests
+{
+    [Test]
+    public async Task GeneratorContractsShareHiddenGeneratedNamespace()
+    {
+        var contractTypes = new[]
+        {
+            typeof(GeneratedModuleMetadata),
+            typeof(GeneratedModuleRegistration),
+            typeof(ModuleDependencyMetadata),
+            typeof(GeneratedSecretMetadata),
+            typeof(SecretPropertyAccessor),
+            typeof(GeneratedModuleEventMetadata),
+            typeof(GeneratedCommandMetadata),
+            typeof(PropertyCommandLinePart),
+            typeof(ArgumentPart),
+            typeof(FlagPart),
+            typeof(OptionPart),
+            typeof(RuntimeMetadataRegistry),
+            typeof(IncompleteRuntimeMetadataAttribute),
+        };
+        var generatedTypes = typeof(RuntimeMetadataRegistry).Assembly.ExportedTypes
+            .Where(type => type.Namespace == "ModularPipelines.Generated")
+            .ToArray();
+
+        await Assert.That(generatedTypes).IsEquivalentTo(contractTypes);
+
+        foreach (var type in generatedTypes)
+        {
+            var editorBrowsable = type.GetCustomAttribute<EditorBrowsableAttribute>();
+
+            await Assert.That(type.Namespace).IsEqualTo("ModularPipelines.Generated");
+            await Assert.That(editorBrowsable).IsNotNull();
+            await Assert.That(editorBrowsable!.State).IsEqualTo(EditorBrowsableState.Never);
+        }
+    }
+
+    [Test]
+    public async Task CommandProviderInterfacesAreInternal()
+    {
+        var assembly = typeof(RuntimeMetadataRegistry).Assembly;
+        var interfaceNames = new[]
+        {
+            "ModularPipelines.Helpers.Internal.ICommandArgumentBuilder",
+            "ModularPipelines.Helpers.Internal.ICommandModelProvider",
+            "ModularPipelines.Helpers.Internal.ICommandPartsProvider",
+        };
+
+        foreach (var interfaceName in interfaceNames)
+        {
+            var type = assembly.GetType(interfaceName);
+            await Assert.That(type).IsNotNull();
+            await Assert.That(type!.IsNotPublic).IsTrue();
+        }
+
+        await Assert.That(assembly.ExportedTypes)
+            .DoesNotContain(type => type.Namespace == "ModularPipelines.Helpers.Internal");
+    }
+}

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -7,6 +7,8 @@ using ModularPipelines.Models;
 using ModularPipelines.Options;
 using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.UnitTests.Attributes;
 
 public class CliAttributeTests

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
@@ -4,6 +4,8 @@ using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Modules;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.UnitTests.Attributes;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
@@ -2,7 +2,6 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers.Internal;
-using ModularPipelines.Metadata;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 using ModularPipelines.VisualBasic.TestFixtures;
@@ -10,6 +9,8 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
+
+using ModularPipelines.Generated;
 
 namespace ModularPipelines.UnitTests.Attributes;
 

--- a/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
@@ -10,6 +10,8 @@ using ModularPipelines.Options;
 using ModularPipelines.VisualBasic.TestFixtures;
 using Moq;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.UnitTests.Attributes;
 
 internal class GeneratedCharacterSecretOptions

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -9,6 +9,8 @@ using ModularPipelines.Models;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.UnitTests.Context;
 
 public class CommandLineBuilderTests : TestBase

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -13,6 +13,8 @@ using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 
+using ModularPipelines.Generated;
+
 namespace ModularPipelines.UnitTests.Engine;
 
 public class GeneratedModuleMetadataTests


### PR DESCRIPTION
Closes #4219.

## Summary
- move generated-code contracts into `ModularPipelines.Generated`
- apply `EditorBrowsable(EditorBrowsableState.Never)` to every public generated contract
- internalize the three command provider interfaces and remove public `Helpers.Internal` surface
- update all source generators, runtime consumers, diagnostics, and test fixtures to the consolidated namespace
- document `RuntimeMetadataRegistry` as the supported third-party generator entry point

## Validation
- `ModularPipelines.Tests.slnf` Release build (178 existing warnings, 0 errors)
- source-generator unit-test project Release build (0 warnings/errors)
- `ModularPipelines.Testing.slnx` Release build (0 warnings/errors)
- 93 focused source-generator, runtime metadata, and API-shape tests passed
- changed-file whitespace formatting, stale-namespace scan, and `git diff --check`

The broad `IncompleteMetadataDiagnosticTests` class exceeded the mandated 2 GB local guard (exit 137) and was not retried with higher limits. Its two observed external-rescan failures reproduce unchanged on a detached clean `origin/main`; four directly relevant tests in that class pass on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for integrating third-party source generators with Native AOT applications.
  - Improved generated metadata registration for command options, module information, and secret accessors.
- **Bug Fixes**
  - Updated metadata discovery and diagnostics to consistently use the generated metadata registry.
  - Improved compatibility for generated module and command metadata across runtime scenarios.
- **Refactor**
  - Consolidated generated contracts under a dedicated namespace and reduced exposure of internal command-provider interfaces.
- **Tests**
  - Added coverage validating generated metadata contracts and API visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->