### PR TITLE
Align context service resolution

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -79,6 +79,20 @@ Replace the removed `WindowsRequirement`, `LinuxRequirement`, `MacOSRequirement`
 `Require.MacOS()`, and `Require.WindowsAdmin()`. `Require.CIEnvironment()` is now
 `Require.Ci()`. `FailedRequirementsException` is now
 `RequirementNotMetException`.
+## Service resolution
+
+Service lookup on `context.Services` now follows the standard .NET naming and
+nullability convention:
+
+- `Get<T>()` is now `GetRequiredService<T>()` and throws when the service is missing.
+- `TryGet<T>()` is now `GetService<T>()` and returns `null` when the service is missing.
+- The duplicate `context.GetService<T>()` and `context.TryGetService<T>()` extension
+  methods have been removed. Resolve services through `context.Services` instead.
+
+```csharp
+var required = context.Services.GetRequiredService<IMyService>();
+var optional = context.Services.GetService<IOptionalService>();
+```
 
 ## Failure modes and execution hints
 

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -160,7 +160,7 @@ registration method:
 
 ```csharp
 public static IPrivateWidget PrivateWidget(this IPipelineContext context) =>
-    context.Services.Get<IPrivateWidget>();
+    context.Services.GetRequiredService<IPrivateWidget>();
 ```
 
 The generator uses that shared declaring type to associate the accessor with its

--- a/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
+++ b/src/ModularPipelines.AmazonWebServices/Extensions/AwsExtensions.Generated.cs
@@ -37,6 +37,6 @@ public static class AwsExtensions
     /// <returns>The aws service.</returns>
     public static IAws Aws(this IPipelineContext context)
     {
-        return context.Services.Get<IAws>();
+        return context.Services.GetRequiredService<IAws>();
     }
 }

--- a/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class AnsibleExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAnsible"/> service for executing ansible commands.</returns>
-    public static IAnsible Ansible(this IPipelineContext context) => context.Services.Get<IAnsible>();
+    public static IAnsible Ansible(this IPipelineContext context) => context.Services.GetRequiredService<IAnsible>();
 }

--- a/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Extensions/ArgoCdExtensions.Generated.cs
@@ -47,5 +47,5 @@ public static class ArgoCdExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IArgoCd"/> service for executing argocd commands.</returns>
-    public static IArgoCd ArgoCd(this IPipelineContext context) => context.Services.Get<IArgoCd>();
+    public static IArgoCd ArgoCd(this IPipelineContext context) => context.Services.GetRequiredService<IArgoCd>();
 }

--- a/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
+++ b/src/ModularPipelines.Azure.Pipelines/Extensions/AzurePipelineExtensions.cs
@@ -18,5 +18,5 @@ public static class AzurePipelineExtensions
         return services;
     }
 
-    public static IAzurePipeline AzurePipeline(this IPipelineContext context) => context.Services.Get<IAzurePipeline>();
+    public static IAzurePipeline AzurePipeline(this IPipelineContext context) => context.Services.GetRequiredService<IAzurePipeline>();
 }

--- a/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzExtensions.Generated.cs
@@ -118,5 +118,5 @@ public static class AzExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAz"/> service for executing az commands.</returns>
-    public static IAz Az(this IPipelineContext context) => context.Services.Get<IAz>();
+    public static IAz Az(this IPipelineContext context) => context.Services.GetRequiredService<IAz>();
 }

--- a/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
+++ b/src/ModularPipelines.Azure/Extensions/AzureExtensions.cs
@@ -86,6 +86,6 @@ public static class AzureExtensions
     /// <returns>The Azure services.</returns>
     public static IAzure Azure(this IPipelineContext context)
     {
-        return context.Services.Get<IAzure>();
+        return context.Services.GetRequiredService<IAzure>();
     }
 }

--- a/src/ModularPipelines.Build/Attributes/SkipIfNoStandardGitHubToken.cs
+++ b/src/ModularPipelines.Build/Attributes/SkipIfNoStandardGitHubToken.cs
@@ -15,7 +15,7 @@ public class SkipIfNoStandardGitHubToken : Attribute, IConditionAttribute
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
-        var options = pipelineContext.Services.Get<IOptions<GitHubSettings>>();
+        var options = pipelineContext.Services.GetRequiredService<IOptions<GitHubSettings>>();
 
         return Task.FromResult(string.IsNullOrEmpty(options?.Value.StandardToken));
     }

--- a/src/ModularPipelines.Build/GitHelpers.cs
+++ b/src/ModularPipelines.Build/GitHelpers.cs
@@ -75,7 +75,7 @@ public static class GitHelpers
 
     private static GitHubSettings GetGitHubSettings(IModuleContext context)
     {
-        var options = context.Services.Get<IOptions<GitHubSettings>>();
+        var options = context.Services.GetRequiredService<IOptions<GitHubSettings>>();
         return options?.Value ?? new GitHubSettings();
     }
 }

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -139,7 +139,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
         }
 
         var testResults = await context.Trx().ParseTrxFile(trxFile);
-        var consoleWriter = context.GetService<IConsoleWriter>();
+        var consoleWriter = context.Services.GetRequiredService<IConsoleWriter>();
         PrintFailedTests(consoleWriter, testResults.UnitTestResults, trxFile.Path);
         PrintSkippedTests(consoleWriter, testResults.UnitTestResults);
     }

--- a/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Extensions/BuildahExtensions.Generated.cs
@@ -39,5 +39,5 @@ public static class BuildahExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBuildah"/> service for executing buildah commands.</returns>
-    public static IBuildah Buildah(this IPipelineContext context) => context.Services.Get<IBuildah>();
+    public static IBuildah Buildah(this IPipelineContext context) => context.Services.GetRequiredService<IBuildah>();
 }

--- a/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class ChocoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IChoco"/> service for executing choco commands.</returns>
-    public static IChoco Choco(this IPipelineContext context) => context.Services.Get<IChoco>();
+    public static IChoco Choco(this IPipelineContext context) => context.Services.GetRequiredService<IChoco>();
 }

--- a/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
+++ b/src/ModularPipelines.Cmd/Extensions/CmdExtensions.cs
@@ -30,5 +30,5 @@ public static class CmdExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The Command Prompt context.</returns>
-    public static ICmdContext Cmd(this IPipelineContext context) => context.Services.Get<ICmdContext>();
+    public static ICmdContext Cmd(this IPipelineContext context) => context.Services.GetRequiredService<ICmdContext>();
 }

--- a/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
+++ b/src/ModularPipelines.Cosign/Extensions/CosignExtensions.Generated.cs
@@ -43,5 +43,5 @@ public static class CosignExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICosign"/> service for executing cosign commands.</returns>
-    public static ICosign Cosign(this IPipelineContext context) => context.Services.Get<ICosign>();
+    public static ICosign Cosign(this IPipelineContext context) => context.Services.GetRequiredService<ICosign>();
 }

--- a/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
+++ b/src/ModularPipelines.Docker/Extensions/DockerExtensions.Generated.cs
@@ -52,5 +52,5 @@ public static class DockerExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDocker"/> service for executing docker commands.</returns>
-    public static IDocker Docker(this IPipelineContext context) => context.Services.Get<IDocker>();
+    public static IDocker Docker(this IPipelineContext context) => context.Services.GetRequiredService<IDocker>();
 }

--- a/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
+++ b/src/ModularPipelines.DotNet/Extensions.Manual/TrxExtensions.cs
@@ -35,5 +35,5 @@ public static class TrxExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrx"/> service for parsing TRX test result files.</returns>
-    public static ITrx Trx(this IPipelineContext context) => context.Services.Get<ITrx>();
+    public static ITrx Trx(this IPipelineContext context) => context.Services.GetRequiredService<ITrx>();
 }

--- a/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Extensions/DotNetExtensions.Generated.cs
@@ -47,5 +47,5 @@ public static class DotNetExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IDotNet"/> service for executing dotnet commands.</returns>
-    public static IDotNet DotNet(this IPipelineContext context) => context.Services.Get<IDotNet>();
+    public static IDotNet DotNet(this IPipelineContext context) => context.Services.GetRequiredService<IDotNet>();
 }

--- a/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
@@ -52,5 +52,5 @@ public static class EksctlExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IEksctl"/> service for executing eksctl commands.</returns>
-    public static IEksctl Eksctl(this IPipelineContext context) => context.Services.Get<IEksctl>();
+    public static IEksctl Eksctl(this IPipelineContext context) => context.Services.GetRequiredService<IEksctl>();
 }

--- a/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
+++ b/src/ModularPipelines.Email/Extensions/EmailExtensions.cs
@@ -16,5 +16,5 @@ public static class EmailExtensions
         return services;
     }
 
-    public static IEmail Email(this IPipelineContext context) => context.Services.Get<IEmail>();
+    public static IEmail Email(this IPipelineContext context) => context.Services.GetRequiredService<IEmail>();
 }

--- a/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
+++ b/src/ModularPipelines.Flux/Extensions/FluxExtensions.Generated.cs
@@ -55,5 +55,5 @@ public static class FluxExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlux"/> service for executing flux commands.</returns>
-    public static IFlux Flux(this IPipelineContext context) => context.Services.Get<IFlux>();
+    public static IFlux Flux(this IPipelineContext context) => context.Services.GetRequiredService<IFlux>();
 }

--- a/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
+++ b/src/ModularPipelines.Flyway/Extensions/FlywayExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class FlywayExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IFlyway"/> service for executing flyway commands.</returns>
-    public static IFlyway Flyway(this IPipelineContext context) => context.Services.Get<IFlyway>();
+    public static IFlyway Flyway(this IPipelineContext context) => context.Services.GetRequiredService<IFlyway>();
 }

--- a/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
+++ b/src/ModularPipelines.Ftp/Extensions/FtpExtensions.cs
@@ -16,5 +16,5 @@ public static class FtpExtensions
         return services;
     }
 
-    public static IFtp Ftp(this IPipelineContext context) => context.Services.Get<IFtp>();
+    public static IFtp Ftp(this IPipelineContext context) => context.Services.GetRequiredService<IFtp>();
 }

--- a/src/ModularPipelines.Git/Extensions/GitExtensions.cs
+++ b/src/ModularPipelines.Git/Extensions/GitExtensions.cs
@@ -40,5 +40,5 @@ public static class GitExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGit"/> service for executing Git commands and accessing repository information.</returns>
-    public static IGit Git(this IPipelineContext context) => context.Services.Get<IGit>();
+    public static IGit Git(this IPipelineContext context) => context.Services.GetRequiredService<IGit>();
 }

--- a/src/ModularPipelines.GitHub/Attributes/SkipIfDependabotAttribute.cs
+++ b/src/ModularPipelines.GitHub/Attributes/SkipIfDependabotAttribute.cs
@@ -13,7 +13,7 @@ public class SkipIfDependabotAttribute : Attribute, IConditionAttribute
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
-        var isDependabot = pipelineContext.Services.Get<IGitHubEnvironmentVariables>()?.Actor == "dependabot[bot]";
+        var isDependabot = pipelineContext.Services.GetRequiredService<IGitHubEnvironmentVariables>()?.Actor == "dependabot[bot]";
 
         return Task.FromResult(isDependabot);
     }

--- a/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
@@ -57,5 +57,5 @@ public static class GhExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGh"/> service for executing gh commands.</returns>
-    public static IGh Gh(this IPipelineContext context) => context.Services.Get<IGh>();
+    public static IGh Gh(this IPipelineContext context) => context.Services.GetRequiredService<IGh>();
 }

--- a/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GitHubExtensions.cs
@@ -45,5 +45,5 @@ public static class GitHubExtensions
         return services;
     }
 
-    public static IGitHub GitHub(this IPipelineContext context) => context.Services.Get<IGitHub>();
+    public static IGitHub GitHub(this IPipelineContext context) => context.Services.GetRequiredService<IGitHub>();
 }

--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class GoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGo"/> service for executing go commands.</returns>
-    public static IGo Go(this IPipelineContext context) => context.Services.Get<IGo>();
+    public static IGo Go(this IPipelineContext context) => context.Services.GetRequiredService<IGo>();
 }

--- a/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
+++ b/src/ModularPipelines.Google/Extensions/GcloudExtensions.Generated.cs
@@ -165,5 +165,5 @@ public static class GcloudExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGcloud"/> service for executing gcloud commands.</returns>
-    public static IGcloud Gcloud(this IPipelineContext context) => context.Services.Get<IGcloud>();
+    public static IGcloud Gcloud(this IPipelineContext context) => context.Services.GetRequiredService<IGcloud>();
 }

--- a/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
+++ b/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
@@ -38,5 +38,5 @@ public static class GrypeExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGrype"/> service for executing grype commands.</returns>
-    public static IGrype Grype(this IPipelineContext context) => context.Services.Get<IGrype>();
+    public static IGrype Grype(this IPipelineContext context) => context.Services.GetRequiredService<IGrype>();
 }

--- a/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class HadolintExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHadolint"/> service for executing hadolint commands.</returns>
-    public static IHadolint Hadolint(this IPipelineContext context) => context.Services.Get<IHadolint>();
+    public static IHadolint Hadolint(this IPipelineContext context) => context.Services.GetRequiredService<IHadolint>();
 }

--- a/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
+++ b/src/ModularPipelines.Helm/Extensions/HelmExtensions.Generated.cs
@@ -44,5 +44,5 @@ public static class HelmExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHelm"/> service for executing helm commands.</returns>
-    public static IHelm Helm(this IPipelineContext context) => context.Services.Get<IHelm>();
+    public static IHelm Helm(this IPipelineContext context) => context.Services.GetRequiredService<IHelm>();
 }

--- a/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Extensions/BrewExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class BrewExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IBrew"/> service for executing brew commands.</returns>
-    public static IBrew Brew(this IPipelineContext context) => context.Services.Get<IBrew>();
+    public static IBrew Brew(this IPipelineContext context) => context.Services.GetRequiredService<IBrew>();
 }

--- a/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/GradleExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class GradleExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGradle"/> service for executing gradle commands.</returns>
-    public static IGradle Gradle(this IPipelineContext context) => context.Services.Get<IGradle>();
+    public static IGradle Gradle(this IPipelineContext context) => context.Services.GetRequiredService<IGradle>();
 }

--- a/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class MavenExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMaven"/> service for executing mvn commands.</returns>
-    public static IMaven Maven(this IPipelineContext context) => context.Services.Get<IMaven>();
+    public static IMaven Maven(this IPipelineContext context) => context.Services.GetRequiredService<IMaven>();
 }

--- a/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
+++ b/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class JqExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IJq"/> service for executing jq commands.</returns>
-    public static IJq Jq(this IPipelineContext context) => context.Services.Get<IJq>();
+    public static IJq Jq(this IPipelineContext context) => context.Services.GetRequiredService<IJq>();
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -43,5 +43,5 @@ public static class KindExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKind"/> service for executing kind commands.</returns>
-    public static IKind Kind(this IPipelineContext context) => context.Services.Get<IKind>();
+    public static IKind Kind(this IPipelineContext context) => context.Services.GetRequiredService<IKind>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
@@ -45,5 +45,5 @@ public static class KubernetesExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKubernetes"/> service for executing kubectl commands.</returns>
-    public static IKubernetes Kubernetes(this IPipelineContext context) => context.Services.Get<IKubernetes>();
+    public static IKubernetes Kubernetes(this IPipelineContext context) => context.Services.GetRequiredService<IKubernetes>();
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
@@ -40,5 +40,5 @@ public static class KustomizeExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKustomize"/> service for executing kustomize commands.</returns>
-    public static IKustomize Kustomize(this IPipelineContext context) => context.Services.Get<IKustomize>();
+    public static IKustomize Kustomize(this IPipelineContext context) => context.Services.GetRequiredService<IKustomize>();
 }

--- a/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class LiquibaseExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ILiquibase"/> service for executing liquibase commands.</returns>
-    public static ILiquibase Liquibase(this IPipelineContext context) => context.Services.Get<ILiquibase>();
+    public static ILiquibase Liquibase(this IPipelineContext context) => context.Services.GetRequiredService<ILiquibase>();
 }

--- a/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
+++ b/src/ModularPipelines.MicrosoftTeams/Extensions/MicrosoftTeamsExtensions.cs
@@ -16,5 +16,5 @@ public static class MicrosoftTeamsExtensions
         return services;
     }
 
-    public static IMicrosoftTeams MicrosoftTeams(this IPipelineContext context) => context.Services.Get<IMicrosoftTeams>();
+    public static IMicrosoftTeams MicrosoftTeams(this IPipelineContext context) => context.Services.GetRequiredService<IMicrosoftTeams>();
 }

--- a/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Extensions/MinikubeExtensions.Generated.cs
@@ -44,5 +44,5 @@ public static class MinikubeExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMinikube"/> service for executing minikube commands.</returns>
-    public static IMinikube Minikube(this IPipelineContext context) => context.Services.Get<IMinikube>();
+    public static IMinikube Minikube(this IPipelineContext context) => context.Services.GetRequiredService<IMinikube>();
 }

--- a/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
+++ b/src/ModularPipelines.NerdbankGitVersioning/Extensions/NbgvExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class NbgvExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INbgv"/> service for executing nbgv commands.</returns>
-    public static INbgv Nbgv(this IPipelineContext context) => context.Services.Get<INbgv>();
+    public static INbgv Nbgv(this IPipelineContext context) => context.Services.GetRequiredService<INbgv>();
 }

--- a/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Newman/Extensions/NewmanExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class NewmanExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="INewman"/> service for executing newman commands.</returns>
-    public static INewman Newman(this IPipelineContext context) => context.Services.Get<INewman>();
+    public static INewman Newman(this IPipelineContext context) => context.Services.GetRequiredService<INewman>();
 }

--- a/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
+++ b/src/ModularPipelines.Node/Extensions/NodeExtensions.cs
@@ -17,5 +17,5 @@ public static class NodeExtensions
         return services;
     }
 
-    public static INode Node(this IPipelineContext context) => context.Services.Get<INode>();
+    public static INode Node(this IPipelineContext context) => context.Services.GetRequiredService<INode>();
 }

--- a/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
+++ b/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class PnpmExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPnpm"/> service for executing pnpm commands.</returns>
-    public static IPnpm Pnpm(this IPipelineContext context) => context.Services.Get<IPnpm>();
+    public static IPnpm Pnpm(this IPipelineContext context) => context.Services.GetRequiredService<IPnpm>();
 }

--- a/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
+++ b/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class PackerExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPacker"/> service for executing packer commands.</returns>
-    public static IPacker Packer(this IPipelineContext context) => context.Services.Get<IPacker>();
+    public static IPacker Packer(this IPipelineContext context) => context.Services.GetRequiredService<IPacker>();
 }

--- a/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
@@ -53,5 +53,5 @@ public static class PodmanExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPodman"/> service for executing podman commands.</returns>
-    public static IPodman Podman(this IPipelineContext context) => context.Services.Get<IPodman>();
+    public static IPodman Podman(this IPipelineContext context) => context.Services.GetRequiredService<IPodman>();
 }

--- a/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Extensions/PulumiExtensions.Generated.cs
@@ -52,5 +52,5 @@ public static class PulumiExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPulumi"/> service for executing pulumi commands.</returns>
-    public static IPulumi Pulumi(this IPipelineContext context) => context.Services.Get<IPulumi>();
+    public static IPulumi Pulumi(this IPipelineContext context) => context.Services.GetRequiredService<IPulumi>();
 }

--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class PipExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPip"/> service for executing pip commands.</returns>
-    public static IPip Pip(this IPipelineContext context) => context.Services.Get<IPip>();
+    public static IPip Pip(this IPipelineContext context) => context.Services.GetRequiredService<IPip>();
 }

--- a/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
+++ b/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class CargoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICargo"/> service for executing cargo commands.</returns>
-    public static ICargo Cargo(this IPipelineContext context) => context.Services.Get<ICargo>();
+    public static ICargo Cargo(this IPipelineContext context) => context.Services.GetRequiredService<ICargo>();
 }

--- a/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Extensions/ShellcheckExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class ShellcheckExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IShellcheck"/> service for executing shellcheck commands.</returns>
-    public static IShellcheck Shellcheck(this IPipelineContext context) => context.Services.Get<IShellcheck>();
+    public static IShellcheck Shellcheck(this IPipelineContext context) => context.Services.GetRequiredService<IShellcheck>();
 }

--- a/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class SkopeoExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISkopeo"/> service for executing skopeo commands.</returns>
-    public static ISkopeo Skopeo(this IPipelineContext context) => context.Services.Get<ISkopeo>();
+    public static ISkopeo Skopeo(this IPipelineContext context) => context.Services.GetRequiredService<ISkopeo>();
 }

--- a/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
+++ b/src/ModularPipelines.Slack/Extensions/SlackExtensions.cs
@@ -17,5 +17,5 @@ public static class SlackExtensions
         return services;
     }
 
-    public static ISlack Slack(this IPipelineContext context) => context.Services.Get<ISlack>();
+    public static ISlack Slack(this IPipelineContext context) => context.Services.GetRequiredService<ISlack>();
 }

--- a/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
+++ b/src/ModularPipelines.Snyk/Extensions/SnykExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class SnykExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISnyk"/> service for executing snyk commands.</returns>
-    public static ISnyk Snyk(this IPipelineContext context) => context.Services.Get<ISnyk>();
+    public static ISnyk Snyk(this IPipelineContext context) => context.Services.GetRequiredService<ISnyk>();
 }

--- a/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
+++ b/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class SonarScannerExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISonarScanner"/> service for executing sonar-scanner commands.</returns>
-    public static ISonarScanner SonarScanner(this IPipelineContext context) => context.Services.Get<ISonarScanner>();
+    public static ISonarScanner SonarScanner(this IPipelineContext context) => context.Services.GetRequiredService<ISonarScanner>();
 }

--- a/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
+++ b/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
@@ -39,5 +39,5 @@ public static class SyftExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISyft"/> service for executing syft commands.</returns>
-    public static ISyft Syft(this IPipelineContext context) => context.Services.Get<ISyft>();
+    public static ISyft Syft(this IPipelineContext context) => context.Services.GetRequiredService<ISyft>();
 }

--- a/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
+++ b/src/ModularPipelines.TeamCity/Extensions/TeamCityExtensions.cs
@@ -17,5 +17,5 @@ public static class TeamCityExtensions
         return services;
     }
 
-    public static ITeamCity TeamCity(this IPipelineContext context) => context.Services.Get<ITeamCity>();
+    public static ITeamCity TeamCity(this IPipelineContext context) => context.Services.GetRequiredService<ITeamCity>();
 }

--- a/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
@@ -41,5 +41,5 @@ public static class TerraformExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITerraform"/> service for executing terraform commands.</returns>
-    public static ITerraform Terraform(this IPipelineContext context) => context.Services.Get<ITerraform>();
+    public static ITerraform Terraform(this IPipelineContext context) => context.Services.GetRequiredService<ITerraform>();
 }

--- a/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
+++ b/src/ModularPipelines.Trivy/Extensions/TrivyExtensions.Generated.cs
@@ -41,5 +41,5 @@ public static class TrivyExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ITrivy"/> service for executing trivy commands.</returns>
-    public static ITrivy Trivy(this IPipelineContext context) => context.Services.Get<ITrivy>();
+    public static ITrivy Trivy(this IPipelineContext context) => context.Services.GetRequiredService<ITrivy>();
 }

--- a/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
+++ b/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class VaultExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IVault"/> service for executing vault commands.</returns>
-    public static IVault Vault(this IPipelineContext context) => context.Services.Get<IVault>();
+    public static IVault Vault(this IPipelineContext context) => context.Services.GetRequiredService<IVault>();
 }

--- a/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Extensions/WingetExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class WingetExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IWinget"/> service for executing winget commands.</returns>
-    public static IWinget Winget(this IPipelineContext context) => context.Services.Get<IWinget>();
+    public static IWinget Winget(this IPipelineContext context) => context.Services.GetRequiredService<IWinget>();
 }

--- a/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class YarnExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYarn"/> service for executing yarn commands.</returns>
-    public static IYarn Yarn(this IPipelineContext context) => context.Services.Get<IYarn>();
+    public static IYarn Yarn(this IPipelineContext context) => context.Services.GetRequiredService<IYarn>();
 }

--- a/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
+++ b/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
@@ -37,5 +37,5 @@ public static class YqExtensions
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYq"/> service for executing yq commands.</returns>
-    public static IYq Yq(this IPipelineContext context) => context.Services.Get<IYq>();
+    public static IYq Yq(this IPipelineContext context) => context.Services.GetRequiredService<IYq>();
 }

--- a/src/ModularPipelines/Context/ContextExtensions.cs
+++ b/src/ModularPipelines/Context/ContextExtensions.cs
@@ -13,45 +13,6 @@ namespace ModularPipelines.Context;
 public static class ContextExtensions
 {
     /// <summary>
-    /// Gets a required service from the DI container.
-    /// </summary>
-    /// <typeparam name="T">The type of service to retrieve.</typeparam>
-    /// <param name="context">The pipeline context.</param>
-    /// <returns>The service instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the service is not registered.</exception>
-    /// <example>
-    /// <code>
-    /// var myService = context.GetService&lt;IMyService&gt;();
-    /// </code>
-    /// </example>
-    public static T GetService<T>(this IPipelineContext context)
-        where T : class
-    {
-        return context.Services.Get<T>();
-    }
-
-    /// <summary>
-    /// Tries to get a service from the DI container.
-    /// </summary>
-    /// <typeparam name="T">The type of service to retrieve.</typeparam>
-    /// <param name="context">The pipeline context.</param>
-    /// <returns>The service instance, or null if not registered.</returns>
-    /// <example>
-    /// <code>
-    /// var myService = context.TryGetService&lt;IMyService&gt;();
-    /// if (myService != null)
-    /// {
-    ///     // Use the service
-    /// }
-    /// </code>
-    /// </example>
-    public static T? TryGetService<T>(this IPipelineContext context)
-        where T : class
-    {
-        return context.Services.TryGet<T>();
-    }
-
-    /// <summary>
     /// Gets a configuration value by key, returning null if not found.
     /// </summary>
     /// <param name="context">The pipeline context.</param>

--- a/src/ModularPipelines/Context/Domains/IServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/IServicesContext.cs
@@ -14,14 +14,14 @@ public interface IServicesContext
     /// <typeparam name="T">The service type to resolve.</typeparam>
     /// <returns>The resolved service instance.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the service is not registered.</exception>
-    T Get<T>() where T : class;
+    T GetRequiredService<T>() where T : class;
 
     /// <summary>
     /// Tries to resolve a service from the DI container.
     /// </summary>
     /// <typeparam name="T">The service type to resolve.</typeparam>
     /// <returns>The resolved service instance, or <see langword="null"/> when it is not registered.</returns>
-    T? TryGet<T>() where T : class;
+    T? GetService<T>() where T : class;
 
     /// <summary>
     /// Application configuration.

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -30,7 +30,7 @@ internal class ServicesContext : IServicesContext
     }
 
     /// <inheritdoc />
-    public T Get<T>() where T : class
+    public T GetRequiredService<T>() where T : class
     {
         var service = _serviceProvider.GetService<T>();
         if (service is not null)
@@ -49,7 +49,7 @@ internal class ServicesContext : IServicesContext
     }
 
     /// <inheritdoc />
-    public T? TryGet<T>() where T : class => _serviceProvider.GetService<T>();
+    public T? GetService<T>() where T : class => _serviceProvider.GetService<T>();
 
     /// <inheritdoc />
     public IConfiguration Configuration { get; }

--- a/src/ModularPipelines/Context/ToolsContext.cs
+++ b/src/ModularPipelines/Context/ToolsContext.cs
@@ -9,7 +9,7 @@ internal sealed class ToolsContext(IServicesContext services) : IToolsContext
         where T : class
     {
         var toolType = typeof(T);
-        return services.TryGet<T>() ?? throw ToolRegistrationExceptionFactory.Create(
+        return services.GetService<T>() ?? throw ToolRegistrationExceptionFactory.Create(
             toolType,
             ToolRegistrationExceptionFactory.FindIntegrationAssemblyName(toolType));
     }

--- a/src/ModularPipelines/Distributed/Extensions/ArtifactContextExtensions.cs
+++ b/src/ModularPipelines/Distributed/Extensions/ArtifactContextExtensions.cs
@@ -12,6 +12,6 @@ public static class ArtifactContextExtensions
     /// </summary>
     public static IArtifactContext Artifacts(this IPipelineContext context)
     {
-        return context.GetService<IArtifactContext>();
+        return context.Services.GetRequiredService<IArtifactContext>();
     }
 }

--- a/src/ModularPipelines/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines/PublicAPI.Shipped.txt
@@ -425,9 +425,7 @@ ModularPipelines.Context.Domains.ISecurityContext
 ModularPipelines.Context.Domains.ISecurityContext.Certificates.get -> ModularPipelines.Context.Domains.Security.ICertificatesContext!
 ModularPipelines.Context.Domains.IServicesContext
 ModularPipelines.Context.Domains.IServicesContext.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
-ModularPipelines.Context.Domains.IServicesContext.Get<T>() -> T!
 ModularPipelines.Context.Domains.IServicesContext.Options.get -> ModularPipelines.Options.PipelineOptions!
-ModularPipelines.Context.Domains.IServicesContext.TryGet<T>() -> T?
 ModularPipelines.Context.Domains.IShellContext
 ModularPipelines.Context.Domains.IShellContext.Bash.get -> ModularPipelines.Context.Domains.Shell.IBashContext!
 ModularPipelines.Context.Domains.IShellContext.PowerShell.get -> ModularPipelines.Context.Domains.Shell.IPowerShellContext!
@@ -1874,11 +1872,9 @@ static ModularPipelines.AmbientModuleContext.IsInModuleContext.get -> bool
 static ModularPipelines.Caching.ModuleCacheFingerprint.Validate(string! fingerprint) -> void
 static ModularPipelines.Context.ContextExtensions.GetConfigValue(this ModularPipelines.Context.IPipelineContext! context, string! key) -> string?
 static ModularPipelines.Context.ContextExtensions.GetRequiredConfigValue(this ModularPipelines.Context.IPipelineContext! context, string! key) -> string!
-static ModularPipelines.Context.ContextExtensions.GetService<T>(this ModularPipelines.Context.IPipelineContext! context) -> T!
 static ModularPipelines.Context.ContextExtensions.IsRunningIn(this ModularPipelines.Context.IPipelineContext! context, ModularPipelines.Enums.BuildSystem buildSystem) -> bool
 static ModularPipelines.Context.ContextExtensions.IsRunningInCI(this ModularPipelines.Context.IPipelineContext! context) -> bool
 static ModularPipelines.Context.ContextExtensions.IsRunningLocally(this ModularPipelines.Context.IPipelineContext! context) -> bool
-static ModularPipelines.Context.ContextExtensions.TryGetService<T>(this ModularPipelines.Context.IPipelineContext! context) -> T?
 static ModularPipelines.Context.Domains.Shell.CommandInvocation.operator !=(ModularPipelines.Context.Domains.Shell.CommandInvocation? left, ModularPipelines.Context.Domains.Shell.CommandInvocation? right) -> bool
 static ModularPipelines.Context.Domains.Shell.CommandInvocation.operator ==(ModularPipelines.Context.Domains.Shell.CommandInvocation? left, ModularPipelines.Context.Domains.Shell.CommandInvocation? right) -> bool
 static ModularPipelines.Distributed.ArtifactDescriptor.operator !=(ModularPipelines.Distributed.ArtifactDescriptor? left, ModularPipelines.Distributed.ArtifactDescriptor? right) -> bool

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -167,6 +167,8 @@ ModularPipelines.Context.Domains.IFilesContext.GlobFolders(string! pattern) -> S
 ModularPipelines.Context.Domains.IInstallersContext.InstallAsync(ModularPipelines.Options.InstallerOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.Domains.IInstallersContext.InstallFromWebAsync(ModularPipelines.Options.WebInstallerOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.Domains.ISecurityContext.Hash.get -> ModularPipelines.Context.Domains.Security.IHashContext!
+ModularPipelines.Context.Domains.IServicesContext.GetRequiredService<T>() -> T!
+ModularPipelines.Context.Domains.IServicesContext.GetService<T>() -> T?
 ModularPipelines.Context.Domains.Network.IDownloaderContext.DownloadFileAsync(ModularPipelines.Options.DownloadFileOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.FileSystem.FilePath!>!
 ModularPipelines.Context.Domains.Security.HashEncoding
 ModularPipelines.Context.Domains.Security.HashEncoding.Base64 = 1 -> ModularPipelines.Context.Domains.Security.HashEncoding

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+*REMOVED*ModularPipelines.Context.ContextExtensions.GetService<T>(this ModularPipelines.Context.IPipelineContext! context) -> T!
+*REMOVED*ModularPipelines.Context.ContextExtensions.TryGetService<T>(this ModularPipelines.Context.IPipelineContext! context) -> T?
 *REMOVED*ModularPipelines.Context.Domains.IEnvironmentContext.AppDomainDirectory.get -> ModularPipelines.FileSystem.Folder!
 *REMOVED*ModularPipelines.Context.Domains.IEnvironmentContext.ContentDirectory.get -> ModularPipelines.FileSystem.Folder!
 *REMOVED*ModularPipelines.Context.Domains.IEnvironmentContext.WorkingDirectory.get -> ModularPipelines.FileSystem.Folder!
@@ -7,6 +9,8 @@
 *REMOVED*ModularPipelines.Context.Domains.IFilesContext.GetFolder(System.Environment.SpecialFolder specialFolder) -> ModularPipelines.FileSystem.Folder!
 *REMOVED*ModularPipelines.Context.Domains.IFilesContext.Glob(string! pattern) -> System.Collections.Generic.IEnumerable<ModularPipelines.FileSystem.File!>!
 *REMOVED*ModularPipelines.Context.Domains.IFilesContext.GlobFolders(string! pattern) -> System.Collections.Generic.IEnumerable<ModularPipelines.FileSystem.Folder!>!
+*REMOVED*ModularPipelines.Context.Domains.IServicesContext.Get<T>() -> T!
+*REMOVED*ModularPipelines.Context.Domains.IServicesContext.TryGet<T>() -> T?
 *REMOVED*ModularPipelines.Context.Domains.Network.IDownloaderContext.DownloadFileAsync(ModularPipelines.Options.DownloadFileOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.FileSystem.File!>!
 *REMOVED*ModularPipelines.FileSystem.File
 *REMOVED*ModularPipelines.FileSystem.File.AppendAsync(string! contents, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/test/ModularPipelines.Git.UnitTests/BranchConditionLoggingTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/BranchConditionLoggingTests.cs
@@ -40,7 +40,7 @@ public class BranchConditionLoggingTests
                 new ModularPipelines.FileSystem.FolderPath(TestContext.WorkingDirectory)));
         var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
         var services = new Mock<IServicesContext>();
-        services.Setup(x => x.Get<IGit>()).Returns(git);
+        services.Setup(x => x.GetRequiredService<IGit>()).Returns(git);
         var context = Mock.Of<IPipelineContext>(x =>
             x.Logger == logger.Object &&
             x.Services == services.Object);
@@ -64,7 +64,7 @@ public class BranchConditionLoggingTests
                 new ModularPipelines.FileSystem.FolderPath(TestContext.WorkingDirectory)));
         var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
         var services = new Mock<IServicesContext>();
-        services.Setup(x => x.Get<IGit>()).Returns(git);
+        services.Setup(x => x.GetRequiredService<IGit>()).Returns(git);
         var logger = Mock.Of<ILogger>();
         var context = Mock.Of<IPipelineContext>(x =>
             x.Logger == logger &&

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -20,35 +20,26 @@ namespace ModularPipelines.UnitTests.Context;
 public class ContextExtensionsTests
 {
     [Test]
-    public async Task GetService_ShouldResolveFromDI()
+    public async Task GetRequiredService_ShouldResolveFromDI()
     {
-        // Arrange
-        var mockServices = new Mock<IServicesContext>();
         var expectedService = new TestService();
-        mockServices.Setup(s => s.Get<TestService>()).Returns(expectedService);
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(expectedService)
+            .BuildServiceProvider();
+        var servicesContext = CreateServicesContext(serviceProvider);
 
-        var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(mockServices.Object);
+        var result = servicesContext.GetRequiredService<TestService>();
 
-        // Act
-        var result = mockContext.Object.GetService<TestService>();
-
-        // Assert
         await Assert.That(result).IsSameReferenceAs(expectedService);
     }
 
     [Test]
-    public async Task GetService_WhenServiceNotRegistered_ShouldThrow()
+    public async Task GetRequiredService_WhenServiceNotRegistered_ShouldThrow()
     {
-        // Arrange
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
         var servicesContext = CreateServicesContext(serviceProvider);
 
-        var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(servicesContext);
-
-        // Act & Assert
-        var exception = await Assert.That(() => mockContext.Object.GetService<TestService>())
+        var exception = await Assert.That(() => servicesContext.GetRequiredService<TestService>())
             .ThrowsExactly<InvalidOperationException>();
 
         using (Assert.Multiple())
@@ -113,39 +104,27 @@ public class ContextExtensionsTests
     }
 
     [Test]
-    public async Task TryGetService_WhenServiceNotRegistered_ShouldReturnNull()
+    public async Task GetService_WhenServiceNotRegistered_ShouldReturnNull()
     {
-        // Arrange
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
         var servicesContext = CreateServicesContext(serviceProvider);
 
-        var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(servicesContext);
+        var result = servicesContext.GetService<TestService>();
 
-        // Act
-        var result = mockContext.Object.TryGetService<TestService>();
-
-        // Assert
         await Assert.That(result).IsNull();
     }
 
     [Test]
-    public async Task TryGetService_WhenServiceExists_ShouldReturnService()
+    public async Task GetService_WhenServiceExists_ShouldReturnService()
     {
-        // Arrange
         var expectedService = new TestService();
         using var serviceProvider = new ServiceCollection()
             .AddSingleton(expectedService)
             .BuildServiceProvider();
         var servicesContext = CreateServicesContext(serviceProvider);
 
-        var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(servicesContext);
+        var result = servicesContext.GetService<TestService>();
 
-        // Act
-        var result = mockContext.Object.TryGetService<TestService>();
-
-        // Assert
         await Assert.That(result).IsSameReferenceAs(expectedService);
     }
 

--- a/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
@@ -56,7 +56,7 @@ public class TelemetryIntegrationTests
             IModuleContext context,
             CancellationToken cancellationToken)
         {
-            context.Services.Get<ISecretRegistry>().AddSecret(Secret);
+            context.Services.GetRequiredService<ISecretRegistry>().AddSecret(Secret);
             return await context.Shell.RunAsync(
                 new CommandLineToolOptions(SecretTool)
                 {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -421,6 +421,7 @@ public class GeneratorHardeningTests
 
         await Assert.That(content).Contains("using ModularPipelines.Attributes;");
         await Assert.That(content).Contains("[ModularPipelinesIntegration]");
+        await Assert.That(content).Contains("context.Services.GetRequiredService<ITool>()");
         await Assert.That(content).DoesNotContain("ModuleInitializer");
         await Assert.That(content).DoesNotContain("ModularPipelinesContextRegistry");
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -121,7 +121,7 @@ public class DependencyRegistrationGenerator : ICodeGenerator
             sb.AppendLine("    /// </summary>");
             sb.AppendLine("    /// <param name=\"context\">The pipeline context.</param>");
             sb.AppendLine($"    /// <returns>The <see cref=\"{interfaceName}\"/> service for executing {tool.ToolName} commands.</returns>");
-            sb.AppendLine($"    public static {interfaceName} {serviceName}(this IPipelineContext context) => context.Services.Get<{interfaceName}>();");
+            sb.AppendLine($"    public static {interfaceName} {serviceName}(this IPipelineContext context) => context.Services.GetRequiredService<{interfaceName}>();");
         }
 
         sb.AppendLine("}");


### PR DESCRIPTION
Closes #4229.

## Summary
- rename `IServicesContext.Get<T>()` to `GetRequiredService<T>()`
- rename `TryGet<T>()` to nullable `GetService<T>()`
- remove duplicate `IPipelineContext` service extensions
- update tool accessors, generator output, docs, tests, and PublicAPI baselines

## Validation
- core Release build: 0 warnings, 0 errors
- OptionsGenerator Release build: 0 warnings, 0 errors
- Git integration Release build: 0 warnings, 0 errors
- focused core, Git, and OptionsGenerator tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed service-resolution methods to distinguish required and optional services.
  * Removed legacy service-resolution extensions from the pipeline context.
  * Updated integrations, generated code, and extensions to use the new API.

* **Bug Fixes**
  * Missing required services now fail immediately with an exception instead of returning `null`, improving error visibility.

* **Documentation**
  * Updated the v4 migration guide with the new service-resolution API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->