### PR TITLE
Hide legacy context tool accessors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ pwsh scripts/Invoke-AgentDotNet.ps1 `
 2. **Module Context** (`IModuleContext`):
    - Central interface providing access to all tools and services
    - Includes: file system operations, command execution, logging, Git info
-   - Extensions for each tool integration (e.g., `context.DotNet()`, `context.Git()`)
+   - Discoverable tool properties (e.g., `context.Tools.DotNet`, `context.Tools.Git`)
 
 3. **Host Pattern** (`PipelineHostBuilder`):
    - Built on Microsoft Generic Host

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -10,22 +10,23 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
 2. **Add ModularPipelines to your script:** You can add ModularPipelines as a package reference in your F# script. At the top of your `example.fsx`, add the following line:
 
     ```fsharp
-    #r "nuget: ModularPipelines, 3.*"
+    #r "nuget: ModularPipelines, 4.*"
     ```
 
     Alternatively, you can specify a specific version:
 
     ```fsharp
-    #r "nuget: ModularPipelines, 3.2.8"
+    #r "nuget: ModularPipelines, 4.0.0"
     ```
 3. **Write your F# code:** Below the package reference, you can write your F# code using ModularPipelines. Here’s a simple example that uses ModularPipelines to check the dotnet version:
 
     ```fsharp
-    #r "nuget: ModularPipelines.DotNet, 3.*"
+    #r "nuget: ModularPipelines.DotNet, 4.*"
     open ModularPipelines.DotNet
     open ModularPipelines.Attributes
     open ModularPipelines.Context
     open ModularPipelines.DotNet.Extensions
+    open ModularPipelines.DotNet.Services
     open ModularPipelines.Extensions
     open ModularPipelines.Models
     open ModularPipelines.Modules
@@ -35,14 +36,14 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
     type UpdateDotnetWorkloads() =
         inherit Module<CommandResult>()
         override this.ExecuteAsync (context: IModuleContext, cancellationToken: CancellationToken): Tasks.Task<CommandResult> = 
-                context.DotNet().Workload.Update(cancellationToken = cancellationToken)
+                context.Tools.Get<IDotNet>().Workload.Update(cancellationToken = cancellationToken)
 
     /// Generic attributes are not supported in fsharp, so have to use the old way of declaring dependencies
     [<DependsOn(typeof<UpdateDotnetWorkloads>)>]
     type CheckDotnetSdkModule () =
         inherit Module<CommandResult>()
         override this.ExecuteAsync (context: IModuleContext, cancellationToken: CancellationToken): Tasks.Task<CommandResult> = 
-                context.DotNet().Sdk.Check(cancellationToken = cancellationToken);
+                context.Tools.Get<IDotNet>().Sdk.Check(cancellationToken = cancellationToken);
 
     let args = System.Environment.GetCommandLineArgs()
     let builder = Pipeline.CreateBuilder(args)

--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -36,7 +36,7 @@ await context.Tools.DotNet.BuildAsync(new DotNetBuildOptions
 
 `context.Tools.DotNet` is the canonical API and does not require an integration extension
 namespace import. Projects using C# 13 or another .NET language can use
-`context.Tools.Get<IDotNet>()`. Legacy `context.DotNet()` access is obsolete and hidden
+`context.Tools.Get<ModularPipelines.DotNet.Services.IDotNet>()`. Legacy `context.DotNet()` access is obsolete and hidden
 from IntelliSense.
 
 ## Strong Typing

--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -34,11 +34,8 @@ await context.Tools.DotNet.BuildAsync(new DotNetBuildOptions
 }, cancellationToken: cancellationToken);
 ```
 
-`context.Tools.DotNet` is the canonical C# 14 API and does not require an integration
-extension namespace import. The older `context.DotNet()` extension method remains available
-as a compatibility fallback for projects using an earlier C# language version. When a project
-declares an integration accessor in its own compilation, source-generator warning `MPG0008`
-identifies that fallback on earlier language versions.
+`context.Tools.DotNet` is the canonical API and does not require an integration extension
+namespace import. Legacy `context.DotNet()` access is obsolete and hidden from IntelliSense.
 
 ## Strong Typing
 

--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -35,7 +35,9 @@ await context.Tools.DotNet.BuildAsync(new DotNetBuildOptions
 ```
 
 `context.Tools.DotNet` is the canonical API and does not require an integration extension
-namespace import. Legacy `context.DotNet()` access is obsolete and hidden from IntelliSense.
+namespace import. Projects using C# 13 or another .NET language can use
+`context.Tools.Get<IDotNet>()`. Legacy `context.DotNet()` access is obsolete and hidden
+from IntelliSense.
 
 ## Strong Typing
 

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -161,7 +161,7 @@ registration method:
 
 ```csharp
 [EditorBrowsable(EditorBrowsableState.Never)]
-[Obsolete("Use context.Tools.Get<IPrivateWidget>().")]
+[Obsolete("Use context.Tools.Get<global::YourCompany.Pipelines.PrivateWidget.IPrivateWidget>().")]
 public static IPrivateWidget PrivateWidget(this IPipelineContext context) =>
     context.Services.GetRequiredService<IPrivateWidget>();
 ```
@@ -174,7 +174,8 @@ or `GetType`, because instance-member lookup would hide the generated property.
 as an obsolete, IntelliSense-hidden compatibility fallback. Generated tool properties use C# 14
 extension members. On older language versions, registration metadata still generates and
 `MPG0008` explains why the optional `Tools` property was skipped; use
-`context.Tools.Get<IPrivateWidget>()` instead.
+`context.Tools.Get<YourCompany.Pipelines.PrivateWidget.IPrivateWidget>()` instead. Replace
+`YourCompany.Pipelines.PrivateWidget` with the namespace containing your interface.
 
 Referencing the `ModularPipelines` package includes the source generator as an analyzer.
 The generator emits immutable assembly registration metadata, which each pipeline consumes

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -135,6 +135,7 @@ generator already uses the new mechanism.
 For a hand-written integration, mark its service-registration method:
 
 ```csharp
+using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 
@@ -159,6 +160,8 @@ its public `IPipelineContext` extension accessor in the same static class as the
 registration method:
 
 ```csharp
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete("Use context.Tools.Get<IPrivateWidget>().")]
 public static IPrivateWidget PrivateWidget(this IPipelineContext context) =>
     context.Services.GetRequiredService<IPrivateWidget>();
 ```
@@ -170,7 +173,8 @@ or `GetType`, because instance-member lookup would hide the generated property.
 `context.Tools.*` is the preferred discoverable API. The original extension method can remain
 as an obsolete, IntelliSense-hidden compatibility fallback. Generated tool properties use C# 14
 extension members. On older language versions, registration metadata still generates and
-`MPG0008` explains why the optional `Tools` property was skipped.
+`MPG0008` explains why the optional `Tools` property was skipped; use
+`context.Tools.Get<IPrivateWidget>()` instead.
 
 Referencing the `ModularPipelines` package includes the source generator as an analyzer.
 The generator emits immutable assembly registration metadata, which each pipeline consumes

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -167,10 +167,10 @@ The generator uses that shared declaring type to associate the accessor with its
 registration. Accessor names must be unique across all referenced integration packages.
 They also cannot use names already exposed by `IToolsContext` or `object`, such as `Get`
 or `GetType`, because instance-member lookup would hide the generated property.
-`context.Tools.*` is the preferred discoverable API; the original extension method remains
-available for compatibility. Generated tool properties use C# 14 extension members. On
-older language versions, registration metadata still generates and `MPG0008` explains why
-the optional `Tools` property was skipped and names the `context.X()` compatibility accessor.
+`context.Tools.*` is the preferred discoverable API. The original extension method can remain
+as an obsolete, IntelliSense-hidden compatibility fallback. Generated tool properties use C# 14
+extension members. On older language versions, registration metadata still generates and
+`MPG0008` explains why the optional `Tools` property was skipped.
 
 Referencing the `ModularPipelines` package includes the source generator as an analyzer.
 The generator emits immutable assembly registration metadata, which each pipeline consumes

--- a/docs/docs/how-to/skipping.md
+++ b/docs/docs/how-to/skipping.md
@@ -44,7 +44,7 @@ public class MyModule : Module<CommandResult>
 {
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(
-            async (ctx, _) => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main",
+            async (ctx, _) => (await ctx.Tools.Git.Information.GetInfoAsync())?.BranchName != "main",
             "This should only run on the main branch");
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -64,7 +64,7 @@ public class MyModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(async (ctx, _) =>
         {
-            var repositoryInfo = await ctx.Git().Information.GetInfoAsync();
+            var repositoryInfo = await ctx.Tools.Git.Information.GetInfoAsync();
             return repositoryInfo?.BranchName != "main";
         }, "This should only run on the main branch");
 
@@ -107,7 +107,7 @@ public class CleanupModule : Module<CommandResult>
     protected override void Configure(ModuleConfigurationBuilder module) => module
         .WithSkipWhen(_ => Environment.GetEnvironmentVariable("CI") == "true", "Running in CI")
         .WithSkipWhen(
-            async (ctx, _) => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main",
+            async (ctx, _) => (await ctx.Tools.Git.Information.GetInfoAsync())?.BranchName != "main",
             "Not on the main branch")
         .WithAlwaysRun()  // Run even if dependencies fail (when not skipped)
         .WithTimeout(TimeSpan.FromMinutes(5));

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -86,7 +86,7 @@ accessible and non-generic. Until fixed, Modular Pipelines uses runtime reflecti
 A tool accessor cannot generate a discoverable `context.Tools` property because
 the consuming project uses a language version older than C# 14. Registration
 metadata still generates. Use C# 14 or preview to enable the property, or use
-the diagnostic's `context.X()` compatibility accessor.
+an integration's obsolete `context.X()` compatibility accessor when upgrading is not possible.
 
 **Severity:** Warning
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -86,7 +86,7 @@ accessible and non-generic. Until fixed, Modular Pipelines uses runtime reflecti
 A tool accessor cannot generate a discoverable `context.Tools` property because
 the consuming project uses a language version older than C# 14. Registration
 metadata still generates. Use C# 14 or preview to enable the property, or use
-an integration's obsolete `context.X()` compatibility accessor when upgrading is not possible.
+`context.Tools.Get<IIntegration>()` when upgrading is not possible.
 
 **Severity:** Warning
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -86,7 +86,7 @@ accessible and non-generic. Until fixed, Modular Pipelines uses runtime reflecti
 A tool accessor cannot generate a discoverable `context.Tools` property because
 the consuming project uses a language version older than C# 14. Registration
 metadata still generates. Use C# 14 or preview to enable the property, or use
-`context.Tools.Get<IIntegration>()` when upgrading is not possible.
+`context.Tools.Get<Your.Namespace.IIntegration>()` when upgrading is not possible.
 
 **Severity:** Warning
 

--- a/docs/docs/how-to/storing-and-retrieving-results.md
+++ b/docs/docs/how-to/storing-and-retrieving-results.md
@@ -44,14 +44,14 @@ public class MyModuleRepository : IModuleResultRepository
     
     public async Task SaveResultAsync<T>(ModuleBase module, ModuleResult<T> moduleResult, IPipelineContext pipelineContext)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync();
+        var repositoryInfo = await pipelineContext.Tools.Git.Information.GetInfoAsync();
         var commit = repositoryInfo?.LastCommitSha;
         await _blobContainerClient.UploadBlobAsync(module.GetType().FullName + commit, new BinaryData(JsonSerializer.Serialize(moduleResult)));
     }
 
     public async Task<ModuleResult<T>?> GetResultAsync<T>(ModuleBase module, IPipelineContext pipelineContext)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync();
+        var repositoryInfo = await pipelineContext.Tools.Git.Information.GetInfoAsync();
         var commit = repositoryInfo?.LastCommitSha;
         
         var blobContent = await _blobContainerClient.GetBlobClient(module.GetType().FullName + commit).DownloadContentAsync();

--- a/docs/docs/mp-packages/cli/ansible.md
+++ b/docs/docs/mp-packages/cli/ansible.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Ansible
 ```
 
 Resolve the service with `context.Tools.Ansible`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IAnsible>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Ansible.Services.IAnsible>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/ansible.md
+++ b/docs/docs/mp-packages/cli/ansible.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Ansible
 ```
 
-Resolve the service with `context.Tools.Ansible`. For projects older than C# 14, import `ModularPipelines.Ansible.Extensions` and use the `context.Ansible()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Ansible`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/ansible.md
+++ b/docs/docs/mp-packages/cli/ansible.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Ansible
 ```
 
 Resolve the service with `context.Tools.Ansible`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IAnsible>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/argocd.md
+++ b/docs/docs/mp-packages/cli/argocd.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.ArgoCd
 ```
 
-Resolve the service with `context.Tools.ArgoCd`. For projects older than C# 14, import `ModularPipelines.ArgoCd.Extensions` and use the `context.ArgoCd()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.ArgoCd`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/argocd.md
+++ b/docs/docs/mp-packages/cli/argocd.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.ArgoCd
 ```
 
 Resolve the service with `context.Tools.ArgoCd`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IArgoCd>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.ArgoCd.Services.IArgoCd>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/argocd.md
+++ b/docs/docs/mp-packages/cli/argocd.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.ArgoCd
 ```
 
 Resolve the service with `context.Tools.ArgoCd`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IArgoCd>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/az.md
+++ b/docs/docs/mp-packages/cli/az.md
@@ -13,7 +13,7 @@ title: az CLI reference
 dotnet add package ModularPipelines.Azure
 ```
 
-Resolve the service with `context.Tools.Az`. For projects older than C# 14, import `ModularPipelines.Azure.Extensions` and use the `context.Az()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Az`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/az.md
+++ b/docs/docs/mp-packages/cli/az.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Azure
 ```
 
 Resolve the service with `context.Tools.Az`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IAz>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Azure.Services.IAz>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/az.md
+++ b/docs/docs/mp-packages/cli/az.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Azure
 ```
 
 Resolve the service with `context.Tools.Az`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IAz>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/brew.md
+++ b/docs/docs/mp-packages/cli/brew.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Homebrew
 ```
 
-Resolve the service with `context.Tools.Brew`. For projects older than C# 14, import `ModularPipelines.Homebrew.Extensions` and use the `context.Brew()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Brew`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/brew.md
+++ b/docs/docs/mp-packages/cli/brew.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Homebrew
 ```
 
 Resolve the service with `context.Tools.Brew`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IBrew>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Homebrew.Services.IBrew>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/brew.md
+++ b/docs/docs/mp-packages/cli/brew.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Homebrew
 ```
 
 Resolve the service with `context.Tools.Brew`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IBrew>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/buildah.md
+++ b/docs/docs/mp-packages/cli/buildah.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Buildah
 ```
 
-Resolve the service with `context.Tools.Buildah`. For projects older than C# 14, import `ModularPipelines.Buildah.Extensions` and use the `context.Buildah()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Buildah`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/buildah.md
+++ b/docs/docs/mp-packages/cli/buildah.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Buildah
 ```
 
 Resolve the service with `context.Tools.Buildah`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IBuildah>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/buildah.md
+++ b/docs/docs/mp-packages/cli/buildah.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Buildah
 ```
 
 Resolve the service with `context.Tools.Buildah`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IBuildah>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Buildah.Services.IBuildah>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/cargo.md
+++ b/docs/docs/mp-packages/cli/cargo.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Rust
 ```
 
-Resolve the service with `context.Tools.Cargo`. For projects older than C# 14, import `ModularPipelines.Rust.Extensions` and use the `context.Cargo()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Cargo`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/cargo.md
+++ b/docs/docs/mp-packages/cli/cargo.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Rust
 ```
 
 Resolve the service with `context.Tools.Cargo`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ICargo>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Rust.Services.ICargo>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/cargo.md
+++ b/docs/docs/mp-packages/cli/cargo.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Rust
 ```
 
 Resolve the service with `context.Tools.Cargo`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ICargo>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/choco.md
+++ b/docs/docs/mp-packages/cli/choco.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Chocolatey
 ```
 
 Resolve the service with `context.Tools.Choco`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IChoco>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/choco.md
+++ b/docs/docs/mp-packages/cli/choco.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Chocolatey
 ```
 
 Resolve the service with `context.Tools.Choco`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IChoco>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Chocolatey.Services.IChoco>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/choco.md
+++ b/docs/docs/mp-packages/cli/choco.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Chocolatey
 ```
 
-Resolve the service with `context.Tools.Choco`. For projects older than C# 14, import `ModularPipelines.Chocolatey.Extensions` and use the `context.Choco()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Choco`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/cosign.md
+++ b/docs/docs/mp-packages/cli/cosign.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Cosign
 ```
 
 Resolve the service with `context.Tools.Cosign`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ICosign>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/cosign.md
+++ b/docs/docs/mp-packages/cli/cosign.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Cosign
 ```
 
-Resolve the service with `context.Tools.Cosign`. For projects older than C# 14, import `ModularPipelines.Cosign.Extensions` and use the `context.Cosign()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Cosign`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/cosign.md
+++ b/docs/docs/mp-packages/cli/cosign.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Cosign
 ```
 
 Resolve the service with `context.Tools.Cosign`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ICosign>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Cosign.Services.ICosign>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/docker.md
+++ b/docs/docs/mp-packages/cli/docker.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Docker
 ```
 
-Resolve the service with `context.Tools.Docker`. For projects older than C# 14, import `ModularPipelines.Docker.Extensions` and use the `context.Docker()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Docker`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/docker.md
+++ b/docs/docs/mp-packages/cli/docker.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Docker
 ```
 
 Resolve the service with `context.Tools.Docker`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IDocker>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Docker.Services.IDocker>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/docker.md
+++ b/docs/docs/mp-packages/cli/docker.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Docker
 ```
 
 Resolve the service with `context.Tools.Docker`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IDocker>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/dotnet.md
+++ b/docs/docs/mp-packages/cli/dotnet.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.DotNet
 ```
 
 Resolve the service with `context.Tools.DotNet`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IDotNet>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.DotNet.Services.IDotNet>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/dotnet.md
+++ b/docs/docs/mp-packages/cli/dotnet.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.DotNet
 ```
 
-Resolve the service with `context.Tools.DotNet`. For projects older than C# 14, import `ModularPipelines.DotNet.Extensions` and use the `context.DotNet()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.DotNet`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/dotnet.md
+++ b/docs/docs/mp-packages/cli/dotnet.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.DotNet
 ```
 
 Resolve the service with `context.Tools.DotNet`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IDotNet>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/eksctl.md
+++ b/docs/docs/mp-packages/cli/eksctl.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Eksctl
 ```
 
-Resolve the service with `context.Tools.Eksctl`. For projects older than C# 14, import `ModularPipelines.Eksctl.Extensions` and use the `context.Eksctl()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Eksctl`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/eksctl.md
+++ b/docs/docs/mp-packages/cli/eksctl.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Eksctl
 ```
 
 Resolve the service with `context.Tools.Eksctl`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IEksctl>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Eksctl.Services.IEksctl>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/eksctl.md
+++ b/docs/docs/mp-packages/cli/eksctl.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Eksctl
 ```
 
 Resolve the service with `context.Tools.Eksctl`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IEksctl>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/flux.md
+++ b/docs/docs/mp-packages/cli/flux.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Flux
 ```
 
 Resolve the service with `context.Tools.Flux`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IFlux>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/flux.md
+++ b/docs/docs/mp-packages/cli/flux.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Flux
 ```
 
-Resolve the service with `context.Tools.Flux`. For projects older than C# 14, import `ModularPipelines.Flux.Extensions` and use the `context.Flux()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Flux`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/flux.md
+++ b/docs/docs/mp-packages/cli/flux.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Flux
 ```
 
 Resolve the service with `context.Tools.Flux`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IFlux>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Flux.Services.IFlux>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/flyway.md
+++ b/docs/docs/mp-packages/cli/flyway.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Flyway
 ```
 
-Resolve the service with `context.Tools.Flyway`. For projects older than C# 14, import `ModularPipelines.Flyway.Extensions` and use the `context.Flyway()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Flyway`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/flyway.md
+++ b/docs/docs/mp-packages/cli/flyway.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Flyway
 ```
 
 Resolve the service with `context.Tools.Flyway`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IFlyway>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/flyway.md
+++ b/docs/docs/mp-packages/cli/flyway.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Flyway
 ```
 
 Resolve the service with `context.Tools.Flyway`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IFlyway>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Flyway.Services.IFlyway>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gcloud.md
+++ b/docs/docs/mp-packages/cli/gcloud.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Google
 ```
 
 Resolve the service with `context.Tools.Gcloud`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IGcloud>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gcloud.md
+++ b/docs/docs/mp-packages/cli/gcloud.md
@@ -13,7 +13,7 @@ title: gcloud CLI reference
 dotnet add package ModularPipelines.Google
 ```
 
-Resolve the service with `context.Tools.Gcloud`. For projects older than C# 14, import `ModularPipelines.Google.Extensions` and use the `context.Gcloud()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Gcloud`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gcloud.md
+++ b/docs/docs/mp-packages/cli/gcloud.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Google
 ```
 
 Resolve the service with `context.Tools.Gcloud`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IGcloud>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Google.Services.IGcloud>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gh.md
+++ b/docs/docs/mp-packages/cli/gh.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.GitHub
 ```
 
 Resolve the service with `context.Tools.Gh`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IGh>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.GitHub.Services.IGh>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gh.md
+++ b/docs/docs/mp-packages/cli/gh.md
@@ -13,7 +13,7 @@ title: gh CLI reference
 dotnet add package ModularPipelines.GitHub
 ```
 
-Resolve the service with `context.Tools.Gh`. For projects older than C# 14, import `ModularPipelines.GitHub.Extensions` and use the `context.Gh()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Gh`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gh.md
+++ b/docs/docs/mp-packages/cli/gh.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.GitHub
 ```
 
 Resolve the service with `context.Tools.Gh`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IGh>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/go.md
+++ b/docs/docs/mp-packages/cli/go.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Go
 ```
 
 Resolve the service with `context.Tools.Go`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IGo>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Go.Services.IGo>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/go.md
+++ b/docs/docs/mp-packages/cli/go.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Go
 ```
 
 Resolve the service with `context.Tools.Go`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IGo>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/go.md
+++ b/docs/docs/mp-packages/cli/go.md
@@ -13,7 +13,7 @@ title: go CLI reference
 dotnet add package ModularPipelines.Go
 ```
 
-Resolve the service with `context.Tools.Go`. For projects older than C# 14, import `ModularPipelines.Go.Extensions` and use the `context.Go()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Go`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gradle.md
+++ b/docs/docs/mp-packages/cli/gradle.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Java
 ```
 
-Resolve the service with `context.Tools.Gradle`. For projects older than C# 14, import `ModularPipelines.Java.Extensions` and use the `context.Gradle()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Gradle`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gradle.md
+++ b/docs/docs/mp-packages/cli/gradle.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Java
 ```
 
 Resolve the service with `context.Tools.Gradle`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IGradle>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Java.Services.IGradle>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/gradle.md
+++ b/docs/docs/mp-packages/cli/gradle.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Java
 ```
 
 Resolve the service with `context.Tools.Gradle`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IGradle>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/grype.md
+++ b/docs/docs/mp-packages/cli/grype.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Grype
 ```
 
 Resolve the service with `context.Tools.Grype`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IGrype>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/grype.md
+++ b/docs/docs/mp-packages/cli/grype.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Grype
 ```
 
-Resolve the service with `context.Tools.Grype`. For projects older than C# 14, import `ModularPipelines.Grype.Extensions` and use the `context.Grype()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Grype`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/grype.md
+++ b/docs/docs/mp-packages/cli/grype.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Grype
 ```
 
 Resolve the service with `context.Tools.Grype`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IGrype>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Grype.Services.IGrype>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/hadolint.md
+++ b/docs/docs/mp-packages/cli/hadolint.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Hadolint
 ```
 
 Resolve the service with `context.Tools.Hadolint`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IHadolint>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/hadolint.md
+++ b/docs/docs/mp-packages/cli/hadolint.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Hadolint
 ```
 
 Resolve the service with `context.Tools.Hadolint`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IHadolint>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Hadolint.Services.IHadolint>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/hadolint.md
+++ b/docs/docs/mp-packages/cli/hadolint.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Hadolint
 ```
 
-Resolve the service with `context.Tools.Hadolint`. For projects older than C# 14, import `ModularPipelines.Hadolint.Extensions` and use the `context.Hadolint()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Hadolint`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/helm.md
+++ b/docs/docs/mp-packages/cli/helm.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Helm
 ```
 
 Resolve the service with `context.Tools.Helm`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IHelm>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/helm.md
+++ b/docs/docs/mp-packages/cli/helm.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Helm
 ```
 
-Resolve the service with `context.Tools.Helm`. For projects older than C# 14, import `ModularPipelines.Helm.Extensions` and use the `context.Helm()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Helm`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/helm.md
+++ b/docs/docs/mp-packages/cli/helm.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Helm
 ```
 
 Resolve the service with `context.Tools.Helm`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IHelm>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Helm.Services.IHelm>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/jq.md
+++ b/docs/docs/mp-packages/cli/jq.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Jq
 ```
 
 Resolve the service with `context.Tools.Jq`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IJq>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/jq.md
+++ b/docs/docs/mp-packages/cli/jq.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Jq
 ```
 
-Resolve the service with `context.Tools.Jq`. For projects older than C# 14, import `ModularPipelines.Jq.Extensions` and use the `context.Jq()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Jq`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/jq.md
+++ b/docs/docs/mp-packages/cli/jq.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Jq
 ```
 
 Resolve the service with `context.Tools.Jq`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IJq>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Jq.Services.IJq>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kind.md
+++ b/docs/docs/mp-packages/cli/kind.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Kind
 ```
 
 Resolve the service with `context.Tools.Kind`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IKind>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Kind.Services.IKind>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kind.md
+++ b/docs/docs/mp-packages/cli/kind.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Kind
 ```
 
-Resolve the service with `context.Tools.Kind`. For projects older than C# 14, import `ModularPipelines.Kind.Extensions` and use the `context.Kind()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Kind`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kind.md
+++ b/docs/docs/mp-packages/cli/kind.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Kind
 ```
 
 Resolve the service with `context.Tools.Kind`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IKind>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kubectl.md
+++ b/docs/docs/mp-packages/cli/kubectl.md
@@ -13,7 +13,7 @@ title: kubectl CLI reference
 dotnet add package ModularPipelines.Kubernetes
 ```
 
-Resolve the service with `context.Tools.Kubernetes`. For projects older than C# 14, import `ModularPipelines.Kubernetes.Extensions` and use the `context.Kubernetes()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Kubernetes`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kubectl.md
+++ b/docs/docs/mp-packages/cli/kubectl.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Kubernetes
 ```
 
 Resolve the service with `context.Tools.Kubernetes`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IKubernetes>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kubectl.md
+++ b/docs/docs/mp-packages/cli/kubectl.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Kubernetes
 ```
 
 Resolve the service with `context.Tools.Kubernetes`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IKubernetes>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Kubernetes.Services.IKubernetes>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kustomize.md
+++ b/docs/docs/mp-packages/cli/kustomize.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Kubernetes
 ```
 
 Resolve the service with `context.Tools.Kustomize`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IKustomize>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Kubernetes.Services.IKustomize>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kustomize.md
+++ b/docs/docs/mp-packages/cli/kustomize.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Kubernetes
 ```
 
 Resolve the service with `context.Tools.Kustomize`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IKustomize>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/kustomize.md
+++ b/docs/docs/mp-packages/cli/kustomize.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Kubernetes
 ```
 
-Resolve the service with `context.Tools.Kustomize`. For projects older than C# 14, import `ModularPipelines.Kubernetes.Extensions` and use the `context.Kustomize()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Kustomize`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/liquibase.md
+++ b/docs/docs/mp-packages/cli/liquibase.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Liquibase
 ```
 
-Resolve the service with `context.Tools.Liquibase`. For projects older than C# 14, import `ModularPipelines.Liquibase.Extensions` and use the `context.Liquibase()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Liquibase`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/liquibase.md
+++ b/docs/docs/mp-packages/cli/liquibase.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Liquibase
 ```
 
 Resolve the service with `context.Tools.Liquibase`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ILiquibase>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Liquibase.Services.ILiquibase>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/liquibase.md
+++ b/docs/docs/mp-packages/cli/liquibase.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Liquibase
 ```
 
 Resolve the service with `context.Tools.Liquibase`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ILiquibase>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/minikube.md
+++ b/docs/docs/mp-packages/cli/minikube.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Minikube
 ```
 
 Resolve the service with `context.Tools.Minikube`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IMinikube>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/minikube.md
+++ b/docs/docs/mp-packages/cli/minikube.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Minikube
 ```
 
 Resolve the service with `context.Tools.Minikube`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IMinikube>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Minikube.Services.IMinikube>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/minikube.md
+++ b/docs/docs/mp-packages/cli/minikube.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Minikube
 ```
 
-Resolve the service with `context.Tools.Minikube`. For projects older than C# 14, import `ModularPipelines.Minikube.Extensions` and use the `context.Minikube()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Minikube`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/mvn.md
+++ b/docs/docs/mp-packages/cli/mvn.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Java
 ```
 
 Resolve the service with `context.Tools.Maven`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IMaven>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Java.Services.IMaven>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/mvn.md
+++ b/docs/docs/mp-packages/cli/mvn.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Java
 ```
 
-Resolve the service with `context.Tools.Maven`. For projects older than C# 14, import `ModularPipelines.Java.Extensions` and use the `context.Maven()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Maven`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/mvn.md
+++ b/docs/docs/mp-packages/cli/mvn.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Java
 ```
 
 Resolve the service with `context.Tools.Maven`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IMaven>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/nbgv.md
+++ b/docs/docs/mp-packages/cli/nbgv.md
@@ -24,6 +24,7 @@ dotnet add package ModularPipelines.NerdbankGitVersioning
 ```
 
 Resolve the service with `context.Tools.Nbgv`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<INbgv>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/nbgv.md
+++ b/docs/docs/mp-packages/cli/nbgv.md
@@ -23,7 +23,7 @@ Install the nbgv .NET tool globally or in a tool path available on PATH.
 dotnet add package ModularPipelines.NerdbankGitVersioning
 ```
 
-Resolve the service with `context.Tools.Nbgv`. For projects older than C# 14, import `ModularPipelines.NerdbankGitVersioning.Extensions` and use the `context.Nbgv()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Nbgv`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/nbgv.md
+++ b/docs/docs/mp-packages/cli/nbgv.md
@@ -24,7 +24,7 @@ dotnet add package ModularPipelines.NerdbankGitVersioning
 ```
 
 Resolve the service with `context.Tools.Nbgv`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<INbgv>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.NerdbankGitVersioning.Services.INbgv>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/newman.md
+++ b/docs/docs/mp-packages/cli/newman.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Newman
 ```
 
-Resolve the service with `context.Tools.Newman`. For projects older than C# 14, import `ModularPipelines.Newman.Extensions` and use the `context.Newman()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Newman`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/newman.md
+++ b/docs/docs/mp-packages/cli/newman.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Newman
 ```
 
 Resolve the service with `context.Tools.Newman`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<INewman>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/newman.md
+++ b/docs/docs/mp-packages/cli/newman.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Newman
 ```
 
 Resolve the service with `context.Tools.Newman`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<INewman>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Newman.Services.INewman>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/packer.md
+++ b/docs/docs/mp-packages/cli/packer.md
@@ -13,7 +13,7 @@ title: packer CLI reference
 dotnet add package ModularPipelines.Packer
 ```
 
-Resolve the service with `context.Tools.Packer`. For projects older than C# 14, import `ModularPipelines.Packer.Extensions` and use the `context.Packer()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Packer`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/packer.md
+++ b/docs/docs/mp-packages/cli/packer.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Packer
 ```
 
 Resolve the service with `context.Tools.Packer`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IPacker>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/packer.md
+++ b/docs/docs/mp-packages/cli/packer.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Packer
 ```
 
 Resolve the service with `context.Tools.Packer`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IPacker>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Packer.Services.IPacker>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pip.md
+++ b/docs/docs/mp-packages/cli/pip.md
@@ -13,7 +13,7 @@ title: pip CLI reference
 dotnet add package ModularPipelines.Python
 ```
 
-Resolve the service with `context.Tools.Pip`. For projects older than C# 14, import `ModularPipelines.Python.Extensions` and use the `context.Pip()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Pip`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pip.md
+++ b/docs/docs/mp-packages/cli/pip.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Python
 ```
 
 Resolve the service with `context.Tools.Pip`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IPip>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pip.md
+++ b/docs/docs/mp-packages/cli/pip.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Python
 ```
 
 Resolve the service with `context.Tools.Pip`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IPip>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Python.Services.IPip>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pnpm.md
+++ b/docs/docs/mp-packages/cli/pnpm.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Node
 ```
 
 Resolve the service with `context.Tools.Pnpm`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IPnpm>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Node.Services.IPnpm>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pnpm.md
+++ b/docs/docs/mp-packages/cli/pnpm.md
@@ -13,7 +13,7 @@ title: pnpm CLI reference
 dotnet add package ModularPipelines.Node
 ```
 
-Resolve the service with `context.Tools.Pnpm`. For projects older than C# 14, import `ModularPipelines.Node.Extensions` and use the `context.Pnpm()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Pnpm`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pnpm.md
+++ b/docs/docs/mp-packages/cli/pnpm.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Node
 ```
 
 Resolve the service with `context.Tools.Pnpm`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IPnpm>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/podman.md
+++ b/docs/docs/mp-packages/cli/podman.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Podman
 ```
 
 Resolve the service with `context.Tools.Podman`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IPodman>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Podman.Services.IPodman>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/podman.md
+++ b/docs/docs/mp-packages/cli/podman.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Podman
 ```
 
-Resolve the service with `context.Tools.Podman`. For projects older than C# 14, import `ModularPipelines.Podman.Extensions` and use the `context.Podman()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Podman`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/podman.md
+++ b/docs/docs/mp-packages/cli/podman.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Podman
 ```
 
 Resolve the service with `context.Tools.Podman`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IPodman>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pulumi.md
+++ b/docs/docs/mp-packages/cli/pulumi.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Pulumi
 ```
 
 Resolve the service with `context.Tools.Pulumi`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IPulumi>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pulumi.md
+++ b/docs/docs/mp-packages/cli/pulumi.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Pulumi
 ```
 
 Resolve the service with `context.Tools.Pulumi`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IPulumi>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Pulumi.Services.IPulumi>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/pulumi.md
+++ b/docs/docs/mp-packages/cli/pulumi.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Pulumi
 ```
 
-Resolve the service with `context.Tools.Pulumi`. For projects older than C# 14, import `ModularPipelines.Pulumi.Extensions` and use the `context.Pulumi()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Pulumi`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/shellcheck.md
+++ b/docs/docs/mp-packages/cli/shellcheck.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Shellcheck
 ```
 
 Resolve the service with `context.Tools.Shellcheck`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IShellcheck>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/shellcheck.md
+++ b/docs/docs/mp-packages/cli/shellcheck.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Shellcheck
 ```
 
 Resolve the service with `context.Tools.Shellcheck`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IShellcheck>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Shellcheck.Services.IShellcheck>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/shellcheck.md
+++ b/docs/docs/mp-packages/cli/shellcheck.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Shellcheck
 ```
 
-Resolve the service with `context.Tools.Shellcheck`. For projects older than C# 14, import `ModularPipelines.Shellcheck.Extensions` and use the `context.Shellcheck()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Shellcheck`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/skopeo.md
+++ b/docs/docs/mp-packages/cli/skopeo.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Skopeo
 ```
 
-Resolve the service with `context.Tools.Skopeo`. For projects older than C# 14, import `ModularPipelines.Skopeo.Extensions` and use the `context.Skopeo()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Skopeo`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/skopeo.md
+++ b/docs/docs/mp-packages/cli/skopeo.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Skopeo
 ```
 
 Resolve the service with `context.Tools.Skopeo`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ISkopeo>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Skopeo.Services.ISkopeo>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/skopeo.md
+++ b/docs/docs/mp-packages/cli/skopeo.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Skopeo
 ```
 
 Resolve the service with `context.Tools.Skopeo`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ISkopeo>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/snyk.md
+++ b/docs/docs/mp-packages/cli/snyk.md
@@ -14,6 +14,7 @@ dotnet add package ModularPipelines.Snyk
 ```
 
 Resolve the service with `context.Tools.Snyk`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ISnyk>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/snyk.md
+++ b/docs/docs/mp-packages/cli/snyk.md
@@ -13,7 +13,7 @@ title: snyk CLI reference
 dotnet add package ModularPipelines.Snyk
 ```
 
-Resolve the service with `context.Tools.Snyk`. For projects older than C# 14, import `ModularPipelines.Snyk.Extensions` and use the `context.Snyk()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Snyk`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/snyk.md
+++ b/docs/docs/mp-packages/cli/snyk.md
@@ -14,7 +14,7 @@ dotnet add package ModularPipelines.Snyk
 ```
 
 Resolve the service with `context.Tools.Snyk`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ISnyk>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Snyk.Services.ISnyk>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/sonar-scanner.md
+++ b/docs/docs/mp-packages/cli/sonar-scanner.md
@@ -24,7 +24,7 @@ dotnet add package ModularPipelines.SonarScanner
 ```
 
 Resolve the service with `context.Tools.SonarScanner`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ISonarScanner>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.SonarScanner.Services.ISonarScanner>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/sonar-scanner.md
+++ b/docs/docs/mp-packages/cli/sonar-scanner.md
@@ -23,7 +23,7 @@ The generator workflow downloads the Linux x64 SonarScanner CLI distribution.
 dotnet add package ModularPipelines.SonarScanner
 ```
 
-Resolve the service with `context.Tools.SonarScanner`. For projects older than C# 14, import `ModularPipelines.SonarScanner.Extensions` and use the `context.SonarScanner()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.SonarScanner`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/sonar-scanner.md
+++ b/docs/docs/mp-packages/cli/sonar-scanner.md
@@ -24,6 +24,7 @@ dotnet add package ModularPipelines.SonarScanner
 ```
 
 Resolve the service with `context.Tools.SonarScanner`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ISonarScanner>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/syft.md
+++ b/docs/docs/mp-packages/cli/syft.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Syft
 ```
 
 Resolve the service with `context.Tools.Syft`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ISyft>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/syft.md
+++ b/docs/docs/mp-packages/cli/syft.md
@@ -19,7 +19,7 @@ See the [syft installation guide](https://oss.anchore.com/docs/installation/syft
 dotnet add package ModularPipelines.Syft
 ```
 
-Resolve the service with `context.Tools.Syft`. For projects older than C# 14, import `ModularPipelines.Syft.Extensions` and use the `context.Syft()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Syft`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/syft.md
+++ b/docs/docs/mp-packages/cli/syft.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Syft
 ```
 
 Resolve the service with `context.Tools.Syft`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ISyft>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Syft.Services.ISyft>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/terraform.md
+++ b/docs/docs/mp-packages/cli/terraform.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Terraform
 ```
 
 Resolve the service with `context.Tools.Terraform`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ITerraform>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/terraform.md
+++ b/docs/docs/mp-packages/cli/terraform.md
@@ -19,7 +19,7 @@ See the [terraform installation guide](https://developer.hashicorp.com/terraform
 dotnet add package ModularPipelines.Terraform
 ```
 
-Resolve the service with `context.Tools.Terraform`. For projects older than C# 14, import `ModularPipelines.Terraform.Extensions` and use the `context.Terraform()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Terraform`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/terraform.md
+++ b/docs/docs/mp-packages/cli/terraform.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Terraform
 ```
 
 Resolve the service with `context.Tools.Terraform`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ITerraform>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Terraform.Services.ITerraform>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/trivy.md
+++ b/docs/docs/mp-packages/cli/trivy.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Trivy
 ```
 
 Resolve the service with `context.Tools.Trivy`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ITrivy>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/trivy.md
+++ b/docs/docs/mp-packages/cli/trivy.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Trivy
 ```
 
-Resolve the service with `context.Tools.Trivy`. For projects older than C# 14, import `ModularPipelines.Trivy.Extensions` and use the `context.Trivy()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Trivy`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/trivy.md
+++ b/docs/docs/mp-packages/cli/trivy.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Trivy
 ```
 
 Resolve the service with `context.Tools.Trivy`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<ITrivy>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Trivy.Services.ITrivy>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/vault.md
+++ b/docs/docs/mp-packages/cli/vault.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Vault
 ```
 
 Resolve the service with `context.Tools.Vault`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IVault>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Vault.Services.IVault>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/vault.md
+++ b/docs/docs/mp-packages/cli/vault.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Vault
 ```
 
 Resolve the service with `context.Tools.Vault`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IVault>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/vault.md
+++ b/docs/docs/mp-packages/cli/vault.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Vault
 ```
 
-Resolve the service with `context.Tools.Vault`. For projects older than C# 14, import `ModularPipelines.Vault.Extensions` and use the `context.Vault()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Vault`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/winget.md
+++ b/docs/docs/mp-packages/cli/winget.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.WinGet
 ```
 
 Resolve the service with `context.Tools.Winget`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IWinget>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.WinGet.Services.IWinget>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/winget.md
+++ b/docs/docs/mp-packages/cli/winget.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.WinGet
 ```
 
 Resolve the service with `context.Tools.Winget`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IWinget>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/winget.md
+++ b/docs/docs/mp-packages/cli/winget.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.WinGet
 ```
 
-Resolve the service with `context.Tools.Winget`. For projects older than C# 14, import `ModularPipelines.WinGet.Extensions` and use the `context.Winget()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Winget`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/yarn.md
+++ b/docs/docs/mp-packages/cli/yarn.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Yarn
 ```
 
 Resolve the service with `context.Tools.Yarn`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IYarn>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Yarn.Services.IYarn>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/yarn.md
+++ b/docs/docs/mp-packages/cli/yarn.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Yarn
 ```
 
-Resolve the service with `context.Tools.Yarn`. For projects older than C# 14, import `ModularPipelines.Yarn.Extensions` and use the `context.Yarn()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Yarn`.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/yarn.md
+++ b/docs/docs/mp-packages/cli/yarn.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Yarn
 ```
 
 Resolve the service with `context.Tools.Yarn`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IYarn>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/yq.md
+++ b/docs/docs/mp-packages/cli/yq.md
@@ -20,6 +20,7 @@ dotnet add package ModularPipelines.Yq
 ```
 
 Resolve the service with `context.Tools.Yq`.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<IYq>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/yq.md
+++ b/docs/docs/mp-packages/cli/yq.md
@@ -20,7 +20,7 @@ dotnet add package ModularPipelines.Yq
 ```
 
 Resolve the service with `context.Tools.Yq`.
-Projects using C# 13 or another .NET language can use `context.Tools.Get<IYq>()` instead.
+Projects using C# 13 or another .NET language can use `context.Tools.Get<ModularPipelines.Yq.Services.IYq>()` instead.
 
 ## Module example
 

--- a/docs/docs/mp-packages/cli/yq.md
+++ b/docs/docs/mp-packages/cli/yq.md
@@ -19,7 +19,7 @@ Follow the executable's official documentation for installation instructions.
 dotnet add package ModularPipelines.Yq
 ```
 
-Resolve the service with `context.Tools.Yq`. For projects older than C# 14, import `ModularPipelines.Yq.Extensions` and use the `context.Yq()` extension method as a compatibility fallback.
+Resolve the service with `context.Tools.Yq`.
 
 ## Module example
 

--- a/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
+++ b/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
@@ -36,7 +36,7 @@ public static class AwsExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The aws service.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Aws.")]
+    [global::System.Obsolete("Use context.Tools.Get<IAws>().")]
     public static IAws Aws(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAws>();

--- a/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
+++ b/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
@@ -36,7 +36,7 @@ public static class AwsExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The aws service.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IAws>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.AmazonWebServices.Services.IAws>().")]
     public static IAws Aws(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAws>();

--- a/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
+++ b/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
@@ -35,6 +35,8 @@ public static class AwsExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The aws service.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Aws.")]
     public static IAws Aws(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAws>();

--- a/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class AnsibleExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAnsible"/> service for executing ansible commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IAnsible>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Ansible.Services.IAnsible>().")]
     public static IAnsible Ansible(this IPipelineContext context) => context.Services.GetRequiredService<IAnsible>();
 }

--- a/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class AnsibleExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAnsible"/> service for executing ansible commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Ansible.")]
+    [global::System.Obsolete("Use context.Tools.Get<IAnsible>().")]
     public static IAnsible Ansible(this IPipelineContext context) => context.Services.GetRequiredService<IAnsible>();
 }

--- a/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class AnsibleExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAnsible"/> service for executing ansible commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Ansible.")]
     public static IAnsible Ansible(this IPipelineContext context) => context.Services.GetRequiredService<IAnsible>();
 }

--- a/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
@@ -47,5 +47,7 @@ public static class ArgoCdExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IArgoCd"/> service for executing argocd commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.ArgoCd.")]
     public static IArgoCd ArgoCd(this IPipelineContext context) => context.Services.GetRequiredService<IArgoCd>();
 }

--- a/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
@@ -48,6 +48,6 @@ public static class ArgoCdExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IArgoCd"/> service for executing argocd commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IArgoCd>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.ArgoCd.Services.IArgoCd>().")]
     public static IArgoCd ArgoCd(this IPipelineContext context) => context.Services.GetRequiredService<IArgoCd>();
 }

--- a/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
@@ -48,6 +48,6 @@ public static class ArgoCdExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IArgoCd"/> service for executing argocd commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.ArgoCd.")]
+    [global::System.Obsolete("Use context.Tools.Get<IArgoCd>().")]
     public static IArgoCd ArgoCd(this IPipelineContext context) => context.Services.GetRequiredService<IArgoCd>();
 }

--- a/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
+++ b/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
@@ -20,7 +20,7 @@ public static class AzurePipelineExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.AzurePipeline.")]
+    [global::System.Obsolete("Use context.Tools.Get<IAzurePipeline>().")]
 
     public static IAzurePipeline AzurePipeline(this IPipelineContext context) => context.Services.GetRequiredService<IAzurePipeline>();
 }

--- a/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
+++ b/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
@@ -20,7 +20,7 @@ public static class AzurePipelineExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<IAzurePipeline>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Azure.Pipelines.IAzurePipeline>().")]
 
     public static IAzurePipeline AzurePipeline(this IPipelineContext context) => context.Services.GetRequiredService<IAzurePipeline>();
 }

--- a/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
+++ b/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
@@ -19,8 +19,6 @@ public static class AzurePipelineExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Azure.Pipelines.IAzurePipeline>().")]
-
     public static IAzurePipeline AzurePipeline(this IPipelineContext context) => context.Services.GetRequiredService<IAzurePipeline>();
 }

--- a/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
+++ b/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
@@ -18,5 +18,9 @@ public static class AzurePipelineExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.AzurePipeline.")]
+
     public static IAzurePipeline AzurePipeline(this IPipelineContext context) => context.Services.GetRequiredService<IAzurePipeline>();
 }

--- a/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
@@ -119,6 +119,6 @@ public static class AzExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAz"/> service for executing az commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Az.")]
+    [global::System.Obsolete("Use context.Tools.Get<IAz>().")]
     public static IAz Az(this IPipelineContext context) => context.Services.GetRequiredService<IAz>();
 }

--- a/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
@@ -118,5 +118,7 @@ public static class AzExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAz"/> service for executing az commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Az.")]
     public static IAz Az(this IPipelineContext context) => context.Services.GetRequiredService<IAz>();
 }

--- a/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
@@ -119,6 +119,6 @@ public static class AzExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAz"/> service for executing az commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IAz>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Azure.Services.IAz>().")]
     public static IAz Az(this IPipelineContext context) => context.Services.GetRequiredService<IAz>();
 }

--- a/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
@@ -85,7 +85,7 @@ public static class AzureExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Azure services.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IAzure>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Azure.Services.IAzure>().")]
     public static IAzure Azure(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAzure>();

--- a/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Azure.Extensions;
 /// Extension methods for Azure integration with ModularPipelines.
 /// </summary>
 /// <remarks>
-/// Use <c>context.Azure()</c> to access Azure CLI commands from pipeline modules.
+/// Use <c>context.Tools.Azure</c> to access Azure CLI commands from pipeline modules.
 /// </remarks>
 public static class AzureExtensions
 {
@@ -84,6 +84,8 @@ public static class AzureExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Azure services.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Azure.")]
     public static IAzure Azure(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAzure>();

--- a/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
@@ -85,7 +85,7 @@ public static class AzureExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Azure services.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Azure.")]
+    [global::System.Obsolete("Use context.Tools.Get<IAzure>().")]
     public static IAzure Azure(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAzure>();

--- a/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
@@ -85,7 +85,7 @@ public static class AzureExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Azure services.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Azure.Services.IAzure>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Azure.IAzure>().")]
     public static IAzure Azure(this IPipelineContext context)
     {
         return context.Services.GetRequiredService<IAzure>();

--- a/src/ModularPipelines.Build/Attributes/SkipIfDependencyPullRequest.cs
+++ b/src/ModularPipelines.Build/Attributes/SkipIfDependencyPullRequest.cs
@@ -1,7 +1,6 @@
 using ModularPipelines.Attributes;
 using ModularPipelines.Conditions;
 using ModularPipelines.Context;
-using ModularPipelines.GitHub.Extensions;
 
 namespace ModularPipelines.Build.Attributes;
 
@@ -14,7 +13,7 @@ public class SkipIfDependencyPullRequest : Attribute, IConditionAttribute
 
     public async Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
-        var gitHubEnvironmentVariables = pipelineContext.GitHub().EnvironmentVariables;
+        var gitHubEnvironmentVariables = pipelineContext.Tools.GitHub.EnvironmentVariables;
 
         if (gitHubEnvironmentVariables.EventName != "pull_request")
         {
@@ -32,7 +31,7 @@ public class SkipIfDependencyPullRequest : Attribute, IConditionAttribute
             return false;
         }
 
-        var pr = await pipelineContext.GitHub().Client.PullRequest.Get(repositoryId, prNumber);
+        var pr = await pipelineContext.Tools.GitHub.Client.PullRequest.Get(repositoryId, prNumber);
 
         return pr.Labels.Any(x => x.Name == "dependencies");
     }

--- a/src/ModularPipelines.Build/Attributes/SkipOnMainBranch.cs
+++ b/src/ModularPipelines.Build/Attributes/SkipOnMainBranch.cs
@@ -1,7 +1,6 @@
 using ModularPipelines.Attributes;
 using ModularPipelines.Conditions;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Build.Attributes;
 
@@ -14,7 +13,7 @@ public class SkipOnMainBranch : Attribute, IConditionAttribute
 
     public async Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync().ConfigureAwait(false);
+        var repositoryInfo = await pipelineContext.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false);
         return repositoryInfo?.BranchName == "main";
     }
 }

--- a/src/ModularPipelines.Build/GitHelpers.cs
+++ b/src/ModularPipelines.Build/GitHelpers.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Options;
 using ModularPipelines.Build.Settings;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Git.Options;
 
 namespace ModularPipelines.Build;
@@ -18,7 +17,7 @@ public static class GitHelpers
     {
         var settings = GetGitHubSettings(context);
 
-        await context.Git().Commands.Repository.ConfigAsync(new GitConfigOptions
+        await context.Tools.Git.Commands.Repository.ConfigAsync(new GitConfigOptions
         {
             Local = true,
             Arguments =
@@ -32,7 +31,7 @@ public static class GitHelpers
     {
         var settings = GetGitHubSettings(context);
 
-        await context.Git().Commands.Repository.ConfigAsync(new GitConfigOptions
+        await context.Tools.Git.Commands.Repository.ConfigAsync(new GitConfigOptions
         {
             Local = true,
             Arguments =
@@ -48,7 +47,7 @@ public static class GitHelpers
         CancellationToken cancellationToken)
     {
         var pathArguments = paths.ToArray();
-        var changedFilesResult = await context.Git().Commands.WorkingTree.DiffAsync(
+        var changedFilesResult = await context.Tools.Git.Commands.WorkingTree.DiffAsync(
             new GitDiffOptions
             {
                 NameOnly = true,
@@ -62,7 +61,7 @@ public static class GitHelpers
             return null;
         }
 
-        var diffStatResult = await context.Git().Commands.WorkingTree.DiffAsync(
+        var diffStatResult = await context.Tools.Git.Commands.WorkingTree.DiffAsync(
             new GitDiffOptions
             {
                 Stat = true,

--- a/src/ModularPipelines.Build/Helpers/NugetUploadHelper.cs
+++ b/src/ModularPipelines.Build/Helpers/NugetUploadHelper.cs
@@ -1,6 +1,5 @@
 using EnumerableAsyncProcessor.Extensions;
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.Models;
 using ModularPipelines.FileSystem;
@@ -17,7 +16,7 @@ public static class NugetUploadHelper
         CancellationToken cancellationToken)
     {
         return await packagePaths
-            .SelectAsync(async nugetFile => await context.DotNet().NuGet.PushAsync(new DotNetNuGetPushOptions
+            .SelectAsync(async nugetFile => await context.Tools.DotNet.NuGet.PushAsync(new DotNetNuGetPushOptions
                 {
                     Path = nugetFile,
                     Source = source,

--- a/src/ModularPipelines.Build/Modules/BuildSolutionOnPlatformModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionOnPlatformModule.cs
@@ -1,8 +1,6 @@
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
@@ -12,10 +10,10 @@ public abstract class BuildSolutionOnPlatformModule : Module<CommandResult>
 {
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
 
-        return await context.DotNet().BuildAsync(new DotNetBuildOptions
+        return await context.Tools.DotNet.BuildAsync(new DotNetBuildOptions
         {
             ProjectSolution = Path.Combine(repositoryInfo.Root.Path, "ModularPipelines.All.slnx"),
             Configuration = "Release",

--- a/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
@@ -1,9 +1,7 @@
 using EnumerableAsyncProcessor.Extensions;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
@@ -15,7 +13,7 @@ public class BuildSolutionsModule : Module<CommandResult[]>
 {
     protected override async Task<CommandResult[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var gitRoot = repositoryInfo.Root.Path;
         var solutions = File.ReadLines(Path.Combine(gitRoot, "BuildSolutions.txt"))
@@ -30,7 +28,7 @@ public class BuildSolutionsModule : Module<CommandResult[]>
         // into one compilation unit; that test was removed, not MSBuild parallelism changed.
         var results = await solutions
             .ToAsyncProcessorBuilder()
-            .SelectAsync(async solution => await context.DotNet().BuildAsync(new DotNetBuildOptions
+            .SelectAsync(async solution => await context.Tools.DotNet.BuildAsync(new DotNetBuildOptions
             {
                 ProjectSolution = Path.Combine(gitRoot, solution),
                 Configuration = "Release",

--- a/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
+++ b/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
@@ -4,9 +4,7 @@ using ModularPipelines.Build.Settings;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Attributes;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.GitHub.Attributes;
-using ModularPipelines.GitHub.Extensions;
 using ModularPipelines.Modules;
 using Octokit;
 
@@ -38,13 +36,13 @@ public class CreateReleaseModule : Module<Release>
     {
         var versionInfoResult = await context.GetModule<NugetVersionGeneratorModule>();
 
-        var repositoryIdString = context.GitHub().EnvironmentVariables.RepositoryId;
+        var repositoryIdString = context.Tools.GitHub.EnvironmentVariables.RepositoryId;
         if (!long.TryParse(repositoryIdString, out var repositoryId))
         {
             throw new InvalidOperationException($"Failed to parse RepositoryId '{repositoryIdString}' as a valid long integer.");
         }
 
-        return await context.GitHub().Client.Repository.Release.Create(repositoryId,
+        return await context.Tools.GitHub.Client.Repository.Release.Create(repositoryId,
             new NewRelease($"v{versionInfoResult.Value}")
             {
                 Name = versionInfoResult.Value,

--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -3,11 +3,8 @@ using ModularPipelines.Build.Settings;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Extensions;
-using ModularPipelines.Git.Extensions;
-using ModularPipelines.GitHub.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-using ModularPipelines.Node.Extensions;
 using ModularPipelines.Node.Models;
 
 namespace ModularPipelines.Build.Modules;
@@ -24,7 +21,7 @@ public class FormatMarkdownModule : Module<None>
                 return SkipDecision.Skip("Validated by the fast-fail CI job");
             }
 
-            if (ctx.GitHub().EnvironmentVariables.EventName != "pull_request")
+            if (ctx.Tools.GitHub.EnvironmentVariables.EventName != "pull_request")
             {
                 return SkipDecision.Skip("Not a pull request");
             }
@@ -35,7 +32,7 @@ public class FormatMarkdownModule : Module<None>
 
     protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        await context.Node().Npm.InstallAsync(new NpmInstallOptions
+        await context.Tools.Node.Npm.InstallAsync(new NpmInstallOptions
         {
             Arguments =
             [
@@ -47,7 +44,7 @@ public class FormatMarkdownModule : Module<None>
             SaveDev = true,
         }, cancellationToken);
 
-        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var filesToFormat = new List<string>
         {
@@ -57,7 +54,7 @@ public class FormatMarkdownModule : Module<None>
 
         foreach (var fileToFormat in filesToFormat)
         {
-            await context.Node().Npx.ExecuteAsync(new NpxOptions
+            await context.Tools.Node.Npx.ExecuteAsync(new NpxOptions
             {
                 Arguments =
                 [

--- a/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
+++ b/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
@@ -3,7 +3,6 @@ using Microsoft.Build.Construction;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.FileSystem;
@@ -18,7 +17,7 @@ public class GenerateReadMeModule : Module<None>
 
     protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var gitRootDirectory = repositoryInfo.Root;
 

--- a/src/ModularPipelines.Build/Modules/LocalMachine/AddLocalNugetSourceModule.cs
+++ b/src/ModularPipelines.Build/Modules/LocalMachine/AddLocalNugetSourceModule.cs
@@ -3,7 +3,6 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Build.Settings;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
@@ -32,7 +31,7 @@ public class AddLocalNugetSourceModule : Module<CommandResult>
     {
         var localNugetPathResult = await context.GetModule<CreateLocalNugetFolderModule>();
 
-        return await context.DotNet().NuGet.Add.SourceAsync(new DotNetNuGetAddSourceOptions
+        return await context.Tools.DotNet.NuGet.Add.SourceAsync(new DotNetNuGetAddSourceOptions
         {
             Name = _localNuGetSettings.Value.SourceName,
             Packagesourcepath = localNugetPathResult.Value.AssertExists(),

--- a/src/ModularPipelines.Build/Modules/NugetVersionGeneratorModule.cs
+++ b/src/ModularPipelines.Build/Modules/NugetVersionGeneratorModule.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Build.Settings;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Build.Modules;
@@ -20,7 +19,7 @@ public class NugetVersionGeneratorModule : Module<string>
 
     protected override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var gitVersionInformation = await context.Git().Versioning.GetVersioningInformationAsync(cancellationToken);
+        var gitVersionInformation = await context.Tools.Git.Versioning.GetVersioningInformationAsync(cancellationToken);
 
         var version = _publishSettings.Value.IsAlpha
             ? $"{gitVersionInformation.FullSemVer}-alpha{gitVersionInformation.CommitsSinceVersionSourcePadded!}"

--- a/src/ModularPipelines.Build/Modules/PackProjectsModule.cs
+++ b/src/ModularPipelines.Build/Modules/PackProjectsModule.cs
@@ -2,9 +2,7 @@ using EnumerableAsyncProcessor.Extensions;
 using Microsoft.Build.Construction;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.FileSystem;
@@ -43,7 +41,7 @@ public class PackProjectsModule : Module<CommandResult[]>
     {
         var effectiveVersion = GetEffectiveVersion(projectFile, packageVersion);
 
-        return await context.DotNet().PackAsync(new DotNetPackOptions
+        return await context.Tools.DotNet.PackAsync(new DotNetPackOptions
         {
             ProjectSolution = projectFile.Path,
             Configuration = "Release",

--- a/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
+++ b/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
@@ -1,5 +1,4 @@
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Build.Modules;
@@ -8,7 +7,7 @@ public class PackageFilesRemovalModule : Module<int>
 {
     protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var packageFiles = repositoryInfo.Root
             .GetFiles(path => path.Extension is ".nupkg");

--- a/src/ModularPipelines.Build/Modules/PrintGitInformationModule.cs
+++ b/src/ModularPipelines.Build/Modules/PrintGitInformationModule.cs
@@ -1,8 +1,7 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Build.Helpers;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
@@ -12,7 +11,7 @@ public class PrintGitInformationModule : Module<None>
 {
     protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var gitInformation = await context.Git().Information.GetInfoAsync(cancellationToken);
+        var gitInformation = await context.Tools.Git.Information.GetInfoAsync(cancellationToken);
         context.Logger.LogInformation("Git Info: {GitInfo}", JsonSerializer.Serialize(gitInformation, DiagnosticSerializerOptions.Instance));
 
         return None.Value;

--- a/src/ModularPipelines.Build/Modules/PushVersionTagModule.cs
+++ b/src/ModularPipelines.Build/Modules/PushVersionTagModule.cs
@@ -5,9 +5,7 @@ using ModularPipelines.Build.Settings;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Attributes;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Git.Options;
-using ModularPipelines.GitHub.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -46,7 +44,7 @@ public class PushVersionTagModule : Module<CommandResult>
         // Configure remote URL with authentication token
         var token = _gitHubSettings.Value.StandardToken!;
 
-        await context.Git().Commands.Remotes.RemoteAsync(new GitRemoteOptions
+        await context.Tools.Git.Commands.Remotes.RemoteAsync(new GitRemoteOptions
         {
             Arguments =
             [
@@ -55,12 +53,12 @@ public class PushVersionTagModule : Module<CommandResult>
             ],
         }, null, cancellationToken);
 
-        await context.Git().Commands.Branches.TagAsync(new GitTagOptions
+        await context.Tools.Git.Commands.Branches.TagAsync(new GitTagOptions
         {
             TagName = $"v{versionInformation.Value}",
         }, cancellationToken: cancellationToken);
 
-        return await context.Git().Commands.Remotes.PushAsync(
+        return await context.Tools.Git.Commands.Remotes.PushAsync(
             new GitPushOptions
             {
                 Tags = true,

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -8,10 +8,8 @@ using ModularPipelines.Build.Settings;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.DotNet.Enums;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.DotNet.Parsers.Trx;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -45,7 +43,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
 
     protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var testProject = repositoryInfo.Root
             .GetFiles(file => file.Name.Equals(TestProjectFileName, StringComparison.OrdinalIgnoreCase))
@@ -59,7 +57,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
 
         try
         {
-            return await context.DotNet().RunAsync(new DotNetRunOptions
+            return await context.Tools.DotNet.RunAsync(new DotNetRunOptions
             {
                 Project = testProject.Path,
                 NoBuild = true,
@@ -138,7 +136,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
             return;
         }
 
-        var testResults = await context.Trx().ParseTrxFile(trxFile);
+        var testResults = await context.Tools.Trx.ParseTrxFile(trxFile);
         var consoleWriter = context.Services.GetRequiredService<IConsoleWriter>();
         PrintFailedTests(consoleWriter, testResults.UnitTestResults, trxFile.Path);
         PrintSkippedTests(consoleWriter, testResults.UnitTestResults);

--- a/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
@@ -40,6 +40,6 @@ public static class BuildahExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBuildah"/> service for executing buildah commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IBuildah>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Buildah.Services.IBuildah>().")]
     public static IBuildah Buildah(this IPipelineContext context) => context.Services.GetRequiredService<IBuildah>();
 }

--- a/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
@@ -39,5 +39,7 @@ public static class BuildahExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBuildah"/> service for executing buildah commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Buildah.")]
     public static IBuildah Buildah(this IPipelineContext context) => context.Services.GetRequiredService<IBuildah>();
 }

--- a/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
@@ -40,6 +40,6 @@ public static class BuildahExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBuildah"/> service for executing buildah commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Buildah.")]
+    [global::System.Obsolete("Use context.Tools.Get<IBuildah>().")]
     public static IBuildah Buildah(this IPipelineContext context) => context.Services.GetRequiredService<IBuildah>();
 }

--- a/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class ChocoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IChoco"/> service for executing choco commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Choco.")]
+    [global::System.Obsolete("Use context.Tools.Get<IChoco>().")]
     public static IChoco Choco(this IPipelineContext context) => context.Services.GetRequiredService<IChoco>();
 }

--- a/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class ChocoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IChoco"/> service for executing choco commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Choco.")]
     public static IChoco Choco(this IPipelineContext context) => context.Services.GetRequiredService<IChoco>();
 }

--- a/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class ChocoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IChoco"/> service for executing choco commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IChoco>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Chocolatey.Services.IChoco>().")]
     public static IChoco Choco(this IPipelineContext context) => context.Services.GetRequiredService<IChoco>();
 }

--- a/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
+++ b/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
@@ -31,6 +31,6 @@ public static class CmdExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Command Prompt context.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ICmdContext>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Cmd.ICmdContext>().")]
     public static ICmdContext Cmd(this IPipelineContext context) => context.Services.GetRequiredService<ICmdContext>();
 }

--- a/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
+++ b/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
@@ -30,5 +30,7 @@ public static class CmdExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Command Prompt context.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Cmd.")]
     public static ICmdContext Cmd(this IPipelineContext context) => context.Services.GetRequiredService<ICmdContext>();
 }

--- a/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
+++ b/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
@@ -31,6 +31,6 @@ public static class CmdExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Command Prompt context.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Cmd.")]
+    [global::System.Obsolete("Use context.Tools.Get<ICmdContext>().")]
     public static ICmdContext Cmd(this IPipelineContext context) => context.Services.GetRequiredService<ICmdContext>();
 }

--- a/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
+++ b/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
@@ -44,6 +44,6 @@ public static class CosignExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICosign"/> service for executing cosign commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Cosign.")]
+    [global::System.Obsolete("Use context.Tools.Get<ICosign>().")]
     public static ICosign Cosign(this IPipelineContext context) => context.Services.GetRequiredService<ICosign>();
 }

--- a/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
+++ b/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
@@ -43,5 +43,7 @@ public static class CosignExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICosign"/> service for executing cosign commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Cosign.")]
     public static ICosign Cosign(this IPipelineContext context) => context.Services.GetRequiredService<ICosign>();
 }

--- a/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
+++ b/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
@@ -44,6 +44,6 @@ public static class CosignExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICosign"/> service for executing cosign commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ICosign>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Cosign.Services.ICosign>().")]
     public static ICosign Cosign(this IPipelineContext context) => context.Services.GetRequiredService<ICosign>();
 }

--- a/src/ModularPipelines.Development.Analyzers/Readme.md
+++ b/src/ModularPipelines.Development.Analyzers/Readme.md
@@ -113,7 +113,7 @@ public class FindNugetPackagesModule : Module<List<FilePath>>
 {
     protected override async Task<List<FilePath>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var repositoryInfo = await context.Git().Information.GetInfoAsync()
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync()
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         return repositoryInfo.Root
             .GetFiles(path => path.Extension is ".nupkg")
@@ -138,7 +138,7 @@ public class UploadNugetPackagesModule : Module<None>
         var nugetFiles = await context.GetModule<FindNugetPackagesModule>();
 
         await nugetFiles.ValueOrDefault!
-            .SelectAsync(async nugetFile => await context.DotNet().NuGet.PushAsync(new DotNetNuGetPushOptions
+            .SelectAsync(async nugetFile => await context.Tools.DotNet.NuGet.PushAsync(new DotNetNuGetPushOptions
             {
                 Path = nugetFile,
                 Source = "https://api.nuget.org/v3/index.json",

--- a/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
+++ b/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
@@ -53,6 +53,6 @@ public static class DockerExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDocker"/> service for executing docker commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Docker.")]
+    [global::System.Obsolete("Use context.Tools.Get<IDocker>().")]
     public static IDocker Docker(this IPipelineContext context) => context.Services.GetRequiredService<IDocker>();
 }

--- a/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
+++ b/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
@@ -52,5 +52,7 @@ public static class DockerExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDocker"/> service for executing docker commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Docker.")]
     public static IDocker Docker(this IPipelineContext context) => context.Services.GetRequiredService<IDocker>();
 }

--- a/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
+++ b/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
@@ -53,6 +53,6 @@ public static class DockerExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDocker"/> service for executing docker commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IDocker>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Docker.Services.IDocker>().")]
     public static IDocker Docker(this IPipelineContext context) => context.Services.GetRequiredService<IDocker>();
 }

--- a/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
+++ b/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
@@ -36,6 +36,6 @@ public static class TrxExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrx"/> service for parsing TRX test result files.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Trx.")]
+    [global::System.Obsolete("Use context.Tools.Get<ITrx>().")]
     public static ITrx Trx(this IPipelineContext context) => context.Services.GetRequiredService<ITrx>();
 }

--- a/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
+++ b/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
@@ -36,6 +36,6 @@ public static class TrxExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrx"/> service for parsing TRX test result files.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ITrx>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.DotNet.Services.ITrx>().")]
     public static ITrx Trx(this IPipelineContext context) => context.Services.GetRequiredService<ITrx>();
 }

--- a/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
+++ b/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
@@ -35,5 +35,7 @@ public static class TrxExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrx"/> service for parsing TRX test result files.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Trx.")]
     public static ITrx Trx(this IPipelineContext context) => context.Services.GetRequiredService<ITrx>();
 }

--- a/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
@@ -48,6 +48,6 @@ public static class DotNetExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDotNet"/> service for executing dotnet commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.DotNet.")]
+    [global::System.Obsolete("Use context.Tools.Get<IDotNet>().")]
     public static IDotNet DotNet(this IPipelineContext context) => context.Services.GetRequiredService<IDotNet>();
 }

--- a/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
@@ -48,6 +48,6 @@ public static class DotNetExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDotNet"/> service for executing dotnet commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IDotNet>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.DotNet.Services.IDotNet>().")]
     public static IDotNet DotNet(this IPipelineContext context) => context.Services.GetRequiredService<IDotNet>();
 }

--- a/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
@@ -47,5 +47,7 @@ public static class DotNetExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDotNet"/> service for executing dotnet commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.DotNet.")]
     public static IDotNet DotNet(this IPipelineContext context) => context.Services.GetRequiredService<IDotNet>();
 }

--- a/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
@@ -53,6 +53,6 @@ public static class EksctlExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IEksctl"/> service for executing eksctl commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Eksctl.")]
+    [global::System.Obsolete("Use context.Tools.Get<IEksctl>().")]
     public static IEksctl Eksctl(this IPipelineContext context) => context.Services.GetRequiredService<IEksctl>();
 }

--- a/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
@@ -53,6 +53,6 @@ public static class EksctlExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IEksctl"/> service for executing eksctl commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IEksctl>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Eksctl.Services.IEksctl>().")]
     public static IEksctl Eksctl(this IPipelineContext context) => context.Services.GetRequiredService<IEksctl>();
 }

--- a/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
@@ -52,5 +52,7 @@ public static class EksctlExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IEksctl"/> service for executing eksctl commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Eksctl.")]
     public static IEksctl Eksctl(this IPipelineContext context) => context.Services.GetRequiredService<IEksctl>();
 }

--- a/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
+++ b/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
@@ -18,7 +18,7 @@ public static class EmailExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Email.")]
+    [global::System.Obsolete("Use context.Tools.Get<IEmail>().")]
 
     public static IEmail Email(this IPipelineContext context) => context.Services.GetRequiredService<IEmail>();
 }

--- a/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
+++ b/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
@@ -18,7 +18,7 @@ public static class EmailExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<IEmail>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Email.IEmail>().")]
 
     public static IEmail Email(this IPipelineContext context) => context.Services.GetRequiredService<IEmail>();
 }

--- a/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
+++ b/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
@@ -17,8 +17,6 @@ public static class EmailExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Email.IEmail>().")]
-
     public static IEmail Email(this IPipelineContext context) => context.Services.GetRequiredService<IEmail>();
 }

--- a/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
+++ b/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
@@ -16,5 +16,9 @@ public static class EmailExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.Email.")]
+
     public static IEmail Email(this IPipelineContext context) => context.Services.GetRequiredService<IEmail>();
 }

--- a/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
+++ b/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
@@ -55,5 +55,7 @@ public static class FluxExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlux"/> service for executing flux commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Flux.")]
     public static IFlux Flux(this IPipelineContext context) => context.Services.GetRequiredService<IFlux>();
 }

--- a/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
+++ b/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
@@ -56,6 +56,6 @@ public static class FluxExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlux"/> service for executing flux commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Flux.")]
+    [global::System.Obsolete("Use context.Tools.Get<IFlux>().")]
     public static IFlux Flux(this IPipelineContext context) => context.Services.GetRequiredService<IFlux>();
 }

--- a/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
+++ b/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
@@ -56,6 +56,6 @@ public static class FluxExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlux"/> service for executing flux commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IFlux>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Flux.Services.IFlux>().")]
     public static IFlux Flux(this IPipelineContext context) => context.Services.GetRequiredService<IFlux>();
 }

--- a/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
+++ b/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class FlywayExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlyway"/> service for executing flyway commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Flyway.")]
+    [global::System.Obsolete("Use context.Tools.Get<IFlyway>().")]
     public static IFlyway Flyway(this IPipelineContext context) => context.Services.GetRequiredService<IFlyway>();
 }

--- a/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
+++ b/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class FlywayExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlyway"/> service for executing flyway commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IFlyway>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Flyway.Services.IFlyway>().")]
     public static IFlyway Flyway(this IPipelineContext context) => context.Services.GetRequiredService<IFlyway>();
 }

--- a/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
+++ b/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class FlywayExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlyway"/> service for executing flyway commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Flyway.")]
     public static IFlyway Flyway(this IPipelineContext context) => context.Services.GetRequiredService<IFlyway>();
 }

--- a/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
+++ b/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
@@ -18,7 +18,7 @@ public static class FtpExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<IFtp>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Ftp.IFtp>().")]
 
     public static IFtp Ftp(this IPipelineContext context) => context.Services.GetRequiredService<IFtp>();
 }

--- a/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
+++ b/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
@@ -16,5 +16,9 @@ public static class FtpExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.Ftp.")]
+
     public static IFtp Ftp(this IPipelineContext context) => context.Services.GetRequiredService<IFtp>();
 }

--- a/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
+++ b/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
@@ -17,8 +17,6 @@ public static class FtpExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Ftp.IFtp>().")]
-
     public static IFtp Ftp(this IPipelineContext context) => context.Services.GetRequiredService<IFtp>();
 }

--- a/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
+++ b/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
@@ -18,7 +18,7 @@ public static class FtpExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Ftp.")]
+    [global::System.Obsolete("Use context.Tools.Get<IFtp>().")]
 
     public static IFtp Ftp(this IPipelineContext context) => context.Services.GetRequiredService<IFtp>();
 }

--- a/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
+++ b/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -18,7 +17,7 @@ internal static class BranchConditionHelper
         string logMessageFormat,
         CancellationToken cancellationToken = default)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync(cancellationToken).ConfigureAwait(false);
+        var repositoryInfo = await pipelineContext.Tools.Git.Information.GetInfoAsync(cancellationToken).ConfigureAwait(false);
         var currentBranchName = repositoryInfo?.BranchName;
         pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedBranchName);
         return currentBranchName == expectedBranchName;
@@ -33,7 +32,7 @@ internal static class BranchConditionHelper
         string logMessageFormat,
         CancellationToken cancellationToken = default)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync(cancellationToken).ConfigureAwait(false);
+        var repositoryInfo = await pipelineContext.Tools.Git.Information.GetInfoAsync(cancellationToken).ConfigureAwait(false);
         var currentBranchName = repositoryInfo?.BranchName;
         pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedPrefix);
         return currentBranchName?.StartsWith(expectedPrefix) ?? false;

--- a/src/ModularPipelines.Git/Attributes/RunIfChangedAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfChangedAttribute.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Conditions;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -54,5 +53,5 @@ public sealed class RunIfChangedAttribute : Attribute, IGroupedConditionAttribut
         EvaluateAsync(context, default);
 
     public Task<bool> EvaluateAsync(IPipelineContext context, CancellationToken cancellationToken) =>
-        context.Git().Changes.HasChangesAsync(PathPatterns, Base, cancellationToken);
+        context.Tools.Git.Changes.HasChangesAsync(PathPatterns, Base, cancellationToken);
 }

--- a/src/ModularPipelines.Git/Extensions/GitExtensions.cs
+++ b/src/ModularPipelines.Git/Extensions/GitExtensions.cs
@@ -41,6 +41,6 @@ public static class GitExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGit"/> service for executing Git commands and accessing repository information.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IGit>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Git.IGit>().")]
     public static IGit Git(this IPipelineContext context) => context.Services.GetRequiredService<IGit>();
 }

--- a/src/ModularPipelines.Git/Extensions/GitExtensions.cs
+++ b/src/ModularPipelines.Git/Extensions/GitExtensions.cs
@@ -41,6 +41,6 @@ public static class GitExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGit"/> service for executing Git commands and accessing repository information.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Git.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGit>().")]
     public static IGit Git(this IPipelineContext context) => context.Services.GetRequiredService<IGit>();
 }

--- a/src/ModularPipelines.Git/Extensions/GitExtensions.cs
+++ b/src/ModularPipelines.Git/Extensions/GitExtensions.cs
@@ -40,5 +40,7 @@ public static class GitExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGit"/> service for executing Git commands and accessing repository information.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Git.")]
     public static IGit Git(this IPipelineContext context) => context.Services.GetRequiredService<IGit>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
@@ -58,6 +58,6 @@ public static class GhExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGh"/> service for executing gh commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IGh>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.GitHub.Services.IGh>().")]
     public static IGh Gh(this IPipelineContext context) => context.Services.GetRequiredService<IGh>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
@@ -58,6 +58,6 @@ public static class GhExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGh"/> service for executing gh commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Gh.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGh>().")]
     public static IGh Gh(this IPipelineContext context) => context.Services.GetRequiredService<IGh>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
@@ -57,5 +57,7 @@ public static class GhExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGh"/> service for executing gh commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Gh.")]
     public static IGh Gh(this IPipelineContext context) => context.Services.GetRequiredService<IGh>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
@@ -45,5 +45,9 @@ public static class GitHubExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.GitHub.")]
+
     public static IGitHub GitHub(this IPipelineContext context) => context.Services.GetRequiredService<IGitHub>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
@@ -46,8 +46,6 @@ public static class GitHubExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.GitHub.IGitHub>().")]
-
     public static IGitHub GitHub(this IPipelineContext context) => context.Services.GetRequiredService<IGitHub>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
@@ -47,7 +47,7 @@ public static class GitHubExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<IGitHub>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.GitHub.IGitHub>().")]
 
     public static IGitHub GitHub(this IPipelineContext context) => context.Services.GetRequiredService<IGitHub>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
@@ -47,7 +47,7 @@ public static class GitHubExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.GitHub.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGitHub>().")]
 
     public static IGitHub GitHub(this IPipelineContext context) => context.Services.GetRequiredService<IGitHub>();
 }

--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class GoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGo"/> service for executing go commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Go.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGo>().")]
     public static IGo Go(this IPipelineContext context) => context.Services.GetRequiredService<IGo>();
 }

--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class GoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGo"/> service for executing go commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Go.")]
     public static IGo Go(this IPipelineContext context) => context.Services.GetRequiredService<IGo>();
 }

--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class GoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGo"/> service for executing go commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IGo>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Go.Services.IGo>().")]
     public static IGo Go(this IPipelineContext context) => context.Services.GetRequiredService<IGo>();
 }

--- a/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
+++ b/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
@@ -166,6 +166,6 @@ public static class GcloudExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGcloud"/> service for executing gcloud commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IGcloud>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Google.Services.IGcloud>().")]
     public static IGcloud Gcloud(this IPipelineContext context) => context.Services.GetRequiredService<IGcloud>();
 }

--- a/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
+++ b/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
@@ -166,6 +166,6 @@ public static class GcloudExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGcloud"/> service for executing gcloud commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Gcloud.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGcloud>().")]
     public static IGcloud Gcloud(this IPipelineContext context) => context.Services.GetRequiredService<IGcloud>();
 }

--- a/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
+++ b/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
@@ -165,5 +165,7 @@ public static class GcloudExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGcloud"/> service for executing gcloud commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Gcloud.")]
     public static IGcloud Gcloud(this IPipelineContext context) => context.Services.GetRequiredService<IGcloud>();
 }

--- a/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
+++ b/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
@@ -38,5 +38,7 @@ public static class GrypeExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGrype"/> service for executing grype commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Grype.")]
     public static IGrype Grype(this IPipelineContext context) => context.Services.GetRequiredService<IGrype>();
 }

--- a/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
+++ b/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
@@ -39,6 +39,6 @@ public static class GrypeExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGrype"/> service for executing grype commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IGrype>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Grype.Services.IGrype>().")]
     public static IGrype Grype(this IPipelineContext context) => context.Services.GetRequiredService<IGrype>();
 }

--- a/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
+++ b/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
@@ -39,6 +39,6 @@ public static class GrypeExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGrype"/> service for executing grype commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Grype.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGrype>().")]
     public static IGrype Grype(this IPipelineContext context) => context.Services.GetRequiredService<IGrype>();
 }

--- a/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class HadolintExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHadolint"/> service for executing hadolint commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Hadolint.")]
     public static IHadolint Hadolint(this IPipelineContext context) => context.Services.GetRequiredService<IHadolint>();
 }

--- a/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class HadolintExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHadolint"/> service for executing hadolint commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Hadolint.")]
+    [global::System.Obsolete("Use context.Tools.Get<IHadolint>().")]
     public static IHadolint Hadolint(this IPipelineContext context) => context.Services.GetRequiredService<IHadolint>();
 }

--- a/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class HadolintExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHadolint"/> service for executing hadolint commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IHadolint>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Hadolint.Services.IHadolint>().")]
     public static IHadolint Hadolint(this IPipelineContext context) => context.Services.GetRequiredService<IHadolint>();
 }

--- a/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
+++ b/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
@@ -45,6 +45,6 @@ public static class HelmExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHelm"/> service for executing helm commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Helm.")]
+    [global::System.Obsolete("Use context.Tools.Get<IHelm>().")]
     public static IHelm Helm(this IPipelineContext context) => context.Services.GetRequiredService<IHelm>();
 }

--- a/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
+++ b/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
@@ -44,5 +44,7 @@ public static class HelmExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHelm"/> service for executing helm commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Helm.")]
     public static IHelm Helm(this IPipelineContext context) => context.Services.GetRequiredService<IHelm>();
 }

--- a/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
+++ b/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
@@ -45,6 +45,6 @@ public static class HelmExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHelm"/> service for executing helm commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IHelm>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Helm.Services.IHelm>().")]
     public static IHelm Helm(this IPipelineContext context) => context.Services.GetRequiredService<IHelm>();
 }

--- a/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class BrewExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBrew"/> service for executing brew commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Brew.")]
+    [global::System.Obsolete("Use context.Tools.Get<IBrew>().")]
     public static IBrew Brew(this IPipelineContext context) => context.Services.GetRequiredService<IBrew>();
 }

--- a/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class BrewExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBrew"/> service for executing brew commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IBrew>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Homebrew.Services.IBrew>().")]
     public static IBrew Brew(this IPipelineContext context) => context.Services.GetRequiredService<IBrew>();
 }

--- a/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class BrewExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBrew"/> service for executing brew commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Brew.")]
     public static IBrew Brew(this IPipelineContext context) => context.Services.GetRequiredService<IBrew>();
 }

--- a/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class GradleExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGradle"/> service for executing gradle commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IGradle>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Java.Services.IGradle>().")]
     public static IGradle Gradle(this IPipelineContext context) => context.Services.GetRequiredService<IGradle>();
 }

--- a/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class GradleExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGradle"/> service for executing gradle commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Gradle.")]
     public static IGradle Gradle(this IPipelineContext context) => context.Services.GetRequiredService<IGradle>();
 }

--- a/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class GradleExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGradle"/> service for executing gradle commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Gradle.")]
+    [global::System.Obsolete("Use context.Tools.Get<IGradle>().")]
     public static IGradle Gradle(this IPipelineContext context) => context.Services.GetRequiredService<IGradle>();
 }

--- a/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class MavenExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMaven"/> service for executing mvn commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Maven.")]
+    [global::System.Obsolete("Use context.Tools.Get<IMaven>().")]
     public static IMaven Maven(this IPipelineContext context) => context.Services.GetRequiredService<IMaven>();
 }

--- a/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class MavenExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMaven"/> service for executing mvn commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Maven.")]
     public static IMaven Maven(this IPipelineContext context) => context.Services.GetRequiredService<IMaven>();
 }

--- a/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class MavenExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMaven"/> service for executing mvn commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IMaven>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Java.Services.IMaven>().")]
     public static IMaven Maven(this IPipelineContext context) => context.Services.GetRequiredService<IMaven>();
 }

--- a/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
+++ b/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class JqExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IJq"/> service for executing jq commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Jq.")]
+    [global::System.Obsolete("Use context.Tools.Get<IJq>().")]
     public static IJq Jq(this IPipelineContext context) => context.Services.GetRequiredService<IJq>();
 }

--- a/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
+++ b/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class JqExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IJq"/> service for executing jq commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Jq.")]
     public static IJq Jq(this IPipelineContext context) => context.Services.GetRequiredService<IJq>();
 }

--- a/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
+++ b/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class JqExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IJq"/> service for executing jq commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IJq>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Jq.Services.IJq>().")]
     public static IJq Jq(this IPipelineContext context) => context.Services.GetRequiredService<IJq>();
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -44,6 +44,6 @@ public static class KindExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKind"/> service for executing kind commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IKind>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Kind.Services.IKind>().")]
     public static IKind Kind(this IPipelineContext context) => context.Services.GetRequiredService<IKind>();
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -44,6 +44,6 @@ public static class KindExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKind"/> service for executing kind commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Kind.")]
+    [global::System.Obsolete("Use context.Tools.Get<IKind>().")]
     public static IKind Kind(this IPipelineContext context) => context.Services.GetRequiredService<IKind>();
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -43,5 +43,7 @@ public static class KindExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKind"/> service for executing kind commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Kind.")]
     public static IKind Kind(this IPipelineContext context) => context.Services.GetRequiredService<IKind>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
@@ -45,5 +45,7 @@ public static class KubernetesExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKubernetes"/> service for executing kubectl commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Kubernetes.")]
     public static IKubernetes Kubernetes(this IPipelineContext context) => context.Services.GetRequiredService<IKubernetes>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
@@ -46,6 +46,6 @@ public static class KubernetesExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKubernetes"/> service for executing kubectl commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IKubernetes>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Kubernetes.Services.IKubernetes>().")]
     public static IKubernetes Kubernetes(this IPipelineContext context) => context.Services.GetRequiredService<IKubernetes>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
@@ -46,6 +46,6 @@ public static class KubernetesExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKubernetes"/> service for executing kubectl commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Kubernetes.")]
+    [global::System.Obsolete("Use context.Tools.Get<IKubernetes>().")]
     public static IKubernetes Kubernetes(this IPipelineContext context) => context.Services.GetRequiredService<IKubernetes>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
@@ -40,5 +40,7 @@ public static class KustomizeExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKustomize"/> service for executing kustomize commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Kustomize.")]
     public static IKustomize Kustomize(this IPipelineContext context) => context.Services.GetRequiredService<IKustomize>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
@@ -41,6 +41,6 @@ public static class KustomizeExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKustomize"/> service for executing kustomize commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IKustomize>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Kubernetes.Services.IKustomize>().")]
     public static IKustomize Kustomize(this IPipelineContext context) => context.Services.GetRequiredService<IKustomize>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
@@ -41,6 +41,6 @@ public static class KustomizeExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKustomize"/> service for executing kustomize commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Kustomize.")]
+    [global::System.Obsolete("Use context.Tools.Get<IKustomize>().")]
     public static IKustomize Kustomize(this IPipelineContext context) => context.Services.GetRequiredService<IKustomize>();
 }

--- a/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class LiquibaseExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ILiquibase"/> service for executing liquibase commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Liquibase.")]
     public static ILiquibase Liquibase(this IPipelineContext context) => context.Services.GetRequiredService<ILiquibase>();
 }

--- a/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class LiquibaseExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ILiquibase"/> service for executing liquibase commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ILiquibase>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Liquibase.Services.ILiquibase>().")]
     public static ILiquibase Liquibase(this IPipelineContext context) => context.Services.GetRequiredService<ILiquibase>();
 }

--- a/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class LiquibaseExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ILiquibase"/> service for executing liquibase commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Liquibase.")]
+    [global::System.Obsolete("Use context.Tools.Get<ILiquibase>().")]
     public static ILiquibase Liquibase(this IPipelineContext context) => context.Services.GetRequiredService<ILiquibase>();
 }

--- a/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
+++ b/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
@@ -18,7 +18,7 @@ public static class MicrosoftTeamsExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.MicrosoftTeams.")]
+    [global::System.Obsolete("Use context.Tools.Get<IMicrosoftTeams>().")]
 
     public static IMicrosoftTeams MicrosoftTeams(this IPipelineContext context) => context.Services.GetRequiredService<IMicrosoftTeams>();
 }

--- a/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
+++ b/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
@@ -16,5 +16,9 @@ public static class MicrosoftTeamsExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.MicrosoftTeams.")]
+
     public static IMicrosoftTeams MicrosoftTeams(this IPipelineContext context) => context.Services.GetRequiredService<IMicrosoftTeams>();
 }

--- a/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
+++ b/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
@@ -18,7 +18,7 @@ public static class MicrosoftTeamsExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<IMicrosoftTeams>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.MicrosoftTeams.IMicrosoftTeams>().")]
 
     public static IMicrosoftTeams MicrosoftTeams(this IPipelineContext context) => context.Services.GetRequiredService<IMicrosoftTeams>();
 }

--- a/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
+++ b/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
@@ -17,8 +17,6 @@ public static class MicrosoftTeamsExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.MicrosoftTeams.IMicrosoftTeams>().")]
-
     public static IMicrosoftTeams MicrosoftTeams(this IPipelineContext context) => context.Services.GetRequiredService<IMicrosoftTeams>();
 }

--- a/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
@@ -45,6 +45,6 @@ public static class MinikubeExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMinikube"/> service for executing minikube commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IMinikube>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Minikube.Services.IMinikube>().")]
     public static IMinikube Minikube(this IPipelineContext context) => context.Services.GetRequiredService<IMinikube>();
 }

--- a/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
@@ -44,5 +44,7 @@ public static class MinikubeExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMinikube"/> service for executing minikube commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Minikube.")]
     public static IMinikube Minikube(this IPipelineContext context) => context.Services.GetRequiredService<IMinikube>();
 }

--- a/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
@@ -45,6 +45,6 @@ public static class MinikubeExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMinikube"/> service for executing minikube commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Minikube.")]
+    [global::System.Obsolete("Use context.Tools.Get<IMinikube>().")]
     public static IMinikube Minikube(this IPipelineContext context) => context.Services.GetRequiredService<IMinikube>();
 }

--- a/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
+++ b/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class NbgvExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INbgv"/> service for executing nbgv commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Nbgv.")]
+    [global::System.Obsolete("Use context.Tools.Get<INbgv>().")]
     public static INbgv Nbgv(this IPipelineContext context) => context.Services.GetRequiredService<INbgv>();
 }

--- a/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
+++ b/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class NbgvExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INbgv"/> service for executing nbgv commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<INbgv>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.NerdbankGitVersioning.Services.INbgv>().")]
     public static INbgv Nbgv(this IPipelineContext context) => context.Services.GetRequiredService<INbgv>();
 }

--- a/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
+++ b/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class NbgvExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INbgv"/> service for executing nbgv commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Nbgv.")]
     public static INbgv Nbgv(this IPipelineContext context) => context.Services.GetRequiredService<INbgv>();
 }

--- a/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class NewmanExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INewman"/> service for executing newman commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Newman.")]
+    [global::System.Obsolete("Use context.Tools.Get<INewman>().")]
     public static INewman Newman(this IPipelineContext context) => context.Services.GetRequiredService<INewman>();
 }

--- a/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class NewmanExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INewman"/> service for executing newman commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Newman.")]
     public static INewman Newman(this IPipelineContext context) => context.Services.GetRequiredService<INewman>();
 }

--- a/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class NewmanExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INewman"/> service for executing newman commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<INewman>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Newman.Services.INewman>().")]
     public static INewman Newman(this IPipelineContext context) => context.Services.GetRequiredService<INewman>();
 }

--- a/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
+++ b/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
@@ -19,7 +19,7 @@ public static class NodeExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Node.")]
+    [global::System.Obsolete("Use context.Tools.Get<INode>().")]
 
     public static INode Node(this IPipelineContext context) => context.Services.GetRequiredService<INode>();
 }

--- a/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
+++ b/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
@@ -18,8 +18,6 @@ public static class NodeExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Node.INode>().")]
-
     public static INode Node(this IPipelineContext context) => context.Services.GetRequiredService<INode>();
 }

--- a/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
+++ b/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
@@ -19,7 +19,7 @@ public static class NodeExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<INode>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Node.INode>().")]
 
     public static INode Node(this IPipelineContext context) => context.Services.GetRequiredService<INode>();
 }

--- a/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
+++ b/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
@@ -17,5 +17,9 @@ public static class NodeExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.Node.")]
+
     public static INode Node(this IPipelineContext context) => context.Services.GetRequiredService<INode>();
 }

--- a/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
+++ b/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class PnpmExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPnpm"/> service for executing pnpm commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Pnpm.")]
+    [global::System.Obsolete("Use context.Tools.Get<IPnpm>().")]
     public static IPnpm Pnpm(this IPipelineContext context) => context.Services.GetRequiredService<IPnpm>();
 }

--- a/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
+++ b/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class PnpmExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPnpm"/> service for executing pnpm commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IPnpm>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Node.Services.IPnpm>().")]
     public static IPnpm Pnpm(this IPipelineContext context) => context.Services.GetRequiredService<IPnpm>();
 }

--- a/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
+++ b/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class PnpmExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPnpm"/> service for executing pnpm commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Pnpm.")]
     public static IPnpm Pnpm(this IPipelineContext context) => context.Services.GetRequiredService<IPnpm>();
 }

--- a/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
+++ b/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class PackerExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPacker"/> service for executing packer commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Packer.")]
     public static IPacker Packer(this IPipelineContext context) => context.Services.GetRequiredService<IPacker>();
 }

--- a/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
+++ b/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class PackerExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPacker"/> service for executing packer commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IPacker>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Packer.Services.IPacker>().")]
     public static IPacker Packer(this IPipelineContext context) => context.Services.GetRequiredService<IPacker>();
 }

--- a/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
+++ b/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class PackerExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPacker"/> service for executing packer commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Packer.")]
+    [global::System.Obsolete("Use context.Tools.Get<IPacker>().")]
     public static IPacker Packer(this IPipelineContext context) => context.Services.GetRequiredService<IPacker>();
 }

--- a/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
@@ -54,6 +54,6 @@ public static class PodmanExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPodman"/> service for executing podman commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Podman.")]
+    [global::System.Obsolete("Use context.Tools.Get<IPodman>().")]
     public static IPodman Podman(this IPipelineContext context) => context.Services.GetRequiredService<IPodman>();
 }

--- a/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
@@ -53,5 +53,7 @@ public static class PodmanExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPodman"/> service for executing podman commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Podman.")]
     public static IPodman Podman(this IPipelineContext context) => context.Services.GetRequiredService<IPodman>();
 }

--- a/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
@@ -54,6 +54,6 @@ public static class PodmanExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPodman"/> service for executing podman commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IPodman>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Podman.Services.IPodman>().")]
     public static IPodman Podman(this IPipelineContext context) => context.Services.GetRequiredService<IPodman>();
 }

--- a/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
@@ -53,6 +53,6 @@ public static class PulumiExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPulumi"/> service for executing pulumi commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IPulumi>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Pulumi.Services.IPulumi>().")]
     public static IPulumi Pulumi(this IPipelineContext context) => context.Services.GetRequiredService<IPulumi>();
 }

--- a/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
@@ -53,6 +53,6 @@ public static class PulumiExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPulumi"/> service for executing pulumi commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Pulumi.")]
+    [global::System.Obsolete("Use context.Tools.Get<IPulumi>().")]
     public static IPulumi Pulumi(this IPipelineContext context) => context.Services.GetRequiredService<IPulumi>();
 }

--- a/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
@@ -52,5 +52,7 @@ public static class PulumiExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPulumi"/> service for executing pulumi commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Pulumi.")]
     public static IPulumi Pulumi(this IPipelineContext context) => context.Services.GetRequiredService<IPulumi>();
 }

--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class PipExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPip"/> service for executing pip commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IPip>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Python.Services.IPip>().")]
     public static IPip Pip(this IPipelineContext context) => context.Services.GetRequiredService<IPip>();
 }

--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class PipExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPip"/> service for executing pip commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Pip.")]
     public static IPip Pip(this IPipelineContext context) => context.Services.GetRequiredService<IPip>();
 }

--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class PipExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPip"/> service for executing pip commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Pip.")]
+    [global::System.Obsolete("Use context.Tools.Get<IPip>().")]
     public static IPip Pip(this IPipelineContext context) => context.Services.GetRequiredService<IPip>();
 }

--- a/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
+++ b/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class CargoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICargo"/> service for executing cargo commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Cargo.")]
+    [global::System.Obsolete("Use context.Tools.Get<ICargo>().")]
     public static ICargo Cargo(this IPipelineContext context) => context.Services.GetRequiredService<ICargo>();
 }

--- a/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
+++ b/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class CargoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICargo"/> service for executing cargo commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Cargo.")]
     public static ICargo Cargo(this IPipelineContext context) => context.Services.GetRequiredService<ICargo>();
 }

--- a/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
+++ b/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class CargoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICargo"/> service for executing cargo commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ICargo>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Rust.Services.ICargo>().")]
     public static ICargo Cargo(this IPipelineContext context) => context.Services.GetRequiredService<ICargo>();
 }

--- a/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class ShellcheckExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IShellcheck"/> service for executing shellcheck commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Shellcheck.")]
     public static IShellcheck Shellcheck(this IPipelineContext context) => context.Services.GetRequiredService<IShellcheck>();
 }

--- a/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class ShellcheckExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IShellcheck"/> service for executing shellcheck commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Shellcheck.")]
+    [global::System.Obsolete("Use context.Tools.Get<IShellcheck>().")]
     public static IShellcheck Shellcheck(this IPipelineContext context) => context.Services.GetRequiredService<IShellcheck>();
 }

--- a/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class ShellcheckExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IShellcheck"/> service for executing shellcheck commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IShellcheck>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Shellcheck.Services.IShellcheck>().")]
     public static IShellcheck Shellcheck(this IPipelineContext context) => context.Services.GetRequiredService<IShellcheck>();
 }

--- a/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class SkopeoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISkopeo"/> service for executing skopeo commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Skopeo.")]
     public static ISkopeo Skopeo(this IPipelineContext context) => context.Services.GetRequiredService<ISkopeo>();
 }

--- a/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class SkopeoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISkopeo"/> service for executing skopeo commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Skopeo.")]
+    [global::System.Obsolete("Use context.Tools.Get<ISkopeo>().")]
     public static ISkopeo Skopeo(this IPipelineContext context) => context.Services.GetRequiredService<ISkopeo>();
 }

--- a/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class SkopeoExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISkopeo"/> service for executing skopeo commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ISkopeo>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Skopeo.Services.ISkopeo>().")]
     public static ISkopeo Skopeo(this IPipelineContext context) => context.Services.GetRequiredService<ISkopeo>();
 }

--- a/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
+++ b/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
@@ -18,8 +18,6 @@ public static class SlackExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Slack.ISlack>().")]
-
     public static ISlack Slack(this IPipelineContext context) => context.Services.GetRequiredService<ISlack>();
 }

--- a/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
+++ b/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
@@ -17,5 +17,9 @@ public static class SlackExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.Slack.")]
+
     public static ISlack Slack(this IPipelineContext context) => context.Services.GetRequiredService<ISlack>();
 }

--- a/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
+++ b/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
@@ -19,7 +19,7 @@ public static class SlackExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Slack.")]
+    [global::System.Obsolete("Use context.Tools.Get<ISlack>().")]
 
     public static ISlack Slack(this IPipelineContext context) => context.Services.GetRequiredService<ISlack>();
 }

--- a/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
+++ b/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
@@ -19,7 +19,7 @@ public static class SlackExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<ISlack>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Slack.ISlack>().")]
 
     public static ISlack Slack(this IPipelineContext context) => context.Services.GetRequiredService<ISlack>();
 }

--- a/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
+++ b/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class SnykExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISnyk"/> service for executing snyk commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Snyk.")]
     public static ISnyk Snyk(this IPipelineContext context) => context.Services.GetRequiredService<ISnyk>();
 }

--- a/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
+++ b/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class SnykExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISnyk"/> service for executing snyk commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Snyk.")]
+    [global::System.Obsolete("Use context.Tools.Get<ISnyk>().")]
     public static ISnyk Snyk(this IPipelineContext context) => context.Services.GetRequiredService<ISnyk>();
 }

--- a/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
+++ b/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class SnykExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISnyk"/> service for executing snyk commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ISnyk>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Snyk.Services.ISnyk>().")]
     public static ISnyk Snyk(this IPipelineContext context) => context.Services.GetRequiredService<ISnyk>();
 }

--- a/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
+++ b/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class SonarScannerExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISonarScanner"/> service for executing sonar-scanner commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.SonarScanner.")]
     public static ISonarScanner SonarScanner(this IPipelineContext context) => context.Services.GetRequiredService<ISonarScanner>();
 }

--- a/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
+++ b/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class SonarScannerExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISonarScanner"/> service for executing sonar-scanner commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.SonarScanner.")]
+    [global::System.Obsolete("Use context.Tools.Get<ISonarScanner>().")]
     public static ISonarScanner SonarScanner(this IPipelineContext context) => context.Services.GetRequiredService<ISonarScanner>();
 }

--- a/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
+++ b/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class SonarScannerExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISonarScanner"/> service for executing sonar-scanner commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ISonarScanner>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.SonarScanner.Services.ISonarScanner>().")]
     public static ISonarScanner SonarScanner(this IPipelineContext context) => context.Services.GetRequiredService<ISonarScanner>();
 }

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -65,8 +65,8 @@ internal static class GeneratorDiagnostics
         "MPG0008",
         "Discoverable tool properties require C# 14",
         "Tool accessor '{0}' cannot generate a context.Tools property because language version "
-        + "'{1}' does not support extension members; use C# 14 or preview, or call the "
-        + "compatibility accessor context.{2}()",
+        + "'{1}' does not support extension members; use C# 14 or preview, or call "
+        + "context.Tools.Get<{2}>()",
         DiagnosticSeverity.Warning);
 
     public static DiagnosticDescriptor ConflictingToolProperty { get; } = Create(

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -362,7 +362,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 firstProperty.Location,
                 firstProperty.MethodName,
                 GetLanguageVersionDisplay(parseOptions),
-                EscapeIdentifier(firstProperty.Name)));
+                firstProperty.TypeName));
         }
         else if (uniqueToolProperties.Length > 0)
         {

--- a/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
+++ b/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
@@ -39,5 +39,7 @@ public static class SyftExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISyft"/> service for executing syft commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Syft.")]
     public static ISyft Syft(this IPipelineContext context) => context.Services.GetRequiredService<ISyft>();
 }

--- a/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
+++ b/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
@@ -40,6 +40,6 @@ public static class SyftExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISyft"/> service for executing syft commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Syft.")]
+    [global::System.Obsolete("Use context.Tools.Get<ISyft>().")]
     public static ISyft Syft(this IPipelineContext context) => context.Services.GetRequiredService<ISyft>();
 }

--- a/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
+++ b/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
@@ -40,6 +40,6 @@ public static class SyftExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISyft"/> service for executing syft commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ISyft>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Syft.Services.ISyft>().")]
     public static ISyft Syft(this IPipelineContext context) => context.Services.GetRequiredService<ISyft>();
 }

--- a/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
+++ b/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
@@ -19,7 +19,7 @@ public static class TeamCityExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.Get<ITeamCity>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.TeamCity.ITeamCity>().")]
 
     public static ITeamCity TeamCity(this IPipelineContext context) => context.Services.GetRequiredService<ITeamCity>();
 }

--- a/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
+++ b/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
@@ -19,7 +19,7 @@ public static class TeamCityExtensions
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 
-    [global::System.Obsolete("Use context.Tools.TeamCity.")]
+    [global::System.Obsolete("Use context.Tools.Get<ITeamCity>().")]
 
     public static ITeamCity TeamCity(this IPipelineContext context) => context.Services.GetRequiredService<ITeamCity>();
 }

--- a/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
+++ b/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
@@ -17,5 +17,9 @@ public static class TeamCityExtensions
         return services;
     }
 
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+
+    [global::System.Obsolete("Use context.Tools.TeamCity.")]
+
     public static ITeamCity TeamCity(this IPipelineContext context) => context.Services.GetRequiredService<ITeamCity>();
 }

--- a/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
+++ b/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
@@ -18,8 +18,6 @@ public static class TeamCityExtensions
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-
     [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.TeamCity.ITeamCity>().")]
-
     public static ITeamCity TeamCity(this IPipelineContext context) => context.Services.GetRequiredService<ITeamCity>();
 }

--- a/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
@@ -42,6 +42,6 @@ public static class TerraformExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITerraform"/> service for executing terraform commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Terraform.")]
+    [global::System.Obsolete("Use context.Tools.Get<ITerraform>().")]
     public static ITerraform Terraform(this IPipelineContext context) => context.Services.GetRequiredService<ITerraform>();
 }

--- a/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
@@ -42,6 +42,6 @@ public static class TerraformExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITerraform"/> service for executing terraform commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ITerraform>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Terraform.Services.ITerraform>().")]
     public static ITerraform Terraform(this IPipelineContext context) => context.Services.GetRequiredService<ITerraform>();
 }

--- a/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
@@ -41,5 +41,7 @@ public static class TerraformExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITerraform"/> service for executing terraform commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Terraform.")]
     public static ITerraform Terraform(this IPipelineContext context) => context.Services.GetRequiredService<ITerraform>();
 }

--- a/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
+++ b/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
@@ -41,5 +41,7 @@ public static class TrivyExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrivy"/> service for executing trivy commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Trivy.")]
     public static ITrivy Trivy(this IPipelineContext context) => context.Services.GetRequiredService<ITrivy>();
 }

--- a/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
+++ b/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
@@ -42,6 +42,6 @@ public static class TrivyExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrivy"/> service for executing trivy commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Trivy.")]
+    [global::System.Obsolete("Use context.Tools.Get<ITrivy>().")]
     public static ITrivy Trivy(this IPipelineContext context) => context.Services.GetRequiredService<ITrivy>();
 }

--- a/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
+++ b/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
@@ -42,6 +42,6 @@ public static class TrivyExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrivy"/> service for executing trivy commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<ITrivy>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Trivy.Services.ITrivy>().")]
     public static ITrivy Trivy(this IPipelineContext context) => context.Services.GetRequiredService<ITrivy>();
 }

--- a/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
+++ b/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class VaultExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IVault"/> service for executing vault commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Vault.")]
     public static IVault Vault(this IPipelineContext context) => context.Services.GetRequiredService<IVault>();
 }

--- a/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
+++ b/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class VaultExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IVault"/> service for executing vault commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IVault>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Vault.Services.IVault>().")]
     public static IVault Vault(this IPipelineContext context) => context.Services.GetRequiredService<IVault>();
 }

--- a/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
+++ b/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class VaultExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IVault"/> service for executing vault commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Vault.")]
+    [global::System.Obsolete("Use context.Tools.Get<IVault>().")]
     public static IVault Vault(this IPipelineContext context) => context.Services.GetRequiredService<IVault>();
 }

--- a/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class WingetExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IWinget"/> service for executing winget commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Winget.")]
+    [global::System.Obsolete("Use context.Tools.Get<IWinget>().")]
     public static IWinget Winget(this IPipelineContext context) => context.Services.GetRequiredService<IWinget>();
 }

--- a/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class WingetExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IWinget"/> service for executing winget commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Winget.")]
     public static IWinget Winget(this IPipelineContext context) => context.Services.GetRequiredService<IWinget>();
 }

--- a/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class WingetExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IWinget"/> service for executing winget commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IWinget>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.WinGet.Services.IWinget>().")]
     public static IWinget Winget(this IPipelineContext context) => context.Services.GetRequiredService<IWinget>();
 }

--- a/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class YarnExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYarn"/> service for executing yarn commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Yarn.")]
     public static IYarn Yarn(this IPipelineContext context) => context.Services.GetRequiredService<IYarn>();
 }

--- a/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class YarnExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYarn"/> service for executing yarn commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Yarn.")]
+    [global::System.Obsolete("Use context.Tools.Get<IYarn>().")]
     public static IYarn Yarn(this IPipelineContext context) => context.Services.GetRequiredService<IYarn>();
 }

--- a/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class YarnExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYarn"/> service for executing yarn commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IYarn>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Yarn.Services.IYarn>().")]
     public static IYarn Yarn(this IPipelineContext context) => context.Services.GetRequiredService<IYarn>();
 }

--- a/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
+++ b/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class YqExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYq"/> service for executing yq commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Yq.")]
+    [global::System.Obsolete("Use context.Tools.Get<IYq>().")]
     public static IYq Yq(this IPipelineContext context) => context.Services.GetRequiredService<IYq>();
 }

--- a/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
+++ b/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
@@ -38,6 +38,6 @@ public static class YqExtensions
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYq"/> service for executing yq commands.</returns>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [global::System.Obsolete("Use context.Tools.Get<IYq>().")]
+    [global::System.Obsolete("Use context.Tools.Get<global::ModularPipelines.Yq.Services.IYq>().")]
     public static IYq Yq(this IPipelineContext context) => context.Services.GetRequiredService<IYq>();
 }

--- a/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
+++ b/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
@@ -37,5 +37,7 @@ public static class YqExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYq"/> service for executing yq commands.</returns>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.Obsolete("Use context.Tools.Yq.")]
     public static IYq Yq(this IPipelineContext context) => context.Services.GetRequiredService<IYq>();
 }

--- a/test/ModularPipelines.Azure.UnitTests/AzureCommandTests.cs
+++ b/test/ModularPipelines.Azure.UnitTests/AzureCommandTests.cs
@@ -1,7 +1,6 @@
 using Azure.Identity;
 using Azure.ResourceManager;
 using Microsoft.Extensions.DependencyInjection;
-using ModularPipelines.Azure.Extensions;
 using ModularPipelines.Azure.Options;
 using ModularPipelines.Context;
 using ModularPipelines.Models;
@@ -20,7 +19,7 @@ public class AzureCommandTests : TestBase
     {
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await context.Azure().Az.Account.ListAsync(new AzAccountListOptions
+            return await context.Tools.Azure.Az.Account.ListAsync(new AzAccountListOptions
             {
                 All = true,
             }, new CommandExecutionOptions { InternalDryRun = true }, cancellationToken);
@@ -31,7 +30,7 @@ public class AzureCommandTests : TestBase
     {
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await context.Azure().Az.Account.ManagementGroup.ListAsync(new AzAccountManagementGroupListOptions(),
+            return await context.Tools.Azure.Az.Account.ManagementGroup.ListAsync(new AzAccountManagementGroupListOptions(),
                 new CommandExecutionOptions { InternalDryRun = true }, cancellationToken);
         }
     }

--- a/test/ModularPipelines.Docker.UnitTests/Helpers/DockerTests.cs
+++ b/test/ModularPipelines.Docker.UnitTests/Helpers/DockerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
-using ModularPipelines.Docker.Extensions;
 using ModularPipelines.Docker.Options;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
@@ -22,7 +21,7 @@ public class DockerTests : TestBase
                 .GetFolder("MyApp")
                 .GetFile("Dockerfile");
 
-            return await context.Docker().Image.BuildAsync(new DockerImageBuildOptions(pretendPath.Path)
+            return await context.Tools.Docker.Image.BuildAsync(new DockerImageBuildOptions(pretendPath.Path)
             {
                 BuildArg =
                 [

--- a/test/ModularPipelines.DotNet.UnitTests/DotNetTestResultsTests.cs
+++ b/test/ModularPipelines.DotNet.UnitTests/DotNetTestResultsTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.DotNet.Parsers.Trx;
 using ModularPipelines.Exceptions;
@@ -27,7 +26,7 @@ public class DotNetTestResultsTests : TestBase
         {
             var testProject = TestProjectPaths.TestsForTestsProject;
 
-            return await context.DotNet().TestAsync(
+            return await context.Tools.DotNet.TestAsync(
                 new DotNetTestOptions
                 {
                     Framework = "net10.0",
@@ -71,7 +70,7 @@ public class DotNetTestResultsTests : TestBase
         // IPipelineContext is a scoped service, so we need to create a scope
         await using var scope = host.Services.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<IPipelineContext>();
-        var parsedResults = await context.Trx().ParseTrxFile(TrxFixture);
+        var parsedResults = await context.Tools.Trx.ParseTrxFile(TrxFixture);
 
         await Assert.That(parsedResults.UnitTestResults).Count().IsEqualTo(4);
     }

--- a/test/ModularPipelines.DotNet.UnitTests/DotNetTests.cs
+++ b/test/ModularPipelines.DotNet.UnitTests/DotNetTests.cs
@@ -1,5 +1,4 @@
 using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -15,7 +14,7 @@ public class DotNetTests : TestBase
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // Use the main solution explicitly; the repository contains several solutions.
-            return await context.DotNet().Package.ListAsync(new DotNetPackageListOptions
+            return await context.Tools.DotNet.Package.ListAsync(new DotNetPackageListOptions
             {
                 Project = TestProjectPaths.CoreSolution,
             }, cancellationToken: cancellationToken);
@@ -26,7 +25,7 @@ public class DotNetTests : TestBase
     {
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await context.DotNet().FormatAsync(new DotNetFormatOptions
+            return await context.Tools.DotNet.FormatAsync(new DotNetFormatOptions
             {
                 ProjectSolution = TestProjectPaths.TestsForTestsProject,
             }, cancellationToken: cancellationToken);

--- a/test/ModularPipelines.Git.UnitTests/BranchConditionLoggingTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/BranchConditionLoggingTests.cs
@@ -6,7 +6,6 @@ using ModularPipelines.Context.Domains;
 using ModularPipelines.Git;
 using ModularPipelines.Git.Attributes;
 using ModularPipelines.Git.Models;
-using ModularPipelines.Logging;
 using Moq;
 
 namespace ModularPipelines.Git.UnitTests;
@@ -39,11 +38,10 @@ public class BranchConditionLoggingTests
             .ReturnsAsync(new GitRepositoryInfo(
                 new ModularPipelines.FileSystem.FolderPath(TestContext.WorkingDirectory)));
         var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
-        var services = new Mock<IServicesContext>();
-        services.Setup(x => x.GetRequiredService<IGit>()).Returns(git);
+        var tools = Mock.Of<IToolsContext>(x => x.Get<IGit>() == git);
         var context = Mock.Of<IPipelineContext>(x =>
             x.Logger == logger.Object &&
-            x.Services == services.Object);
+            x.Tools == tools);
 
         var result = await new RunIfBranchAttribute("main").EvaluateAsync(context);
         var logMessage = logger.Invocations
@@ -63,12 +61,11 @@ public class BranchConditionLoggingTests
             .ReturnsAsync(new GitRepositoryInfo(
                 new ModularPipelines.FileSystem.FolderPath(TestContext.WorkingDirectory)));
         var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
-        var services = new Mock<IServicesContext>();
-        services.Setup(x => x.GetRequiredService<IGit>()).Returns(git);
+        var tools = Mock.Of<IToolsContext>(x => x.Get<IGit>() == git);
         var logger = Mock.Of<ILogger>();
         var context = Mock.Of<IPipelineContext>(x =>
             x.Logger == logger &&
-            x.Services == services.Object);
+            x.Tools == tools);
         using var cancellationTokenSource = new CancellationTokenSource();
 
         await new RunIfBranchAttribute("main")

--- a/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
@@ -5,7 +5,6 @@ using ModularPipelines.Context.Domains;
 using ModularPipelines.Context.Domains.Shell;
 using Moq;
 using ModularPipelines.Git;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Git.Models;
 using ModularPipelines.Git.Options;
 using ModularPipelines.Models;
@@ -20,7 +19,7 @@ public class GitInformationTests : TestBase
     public async Task Repository_Info_Is_Cached()
     {
         var context = await GetService<IPipelineContext>();
-        var gitInformation = context.Git().Information;
+        var gitInformation = context.Tools.Git.Information;
         var first = await gitInformation.GetInfoAsync();
         var second = await gitInformation.GetInfoAsync();
 

--- a/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
@@ -9,6 +10,20 @@ namespace ModularPipelines.Git.UnitTests;
 
 public class GitIntegrationMetadataTests
 {
+    [Test]
+    public async Task LegacyContextAccessorIsHiddenAndObsolete()
+    {
+        var accessor = typeof(GitExtensions).GetMethod("Git")!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(accessor.GetCustomAttribute<EditorBrowsableAttribute>()!.State)
+                .IsEqualTo(EditorBrowsableState.Never);
+            await Assert.That(accessor.GetCustomAttribute<ObsoleteAttribute>()!.Message)
+                .IsEqualTo("Use context.Tools.Git.");
+        }
+    }
+
     [Test]
     public async Task GeneratedMetadataRegistersGitServices()
     {

--- a/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
@@ -20,7 +20,7 @@ public class GitIntegrationMetadataTests
             await Assert.That(accessor.GetCustomAttribute<EditorBrowsableAttribute>()!.State)
                 .IsEqualTo(EditorBrowsableState.Never);
             await Assert.That(accessor.GetCustomAttribute<ObsoleteAttribute>()!.Message)
-                .IsEqualTo("Use context.Tools.Get<IGit>().");
+                .IsEqualTo("Use context.Tools.Get<global::ModularPipelines.Git.IGit>().");
         }
     }
 

--- a/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
@@ -20,7 +20,7 @@ public class GitIntegrationMetadataTests
             await Assert.That(accessor.GetCustomAttribute<EditorBrowsableAttribute>()!.State)
                 .IsEqualTo(EditorBrowsableState.Never);
             await Assert.That(accessor.GetCustomAttribute<ObsoleteAttribute>()!.Message)
-                .IsEqualTo("Use context.Tools.Git.");
+                .IsEqualTo("Use context.Tools.Get<IGit>().");
         }
     }
 

--- a/test/ModularPipelines.Git.UnitTests/GitTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitTests.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Git;
-using ModularPipelines.Git.Extensions;
 using ModularPipelines.Git.Options;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -18,7 +17,7 @@ public class GitTests : TestBase
     {
         protected override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await context.Git().Commands.Repository.GitAsync(new GitBaseOptions
+            return await context.Tools.Git.Commands.Repository.GitAsync(new GitBaseOptions
             {
                 Version = true,
             }, cancellationToken: cancellationToken);

--- a/test/ModularPipelines.GitHub.UnitTests/Helpers/GitHubRepositoryInfoTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/Helpers/GitHubRepositoryInfoTests.cs
@@ -1,6 +1,5 @@
 using ModularPipelines.Context;
 using ModularPipelines.GitHub;
-using ModularPipelines.GitHub.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 
@@ -13,7 +12,7 @@ public class GitHubRepositoryInfoTests : TestBase
         protected internal override async Task<IGitHubRepositoryInfo> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return context.GitHub().RepositoryInfo;
+            return context.Tools.GitHub.RepositoryInfo;
         }
     }
 

--- a/test/ModularPipelines.Node.UnitTests/Helpers/NodeTests.cs
+++ b/test/ModularPipelines.Node.UnitTests/Helpers/NodeTests.cs
@@ -1,7 +1,6 @@
 using ModularPipelines.Context;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-using ModularPipelines.Node.Extensions;
 using ModularPipelines.TestHelpers;
 using ModularPipelines.TestHelpers.Assertions;
 
@@ -13,7 +12,7 @@ public class NodeTests : TestBase
     {
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await context.Node().VersionAsync(cancellationToken: cancellationToken);
+            return await context.Tools.Node.VersionAsync(cancellationToken: cancellationToken);
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -215,7 +215,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             await Assert.That(diagnostic.Id).IsEqualTo("MPG0008");
             await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
             await Assert.That(diagnostic.GetMessage()).Contains("C# 14");
-            await Assert.That(diagnostic.GetMessage()).Contains("context.Git()");
+            await Assert.That(diagnostic.GetMessage()).Contains("context.Tools.Get<global::IGit>()");
             await Assert.That(generatedSource).DoesNotContain("extension(");
             await Assert.That(generatedSource)
                 .Contains("global::GitIntegration.Register(services);");
@@ -250,7 +250,7 @@ public class ModularPipelinesIntegrationGeneratorTests
         var diagnostic = result.Diagnostics.Single();
 
         await Assert.That(diagnostic.Id).IsEqualTo("MPG0008");
-        await Assert.That(diagnostic.GetMessage()).Contains("context.@class()");
+        await Assert.That(diagnostic.GetMessage()).Contains("context.Tools.Get<global::IClassTool>()");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -3,7 +3,6 @@ using System.Reflection.Emit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Cmd;
-using ModularPipelines.Cmd.Extensions;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Context.Domains.Environment;
@@ -47,6 +46,24 @@ public class ContextExtensionsTests
             await Assert.That(exception!.Message).Contains("Register it with the pipeline service collection");
             await Assert.That(exception.Message).DoesNotContain("ModularPipelinesIntegration");
             await Assert.That(exception.Message).DoesNotContain("Native AOT");
+        }
+    }
+
+    [Test]
+    public async Task CmdTool_WhenIntegrationNotRegistered_ShouldSuggestAttributedRegistration()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var toolsContext = new ToolsContext(CreateServicesContext(serviceProvider));
+
+        var exception = await Assert.That(() => toolsContext.Cmd)
+            .ThrowsExactly<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("ModularPipelines.Cmd");
+            await Assert.That(exception.Message).Contains("[ModularPipelinesIntegration]");
+            await Assert.That(exception.Message).Contains("Native AOT");
+            await Assert.That(exception.Message).DoesNotContain("Register*Context()");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -259,7 +259,7 @@ public class GeneratorHardeningTests
         var expectedDeclaration = string.Join(Environment.NewLine,
         [
             "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]",
-            "    [global::System.Obsolete(\"Use context.Tools.Get<ITool>().\")]",
+            "    [global::System.Obsolete(\"Use context.Tools.Get<global::ModularPipelines.Tool.Services.ITool>().\")]",
             "    public static ITool Tool(this IPipelineContext context)",
         ]);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -256,12 +256,14 @@ public class GeneratorHardeningTests
             .GenerateAsync(Tool(Command("ToolRunOptions", "ToolOptions", ["run"]))))
             .Single();
 
-        await Assert.That(registrationFile.Content)
-            .Contains("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
-        await Assert.That(registrationFile.Content)
-            .Contains("[global::System.Obsolete(\"Use context.Tools.Tool.\")]");
-        await Assert.That(registrationFile.Content)
-            .Contains("public static ITool Tool(this IPipelineContext context)");
+        var expectedDeclaration = string.Join(Environment.NewLine,
+        [
+            "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]",
+            "    [global::System.Obsolete(\"Use context.Tools.Get<ITool>().\")]",
+            "    public static ITool Tool(this IPipelineContext context)",
+        ]);
+
+        await Assert.That(registrationFile.Content).Contains(expectedDeclaration);
     }
 
     #region NormalizeCommandClassNames

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -249,6 +249,21 @@ public class GeneratorHardeningTests
             .DoesNotContain("public static ITool Tool(this IPipelineContext context)");
     }
 
+    [Test]
+    public async Task Command_Facade_Compatibility_Accessor_Is_Hidden_And_Obsolete()
+    {
+        var registrationFile = (await new DependencyRegistrationGenerator()
+            .GenerateAsync(Tool(Command("ToolRunOptions", "ToolOptions", ["run"]))))
+            .Single();
+
+        await Assert.That(registrationFile.Content)
+            .Contains("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
+        await Assert.That(registrationFile.Content)
+            .Contains("[global::System.Obsolete(\"Use context.Tools.Tool.\")]");
+        await Assert.That(registrationFile.Content)
+            .Contains("public static ITool Tool(this IPipelineContext context)");
+    }
+
     #region NormalizeCommandClassNames
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -56,9 +56,7 @@ public class MarkdownDocumentationGeneratorTests
             .Contains("This package does not install the `fake-cli` executable");
         await Assert.That(files[0].Content).Contains("`fake-cli` is available on `PATH`");
         await Assert.That(files[0].Content).Contains("context.Tools.Fake");
-        await Assert.That(files[0].Content).Contains("compatibility fallback");
-        await Assert.That(files[0].Content)
-            .Contains("import `ModularPipelines.Fake.Extensions`");
+        await Assert.That(files[0].Content).DoesNotContain("context.Fake()");
         await Assert.That(files[0].Content)
             .DoesNotContain("using ModularPipelines.Fake.Extensions;");
         await Assert.That(files[0].Content).Contains("using ModularPipelines.Context;");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -56,6 +56,7 @@ public class MarkdownDocumentationGeneratorTests
             .Contains("This package does not install the `fake-cli` executable");
         await Assert.That(files[0].Content).Contains("`fake-cli` is available on `PATH`");
         await Assert.That(files[0].Content).Contains("context.Tools.Fake");
+        await Assert.That(files[0].Content).Contains("context.Tools.Get<IFake>()");
         await Assert.That(files[0].Content).DoesNotContain("context.Fake()");
         await Assert.That(files[0].Content)
             .DoesNotContain("using ModularPipelines.Fake.Extensions;");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -56,7 +56,8 @@ public class MarkdownDocumentationGeneratorTests
             .Contains("This package does not install the `fake-cli` executable");
         await Assert.That(files[0].Content).Contains("`fake-cli` is available on `PATH`");
         await Assert.That(files[0].Content).Contains("context.Tools.Fake");
-        await Assert.That(files[0].Content).Contains("context.Tools.Get<IFake>()");
+        await Assert.That(files[0].Content)
+            .Contains("context.Tools.Get<ModularPipelines.Fake.Services.IFake>()");
         await Assert.That(files[0].Content).DoesNotContain("context.Fake()");
         await Assert.That(files[0].Content)
             .DoesNotContain("using ModularPipelines.Fake.Extensions;");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -122,7 +122,8 @@ public class DependencyRegistrationGenerator : ICodeGenerator
             sb.AppendLine("    /// <param name=\"context\">The pipeline context.</param>");
             sb.AppendLine($"    /// <returns>The <see cref=\"{interfaceName}\"/> service for executing {tool.ToolName} commands.</returns>");
             sb.AppendLine("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
-            sb.AppendLine($"    [global::System.Obsolete(\"Use context.Tools.Get<I{serviceName}>().\")]");
+            sb.AppendLine(
+                $"    [global::System.Obsolete(\"Use context.Tools.Get<global::{tool.TargetNamespace}.Services.I{serviceName}>().\")]");
             sb.AppendLine($"    public static {interfaceName} {serviceName}(this IPipelineContext context) => context.Services.GetRequiredService<{interfaceName}>();");
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -121,6 +121,8 @@ public class DependencyRegistrationGenerator : ICodeGenerator
             sb.AppendLine("    /// </summary>");
             sb.AppendLine("    /// <param name=\"context\">The pipeline context.</param>");
             sb.AppendLine($"    /// <returns>The <see cref=\"{interfaceName}\"/> service for executing {tool.ToolName} commands.</returns>");
+            sb.AppendLine("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
+            sb.AppendLine($"    [global::System.Obsolete(\"Use context.Tools.{serviceName}.\")]");
             sb.AppendLine($"    public static {interfaceName} {serviceName}(this IPipelineContext context) => context.Services.GetRequiredService<{interfaceName}>();");
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -122,7 +122,7 @@ public class DependencyRegistrationGenerator : ICodeGenerator
             sb.AppendLine("    /// <param name=\"context\">The pipeline context.</param>");
             sb.AppendLine($"    /// <returns>The <see cref=\"{interfaceName}\"/> service for executing {tool.ToolName} commands.</returns>");
             sb.AppendLine("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
-            sb.AppendLine($"    [global::System.Obsolete(\"Use context.Tools.{serviceName}.\")]");
+            sb.AppendLine($"    [global::System.Obsolete(\"Use context.Tools.Get<I{serviceName}>().\")]");
             sb.AppendLine($"    public static {interfaceName} {serviceName}(this IPipelineContext context) => context.Services.GetRequiredService<{interfaceName}>();");
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -65,10 +65,7 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine($"dotnet add package {tool.TargetNamespace}");
         sb.AppendLine("```");
         sb.AppendLine();
-        sb.AppendLine(
-            $"Resolve the service with `context.Tools.{tool.NamespacePrefix}`. "
-            + $"For projects older than C# 14, import `{tool.TargetNamespace}.Extensions` "
-            + $"and use the `context.{tool.NamespacePrefix}()` extension method as a compatibility fallback.");
+        sb.AppendLine($"Resolve the service with `context.Tools.{tool.NamespacePrefix}`.");
         sb.AppendLine();
         AppendExample(sb, tool, commands);
         AppendGlobalOptions(sb, tool);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -66,6 +66,8 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine("```");
         sb.AppendLine();
         sb.AppendLine($"Resolve the service with `context.Tools.{tool.NamespacePrefix}`.");
+        sb.AppendLine(
+            $"Projects using C# 13 or another .NET language can use `context.Tools.Get<I{tool.NamespacePrefix}>()` instead.");
         sb.AppendLine();
         AppendExample(sb, tool, commands);
         AppendGlobalOptions(sb, tool);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -67,7 +67,7 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine();
         sb.AppendLine($"Resolve the service with `context.Tools.{tool.NamespacePrefix}`.");
         sb.AppendLine(
-            $"Projects using C# 13 or another .NET language can use `context.Tools.Get<I{tool.NamespacePrefix}>()` instead.");
+            $"Projects using C# 13 or another .NET language can use `context.Tools.Get<{tool.TargetNamespace}.Services.I{tool.NamespacePrefix}>()` instead.");
         sb.AppendLine();
         AppendExample(sb, tool, commands);
         AppendGlobalOptions(sb, tool);


### PR DESCRIPTION
Closes #4228.

## Summary
- mark all 58 legacy context tool extension methods obsolete and hidden from IntelliSense while retaining the C# 13/F# compatibility path for one final major
- make context.Tools.* canonical throughout the build pipeline, current tests, generated CLI docs, and source-generator guidance
- update the options generator so regenerated integrations and documentation preserve the v4 policy
- add generator and handwritten Git accessor coverage

## Validation
- ModularPipelines.slnx Release build: 0 warnings/errors
- OptionsGenerator solution Release build: 0 warnings/errors
- GeneratorHardeningTests: 174/174
- MarkdownDocumentationGeneratorTests: 27/27
- Git solution Release build: 0 warnings/errors, including CI-mode PublicApiAnalyzers
- DotNet solution Release build: 0 warnings/errors
- Node solution Release build: 0 warnings/errors
- Docker solution Release build: 0 warnings/errors
- GitHub solution Release build: 0 errors (3 existing test nullability warnings)
- ContextExtensionsTests: 19/19
- GitIntegrationMetadataTests: 2/2
- public API baseline assertion: 61 projects verified
- automated source audit: 58/58 legacy accessors have matching EditorBrowsable(Never) and Obsolete attributes
- git diff --check

Azure's guarded local build reached the mandated 2 GB process-tree limit (2071 MB) and was not retried with a raised limit; CI will run that expensive integration build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized tool access through the discoverable `context.Tools.*` API across integrations.
  * Legacy context accessors now provide deprecation guidance and are hidden from IntelliSense.

* **Documentation**
  * Updated integration and CLI guides to show `context.Tools.*` usage.
  * Added guidance for C# 13 and other .NET languages using `context.Tools.Get<T>()`.
  * Simplified migration and diagnostic guidance by removing outdated compatibility-fallback instructions.

* **Tests**
  * Updated tests and generator validations for the new access pattern and legacy accessor metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->