### PR TITLE
Align module console writer API

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -120,6 +120,12 @@ are now `RunIdentifier`. `ModuleAssignmentConfig` is now
 registered with `AddDistributedArtifactStore<TStore>()` or
 `AddDistributedArtifactStoreFactory<TFactory>()`.
 
+## Module console output
+
+`IConsoleWriter` now lives in `ModularPipelines.Logging` and is available from
+`context.Console`. Use `WriteLine` for plain text, `WriteMarkupLine` for
+Spectre.Console markup, and `Write` for renderables. `LogToConsole` was removed.
+
 ## Failure modes and execution hints
 
 Pipeline failure behavior now uses `FailureMode` instead of `ExecutionMode`:

--- a/docs/docs/how-to/logging.md
+++ b/docs/docs/how-to/logging.md
@@ -34,6 +34,21 @@ If you're in a module, it's part of your `context` object. Call `context.Logger`
 ### Elsewhere
 If you're in another class, inject `IModuleLoggerAccessor` and use its `Logger` property.
 
+## Module-aware console output
+
+Use `context.Console` when a module needs plain text or Spectre.Console rendering
+instead of structured logging. Its output remains grouped with the module and secrets
+are obfuscated before rendering.
+
+```csharp
+context.Console.WriteLine("Literal [brackets] stay literal");
+context.Console.WriteMarkupLine("[green]Build succeeded[/]");
+context.Console.Write(new Table().AddColumn("Result").AddRow("Succeeded"));
+```
+
+Do not use `System.Console` or `AnsiConsole` directly; they bypass module buffering
+and can interfere with the progress display.
+
 ## Command Logging
 
 When you execute CLI commands (e.g., `dotnet build`, `docker run`), ModularPipelines logs the command execution details. You can control what gets logged using `CommandLoggingOptions`.

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -11,6 +11,7 @@ using ModularPipelines.Context;
 using ModularPipelines.DotNet.Enums;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.DotNet.Parsers.Trx;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -138,7 +139,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
         }
 
         var testResults = await context.Tools.Trx.ParseTrxFile(trxFile);
-        var consoleWriter = context.Services.GetRequiredService<IConsoleWriter>();
+        var consoleWriter = context.Console;
         PrintFailedTests(consoleWriter, testResults.UnitTestResults, trxFile.Path);
         PrintSkippedTests(consoleWriter, testResults.UnitTestResults);
     }
@@ -178,12 +179,12 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
                 Markup.Escape(GetFailureLocation(failedTest)));
         }
 
-        consoleWriter.LogToConsole($"[red]✗ {failedTests.Count} failed[/]");
+        consoleWriter.WriteMarkupLine($"[red]✗ {failedTests.Count} failed[/]");
         consoleWriter.Write(table);
 
         if (failedTests.Count > MaximumFailuresToDisplay)
         {
-            consoleWriter.LogToConsole(
+            consoleWriter.WriteMarkupLine(
                 $"[dim]Showing first {MaximumFailuresToDisplay}; "
                 + $"{failedTests.Count - MaximumFailuresToDisplay} more in {Markup.Escape(trxFilePath)}[/]");
         }
@@ -215,7 +216,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
                 Markup.Escape(GetSkipReason(skippedTest)));
         }
 
-        consoleWriter.LogToConsole($"[dim]⏭ {skippedTests.Count} skipped[/]");
+        consoleWriter.WriteMarkupLine($"[dim]⏭ {skippedTests.Count} skipped[/]");
         consoleWriter.Write(table);
     }
 

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -11,7 +11,6 @@ using ModularPipelines.Context;
 using ModularPipelines.DotNet.Enums;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.DotNet.Parsers.Trx;
-using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -53,7 +53,7 @@ internal sealed class PipelineCommandHandler(
                 ?? throw new InvalidOperationException("A dependency graph path is required."),
                 cancellationToken)
             .ConfigureAwait(false);
-        consoleWriter.LogToConsole(
+        consoleWriter.WriteLine(
             $"Dependency graph written to {Path.GetFullPath(commandLineOptions.GraphPath)}");
     }
 
@@ -96,7 +96,7 @@ internal sealed class PipelineCommandHandler(
 
     private PipelineSummary ReportSuccessfulValidation()
     {
-        consoleWriter.LogToConsole("[green]Pipeline validation succeeded.[/]");
+        consoleWriter.WriteMarkupLine("[green]Pipeline validation succeeded.[/]");
         return CreateSummary();
     }
 

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
@@ -26,7 +26,7 @@ internal static class PipelineCommandLineHelp
 
     public static PipelineSummary Show(IConsoleWriter consoleWriter)
     {
-        consoleWriter.LogToConsole(Spectre.Console.Markup.Escape(Usage));
+        consoleWriter.WriteLine(Usage);
         var now = DateTimeOffset.UtcNow;
         return new PipelineSummary([], [], TimeSpan.Zero, now, now);
     }

--- a/src/ModularPipelines/Console/BufferedSecretRemasker.cs
+++ b/src/ModularPipelines/Console/BufferedSecretRemasker.cs
@@ -1,0 +1,393 @@
+using System.Text;
+using ModularPipelines.Logging;
+using ModularPipelines.Secrets;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace ModularPipelines.Console;
+
+/// <summary>
+/// Groups buffered fragments across secret boundaries and remasks them immediately before emission.
+/// </summary>
+internal sealed class BufferedSecretRemasker(
+    ISecretObfuscator? secretObfuscator,
+    ISecretProvider? secretProvider)
+{
+    private readonly ISecretObfuscator? _secretObfuscator = secretObfuscator;
+    private readonly ISecretProvider? _secretProvider = secretProvider;
+
+    public int GetIncrementalFlushableOutputCount(IReadOnlyList<BufferedOutput> outputs)
+    {
+        if (_secretObfuscator is null)
+        {
+            return outputs.Count;
+        }
+
+        var count = outputs.Count;
+        while (count > 0
+               && outputs[count - 1].IsMaskable
+               && (!outputs[count - 1].AppendNewLine
+                   || HasPotentialSecretAtIncrementalFlushBoundary(outputs, count)))
+        {
+            count--;
+        }
+
+        return count;
+    }
+
+    public int TryWrite(
+        IAnsiConsole console,
+        IReadOnlyList<BufferedOutput> outputs,
+        int index)
+    {
+        if (_secretObfuscator is null || !outputs[index].IsMaskable)
+        {
+            return 0;
+        }
+
+        var maskableOutputs = GetMaskableOutputs(outputs, index);
+        Write(console, maskableOutputs);
+        return maskableOutputs.Length;
+    }
+
+    public void WriteRenderable(
+        IAnsiConsole console,
+        IRenderable renderable,
+        ISecretObfuscator? outputObfuscator = null)
+    {
+        outputObfuscator ??= _secretObfuscator;
+        if (outputObfuscator is null)
+        {
+            console.Write(renderable);
+            return;
+        }
+
+        var remasked = renderable is SecretObfuscatedRenderable
+        {
+            RequiresPostRenderObfuscation: false,
+        }
+            ? renderable
+            : new SecretObfuscatedRenderable(renderable, outputObfuscator);
+        if (_secretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(
+                (Console: console, Renderable: remasked),
+                static state => state.Console.Write(state.Renderable));
+            return;
+        }
+
+        console.Write(remasked);
+    }
+
+    private BufferedOutput[] GetMaskableOutputs(
+        IReadOnlyList<BufferedOutput> outputs,
+        int firstIndex)
+    {
+        var lastIndex = firstIndex;
+        while (lastIndex + 1 < outputs.Count && outputs[lastIndex + 1].IsMaskable)
+        {
+            if (outputs[lastIndex].AppendNewLine
+                && !HasPotentialSecretAcrossLineBoundary(outputs, firstIndex, lastIndex))
+            {
+                break;
+            }
+
+            lastIndex++;
+        }
+
+        return [.. outputs.Skip(firstIndex).Take(lastIndex - firstIndex + 1)];
+    }
+
+    private void Write(IAnsiConsole console, BufferedOutput[] outputs)
+    {
+        if (outputs.All(static output => output is { IsRenderable: false, IsPreObfuscated: true }))
+        {
+            WritePreObfuscatedStringsWithCurrentSecrets(console, outputs);
+            return;
+        }
+
+        if (outputs.All(static output => output is { IsRenderable: false, IsPreObfuscated: false }))
+        {
+            WriteRawStringsWithCurrentSecrets(console, GetSource(outputs));
+            WriteTrailingNewLine(console, outputs);
+            return;
+        }
+
+        var renderables = GetRenderables(outputs);
+        var renderable = renderables.Count == 1
+            ? renderables[0]
+            : new ConcatenatedRenderable(renderables);
+        WriteRenderable(console, renderable, GetCombinedOutputObfuscator(outputs.Length));
+        WriteTrailingNewLine(console, outputs);
+    }
+
+    private bool HasPotentialSecretAtIncrementalFlushBoundary(
+        IReadOnlyList<BufferedOutput> outputs,
+        int outputCount)
+    {
+        var firstMaskableIndex = outputCount - 1;
+        while (firstMaskableIndex > 0 && outputs[firstMaskableIndex - 1].IsMaskable)
+        {
+            firstMaskableIndex--;
+        }
+
+        var source = GetSource(outputs, firstMaskableIndex, outputCount, includeTrailingNewLine: true);
+
+        // ModuleOutputBuffer adds a blank separator after every visible incremental group.
+        return GetPotentialSecretPrefixLength(source + Environment.NewLine) > 0;
+    }
+
+    private bool HasPotentialSecretAcrossLineBoundary(
+        IReadOnlyList<BufferedOutput> outputs,
+        int firstIndex,
+        int lastIndex)
+    {
+        if (_secretProvider is null)
+        {
+            return false;
+        }
+
+        var source = GetSource(outputs, firstIndex, lastIndex + 1, includeTrailingNewLine: true);
+        return GetPotentialSecretPrefixLength(source) > 0;
+    }
+
+    private ISecretObfuscator? GetCombinedOutputObfuscator(int outputCount)
+    {
+        if (_secretObfuscator is null
+            || _secretObfuscator is SecretObfuscator
+            || _secretProvider is null
+            || outputCount == 1)
+        {
+            return _secretObfuscator;
+        }
+
+        return new RegisteredSecretsOnlyObfuscator(_secretObfuscator, _secretProvider);
+    }
+
+    private int GetPotentialSecretPrefixLength(string value)
+    {
+        if (_secretProvider is null || value.Length == 0)
+        {
+            return 0;
+        }
+
+        var comparison = _secretObfuscator is ITrackedSecretObfuscator tracked
+            ? tracked.PatternComparison
+            : StringComparison.OrdinalIgnoreCase;
+        var retainedLength = 0;
+        var secrets = _secretProvider.GetSnapshot().Secrets ?? [];
+        foreach (var secret in secrets.Where(static secret => !string.IsNullOrEmpty(secret)))
+        {
+            var maximumLength = Math.Min(value.Length, secret.Length - 1);
+            for (var length = maximumLength; length > 0; length--)
+            {
+                if (secret.AsSpan().StartsWith(value.AsSpan(value.Length - length), comparison))
+                {
+                    retainedLength = Math.Max(retainedLength, length);
+                    break;
+                }
+            }
+        }
+
+        return retainedLength;
+    }
+
+    private void WriteRawStringsWithCurrentSecrets(IAnsiConsole console, string source)
+    {
+        if (_secretObfuscator is null)
+        {
+            console.Markup(source);
+            return;
+        }
+
+        if (_secretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(
+                (Console: console, Source: source, Obfuscator: _secretObfuscator),
+                static state => state.Console.Write(
+                    ObfuscatedMarkup.Create(state.Source, state.Obfuscator)));
+            return;
+        }
+
+        console.Write(ObfuscatedMarkup.Create(source, _secretObfuscator));
+    }
+
+    private void WritePreObfuscatedStringsWithCurrentSecrets(
+        IAnsiConsole console,
+        BufferedOutput[] outputs)
+    {
+        if (_secretObfuscator is null || _secretProvider is null)
+        {
+            WritePreObfuscatedStrings(console, outputs);
+            return;
+        }
+
+        if (_secretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(
+                (Remasker: this, Console: console, Outputs: outputs),
+                static state => state.Remasker.WritePreObfuscatedStrings(
+                    state.Console,
+                    state.Outputs));
+            return;
+        }
+
+        WritePreObfuscatedStrings(console, outputs);
+    }
+
+    private void WritePreObfuscatedStrings(IAnsiConsole console, BufferedOutput[] outputs)
+    {
+        console.Write(new Text(RemaskCurrentSecrets(GetSource(outputs))));
+        WriteTrailingNewLine(console, outputs);
+    }
+
+    private string RemaskCurrentSecrets(string source)
+    {
+        if (_secretObfuscator is null || _secretProvider is null)
+        {
+            return source;
+        }
+
+        var comparison = _secretObfuscator is ITrackedSecretObfuscator tracked
+            ? tracked.PatternComparison
+            : StringComparison.OrdinalIgnoreCase;
+        var comparer = comparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        var secrets = (_secretProvider.GetSnapshot().Secrets ?? [])
+            .Where(static secret => !string.IsNullOrEmpty(secret))
+            .Distinct(comparer)
+            .OrderByDescending(static secret => secret.Length)
+            .ToArray();
+        if (secrets.Length == 0)
+        {
+            return source;
+        }
+
+        var output = new StringBuilder(source.Length);
+        for (var offset = 0; offset < source.Length;)
+        {
+            var matchedSecret = secrets.FirstOrDefault(secret =>
+                source.AsSpan(offset).StartsWith(secret.AsSpan(), comparison));
+            if (matchedSecret is null)
+            {
+                output.Append(source[offset]);
+                offset++;
+                continue;
+            }
+
+            output.Append(_secretObfuscator.Obfuscate(
+                source.Substring(offset, matchedSecret.Length),
+                null));
+            offset += matchedSecret.Length;
+        }
+
+        return output.ToString();
+    }
+
+    private static List<IRenderable> GetRenderables(BufferedOutput[] outputs)
+    {
+        var renderables = new List<IRenderable>((outputs.Length * 2) - 1);
+        for (var index = 0; index < outputs.Length; index++)
+        {
+            var output = outputs[index];
+            renderables.Add(GetRenderable(output));
+            if (output.AppendNewLine && index < outputs.Length - 1)
+            {
+                renderables.Add(new Text(Environment.NewLine));
+            }
+        }
+
+        return renderables;
+    }
+
+    private static IRenderable GetRenderable(BufferedOutput output) =>
+        output.Renderable
+        ?? (output.StringValue is { } value
+            ? new BufferedStringRenderable(value)
+            : throw new InvalidOperationException("Buffered output is not maskable."));
+
+    private static string GetSource(BufferedOutput[] outputs) =>
+        GetSource(outputs, 0, outputs.Length, includeTrailingNewLine: false);
+
+    private static string GetSource(
+        IReadOnlyList<BufferedOutput> outputs,
+        int firstIndex,
+        int exclusiveEndIndex,
+        bool includeTrailingNewLine)
+    {
+        var source = new StringBuilder();
+        for (var index = firstIndex; index < exclusiveEndIndex; index++)
+        {
+            source.Append(outputs[index].MaskablePlainText);
+            if (outputs[index].AppendNewLine
+                && (includeTrailingNewLine || index < exclusiveEndIndex - 1))
+            {
+                source.Append(Environment.NewLine);
+            }
+        }
+
+        return source.ToString();
+    }
+
+    private static void WriteTrailingNewLine(IAnsiConsole console, BufferedOutput[] outputs)
+    {
+        if (outputs[^1].AppendNewLine)
+        {
+            console.WriteLine();
+        }
+    }
+
+    private sealed class ConcatenatedRenderable(IReadOnlyList<IRenderable> renderables) : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            var text = string.Concat(Render(options, maxWidth)
+                .Where(static segment => !segment.IsControlCode)
+                .Select(static segment => segment.Text));
+            return ((IRenderable) new Text(text)).Measure(options, maxWidth);
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
+            renderables.SelectMany(renderable => renderable.Render(options, maxWidth));
+    }
+
+    private sealed class BufferedStringRenderable(string value) : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            try
+            {
+                return ((IRenderable) new Markup(value)).Measure(options, maxWidth);
+            }
+            catch (Exception)
+            {
+                return ((IRenderable) new Text(value)).Measure(options, maxWidth);
+            }
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            try
+            {
+                return [.. ((IRenderable) new Markup(value)).Render(options, maxWidth)];
+            }
+            catch (Exception)
+            {
+                return [.. ((IRenderable) new Text(value)).Render(options, maxWidth)];
+            }
+        }
+    }
+
+    private sealed class RegisteredSecretsOnlyObfuscator(
+        ISecretObfuscator inner,
+        ISecretProvider secretProvider) : ISecretObfuscator
+    {
+        private readonly BufferedSecretRemasker _remasker = new(inner, secretProvider);
+
+        public bool HasSecrets => inner.HasSecrets;
+
+        public string Obfuscate(string? input, object? optionsObject) =>
+            _remasker.RemaskCurrentSecrets(input ?? string.Empty);
+    }
+}

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -103,7 +103,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 OutputLoggerCategories.Pipeline,
                 logLevel),
             // Unattributed logs do not represent pipeline completion status.
-            showSuccessMarker: false);
+            showSuccessMarker: false,
+            renderableSecretObfuscator: _secretObfuscator,
+            renderableSecretProvider: _secretProvider);
     }
 
     /// <inheritdoc />
@@ -319,7 +321,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     : 0,
                 outputExcerptSecretObfuscator: _secretObfuscator,
                 outputExcerptSecretProvider: _secretProvider,
-                outputExcerptLogger: _outputExcerptLogger));
+                outputExcerptLogger: _outputExcerptLogger,
+                renderableSecretObfuscator: _secretObfuscator,
+                renderableSecretProvider: _secretProvider));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -105,7 +105,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
             // Unattributed logs do not represent pipeline completion status.
             showSuccessMarker: false,
             renderableSecretObfuscator: _secretObfuscator,
-            renderableSecretProvider: _secretProvider);
+            renderableSecretProvider: _secretProvider,
+            renderableConsole: _ansiConsole);
     }
 
     /// <inheritdoc />
@@ -323,7 +324,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 outputExcerptSecretProvider: _secretProvider,
                 outputExcerptLogger: _outputExcerptLogger,
                 renderableSecretObfuscator: _secretObfuscator,
-                renderableSecretProvider: _secretProvider));
+                renderableSecretProvider: _secretProvider,
+                renderableConsole: _ansiConsole));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -228,6 +228,15 @@ internal class CoordinatedTextWriter : TextWriter
         var buffer = moduleType is not null
             ? _coordinator.GetModuleBuffer(moduleType)
             : _coordinator.GetUnattributedBuffer();
+        if (buffer is IPreObfuscatedModuleOutputBuffer preObfuscatedBuffer)
+        {
+            preObfuscatedBuffer.WritePreObfuscated(
+                message,
+                _isError ? ModuleOutputStream.StandardError : ModuleOutputStream.StandardOutput,
+                appendNewLine);
+            return;
+        }
+
         if (_isError)
         {
             if (appendNewLine)

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -4,6 +4,7 @@ using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
 using ModularPipelines.Reporting;
+using Spectre.Console.Rendering;
 
 namespace ModularPipelines.Console;
 
@@ -41,6 +42,11 @@ internal interface IModuleOutputBuffer
     /// Adds plain string output without a trailing line terminator.
     /// </summary>
     void Write(string message) => WriteLine(message);
+
+    /// <summary>
+    /// Adds a rich renderable and its plain-text report representation to the buffer.
+    /// </summary>
+    void WriteRenderable(IRenderable renderable, string plainText) => WriteLine(plainText);
 
     /// <summary>
     /// Adds a standard-error line to the buffer.

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -171,3 +171,17 @@ internal interface IModuleOutputBuffer
         IReadOnlyList<ILogger>? fallbackLoggers = null,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Accepts output already processed by the console interception obfuscator.
+/// </summary>
+internal interface IPreObfuscatedModuleOutputBuffer
+{
+    /// <summary>
+    /// Buffers processed output without losing its masking provenance.
+    /// </summary>
+    void WritePreObfuscated(
+        string message,
+        ModuleOutputStream stream,
+        bool appendNewLine);
+}

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -49,6 +49,21 @@ internal interface IModuleOutputBuffer
     void WriteRenderable(IRenderable renderable, string plainText) => WriteLine(plainText);
 
     /// <summary>
+    /// Adds a rich renderable and controls whether a line terminator follows it.
+    /// </summary>
+    void WriteRenderable(IRenderable renderable, string plainText, bool appendNewLine)
+    {
+        if (appendNewLine)
+        {
+            WriteRenderable(renderable, plainText);
+        }
+        else
+        {
+            Write(plainText);
+        }
+    }
+
+    /// <summary>
     /// Adds a standard-error line to the buffer.
     /// </summary>
     /// <param name="message">The message to buffer.</param>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -586,7 +586,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         var count = _outputs.Count;
         while (count > 0
-               && _outputs[count - 1] is { IsRenderable: true, AppendNewLine: false })
+               && IsMaskableOutput(_outputs[count - 1])
+               && !_outputs[count - 1].AppendNewLine)
         {
             count--;
         }
@@ -779,6 +780,39 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return 1;
         }
 
+        if (_renderableSecretObfuscator is not null && IsMaskableOutput(output))
+        {
+            var lastMaskableIndex = index;
+            while (lastMaskableIndex + 1 < outputs.Count
+                   && !outputs[lastMaskableIndex].AppendNewLine
+                   && IsMaskableOutput(outputs[lastMaskableIndex + 1]))
+            {
+                lastMaskableIndex++;
+            }
+
+            var containsRenderable = outputs
+                .Skip(index)
+                .Take(lastMaskableIndex - index + 1)
+                .Any(static item => item.IsRenderable);
+            if (containsRenderable)
+            {
+                var combinedRenderable = lastMaskableIndex == index
+                    ? output.Renderable!
+                    : new ConcatenatedRenderable(
+                        [.. outputs
+                            .Skip(index)
+                            .Take(lastMaskableIndex - index + 1)
+                            .Select(GetMaskableRenderable)]);
+                WriteRenderableWithCurrentSecrets(directConsole, combinedRenderable);
+                if (outputs[lastMaskableIndex].AppendNewLine)
+                {
+                    directConsole.WriteLine();
+                }
+
+                return lastMaskableIndex - index + 1;
+            }
+        }
+
         if (output.IsString)
         {
             WriteDirect(directConsole, console, output.StringValue, output.AppendNewLine);
@@ -787,30 +821,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         if (output.Renderable is { } renderable)
         {
-            var lastRenderableIndex = index;
-            while (_renderableSecretObfuscator is not null
-                   && lastRenderableIndex + 1 < outputs.Count
-                   && !outputs[lastRenderableIndex].AppendNewLine
-                   && outputs[lastRenderableIndex + 1].IsRenderable)
-            {
-                lastRenderableIndex++;
-            }
-
-            var combinedRenderable = lastRenderableIndex == index
-                ? renderable
-                : new ConcatenatedRenderable(
-                    outputs
-                        .Skip(index)
-                        .Take(lastRenderableIndex - index + 1)
-                        .Select(static item => item.Renderable!)
-                        .ToArray());
-            WriteRenderableWithCurrentSecrets(directConsole, combinedRenderable);
-            if (outputs[lastRenderableIndex].AppendNewLine)
+            WriteRenderableWithCurrentSecrets(directConsole, renderable);
+            if (output.AppendNewLine)
             {
                 directConsole.WriteLine();
             }
 
-            return lastRenderableIndex - index + 1;
+            return 1;
         }
 
         if (output.LogEvent is not { } logEvent)
@@ -834,6 +851,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         logEvent.WriteTo(logger);
         return 1;
     }
+
+    private static bool IsMaskableOutput(BufferedOutput output) =>
+        output.IsRenderable || (output.IsString && !output.IsRawBuildSystemCommand);
+
+    private static IRenderable GetMaskableRenderable(BufferedOutput output) =>
+        output.Renderable
+        ?? (output.StringValue is { } value
+            ? new BufferedStringRenderable(value)
+            : throw new InvalidOperationException("Buffered output is not maskable."));
 
     private void WriteStructuredLogDirectly(
         TextWriter console,
@@ -1147,6 +1173,33 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
             renderables.SelectMany(renderable => renderable.Render(options, maxWidth));
+    }
+
+    private sealed class BufferedStringRenderable(string value) : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            try
+            {
+                return ((IRenderable) new Markup(value)).Measure(options, maxWidth);
+            }
+            catch (Exception)
+            {
+                return ((IRenderable) new Text(value)).Measure(options, maxWidth);
+            }
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            try
+            {
+                return [.. ((IRenderable) new Markup(value)).Render(options, maxWidth)];
+            }
+            catch (Exception)
+            {
+                return [.. ((IRenderable) new Text(value)).Render(options, maxWidth)];
+            }
+        }
     }
 }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text;
 using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
@@ -29,7 +30,7 @@ namespace ModularPipelines.Console;
 /// </para>
 /// </remarks>
 [ExcludeFromCodeCoverage]
-internal class ModuleOutputBuffer : IModuleOutputBuffer
+internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOutputBuffer
 {
     private static readonly TimeSpan DefaultRenderGateTimeout = TimeSpan.FromSeconds(1);
     private readonly List<BufferedOutput> _outputs = [];
@@ -212,6 +213,21 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 message,
                 ModuleOutputStream.StandardError,
                 appendNewLine: false),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
+    public void WritePreObfuscated(
+        string message,
+        ModuleOutputStream stream,
+        bool appendNewLine)
+    {
+        AddOutput(
+            BufferedOutput.FromString(
+                message,
+                stream,
+                appendNewLine,
+                isPreObfuscated: true),
             allowAfterCompletion: true);
     }
 
@@ -840,9 +856,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         var lastMaskableIndex = index;
         while (lastMaskableIndex + 1 < outputs.Count
-               && !outputs[lastMaskableIndex].AppendNewLine
                && IsMaskableOutput(outputs[lastMaskableIndex + 1]))
         {
+            if (outputs[lastMaskableIndex].AppendNewLine
+                && !HasPotentialSecretAcrossLineBoundary(outputs, index, lastMaskableIndex))
+            {
+                break;
+            }
+
             lastMaskableIndex++;
         }
 
@@ -852,16 +873,35 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 .Skip(index)
                 .Take(lastMaskableIndex - index + 1),
         ];
-        if (!maskableOutputs.Any(static output => output.IsRenderable))
+        if (!maskableOutputs.Any(static output => output.IsRenderable)
+            && maskableOutputs.All(static output => output.IsPreObfuscated))
         {
             return 0;
         }
 
-        var renderable = maskableOutputs.Length == 1
-            ? maskableOutputs[0].Renderable!
+        if (!maskableOutputs.Any(static output => output.IsRenderable)
+            && !maskableOutputs.Any(static output => output.IsPreObfuscated))
+        {
+            WriteRawStringsWithCurrentSecrets(
+                directConsole,
+                GetMaskableSource(maskableOutputs));
+            if (maskableOutputs[^1].AppendNewLine)
+            {
+                directConsole.WriteLine();
+            }
+
+            return maskableOutputs.Length;
+        }
+
+        var maskableRenderables = GetMaskableRenderables(maskableOutputs);
+        var renderable = maskableRenderables.Count == 1
+            ? maskableRenderables[0]
             : new ConcatenatedRenderable(
-                [.. maskableOutputs.Select(GetMaskableRenderable)]);
-        WriteRenderableWithCurrentSecrets(directConsole, renderable);
+                maskableRenderables);
+        WriteRenderableWithCurrentSecrets(
+            directConsole,
+            renderable,
+            GetMixedOutputObfuscator(maskableOutputs));
         if (maskableOutputs[^1].AppendNewLine)
         {
             directConsole.WriteLine();
@@ -878,6 +918,117 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ?? (output.StringValue is { } value
             ? new BufferedStringRenderable(value)
             : throw new InvalidOperationException("Buffered output is not maskable."));
+
+    private static List<IRenderable> GetMaskableRenderables(
+        BufferedOutput[] outputs)
+    {
+        var renderables = new List<IRenderable>((outputs.Length * 2) - 1);
+        for (var index = 0; index < outputs.Length; index++)
+        {
+            var output = outputs[index];
+            renderables.Add(GetMaskableRenderable(output));
+            if (output.AppendNewLine && index < outputs.Length - 1)
+            {
+                renderables.Add(new Text(Environment.NewLine));
+            }
+        }
+
+        return renderables;
+    }
+
+    private static string GetMaskableSource(BufferedOutput[] outputs)
+    {
+        var source = new StringBuilder();
+        for (var index = 0; index < outputs.Length; index++)
+        {
+            source.Append(GetMaskablePlainText(outputs[index]));
+            if (outputs[index].AppendNewLine && index < outputs.Length - 1)
+            {
+                source.Append(Environment.NewLine);
+            }
+        }
+
+        return source.ToString();
+    }
+
+    private bool HasPotentialSecretAcrossLineBoundary(
+        IReadOnlyList<BufferedOutput> outputs,
+        int firstIndex,
+        int lastIndex)
+    {
+        if (_renderableSecretProvider is null)
+        {
+            return false;
+        }
+
+        var source = new StringBuilder();
+        for (var index = firstIndex; index <= lastIndex; index++)
+        {
+            source.Append(GetMaskablePlainText(outputs[index]));
+            if (outputs[index].AppendNewLine)
+            {
+                source.Append(Environment.NewLine);
+            }
+        }
+
+        return GetPotentialSecretPrefixLength(source.ToString()) > 0;
+    }
+
+    private ISecretObfuscator? GetMixedOutputObfuscator(
+        BufferedOutput[] outputs)
+    {
+        if (_renderableSecretObfuscator is null
+            || _renderableSecretObfuscator is SecretObfuscator
+            || outputs[0] is not { IsPreObfuscated: true, StringValue: { } value })
+        {
+            return _renderableSecretObfuscator;
+        }
+
+        var boundarySource = value + (outputs[0].AppendNewLine && outputs.Length > 1
+            ? Environment.NewLine
+            : string.Empty);
+        var retainedLength = GetPotentialSecretPrefixLength(boundarySource);
+        var protectedLength = Math.Clamp(
+            boundarySource.Length - retainedLength,
+            0,
+            value.Length);
+        return protectedLength == 0
+            ? _renderableSecretObfuscator
+            : new PrefixPreservingSecretObfuscator(
+                _renderableSecretObfuscator,
+                value[..protectedLength]);
+    }
+
+    private int GetPotentialSecretPrefixLength(string value)
+    {
+        if (_renderableSecretProvider is null || value.Length == 0)
+        {
+            return 0;
+        }
+
+        var comparison = _renderableSecretObfuscator is ITrackedSecretObfuscator tracked
+            ? tracked.PatternComparison
+            : StringComparison.OrdinalIgnoreCase;
+        var retainedLength = 0;
+        var secrets = _renderableSecretProvider.GetSnapshot().Secrets ?? [];
+        foreach (var secret in secrets.Where(static secret => !string.IsNullOrEmpty(secret)))
+        {
+            var maximumLength = Math.Min(value.Length, secret.Length - 1);
+            for (var length = maximumLength; length > 0; length--)
+            {
+                if (secret.AsSpan().StartsWith(value.AsSpan(value.Length - length), comparison))
+                {
+                    retainedLength = Math.Max(retainedLength, length);
+                    break;
+                }
+            }
+        }
+
+        return retainedLength;
+    }
+
+    private static string GetMaskablePlainText(BufferedOutput output) =>
+        output.StringValue ?? output.RenderablePlainText ?? string.Empty;
 
     private void WriteStructuredLogDirectly(
         TextWriter console,
@@ -908,9 +1059,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
     private void WriteRenderableWithCurrentSecrets(
         IAnsiConsole directConsole,
-        IRenderable renderable)
+        IRenderable renderable,
+        ISecretObfuscator? secretObfuscator = null)
     {
-        if (_renderableSecretObfuscator is null)
+        secretObfuscator ??= _renderableSecretObfuscator;
+        if (secretObfuscator is null)
         {
             directConsole.Write(renderable);
             return;
@@ -921,7 +1074,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             RequiresPostRenderObfuscation: false,
         }
             ? renderable
-            : new SecretObfuscatedRenderable(renderable, _renderableSecretObfuscator);
+            : new SecretObfuscatedRenderable(renderable, secretObfuscator);
         if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
         {
             emissionGuard.ExecuteWithStableSecrets(
@@ -931,6 +1084,28 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
 
         directConsole.Write(remasked);
+    }
+
+    private void WriteRawStringsWithCurrentSecrets(
+        IAnsiConsole directConsole,
+        string source)
+    {
+        if (_renderableSecretObfuscator is null)
+        {
+            directConsole.Markup(source);
+            return;
+        }
+
+        if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(
+                (Console: directConsole, Source: source, Obfuscator: _renderableSecretObfuscator),
+                static state => state.Console.Write(
+                    ObfuscatedMarkup.Create(state.Source, state.Obfuscator)));
+            return;
+        }
+
+        directConsole.Write(ObfuscatedMarkup.Create(source, _renderableSecretObfuscator));
     }
 
     private void RecordRenderedOutput(OutputFlushKind flushKind, bool renderedConsoleOutput)
@@ -1219,6 +1394,22 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
         }
     }
+
+    private sealed class PrefixPreservingSecretObfuscator(
+        ISecretObfuscator inner,
+        string protectedPrefix) : ISecretObfuscator
+    {
+        public bool HasSecrets => inner.HasSecrets;
+
+        public string Obfuscate(string? input, object? optionsObject)
+        {
+            var output = inner.Obfuscate(input, optionsObject);
+            var obfuscatedPrefix = inner.Obfuscate(protectedPrefix, optionsObject);
+            return output.StartsWith(obfuscatedPrefix, StringComparison.Ordinal)
+                ? protectedPrefix + output[obfuscatedPrefix.Length..]
+                : output;
+        }
+    }
 }
 
 /// <summary>
@@ -1262,6 +1453,11 @@ internal readonly struct BufferedOutput
     public bool IsRawBuildSystemCommand { get; private init; }
 
     /// <summary>
+    /// Gets a value indicating whether console interception already obfuscated this string.
+    /// </summary>
+    public bool IsPreObfuscated { get; private init; }
+
+    /// <summary>
     /// Gets the output stream represented by this item.
     /// </summary>
     public ModuleOutputStream Stream { get; private init; }
@@ -1277,8 +1473,15 @@ internal readonly struct BufferedOutput
     public static BufferedOutput FromString(
         string value,
         ModuleOutputStream stream = ModuleOutputStream.StandardOutput,
-        bool appendNewLine = true) =>
-        new() { StringValue = value, Stream = stream, AppendNewLine = appendNewLine };
+        bool appendNewLine = true,
+        bool isPreObfuscated = false) =>
+        new()
+        {
+            StringValue = value,
+            Stream = stream,
+            AppendNewLine = appendNewLine,
+            IsPreObfuscated = isPreObfuscated,
+        };
 
     /// <summary>
     /// Creates a buffered output from a raw build-system command.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -780,37 +780,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return 1;
         }
 
-        if (_renderableSecretObfuscator is not null && IsMaskableOutput(output))
+        var renderedMaskableOutputCount = TryRenderMaskableOutput(
+            directConsole,
+            outputs,
+            index);
+        if (renderedMaskableOutputCount > 0)
         {
-            var lastMaskableIndex = index;
-            while (lastMaskableIndex + 1 < outputs.Count
-                   && !outputs[lastMaskableIndex].AppendNewLine
-                   && IsMaskableOutput(outputs[lastMaskableIndex + 1]))
-            {
-                lastMaskableIndex++;
-            }
-
-            var containsRenderable = outputs
-                .Skip(index)
-                .Take(lastMaskableIndex - index + 1)
-                .Any(static item => item.IsRenderable);
-            if (containsRenderable)
-            {
-                var combinedRenderable = lastMaskableIndex == index
-                    ? output.Renderable!
-                    : new ConcatenatedRenderable(
-                        [.. outputs
-                            .Skip(index)
-                            .Take(lastMaskableIndex - index + 1)
-                            .Select(GetMaskableRenderable)]);
-                WriteRenderableWithCurrentSecrets(directConsole, combinedRenderable);
-                if (outputs[lastMaskableIndex].AppendNewLine)
-                {
-                    directConsole.WriteLine();
-                }
-
-                return lastMaskableIndex - index + 1;
-            }
+            return renderedMaskableOutputCount;
         }
 
         if (output.IsString)
@@ -850,6 +826,48 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         // while other providers (for example file logging) still receive the event.
         logEvent.WriteTo(logger);
         return 1;
+    }
+
+    private int TryRenderMaskableOutput(
+        IAnsiConsole directConsole,
+        IReadOnlyList<BufferedOutput> outputs,
+        int index)
+    {
+        if (_renderableSecretObfuscator is null || !IsMaskableOutput(outputs[index]))
+        {
+            return 0;
+        }
+
+        var lastMaskableIndex = index;
+        while (lastMaskableIndex + 1 < outputs.Count
+               && !outputs[lastMaskableIndex].AppendNewLine
+               && IsMaskableOutput(outputs[lastMaskableIndex + 1]))
+        {
+            lastMaskableIndex++;
+        }
+
+        BufferedOutput[] maskableOutputs =
+        [
+            .. outputs
+                .Skip(index)
+                .Take(lastMaskableIndex - index + 1),
+        ];
+        if (!maskableOutputs.Any(static output => output.IsRenderable))
+        {
+            return 0;
+        }
+
+        var renderable = maskableOutputs.Length == 1
+            ? maskableOutputs[0].Renderable!
+            : new ConcatenatedRenderable(
+                [.. maskableOutputs.Select(GetMaskableRenderable)]);
+        WriteRenderableWithCurrentSecrets(directConsole, renderable);
+        if (maskableOutputs[^1].AppendNewLine)
+        {
+            directConsole.WriteLine();
+        }
+
+        return maskableOutputs.Length;
     }
 
     private static bool IsMaskableOutput(BufferedOutput output) =>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -787,7 +787,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return;
         }
 
-        var remasked = new SecretObfuscatedRenderable(renderable, concreteObfuscator);
+        var remasked = renderable is SecretObfuscatedRenderable
+        {
+            RequiresPostRenderObfuscation: false,
+        }
+            ? renderable
+            : new SecretObfuscatedRenderable(renderable, concreteObfuscator);
         if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
         {
             emissionGuard.ExecuteWithStableSecrets(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -724,65 +724,99 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         foreach (var output in outputs)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            if (output.IsRawBuildSystemCommand)
-            {
-                console.WriteLine(output.StringValue);
-            }
-            else if (output.IsString)
-            {
-                WriteDirect(
-                    directConsole,
-                    console,
-                    output.StringValue,
-                    output.AppendNewLine);
-            }
-            else if (output.Renderable is { } renderable)
-            {
-                WriteRenderableWithCurrentSecrets(directConsole, renderable);
-                if (output.AppendNewLine)
-                {
-                    directConsole.WriteLine();
-                }
-            }
-            else if (output.LogEvent is { } logEvent)
-            {
-                if (writeStructuredLogsDirectly)
-                {
-                    var failedLoggers = WriteToFallbackLoggers(
-                        logEvent,
-                        fallbackLoggers,
-                        console);
-                    if (failedLoggers.Count > 0)
-                    {
-                        failedStructuredDeliveries.Add(
-                            new StructuredDeliveryRetry(logEvent, failedLoggers));
-                    }
-
-                    var wroteToDirectStructuredLogSink = fallbackLoggers.Any(logger =>
-                        logger is IDirectStructuredLogSink && !failedLoggers.Contains(logger));
-                    if (_isSpectreEnabled(logEvent.Level)
-                        && !wroteToDirectStructuredLogSink)
-                    {
-                        WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
-                        if (logEvent.FormatException() is { } formattedException)
-                        {
-                            console.WriteLine(formattedException);
-                        }
-                    }
-                }
-                else
-                {
-                    // Synchronous MEL.Spectre rendering preserves this buffer's position
-                    // while other providers (for example file logging) still receive the event.
-                    logEvent.WriteTo(logger);
-                }
-            }
+            RenderBufferedOutput(
+                console,
+                directConsole,
+                logger,
+                output,
+                fallbackLoggers,
+                failedStructuredDeliveries,
+                writeStructuredLogsDirectly);
 
             // Advance only after the sink returns successfully. A sink that accepts
             // output and then throws may cause a duplicate on retry, but retaining
             // the item avoids guaranteed data loss when delivery never happened.
             renderedCount++;
+        }
+    }
+
+    private void RenderBufferedOutput(
+        TextWriter console,
+        IAnsiConsole directConsole,
+        ILogger logger,
+        BufferedOutput output,
+        IReadOnlyList<ILogger> fallbackLoggers,
+        List<StructuredDeliveryRetry> failedStructuredDeliveries,
+        bool writeStructuredLogsDirectly)
+    {
+        if (output.IsRawBuildSystemCommand)
+        {
+            console.WriteLine(output.StringValue);
+            return;
+        }
+
+        if (output.IsString)
+        {
+            WriteDirect(directConsole, console, output.StringValue, output.AppendNewLine);
+            return;
+        }
+
+        if (output.Renderable is { } renderable)
+        {
+            WriteRenderableWithCurrentSecrets(directConsole, renderable);
+            if (output.AppendNewLine)
+            {
+                directConsole.WriteLine();
+            }
+
+            return;
+        }
+
+        if (output.LogEvent is not { } logEvent)
+        {
+            return;
+        }
+
+        if (writeStructuredLogsDirectly)
+        {
+            WriteStructuredLogDirectly(
+                console,
+                directConsole,
+                logEvent,
+                fallbackLoggers,
+                failedStructuredDeliveries);
+            return;
+        }
+
+        // Synchronous MEL.Spectre rendering preserves this buffer's position
+        // while other providers (for example file logging) still receive the event.
+        logEvent.WriteTo(logger);
+    }
+
+    private void WriteStructuredLogDirectly(
+        TextWriter console,
+        IAnsiConsole directConsole,
+        IBufferedLogEvent logEvent,
+        IReadOnlyList<ILogger> fallbackLoggers,
+        List<StructuredDeliveryRetry> failedStructuredDeliveries)
+    {
+        var failedLoggers = WriteToFallbackLoggers(logEvent, fallbackLoggers, console);
+        if (failedLoggers.Count > 0)
+        {
+            failedStructuredDeliveries.Add(new StructuredDeliveryRetry(logEvent, failedLoggers));
+        }
+
+        var wroteToDirectStructuredLogSink = fallbackLoggers.Any(logger =>
+            logger is IDirectStructuredLogSink && !failedLoggers.Contains(logger));
+        if (!_isSpectreEnabled(logEvent.Level) || wroteToDirectStructuredLogSink)
+        {
+            return;
+        }
+
+        WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
+        if (logEvent.FormatException() is { } formattedException)
+        {
+            console.WriteLine(formattedException);
         }
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -10,6 +10,7 @@ using ModularPipelines.Models;
 using ModularPipelines.Reporting;
 using ModularPipelines.Secrets;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace ModularPipelines.Console;
 
@@ -157,6 +158,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 message,
                 ModuleOutputStream.StandardOutput,
                 appendNewLine: false),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
+    public void WriteRenderable(IRenderable renderable, string plainText)
+    {
+        AddOutput(
+            BufferedOutput.FromRenderable(renderable, plainText),
             allowAfterCompletion: true);
     }
 
@@ -450,6 +459,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 return;
             }
 
+            if (output.IsRenderable)
+            {
+                _outputExcerptBuffer.Append(
+                    output.RenderablePlainText!,
+                    output.Stream,
+                    appendNewLine: true);
+                return;
+            }
+
             if (output.LogEvent is not { } logEvent)
             {
                 return;
@@ -690,6 +708,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                     output.StringValue,
                     output.AppendNewLine);
             }
+            else if (output.Renderable is { } renderable)
+            {
+                directConsole.Write(renderable);
+                directConsole.WriteLine();
+            }
             else if (output.LogEvent is { } logEvent)
             {
                 if (writeStructuredLogsDirectly)
@@ -885,6 +908,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return !string.IsNullOrEmpty(output.StringValue);
         }
 
+        if (output.IsRenderable)
+        {
+            return true;
+        }
+
         if (output.LogEvent is not { } logEvent)
         {
             return false;
@@ -984,9 +1012,24 @@ internal readonly struct BufferedOutput
     public IBufferedLogEvent? LogEvent { get; private init; }
 
     /// <summary>
+    /// Gets the rich renderable value, when present.
+    /// </summary>
+    public IRenderable? Renderable { get; private init; }
+
+    /// <summary>
+    /// Gets the plain-text representation retained for run reports.
+    /// </summary>
+    public string? RenderablePlainText { get; private init; }
+
+    /// <summary>
     /// Gets a value indicating whether this output contains a string.
     /// </summary>
     public bool IsString => StringValue != null;
+
+    /// <summary>
+    /// Gets a value indicating whether this output contains a rich renderable.
+    /// </summary>
+    public bool IsRenderable => Renderable != null;
 
     /// <summary>
     /// Gets a value indicating whether this string is a raw build-system command.
@@ -1020,6 +1063,18 @@ internal readonly struct BufferedOutput
         {
             StringValue = value,
             IsRawBuildSystemCommand = true,
+        };
+
+    /// <summary>
+    /// Creates buffered output from a rich renderable.
+    /// </summary>
+    public static BufferedOutput FromRenderable(IRenderable renderable, string plainText) =>
+        new()
+        {
+            Renderable = renderable,
+            RenderablePlainText = plainText,
+            Stream = ModuleOutputStream.StandardOutput,
+            AppendNewLine = true,
         };
 
     /// <summary>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -824,7 +824,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IAnsiConsole directConsole,
         IRenderable renderable)
     {
-        if (_renderableSecretObfuscator is not SecretObfuscator concreteObfuscator)
+        if (_renderableSecretObfuscator is null)
         {
             directConsole.Write(renderable);
             return;
@@ -835,7 +835,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             RequiresPostRenderObfuscation: false,
         }
             ? renderable
-            : new SecretObfuscatedRenderable(renderable, concreteObfuscator);
+            : new SecretObfuscatedRenderable(renderable, _renderableSecretObfuscator);
         if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
         {
             emissionGuard.ExecuteWithStableSecrets(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -45,6 +45,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly bool _showSuccessMarker;
     private readonly ISecretObfuscator? _renderableSecretObfuscator;
     private readonly ISecretProvider? _renderableSecretProvider;
+    private readonly IAnsiConsole? _renderableConsole;
     private readonly ModuleOutputExcerptBuffer? _outputExcerptBuffer;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
@@ -74,6 +75,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
     /// <param name="renderableSecretObfuscator">Obfuscator used to mask rich output again immediately before emission.</param>
     /// <param name="renderableSecretProvider">Provider used to stabilize secrets while rich output is emitted.</param>
+    /// <param name="renderableConsole">Console whose profile controls rich output layout.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
@@ -85,7 +87,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ISecretObfuscator? outputExcerptSecretObfuscator = null,
         ISecretProvider? outputExcerptSecretProvider = null,
         ISecretObfuscator? renderableSecretObfuscator = null,
-        ISecretProvider? renderableSecretProvider = null)
+        ISecretProvider? renderableSecretProvider = null,
+        IAnsiConsole? renderableConsole = null)
         : this(
             moduleType.Name,
             moduleType,
@@ -98,7 +101,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             outputExcerptSecretObfuscator: outputExcerptSecretObfuscator,
             outputExcerptSecretProvider: outputExcerptSecretProvider,
             renderableSecretObfuscator: renderableSecretObfuscator,
-            renderableSecretProvider: renderableSecretProvider)
+            renderableSecretProvider: renderableSecretProvider,
+            renderableConsole: renderableConsole)
     {
     }
 
@@ -120,6 +124,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputExcerptLogger">Logger for fail-closed excerpt diagnostics.</param>
     /// <param name="renderableSecretObfuscator">Obfuscator used to mask rich output again immediately before emission.</param>
     /// <param name="renderableSecretProvider">Provider used to stabilize secrets while rich output is emitted.</param>
+    /// <param name="renderableConsole">Console whose profile controls rich output layout.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -134,7 +139,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ISecretProvider? outputExcerptSecretProvider = null,
         ILogger? outputExcerptLogger = null,
         ISecretObfuscator? renderableSecretObfuscator = null,
-        ISecretProvider? renderableSecretProvider = null)
+        ISecretProvider? renderableSecretProvider = null,
+        IAnsiConsole? renderableConsole = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -147,6 +153,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _showSuccessMarker = showSuccessMarker;
         _renderableSecretObfuscator = renderableSecretObfuscator;
         _renderableSecretProvider = renderableSecretProvider;
+        _renderableConsole = renderableConsole;
         _outputExcerptBuffer = outputExcerptMaximumBytes > 0
             ? new ModuleOutputExcerptBuffer(
                 outputExcerptMaximumBytes,
@@ -432,7 +439,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
     internal IAnsiConsole GetDirectConsole(TextWriter writer)
     {
-        return _directConsoles.GetValue(writer, static value => CreateDirectConsole(value));
+        return _directConsoles.GetValue(writer, CreateDirectConsole);
     }
 
     private void AddOutput(BufferedOutput output, bool allowAfterCompletion)
@@ -986,14 +993,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return !foundBufferedConsoleLogger && isStructuredLogEnabled(logEvent.Level);
     }
 
-    private static IAnsiConsole CreateDirectConsole(TextWriter writer)
+    private IAnsiConsole CreateDirectConsole(TextWriter writer)
     {
+        var sourceProfile = _renderableConsole?.Profile ?? AnsiConsole.Profile;
         var console = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Out = new AnsiConsoleOutput(writer),
         });
-        console.Profile.Width = AnsiConsole.Profile.Width;
-        console.Profile.Capabilities = AnsiConsole.Profile.Capabilities;
+        console.Profile.Width = sourceProfile.Width;
+        console.Profile.Capabilities = sourceProfile.Capabilities;
         return console;
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -603,12 +603,36 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         var count = _outputs.Count;
         while (count > 0
                && IsMaskableOutput(_outputs[count - 1])
-               && !_outputs[count - 1].AppendNewLine)
+               && (!_outputs[count - 1].AppendNewLine
+                   || HasPotentialSecretAtIncrementalFlushBoundary(count)))
         {
             count--;
         }
 
         return count;
+    }
+
+    private bool HasPotentialSecretAtIncrementalFlushBoundary(int outputCount)
+    {
+        var firstMaskableIndex = outputCount - 1;
+        while (firstMaskableIndex > 0 && IsMaskableOutput(_outputs[firstMaskableIndex - 1]))
+        {
+            firstMaskableIndex--;
+        }
+
+        var source = new StringBuilder();
+        for (var index = firstMaskableIndex; index < outputCount; index++)
+        {
+            source.Append(GetMaskablePlainText(_outputs[index]));
+            if (_outputs[index].AppendNewLine)
+            {
+                source.Append(Environment.NewLine);
+            }
+        }
+
+        // RenderOutputGroup adds a blank separator after every visible incremental group.
+        source.Append(Environment.NewLine);
+        return GetPotentialSecretPrefixLength(source.ToString()) > 0;
     }
 
     private void RenderOutputs(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -164,8 +164,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <inheritdoc />
     public void WriteRenderable(IRenderable renderable, string plainText)
     {
+        WriteRenderable(renderable, plainText, appendNewLine: true);
+    }
+
+    /// <inheritdoc />
+    public void WriteRenderable(IRenderable renderable, string plainText, bool appendNewLine)
+    {
         AddOutput(
-            BufferedOutput.FromRenderable(renderable, plainText),
+            BufferedOutput.FromRenderable(renderable, plainText, appendNewLine),
             allowAfterCompletion: true);
     }
 
@@ -464,7 +470,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 _outputExcerptBuffer.Append(
                     output.RenderablePlainText!,
                     output.Stream,
-                    appendNewLine: true);
+                    output.AppendNewLine);
                 return;
             }
 
@@ -711,7 +717,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             else if (output.Renderable is { } renderable)
             {
                 directConsole.Write(renderable);
-                directConsole.WriteLine();
+                if (output.AppendNewLine)
+                {
+                    directConsole.WriteLine();
+                }
             }
             else if (output.LogEvent is { } logEvent)
             {
@@ -1068,13 +1077,16 @@ internal readonly struct BufferedOutput
     /// <summary>
     /// Creates buffered output from a rich renderable.
     /// </summary>
-    public static BufferedOutput FromRenderable(IRenderable renderable, string plainText) =>
+    public static BufferedOutput FromRenderable(
+        IRenderable renderable,
+        string plainText,
+        bool appendNewLine = true) =>
         new()
         {
             Renderable = renderable,
             RenderablePlainText = plainText,
             Stream = ModuleOutputStream.StandardOutput,
-            AppendNewLine = true,
+            AppendNewLine = appendNewLine,
         };
 
     /// <summary>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Text;
 using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
@@ -44,8 +43,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
     private readonly bool _showFailureHeaderWithoutOutput;
     private readonly bool _showSuccessMarker;
-    private readonly ISecretObfuscator? _renderableSecretObfuscator;
-    private readonly ISecretProvider? _renderableSecretProvider;
+    private readonly BufferedSecretRemasker _secretRemasker;
     private readonly IAnsiConsole? _renderableConsole;
     private readonly ModuleOutputExcerptBuffer? _outputExcerptBuffer;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
@@ -152,8 +150,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
         _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
-        _renderableSecretObfuscator = renderableSecretObfuscator;
-        _renderableSecretProvider = renderableSecretProvider;
+        _secretRemasker = new BufferedSecretRemasker(
+            renderableSecretObfuscator,
+            renderableSecretProvider);
         _renderableConsole = renderableConsole;
         _outputExcerptBuffer = outputExcerptMaximumBytes > 0
             ? new ModuleOutputExcerptBuffer(
@@ -594,45 +593,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
 
     private int GetFlushableOutputCount(OutputFlushKind flushKind)
     {
-        if (flushKind is OutputFlushKind.Complete
-            || _renderableSecretObfuscator is null)
-        {
-            return _outputs.Count;
-        }
-
-        var count = _outputs.Count;
-        while (count > 0
-               && IsMaskableOutput(_outputs[count - 1])
-               && (!_outputs[count - 1].AppendNewLine
-                   || HasPotentialSecretAtIncrementalFlushBoundary(count)))
-        {
-            count--;
-        }
-
-        return count;
-    }
-
-    private bool HasPotentialSecretAtIncrementalFlushBoundary(int outputCount)
-    {
-        var firstMaskableIndex = outputCount - 1;
-        while (firstMaskableIndex > 0 && IsMaskableOutput(_outputs[firstMaskableIndex - 1]))
-        {
-            firstMaskableIndex--;
-        }
-
-        var source = new StringBuilder();
-        for (var index = firstMaskableIndex; index < outputCount; index++)
-        {
-            source.Append(GetMaskablePlainText(_outputs[index]));
-            if (_outputs[index].AppendNewLine)
-            {
-                source.Append(Environment.NewLine);
-            }
-        }
-
-        // RenderOutputGroup adds a blank separator after every visible incremental group.
-        source.Append(Environment.NewLine);
-        return GetPotentialSecretPrefixLength(source.ToString()) > 0;
+        return flushKind is OutputFlushKind.Complete
+            ? _outputs.Count
+            : _secretRemasker.GetIncrementalFlushableOutputCount(_outputs);
     }
 
     private void RenderOutputs(
@@ -837,7 +800,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
 
         if (output.Renderable is { } renderable)
         {
-            WriteRenderableWithCurrentSecrets(directConsole, renderable);
+            _secretRemasker.WriteRenderable(directConsole, renderable);
             if (output.AppendNewLine)
             {
                 directConsole.WriteLine();
@@ -871,182 +834,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
     private int TryRenderMaskableOutput(
         IAnsiConsole directConsole,
         IReadOnlyList<BufferedOutput> outputs,
-        int index)
-    {
-        if (_renderableSecretObfuscator is null || !IsMaskableOutput(outputs[index]))
-        {
-            return 0;
-        }
-
-        var lastMaskableIndex = index;
-        while (lastMaskableIndex + 1 < outputs.Count
-               && IsMaskableOutput(outputs[lastMaskableIndex + 1]))
-        {
-            if (outputs[lastMaskableIndex].AppendNewLine
-                && !HasPotentialSecretAcrossLineBoundary(outputs, index, lastMaskableIndex))
-            {
-                break;
-            }
-
-            lastMaskableIndex++;
-        }
-
-        BufferedOutput[] maskableOutputs =
-        [
-            .. outputs
-                .Skip(index)
-                .Take(lastMaskableIndex - index + 1),
-        ];
-        if (!maskableOutputs.Any(static output => output.IsRenderable)
-            && maskableOutputs.All(static output => output.IsPreObfuscated))
-        {
-            WritePreObfuscatedStringsWithCurrentSecrets(
-                directConsole,
-                maskableOutputs);
-            return maskableOutputs.Length;
-        }
-
-        if (!maskableOutputs.Any(static output => output.IsRenderable)
-            && !maskableOutputs.Any(static output => output.IsPreObfuscated))
-        {
-            WriteRawStringsWithCurrentSecrets(
-                directConsole,
-                GetMaskableSource(maskableOutputs));
-            if (maskableOutputs[^1].AppendNewLine)
-            {
-                directConsole.WriteLine();
-            }
-
-            return maskableOutputs.Length;
-        }
-
-        var maskableRenderables = GetMaskableRenderables(maskableOutputs);
-        var renderable = maskableRenderables.Count == 1
-            ? maskableRenderables[0]
-            : new ConcatenatedRenderable(
-                maskableRenderables);
-        WriteRenderableWithCurrentSecrets(
-            directConsole,
-            renderable,
-            GetCombinedOutputObfuscator(maskableOutputs));
-        if (maskableOutputs[^1].AppendNewLine)
-        {
-            directConsole.WriteLine();
-        }
-
-        return maskableOutputs.Length;
-    }
-
-    private static bool IsMaskableOutput(BufferedOutput output) =>
-        output.IsRenderable || (output.IsString && !output.IsRawBuildSystemCommand);
-
-    private static IRenderable GetMaskableRenderable(BufferedOutput output) =>
-        output.Renderable
-        ?? (output.StringValue is { } value
-            ? new BufferedStringRenderable(value)
-            : throw new InvalidOperationException("Buffered output is not maskable."));
-
-    private static List<IRenderable> GetMaskableRenderables(
-        BufferedOutput[] outputs)
-    {
-        var renderables = new List<IRenderable>((outputs.Length * 2) - 1);
-        for (var index = 0; index < outputs.Length; index++)
-        {
-            var output = outputs[index];
-            renderables.Add(GetMaskableRenderable(output));
-            if (output.AppendNewLine && index < outputs.Length - 1)
-            {
-                renderables.Add(new Text(Environment.NewLine));
-            }
-        }
-
-        return renderables;
-    }
-
-    private static string GetMaskableSource(BufferedOutput[] outputs)
-    {
-        var source = new StringBuilder();
-        for (var index = 0; index < outputs.Length; index++)
-        {
-            source.Append(GetMaskablePlainText(outputs[index]));
-            if (outputs[index].AppendNewLine && index < outputs.Length - 1)
-            {
-                source.Append(Environment.NewLine);
-            }
-        }
-
-        return source.ToString();
-    }
-
-    private bool HasPotentialSecretAcrossLineBoundary(
-        IReadOnlyList<BufferedOutput> outputs,
-        int firstIndex,
-        int lastIndex)
-    {
-        if (_renderableSecretProvider is null)
-        {
-            return false;
-        }
-
-        var source = new StringBuilder();
-        for (var index = firstIndex; index <= lastIndex; index++)
-        {
-            source.Append(GetMaskablePlainText(outputs[index]));
-            if (outputs[index].AppendNewLine)
-            {
-                source.Append(Environment.NewLine);
-            }
-        }
-
-        return GetPotentialSecretPrefixLength(source.ToString()) > 0;
-    }
-
-    private ISecretObfuscator? GetCombinedOutputObfuscator(
-        BufferedOutput[] outputs)
-    {
-        if (_renderableSecretObfuscator is null
-            || _renderableSecretObfuscator is SecretObfuscator
-            || _renderableSecretProvider is null
-            || outputs.Length == 1)
-        {
-            return _renderableSecretObfuscator;
-        }
-
-        return new RegisteredSecretsOnlyObfuscator(
-            _renderableSecretObfuscator,
-            _renderableSecretProvider);
-    }
-
-    private int GetPotentialSecretPrefixLength(string value)
-    {
-        if (_renderableSecretProvider is null || value.Length == 0)
-        {
-            return 0;
-        }
-
-        var comparison = _renderableSecretObfuscator is ITrackedSecretObfuscator tracked
-            ? tracked.PatternComparison
-            : StringComparison.OrdinalIgnoreCase;
-        var retainedLength = 0;
-        var secrets = _renderableSecretProvider.GetSnapshot().Secrets ?? [];
-        foreach (var secret in secrets.Where(static secret => !string.IsNullOrEmpty(secret)))
-        {
-            var maximumLength = Math.Min(value.Length, secret.Length - 1);
-            for (var length = maximumLength; length > 0; length--)
-            {
-                if (secret.AsSpan().StartsWith(value.AsSpan(value.Length - length), comparison))
-                {
-                    retainedLength = Math.Max(retainedLength, length);
-                    break;
-                }
-            }
-        }
-
-        return retainedLength;
-    }
-
-    private static string GetMaskablePlainText(BufferedOutput output) =>
-        output.StringValue ?? output.RenderablePlainText ?? string.Empty;
+        int index) =>
+        _secretRemasker.TryWrite(directConsole, outputs, index);
 
     private void WriteStructuredLogDirectly(
         TextWriter console,
@@ -1073,142 +862,6 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         {
             console.WriteLine(formattedException);
         }
-    }
-
-    private void WriteRenderableWithCurrentSecrets(
-        IAnsiConsole directConsole,
-        IRenderable renderable,
-        ISecretObfuscator? secretObfuscator = null)
-    {
-        secretObfuscator ??= _renderableSecretObfuscator;
-        if (secretObfuscator is null)
-        {
-            directConsole.Write(renderable);
-            return;
-        }
-
-        var remasked = renderable is SecretObfuscatedRenderable
-        {
-            RequiresPostRenderObfuscation: false,
-        }
-            ? renderable
-            : new SecretObfuscatedRenderable(renderable, secretObfuscator);
-        if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
-        {
-            emissionGuard.ExecuteWithStableSecrets(
-                (Console: directConsole, Renderable: remasked),
-                static state => state.Console.Write(state.Renderable));
-            return;
-        }
-
-        directConsole.Write(remasked);
-    }
-
-    private void WriteRawStringsWithCurrentSecrets(
-        IAnsiConsole directConsole,
-        string source)
-    {
-        if (_renderableSecretObfuscator is null)
-        {
-            directConsole.Markup(source);
-            return;
-        }
-
-        if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
-        {
-            emissionGuard.ExecuteWithStableSecrets(
-                (Console: directConsole, Source: source, Obfuscator: _renderableSecretObfuscator),
-                static state => state.Console.Write(
-                    ObfuscatedMarkup.Create(state.Source, state.Obfuscator)));
-            return;
-        }
-
-        directConsole.Write(ObfuscatedMarkup.Create(source, _renderableSecretObfuscator));
-    }
-
-    private void WritePreObfuscatedStringsWithCurrentSecrets(
-        IAnsiConsole directConsole,
-        BufferedOutput[] outputs)
-    {
-        if (_renderableSecretObfuscator is null || _renderableSecretProvider is null)
-        {
-            WritePreObfuscatedStrings(directConsole, outputs);
-            return;
-        }
-
-        if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
-        {
-            emissionGuard.ExecuteWithStableSecrets(
-                (Buffer: this, Console: directConsole, Outputs: outputs),
-                static state => state.Buffer.WritePreObfuscatedStrings(
-                    state.Console,
-                    state.Outputs));
-            return;
-        }
-
-        WritePreObfuscatedStrings(directConsole, outputs);
-    }
-
-    private void WritePreObfuscatedStrings(
-        IAnsiConsole directConsole,
-        BufferedOutput[] outputs)
-    {
-        var source = GetMaskableSource(outputs);
-        directConsole.Write(new Text(RemaskCurrentSecrets(
-            source,
-            _renderableSecretObfuscator,
-            _renderableSecretProvider)));
-        if (outputs[^1].AppendNewLine)
-        {
-            directConsole.WriteLine();
-        }
-    }
-
-    private static string RemaskCurrentSecrets(
-        string source,
-        ISecretObfuscator? secretObfuscator,
-        ISecretProvider? secretProvider)
-    {
-        if (secretObfuscator is null || secretProvider is null)
-        {
-            return source;
-        }
-
-        var comparison = secretObfuscator is ITrackedSecretObfuscator tracked
-            ? tracked.PatternComparison
-            : StringComparison.OrdinalIgnoreCase;
-        var comparer = comparison == StringComparison.Ordinal
-            ? StringComparer.Ordinal
-            : StringComparer.OrdinalIgnoreCase;
-        var secrets = (secretProvider.GetSnapshot().Secrets ?? [])
-            .Where(static secret => !string.IsNullOrEmpty(secret))
-            .Distinct(comparer)
-            .OrderByDescending(static secret => secret.Length)
-            .ToArray();
-        if (secrets.Length == 0)
-        {
-            return source;
-        }
-
-        var output = new StringBuilder(source.Length);
-        for (var offset = 0; offset < source.Length;)
-        {
-            var matchedSecret = secrets.FirstOrDefault(secret =>
-                source.AsSpan(offset).StartsWith(secret.AsSpan(), comparison));
-            if (matchedSecret is null)
-            {
-                output.Append(source[offset]);
-                offset++;
-                continue;
-            }
-
-            output.Append(secretObfuscator.Obfuscate(
-                source.Substring(offset, matchedSecret.Length),
-                null));
-            offset += matchedSecret.Length;
-        }
-
-        return output.ToString();
     }
 
     private void RecordRenderedOutput(OutputFlushKind flushKind, bool renderedConsoleOutput)
@@ -1456,57 +1109,6 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
             console.WriteLine,
             value => WriteDirect(directConsole, console, value));
     }
-
-    private sealed class ConcatenatedRenderable(IReadOnlyList<IRenderable> renderables) : IRenderable
-    {
-        public Measurement Measure(RenderOptions options, int maxWidth)
-        {
-            var text = string.Concat(Render(options, maxWidth)
-                .Where(static segment => !segment.IsControlCode)
-                .Select(static segment => segment.Text));
-            return ((IRenderable) new Text(text)).Measure(options, maxWidth);
-        }
-
-        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
-            renderables.SelectMany(renderable => renderable.Render(options, maxWidth));
-    }
-
-    private sealed class BufferedStringRenderable(string value) : IRenderable
-    {
-        public Measurement Measure(RenderOptions options, int maxWidth)
-        {
-            try
-            {
-                return ((IRenderable) new Markup(value)).Measure(options, maxWidth);
-            }
-            catch (Exception)
-            {
-                return ((IRenderable) new Text(value)).Measure(options, maxWidth);
-            }
-        }
-
-        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
-        {
-            try
-            {
-                return [.. ((IRenderable) new Markup(value)).Render(options, maxWidth)];
-            }
-            catch (Exception)
-            {
-                return [.. ((IRenderable) new Text(value)).Render(options, maxWidth)];
-            }
-        }
-    }
-
-    private sealed class RegisteredSecretsOnlyObfuscator(
-        ISecretObfuscator inner,
-        ISecretProvider secretProvider) : ISecretObfuscator
-    {
-        public bool HasSecrets => inner.HasSecrets;
-
-        public string Obfuscate(string? input, object? optionsObject) =>
-            RemaskCurrentSecrets(input ?? string.Empty, inner, secretProvider);
-    }
 }
 
 /// <summary>
@@ -1543,6 +1145,16 @@ internal readonly struct BufferedOutput
     /// Gets a value indicating whether this output contains a rich renderable.
     /// </summary>
     public bool IsRenderable => Renderable != null;
+
+    /// <summary>
+    /// Gets a value indicating whether this output participates in secret-aware rendering.
+    /// </summary>
+    internal bool IsMaskable => IsRenderable || (IsString && !IsRawBuildSystemCommand);
+
+    /// <summary>
+    /// Gets the plain-text representation used for cross-fragment secret matching.
+    /// </summary>
+    internal string MaskablePlainText => StringValue ?? RenderablePlainText ?? string.Empty;
 
     /// <summary>
     /// Gets a value indicating whether this string is a raw build-system command.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -900,7 +900,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         if (!maskableOutputs.Any(static output => output.IsRenderable)
             && maskableOutputs.All(static output => output.IsPreObfuscated))
         {
-            return 0;
+            WritePreObfuscatedStringsWithCurrentSecrets(
+                directConsole,
+                maskableOutputs);
+            return maskableOutputs.Length;
         }
 
         if (!maskableOutputs.Any(static output => output.IsRenderable)
@@ -925,7 +928,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         WriteRenderableWithCurrentSecrets(
             directConsole,
             renderable,
-            GetMixedOutputObfuscator(maskableOutputs));
+            GetCombinedOutputObfuscator(maskableOutputs));
         if (maskableOutputs[^1].AppendNewLine)
         {
             directConsole.WriteLine();
@@ -998,29 +1001,20 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         return GetPotentialSecretPrefixLength(source.ToString()) > 0;
     }
 
-    private ISecretObfuscator? GetMixedOutputObfuscator(
+    private ISecretObfuscator? GetCombinedOutputObfuscator(
         BufferedOutput[] outputs)
     {
         if (_renderableSecretObfuscator is null
             || _renderableSecretObfuscator is SecretObfuscator
-            || outputs[0] is not { IsPreObfuscated: true, StringValue: { } value })
+            || _renderableSecretProvider is null
+            || outputs.Length == 1)
         {
             return _renderableSecretObfuscator;
         }
 
-        var boundarySource = value + (outputs[0].AppendNewLine && outputs.Length > 1
-            ? Environment.NewLine
-            : string.Empty);
-        var retainedLength = GetPotentialSecretPrefixLength(boundarySource);
-        var protectedLength = Math.Clamp(
-            boundarySource.Length - retainedLength,
-            0,
-            value.Length);
-        return protectedLength == 0
-            ? _renderableSecretObfuscator
-            : new PrefixPreservingSecretObfuscator(
-                _renderableSecretObfuscator,
-                value[..protectedLength]);
+        return new RegisteredSecretsOnlyObfuscator(
+            _renderableSecretObfuscator,
+            _renderableSecretProvider);
     }
 
     private int GetPotentialSecretPrefixLength(string value)
@@ -1130,6 +1124,91 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         }
 
         directConsole.Write(ObfuscatedMarkup.Create(source, _renderableSecretObfuscator));
+    }
+
+    private void WritePreObfuscatedStringsWithCurrentSecrets(
+        IAnsiConsole directConsole,
+        BufferedOutput[] outputs)
+    {
+        if (_renderableSecretObfuscator is null || _renderableSecretProvider is null)
+        {
+            WritePreObfuscatedStrings(directConsole, outputs);
+            return;
+        }
+
+        if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(
+                (Buffer: this, Console: directConsole, Outputs: outputs),
+                static state => state.Buffer.WritePreObfuscatedStrings(
+                    state.Console,
+                    state.Outputs));
+            return;
+        }
+
+        WritePreObfuscatedStrings(directConsole, outputs);
+    }
+
+    private void WritePreObfuscatedStrings(
+        IAnsiConsole directConsole,
+        BufferedOutput[] outputs)
+    {
+        var source = GetMaskableSource(outputs);
+        directConsole.Write(new Text(RemaskCurrentSecrets(
+            source,
+            _renderableSecretObfuscator,
+            _renderableSecretProvider)));
+        if (outputs[^1].AppendNewLine)
+        {
+            directConsole.WriteLine();
+        }
+    }
+
+    private static string RemaskCurrentSecrets(
+        string source,
+        ISecretObfuscator? secretObfuscator,
+        ISecretProvider? secretProvider)
+    {
+        if (secretObfuscator is null || secretProvider is null)
+        {
+            return source;
+        }
+
+        var comparison = secretObfuscator is ITrackedSecretObfuscator tracked
+            ? tracked.PatternComparison
+            : StringComparison.OrdinalIgnoreCase;
+        var comparer = comparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        var secrets = (secretProvider.GetSnapshot().Secrets ?? [])
+            .Where(static secret => !string.IsNullOrEmpty(secret))
+            .Distinct(comparer)
+            .OrderByDescending(static secret => secret.Length)
+            .ToArray();
+        if (secrets.Length == 0)
+        {
+            return source;
+        }
+
+        var output = new StringBuilder(source.Length);
+        for (var offset = 0; offset < source.Length;)
+        {
+            var matchedSecret = secrets.FirstOrDefault(secret =>
+                source.AsSpan(offset).StartsWith(secret.AsSpan(), comparison));
+            if (matchedSecret is null)
+            {
+                output.Append(source[offset]);
+                offset++;
+                continue;
+            }
+
+            output.Append(secretObfuscator.Obfuscate(
+                source.Substring(offset, matchedSecret.Length),
+                null));
+            offset += matchedSecret.Length;
+        }
+
+        return output.ToString();
     }
 
     private void RecordRenderedOutput(OutputFlushKind flushKind, bool renderedConsoleOutput)
@@ -1419,20 +1498,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer, IPreObfuscatedModuleOut
         }
     }
 
-    private sealed class PrefixPreservingSecretObfuscator(
+    private sealed class RegisteredSecretsOnlyObfuscator(
         ISecretObfuscator inner,
-        string protectedPrefix) : ISecretObfuscator
+        ISecretProvider secretProvider) : ISecretObfuscator
     {
         public bool HasSecrets => inner.HasSecrets;
 
-        public string Obfuscate(string? input, object? optionsObject)
-        {
-            var output = inner.Obfuscate(input, optionsObject);
-            var obfuscatedPrefix = inner.Obfuscate(protectedPrefix, optionsObject);
-            return output.StartsWith(obfuscatedPrefix, StringComparison.Ordinal)
-                ? protectedPrefix + output[obfuscatedPrefix.Length..]
-                : output;
-        }
+        public string Obfuscate(string? input, object? optionsObject) =>
+            RemaskCurrentSecrets(input ?? string.Empty, inner, secretProvider);
     }
 }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -43,6 +43,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
     private readonly bool _showFailureHeaderWithoutOutput;
     private readonly bool _showSuccessMarker;
+    private readonly ISecretObfuscator? _renderableSecretObfuscator;
+    private readonly ISecretProvider? _renderableSecretProvider;
     private readonly ModuleOutputExcerptBuffer? _outputExcerptBuffer;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
@@ -70,6 +72,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
     /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
+    /// <param name="renderableSecretObfuscator">Obfuscator used to mask rich output again immediately before emission.</param>
+    /// <param name="renderableSecretProvider">Provider used to stabilize secrets while rich output is emitted.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
@@ -79,7 +83,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         bool showFailureHeaderWithoutOutput = false,
         int outputExcerptMaximumBytes = 0,
         ISecretObfuscator? outputExcerptSecretObfuscator = null,
-        ISecretProvider? outputExcerptSecretProvider = null)
+        ISecretProvider? outputExcerptSecretProvider = null,
+        ISecretObfuscator? renderableSecretObfuscator = null,
+        ISecretProvider? renderableSecretProvider = null)
         : this(
             moduleType.Name,
             moduleType,
@@ -90,7 +96,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             showFailureHeaderWithoutOutput,
             outputExcerptMaximumBytes: outputExcerptMaximumBytes,
             outputExcerptSecretObfuscator: outputExcerptSecretObfuscator,
-            outputExcerptSecretProvider: outputExcerptSecretProvider)
+            outputExcerptSecretProvider: outputExcerptSecretProvider,
+            renderableSecretObfuscator: renderableSecretObfuscator,
+            renderableSecretProvider: renderableSecretProvider)
     {
     }
 
@@ -110,6 +118,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
     /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
     /// <param name="outputExcerptLogger">Logger for fail-closed excerpt diagnostics.</param>
+    /// <param name="renderableSecretObfuscator">Obfuscator used to mask rich output again immediately before emission.</param>
+    /// <param name="renderableSecretProvider">Provider used to stabilize secrets while rich output is emitted.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -122,7 +132,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         int outputExcerptMaximumBytes = 0,
         ISecretObfuscator? outputExcerptSecretObfuscator = null,
         ISecretProvider? outputExcerptSecretProvider = null,
-        ILogger? outputExcerptLogger = null)
+        ILogger? outputExcerptLogger = null,
+        ISecretObfuscator? renderableSecretObfuscator = null,
+        ISecretProvider? renderableSecretProvider = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -133,6 +145,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
         _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
+        _renderableSecretObfuscator = renderableSecretObfuscator;
+        _renderableSecretProvider = renderableSecretProvider;
         _outputExcerptBuffer = outputExcerptMaximumBytes > 0
             ? new ModuleOutputExcerptBuffer(
                 outputExcerptMaximumBytes,
@@ -716,7 +730,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
             else if (output.Renderable is { } renderable)
             {
-                directConsole.Write(renderable);
+                WriteRenderableWithCurrentSecrets(directConsole, renderable);
                 if (output.AppendNewLine)
                 {
                     directConsole.WriteLine();
@@ -761,6 +775,28 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             // the item avoids guaranteed data loss when delivery never happened.
             renderedCount++;
         }
+    }
+
+    private void WriteRenderableWithCurrentSecrets(
+        IAnsiConsole directConsole,
+        IRenderable renderable)
+    {
+        if (_renderableSecretObfuscator is not SecretObfuscator concreteObfuscator)
+        {
+            directConsole.Write(renderable);
+            return;
+        }
+
+        var remasked = new SecretObfuscatedRenderable(renderable, concreteObfuscator);
+        if (_renderableSecretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(
+                (Console: directConsole, Renderable: remasked),
+                static state => state.Console.Write(state.Renderable));
+            return;
+        }
+
+        directConsole.Write(remasked);
     }
 
     private void RecordRenderedOutput(OutputFlushKind flushKind, bool renderedConsoleOutput)

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -540,7 +540,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                                        && _exception is not null
                                        && (_hasRenderedIncrementalOutput || _showFailureHeaderWithoutOutput)
                                        && !_hasRenderedCompletionHeader;
-            if (_outputs.Count == 0
+            var flushableOutputCount = GetFlushableOutputCount(flushKind);
+            if (flushableOutputCount == 0
                 && _structuredDeliveryRetries.Count == 0
                 && !needsExceptionHeader)
             {
@@ -549,6 +550,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                     _hasRenderedIncrementalOutput = false;
                 }
 
+                _thresholdFlushRequested = false;
                 outputs = null!;
                 structuredDeliveryRetries = null!;
                 shouldRenderOutputGroup = false;
@@ -557,21 +559,39 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 return false;
             }
 
-            outputs = [.. _outputs];
+            outputs = _outputs.GetRange(0, flushableOutputCount);
             structuredDeliveryRetries = [.. _structuredDeliveryRetries];
             shouldRenderOutputGroup = needsExceptionHeader
-                                      || _outputs.Any(output => ProducesConsoleOutput(
+                                      || outputs.Any(output => ProducesConsoleOutput(
                                           output,
                                           isStructuredLogEnabled,
                                           fallbackLoggers));
             isContinuation = _hasRenderedIncrementalOutput;
-            _outputs.Clear();
+            _outputs.RemoveRange(0, flushableOutputCount);
             _structuredDeliveryRetries.Clear();
             _thresholdFlushRequested = false;
             _isIncrementalFlushInProgress = flushKind is OutputFlushKind.Incremental;
             exception = _exception;
             return true;
         }
+    }
+
+    private int GetFlushableOutputCount(OutputFlushKind flushKind)
+    {
+        if (flushKind is OutputFlushKind.Complete
+            || _renderableSecretObfuscator is null)
+        {
+            return _outputs.Count;
+        }
+
+        var count = _outputs.Count;
+        while (count > 0
+               && _outputs[count - 1] is { IsRenderable: true, AppendNewLine: false })
+        {
+            count--;
+        }
+
+        return count;
     }
 
     private void RenderOutputs(
@@ -721,14 +741,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
-        foreach (var output in outputs)
+        for (var index = 0; index < outputs.Count;)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            RenderBufferedOutput(
+            var renderedOutputCount = RenderBufferedOutput(
                 console,
                 directConsole,
                 logger,
-                output,
+                outputs,
+                index,
                 fallbackLoggers,
                 failedStructuredDeliveries,
                 writeStructuredLogsDirectly);
@@ -736,45 +757,65 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             // Advance only after the sink returns successfully. A sink that accepts
             // output and then throws may cause a duplicate on retry, but retaining
             // the item avoids guaranteed data loss when delivery never happened.
-            renderedCount++;
+            renderedCount += renderedOutputCount;
+            index += renderedOutputCount;
         }
     }
 
-    private void RenderBufferedOutput(
+    private int RenderBufferedOutput(
         TextWriter console,
         IAnsiConsole directConsole,
         ILogger logger,
-        BufferedOutput output,
+        IReadOnlyList<BufferedOutput> outputs,
+        int index,
         IReadOnlyList<ILogger> fallbackLoggers,
         List<StructuredDeliveryRetry> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly)
     {
+        var output = outputs[index];
         if (output.IsRawBuildSystemCommand)
         {
             console.WriteLine(output.StringValue);
-            return;
+            return 1;
         }
 
         if (output.IsString)
         {
             WriteDirect(directConsole, console, output.StringValue, output.AppendNewLine);
-            return;
+            return 1;
         }
 
         if (output.Renderable is { } renderable)
         {
-            WriteRenderableWithCurrentSecrets(directConsole, renderable);
-            if (output.AppendNewLine)
+            var lastRenderableIndex = index;
+            while (_renderableSecretObfuscator is not null
+                   && lastRenderableIndex + 1 < outputs.Count
+                   && !outputs[lastRenderableIndex].AppendNewLine
+                   && outputs[lastRenderableIndex + 1].IsRenderable)
+            {
+                lastRenderableIndex++;
+            }
+
+            var combinedRenderable = lastRenderableIndex == index
+                ? renderable
+                : new ConcatenatedRenderable(
+                    outputs
+                        .Skip(index)
+                        .Take(lastRenderableIndex - index + 1)
+                        .Select(static item => item.Renderable!)
+                        .ToArray());
+            WriteRenderableWithCurrentSecrets(directConsole, combinedRenderable);
+            if (outputs[lastRenderableIndex].AppendNewLine)
             {
                 directConsole.WriteLine();
             }
 
-            return;
+            return lastRenderableIndex - index + 1;
         }
 
         if (output.LogEvent is not { } logEvent)
         {
-            return;
+            return 1;
         }
 
         if (writeStructuredLogsDirectly)
@@ -785,12 +826,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 logEvent,
                 fallbackLoggers,
                 failedStructuredDeliveries);
-            return;
+            return 1;
         }
 
         // Synchronous MEL.Spectre rendering preserves this buffer's position
         // while other providers (for example file logging) still receive the event.
         logEvent.WriteTo(logger);
+        return 1;
     }
 
     private void WriteStructuredLogDirectly(
@@ -1091,6 +1133,20 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             command,
             console.WriteLine,
             value => WriteDirect(directConsole, console, value));
+    }
+
+    private sealed class ConcatenatedRenderable(IReadOnlyList<IRenderable> renderables) : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            var text = string.Concat(Render(options, maxWidth)
+                .Where(static segment => !segment.IsControlCode)
+                .Select(static segment => segment.Text));
+            return ((IRenderable) new Text(text)).Measure(options, maxWidth);
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
+            renderables.SelectMany(renderable => renderable.Render(options, maxWidth));
     }
 }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -439,7 +439,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
     internal IAnsiConsole GetDirectConsole(TextWriter writer)
     {
-        return _directConsoles.GetValue(writer, CreateDirectConsole);
+        var directConsole = _directConsoles.GetValue(writer, CreateDirectConsole);
+        RefreshDirectConsoleProfile(directConsole);
+        return directConsole;
     }
 
     private void AddOutput(BufferedOutput output, bool allowAfterCompletion)
@@ -995,15 +997,18 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
     private IAnsiConsole CreateDirectConsole(TextWriter writer)
     {
-        var sourceProfile = _renderableConsole?.Profile ?? AnsiConsole.Profile;
-        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        return AnsiConsole.Create(new AnsiConsoleSettings
         {
             Out = new AnsiConsoleOutput(writer),
         });
-        console.Profile.Width = sourceProfile.Width;
-        console.Profile.Height = sourceProfile.Height;
-        console.Profile.Capabilities = sourceProfile.Capabilities;
-        return console;
+    }
+
+    private void RefreshDirectConsoleProfile(IAnsiConsole directConsole)
+    {
+        var sourceProfile = _renderableConsole?.Profile ?? AnsiConsole.Profile;
+        directConsole.Profile.Width = sourceProfile.Width;
+        directConsole.Profile.Height = sourceProfile.Height;
+        directConsole.Profile.Capabilities = sourceProfile.Capabilities;
     }
 
     private static void WriteDirect(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -365,7 +365,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         var exclusiveSink = effectiveFallbackLoggers
             .OfType<IExclusiveStructuredLogSink>()
             .SingleOrDefault();
-        Func<LogLevel, bool> isStructuredLogEnabled = exclusiveSink is null
+        var isStructuredLogEnabled = exclusiveSink is null
             ? _isSpectreEnabled
             : exclusiveSink.IsEnabled;
         if (!TryTakeOutputs(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1001,6 +1001,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             Out = new AnsiConsoleOutput(writer),
         });
         console.Profile.Width = sourceProfile.Width;
+        console.Profile.Height = sourceProfile.Height;
         console.Profile.Capabilities = sourceProfile.Capabilities;
         return console;
     }

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -177,7 +177,7 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
     public ILogger Logger => _logger;
 
     /// <inheritdoc />
-    public IConsoleWriter Console => _pipelineContext.Console;
+    public IConsoleWriter Console => _logger as IConsoleWriter ?? _pipelineContext.Console;
 
     /// <inheritdoc />
     public IShellContext Shell => _pipelineContext.Shell;

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -177,6 +177,9 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
     public ILogger Logger => _logger;
 
     /// <inheritdoc />
+    public IConsoleWriter Console => (IConsoleWriter) _logger;
+
+    /// <inheritdoc />
     public IShellContext Shell => _pipelineContext.Shell;
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -177,7 +177,7 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
     public ILogger Logger => _logger;
 
     /// <inheritdoc />
-    public IConsoleWriter Console => (IConsoleWriter) _logger;
+    public IConsoleWriter Console => _pipelineContext.Console;
 
     /// <inheritdoc />
     public IShellContext Shell => _pipelineContext.Shell;

--- a/src/ModularPipelines/Context/ModuleHookContext.cs
+++ b/src/ModularPipelines/Context/ModuleHookContext.cs
@@ -15,6 +15,7 @@ namespace ModularPipelines.Context;
 internal class ModuleHookContext : IModuleHookContext
 {
     private readonly IPipelineContext _pipelineContext;
+    private readonly IConsoleWriter _consoleWriter;
     private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly DateTimeOffset _startTime;
 
@@ -24,7 +25,8 @@ internal class ModuleHookContext : IModuleHookContext
         DateTimeOffset startTime,
         IModuleResult? result,
         IPipelineContext pipelineContext,
-        IModuleMetadataRegistry metadataRegistry)
+        IModuleMetadataRegistry metadataRegistry,
+        IConsoleWriter? consoleWriter = null)
     {
         Module = module;
         ModuleAttributes = moduleAttributes;
@@ -32,6 +34,7 @@ internal class ModuleHookContext : IModuleHookContext
         Result = result;
         _pipelineContext = pipelineContext;
         _metadataRegistry = metadataRegistry;
+        _consoleWriter = consoleWriter ?? pipelineContext.Console;
     }
 
     #region IModuleHookContext members
@@ -92,7 +95,7 @@ internal class ModuleHookContext : IModuleHookContext
     public ILogger Logger => _pipelineContext.Logger;
 
     /// <inheritdoc />
-    public IConsoleWriter Console => _pipelineContext.Console;
+    public IConsoleWriter Console => _consoleWriter;
 
     /// <inheritdoc />
     public IShellContext Shell => _pipelineContext.Shell;

--- a/src/ModularPipelines/Context/ModuleHookContext.cs
+++ b/src/ModularPipelines/Context/ModuleHookContext.cs
@@ -92,6 +92,9 @@ internal class ModuleHookContext : IModuleHookContext
     public ILogger Logger => _pipelineContext.Logger;
 
     /// <inheritdoc />
+    public IConsoleWriter Console => _pipelineContext.Console;
+
+    /// <inheritdoc />
     public IShellContext Shell => _pipelineContext.Shell;
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -29,7 +29,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     public ILogger Logger => _logger ??= _moduleLoggerAccessor.GetLogger();
 
     /// <inheritdoc />
-    public IConsoleWriter Console => (IConsoleWriter) Logger;
+    public IConsoleWriter Console { get; }
 
     /// <inheritdoc />
     public IShellContext Shell { get; }
@@ -84,6 +84,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
         IDependencyCollisionDetector dependencyCollisionDetector,
         IModuleResultRepository moduleResultRepository,
         IInternalModuleLoggerAccessor moduleLoggerAccessor,
+        IConsoleWriter consoleWriter,
         EngineCancellationToken engineCancellationToken,
         IShellContext shell,
         IFilesContext files,
@@ -98,6 +99,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     {
         _moduleLookup = moduleLookup;
         _moduleLoggerAccessor = moduleLoggerAccessor;
+        Console = consoleWriter;
         DependencyCollisionDetector = dependencyCollisionDetector;
         ModuleResultRepository = moduleResultRepository;
         EngineCancellationToken = engineCancellationToken;

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -29,6 +29,9 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     public ILogger Logger => _logger ??= _moduleLoggerAccessor.GetLogger();
 
     /// <inheritdoc />
+    public IConsoleWriter Console => (IConsoleWriter) Logger;
+
+    /// <inheritdoc />
     public IShellContext Shell { get; }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Engine/DependencyPrinter.cs
+++ b/src/ModularPipelines/Engine/DependencyPrinter.cs
@@ -54,7 +54,7 @@ internal class DependencyPrinter : IDependencyPrinter
         _formatter.WriteGroupCommand(
             startCommand,
             _commandWriter.WriteLine,
-            _consoleWriter.WriteLine);
+            _consoleWriter.WriteMarkupLine);
 
         _consoleWriter.Write(tree);
 
@@ -62,6 +62,6 @@ internal class DependencyPrinter : IDependencyPrinter
         _formatter.WriteGroupCommand(
             endCommand,
             _commandWriter.WriteLine,
-            _consoleWriter.WriteLine);
+            _consoleWriter.WriteMarkupLine);
     }
 }

--- a/src/ModularPipelines/Engine/DependencyPrinter.cs
+++ b/src/ModularPipelines/Engine/DependencyPrinter.cs
@@ -54,7 +54,7 @@ internal class DependencyPrinter : IDependencyPrinter
         _formatter.WriteGroupCommand(
             startCommand,
             _commandWriter.WriteLine,
-            _consoleWriter.LogToConsole);
+            _consoleWriter.WriteLine);
 
         _consoleWriter.Write(tree);
 
@@ -62,6 +62,6 @@ internal class DependencyPrinter : IDependencyPrinter
         _formatter.WriteGroupCommand(
             endCommand,
             _commandWriter.WriteLine,
-            _consoleWriter.LogToConsole);
+            _consoleWriter.WriteLine);
     }
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleLifecycleContext.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleLifecycleContext.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Context;
+using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine.Execution;
@@ -14,7 +15,7 @@ internal class ModuleLifecycleContext
         IReadOnlyList<Attribute> moduleAttributes,
         DateTimeOffset startTime,
         IPipelineContext pipelineContext,
-        IServiceProvider scopedServiceProvider,
+        IConsoleWriter consoleWriter,
         CancellationToken cancellationToken)
     {
         Module = module;
@@ -22,7 +23,7 @@ internal class ModuleLifecycleContext
         ModuleAttributes = moduleAttributes;
         StartTime = startTime;
         PipelineContext = pipelineContext;
-        ScopedServiceProvider = scopedServiceProvider;
+        ConsoleWriter = consoleWriter;
         CancellationToken = cancellationToken;
     }
 
@@ -52,9 +53,9 @@ internal class ModuleLifecycleContext
     public IPipelineContext PipelineContext { get; }
 
     /// <summary>
-    /// Gets the scoped service provider for this module execution.
+    /// Gets the console writer scoped to this module execution.
     /// </summary>
-    public IServiceProvider ScopedServiceProvider { get; }
+    public IConsoleWriter ConsoleWriter { get; }
 
     /// <summary>
     /// Gets the cancellation token.

--- a/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
@@ -44,7 +43,7 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             result: null,
             context.PipelineContext,
             _metadataRegistry,
-            GetConsoleWriter(context));
+            context.ConsoleWriter);
 
         await _eventHandlerInvoker.InvokeReadyHandlersAsync(handlers, hookContext).ConfigureAwait(false);
     }
@@ -65,7 +64,7 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             result: null,
             context.PipelineContext,
             _metadataRegistry,
-            GetConsoleWriter(context));
+            context.ConsoleWriter);
 
         await _eventHandlerInvoker.InvokeStartHandlersAsync(handlers, hookContext).ConfigureAwait(false);
     }
@@ -86,7 +85,7 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             result,
             context.PipelineContext,
             _metadataRegistry,
-            GetConsoleWriter(context));
+            context.ConsoleWriter);
 
         await _eventHandlerInvoker.InvokeEndHandlersAsync(handlers, hookContext, result).ConfigureAwait(false);
     }
@@ -110,7 +109,7 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             result,
             context.PipelineContext,
             _metadataRegistry,
-            GetConsoleWriter(context));
+            context.ConsoleWriter);
 
         await _eventHandlerInvoker.InvokeFailureHandlersAsync(handlers, hookContext, exception).ConfigureAwait(false);
     }
@@ -131,14 +130,8 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             result: null,
             context.PipelineContext,
             _metadataRegistry,
-            GetConsoleWriter(context));
+            context.ConsoleWriter);
 
         await _eventHandlerInvoker.InvokeSkippedHandlersAsync(handlers, hookContext, skipReason).ConfigureAwait(false);
     }
-
-    private static IConsoleWriter GetConsoleWriter(ModuleLifecycleContext context)
-        => context.ScopedServiceProvider
-               .GetRequiredService<IInternalModuleLoggerAccessor>()
-               .GetLogger(context.ModuleType) as IConsoleWriter
-           ?? context.PipelineContext.Console;
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
@@ -1,7 +1,9 @@
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ModularPipelines.Engine.Execution;
 
@@ -41,7 +43,8 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             readyTime,
             result: null,
             context.PipelineContext,
-            _metadataRegistry);
+            _metadataRegistry,
+            GetConsoleWriter(context));
 
         await _eventHandlerInvoker.InvokeReadyHandlersAsync(handlers, hookContext).ConfigureAwait(false);
     }
@@ -61,7 +64,8 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             context.StartTime,
             result: null,
             context.PipelineContext,
-            _metadataRegistry);
+            _metadataRegistry,
+            GetConsoleWriter(context));
 
         await _eventHandlerInvoker.InvokeStartHandlersAsync(handlers, hookContext).ConfigureAwait(false);
     }
@@ -81,7 +85,8 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             context.StartTime,
             result,
             context.PipelineContext,
-            _metadataRegistry);
+            _metadataRegistry,
+            GetConsoleWriter(context));
 
         await _eventHandlerInvoker.InvokeEndHandlersAsync(handlers, hookContext, result).ConfigureAwait(false);
     }
@@ -104,7 +109,8 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             context.StartTime,
             result,
             context.PipelineContext,
-            _metadataRegistry);
+            _metadataRegistry,
+            GetConsoleWriter(context));
 
         await _eventHandlerInvoker.InvokeFailureHandlersAsync(handlers, hookContext, exception).ConfigureAwait(false);
     }
@@ -124,8 +130,15 @@ internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
             context.StartTime,
             result: null,
             context.PipelineContext,
-            _metadataRegistry);
+            _metadataRegistry,
+            GetConsoleWriter(context));
 
         await _eventHandlerInvoker.InvokeSkippedHandlersAsync(handlers, hookContext, skipReason).ConfigureAwait(false);
     }
+
+    private static IConsoleWriter GetConsoleWriter(ModuleLifecycleContext context)
+        => context.ScopedServiceProvider
+               .GetRequiredService<IInternalModuleLoggerAccessor>()
+               .GetLogger(context.ModuleType) as IConsoleWriter
+           ?? context.PipelineContext.Console;
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
@@ -1,9 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace ModularPipelines.Engine.Execution;
 

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -187,6 +187,9 @@ internal class ModuleRunner : IModuleRunner
                 // until this point prevents limiter wait time from being reported as execution time.
                 if (!scheduler.MarkModuleStarted(moduleType))
                 {
+                    readyLogger ??= GetAmbientOrScopedModuleLogger(
+                        scope.ServiceProvider,
+                        moduleType) as IInternalModuleLogger;
                     readyLogger?.PreserveBufferForDeferredExecution();
                     _logger.LogDebug("Module {ModuleName} deferred due to constraint check failure", moduleName);
                     return; // Module will be rescheduled by the scheduler

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -160,17 +160,15 @@ internal class ModuleRunner : IModuleRunner
 
                 if (moduleState.TryStartReadyEvents())
                 {
-                    var readyConsoleWriter = GetModuleLogger(scope.ServiceProvider, moduleType)
-                        as IConsoleWriter
-                        ?? scope.ServiceProvider.GetRequiredService<IPipelineContext>().Console;
-                    await _pipelineSetupExecutor
-                        .OnModuleReadyAsync(moduleState, readyConsoleWriter)
-                        .ConfigureAwait(false);
+                    var pipelineContext = scope.ServiceProvider.GetRequiredService<IPipelineContext>();
                     var readyLifecycleContext = CreateLifecycleContext(
                         moduleState,
-                        scope.ServiceProvider.GetRequiredService<IPipelineContext>(),
+                        pipelineContext,
                         scope.ServiceProvider,
                         cancellationToken);
+                    await _pipelineSetupExecutor
+                        .OnModuleReadyAsync(moduleState, readyLifecycleContext.ConsoleWriter)
+                        .ConfigureAwait(false);
                     await InvokeReadyEventAsync(moduleState, readyLifecycleContext).ConfigureAwait(false);
                 }
 
@@ -912,19 +910,21 @@ internal class ModuleRunner : IModuleRunner
         var moduleType = moduleState.ModuleType;
 
         // Before module hooks - module is starting execution.
-        await _pipelineSetupExecutor.OnModuleStartAsync(moduleState).ConfigureAwait(false);
+        var lifecycleContext = CreateLifecycleContext(
+            moduleState,
+            pipelineContext,
+            scopedServiceProvider,
+            cancellationToken);
+
+        await _pipelineSetupExecutor
+            .OnModuleStartAsync(moduleState, lifecycleContext.ConsoleWriter)
+            .ConfigureAwait(false);
 
         var estimatedDuration = await _moduleEstimatedTimeProvider.GetModuleEstimatedTimeAsync(moduleType).ConfigureAwait(false);
         await _mediator.Publish(
                 new ModuleStartedNotification(moduleState, estimatedDuration),
                 CancellationToken.None)
             .ConfigureAwait(false);
-
-        var lifecycleContext = CreateLifecycleContext(
-            moduleState,
-            pipelineContext,
-            scopedServiceProvider,
-            cancellationToken);
 
         try
         {
@@ -1018,7 +1018,8 @@ internal class ModuleRunner : IModuleRunner
             _moduleAttributeEventService.GetAttributes(moduleState.ModuleType),
             startTime,
             pipelineContext,
-            scopedServiceProvider,
+            GetModuleLogger(scopedServiceProvider, moduleState.ModuleType) as IConsoleWriter
+                ?? pipelineContext.Console,
             cancellationToken)
         {
             ReadyTime = moduleState.ReadyTime ?? startTime,
@@ -1049,7 +1050,9 @@ internal class ModuleRunner : IModuleRunner
         try
         {
             await _lifecycleEventInvoker.InvokeFailedEventAsync(lifecycleContext, result, exception).ConfigureAwait(false);
-            await _pipelineSetupExecutor.OnModuleFailureAsync(moduleState, exception).ConfigureAwait(false);
+            await _pipelineSetupExecutor
+                .OnModuleFailureAsync(moduleState, exception, lifecycleContext.ConsoleWriter)
+                .ConfigureAwait(false);
         }
         finally
         {
@@ -1074,7 +1077,12 @@ internal class ModuleRunner : IModuleRunner
                     ModuleStatus.Skipped,
                     executionContext.SkipResult!)
                 .ConfigureAwait(false);
-            await _pipelineSetupExecutor.OnModuleSkippedAsync(moduleState, executionContext.SkipResult!).ConfigureAwait(false);
+            await _pipelineSetupExecutor
+                .OnModuleSkippedAsync(
+                    moduleState,
+                    executionContext.SkipResult!,
+                    lifecycleContext.ConsoleWriter)
+                .ConfigureAwait(false);
             return;
         }
 
@@ -1086,7 +1094,9 @@ internal class ModuleRunner : IModuleRunner
                 .ConfigureAwait(false);
         }
 
-        await _pipelineSetupExecutor.OnModuleEndAsync(moduleState, result).ConfigureAwait(false);
+        await _pipelineSetupExecutor
+            .OnModuleEndAsync(moduleState, result, lifecycleContext.ConsoleWriter)
+            .ConfigureAwait(false);
         await _lifecycleEventInvoker.InvokeEndEventAsync(lifecycleContext, executionContext.Status, result).ConfigureAwait(false);
 
         if (!_manageArtifactsLocally

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -139,19 +139,13 @@ internal class ModuleRunner : IModuleRunner
         {
             try
             {
-                if (!skipDependencyWait)
-                {
-                    await _dependencyWaiter.WaitForDependenciesAsync(
-                            moduleState,
-                            scheduler,
-                            scope.ServiceProvider,
-                            cancellationToken)
-                        .ConfigureAwait(false);
-                }
-                else
-                {
-                    _logger.LogDebug("Skipping dependency wait for late-started AlwaysRun module: {ModuleName}", moduleName);
-                }
+                await WaitForDependenciesAsync(
+                        moduleState,
+                        scheduler,
+                        scope.ServiceProvider,
+                        cancellationToken,
+                        skipDependencyWait)
+                    .ConfigureAwait(false);
 
                 var allowHistoricalResultWhenSkipped = !await HasRunnableArtifactConsumerAsync(
                         moduleType,
@@ -224,14 +218,11 @@ internal class ModuleRunner : IModuleRunner
                     scheduler,
                     handledException,
                     cancellationToken);
-                if (readyLogger is not null)
-                {
-                    readyLogger.SetException(handledException);
-                    readyLogger.SetStatus(
-                        moduleState.Result?.Status
-                        ?? _resultRegistry.GetResult(moduleType)?.Status
-                        ?? Enums.ModuleStatus.Failed);
-                }
+                FinalizeReadyLoggerAfterFailure(
+                    readyLogger,
+                    moduleState,
+                    moduleType,
+                    handledException);
 
                 if (_pipelineOptions.Value.FailureMode == FailureMode.FailFast)
                 {
@@ -244,6 +235,47 @@ internal class ModuleRunner : IModuleRunner
                 }
             }
         }
+    }
+
+    private async Task WaitForDependenciesAsync(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken,
+        bool skipDependencyWait)
+    {
+        if (skipDependencyWait)
+        {
+            _logger.LogDebug(
+                "Skipping dependency wait for late-started AlwaysRun module: {ModuleName}",
+                moduleState.ModuleType.Name);
+            return;
+        }
+
+        await _dependencyWaiter.WaitForDependenciesAsync(
+                moduleState,
+                scheduler,
+                serviceProvider,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private void FinalizeReadyLoggerAfterFailure(
+        IInternalModuleLogger? readyLogger,
+        ModuleState moduleState,
+        Type moduleType,
+        Exception exception)
+    {
+        if (readyLogger is null)
+        {
+            return;
+        }
+
+        readyLogger.SetException(exception);
+        readyLogger.SetStatus(
+            moduleState.Result?.Status
+            ?? _resultRegistry.GetResult(moduleType)?.Status
+            ?? Enums.ModuleStatus.Failed);
     }
 
     internal static Exception NormalizeLimiterCancellation(

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -278,7 +278,7 @@ internal class ModuleRunner : IModuleRunner
         readyLogger.SetStatus(
             moduleState.Result?.Status
             ?? _resultRegistry.GetResult(moduleType)?.Status
-            ?? Enums.ModuleStatus.Failed);
+            ?? ModuleStatus.Failed);
     }
 
     internal static Exception NormalizeLimiterCancellation(

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -224,6 +224,14 @@ internal class ModuleRunner : IModuleRunner
                     scheduler,
                     handledException,
                     cancellationToken);
+                if (readyLogger is not null)
+                {
+                    readyLogger.SetException(handledException);
+                    readyLogger.SetStatus(
+                        moduleState.Result?.Status
+                        ?? _resultRegistry.GetResult(moduleType)?.Status
+                        ?? Enums.ModuleStatus.Failed);
+                }
 
                 if (_pipelineOptions.Value.FailureMode == FailureMode.FailFast)
                 {
@@ -812,9 +820,7 @@ internal class ModuleRunner : IModuleRunner
         var pipelineContext = scopedServiceProvider.GetRequiredService<IPipelineContext>();
 
         // Create module-specific context
-        var logger = ModuleLogger.CurrentModuleType.Value == moduleType
-            ? ModuleLogger.Values.Value ?? GetModuleLogger(scopedServiceProvider, moduleType)
-            : GetModuleLogger(scopedServiceProvider, moduleType);
+        var logger = GetAmbientOrScopedModuleLogger(scopedServiceProvider, moduleType);
         var moduleContext = new ModuleContext(
             pipelineContext,
             module,
@@ -1021,7 +1027,7 @@ internal class ModuleRunner : IModuleRunner
             _moduleAttributeEventService.GetAttributes(moduleState.ModuleType),
             startTime,
             pipelineContext,
-            GetModuleLogger(scopedServiceProvider, moduleState.ModuleType) as IConsoleWriter
+            GetAmbientOrScopedModuleLogger(scopedServiceProvider, moduleState.ModuleType) as IConsoleWriter
                 ?? pipelineContext.Console,
             cancellationToken)
         {
@@ -1243,6 +1249,13 @@ internal class ModuleRunner : IModuleRunner
         var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
         return (IModuleLogger) serviceProvider.GetRequiredService(loggerType);
     }
+
+    private static IModuleLogger GetAmbientOrScopedModuleLogger(
+        IServiceProvider serviceProvider,
+        Type moduleType) =>
+        ModuleLogger.CurrentModuleType.Value == moduleType
+            ? ModuleLogger.Values.Value ?? GetModuleLogger(serviceProvider, moduleType)
+            : GetModuleLogger(serviceProvider, moduleType);
 }
 
 internal sealed class NormalizedWorkerCancellationException(

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -131,6 +131,7 @@ internal class ModuleRunner : IModuleRunner
         var moduleType = moduleState.ModuleType;
         var moduleName = moduleType.Name;
         var limiterCancellationToken = default(CancellationToken);
+        IInternalModuleLogger? readyLogger = null;
 
         // Create a scope to resolve scoped services like IModuleContext and ModuleLogger<T>
         var scope = _serviceProvider.CreateAsyncScope();
@@ -166,6 +167,7 @@ internal class ModuleRunner : IModuleRunner
                         pipelineContext,
                         scope.ServiceProvider,
                         cancellationToken);
+                    readyLogger = readyLifecycleContext.ConsoleWriter as IInternalModuleLogger;
                     await _pipelineSetupExecutor
                         .OnModuleReadyAsync(moduleState, readyLifecycleContext.ConsoleWriter)
                         .ConfigureAwait(false);
@@ -191,6 +193,7 @@ internal class ModuleRunner : IModuleRunner
                 // until this point prevents limiter wait time from being reported as execution time.
                 if (!scheduler.MarkModuleStarted(moduleType))
                 {
+                    readyLogger?.PreserveBufferForDeferredExecution();
                     _logger.LogDebug("Module {ModuleName} deferred due to constraint check failure", moduleName);
                     return; // Module will be rescheduled by the scheduler
                 }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -160,7 +160,12 @@ internal class ModuleRunner : IModuleRunner
 
                 if (moduleState.TryStartReadyEvents())
                 {
-                    await _pipelineSetupExecutor.OnModuleReadyAsync(moduleState).ConfigureAwait(false);
+                    var readyConsoleWriter = GetModuleLogger(scope.ServiceProvider, moduleType)
+                        as IConsoleWriter
+                        ?? scope.ServiceProvider.GetRequiredService<IPipelineContext>().Console;
+                    await _pipelineSetupExecutor
+                        .OnModuleReadyAsync(moduleState, readyConsoleWriter)
+                        .ConfigureAwait(false);
                     var readyLifecycleContext = CreateLifecycleContext(
                         moduleState,
                         scope.ServiceProvider.GetRequiredService<IPipelineContext>(),

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -218,6 +218,9 @@ internal class ModuleRunner : IModuleRunner
                     scheduler,
                     handledException,
                     cancellationToken);
+                readyLogger ??= GetAmbientOrScopedModuleLogger(
+                    scope.ServiceProvider,
+                    moduleType) as IInternalModuleLogger;
                 FinalizeReadyLoggerAfterFailure(
                     readyLogger,
                     moduleState,

--- a/src/ModularPipelines/Engine/IPipelineSetupExecutor.cs
+++ b/src/ModularPipelines/Engine/IPipelineSetupExecutor.cs
@@ -11,11 +11,11 @@ internal interface IPipelineSetupExecutor
 
     Task OnModuleReadyAsync(ModuleState moduleState, IConsoleWriter consoleWriter);
 
-    Task OnModuleStartAsync(ModuleState moduleState);
+    Task OnModuleStartAsync(ModuleState moduleState, IConsoleWriter consoleWriter);
 
-    Task OnModuleEndAsync(ModuleState moduleState, IModuleResult result);
+    Task OnModuleEndAsync(ModuleState moduleState, IModuleResult result, IConsoleWriter consoleWriter);
 
-    Task OnModuleFailureAsync(ModuleState moduleState, Exception exception);
+    Task OnModuleFailureAsync(ModuleState moduleState, Exception exception, IConsoleWriter consoleWriter);
 
-    Task OnModuleSkippedAsync(ModuleState moduleState, SkipDecision reason);
+    Task OnModuleSkippedAsync(ModuleState moduleState, SkipDecision reason, IConsoleWriter consoleWriter);
 }

--- a/src/ModularPipelines/Engine/IPipelineSetupExecutor.cs
+++ b/src/ModularPipelines/Engine/IPipelineSetupExecutor.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Models;
+using ModularPipelines.Logging;
 
 namespace ModularPipelines.Engine;
 
@@ -8,7 +9,7 @@ internal interface IPipelineSetupExecutor
 
     Task OnPipelineEndAsync(PipelineSummary pipelineSummary);
 
-    Task OnModuleReadyAsync(ModuleState moduleState);
+    Task OnModuleReadyAsync(ModuleState moduleState, IConsoleWriter consoleWriter);
 
     Task OnModuleStartAsync(ModuleState moduleState);
 

--- a/src/ModularPipelines/Engine/IPipelineSetupExecutor.cs
+++ b/src/ModularPipelines/Engine/IPipelineSetupExecutor.cs
@@ -1,5 +1,5 @@
-using ModularPipelines.Models;
 using ModularPipelines.Logging;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Engine;
 

--- a/src/ModularPipelines/Engine/PipelineSetupExecutor.cs
+++ b/src/ModularPipelines/Engine/PipelineSetupExecutor.cs
@@ -60,42 +60,51 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
                 CreateModuleHookContext(moduleState, consoleWriter));
     }
 
-    public Task OnModuleStartAsync(ModuleState moduleState)
+    public Task OnModuleStartAsync(ModuleState moduleState, IConsoleWriter consoleWriter)
     {
         return _moduleEventHandlers.Count == 0
             ? Task.CompletedTask
             : _eventHandlerInvoker.InvokeStartHandlersAsync(
                 _moduleEventHandlers,
-                CreateModuleHookContext(moduleState));
+                CreateModuleHookContext(moduleState, consoleWriter));
     }
 
-    public Task OnModuleEndAsync(ModuleState moduleState, IModuleResult result)
+    public Task OnModuleEndAsync(
+        ModuleState moduleState,
+        IModuleResult result,
+        IConsoleWriter consoleWriter)
     {
         return _moduleEventHandlers.Count == 0
             ? Task.CompletedTask
             : _eventHandlerInvoker.InvokeEndHandlersAsync(
                 _moduleEventHandlers,
-                CreateModuleHookContext(moduleState),
+                CreateModuleHookContext(moduleState, consoleWriter),
                 result);
     }
 
-    public Task OnModuleFailureAsync(ModuleState moduleState, Exception exception)
+    public Task OnModuleFailureAsync(
+        ModuleState moduleState,
+        Exception exception,
+        IConsoleWriter consoleWriter)
     {
         return _moduleEventHandlers.Count == 0
             ? Task.CompletedTask
             : _eventHandlerInvoker.InvokeFailureHandlersAsync(
                 _moduleEventHandlers,
-                CreateModuleHookContext(moduleState),
+                CreateModuleHookContext(moduleState, consoleWriter),
                 exception);
     }
 
-    public Task OnModuleSkippedAsync(ModuleState moduleState, SkipDecision reason)
+    public Task OnModuleSkippedAsync(
+        ModuleState moduleState,
+        SkipDecision reason,
+        IConsoleWriter consoleWriter)
     {
         return _moduleEventHandlers.Count == 0
             ? Task.CompletedTask
             : _eventHandlerInvoker.InvokeSkippedHandlersAsync(
                 _moduleEventHandlers,
-                CreateModuleHookContext(moduleState),
+                CreateModuleHookContext(moduleState, consoleWriter),
                 reason);
     }
 
@@ -106,7 +115,7 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
 
     private ModuleHookContext CreateModuleHookContext(
         ModuleState moduleState,
-        IConsoleWriter? consoleWriter = null)
+        IConsoleWriter consoleWriter)
     {
         var moduleType = moduleState.ModuleType;
         var moduleAttributes = _attributeEventService.GetAttributes(moduleType);

--- a/src/ModularPipelines/Engine/PipelineSetupExecutor.cs
+++ b/src/ModularPipelines/Engine/PipelineSetupExecutor.cs
@@ -2,6 +2,7 @@ using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Events;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.Engine;
@@ -50,13 +51,13 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
                 pipelineSummary);
     }
 
-    public Task OnModuleReadyAsync(ModuleState moduleState)
+    public Task OnModuleReadyAsync(ModuleState moduleState, IConsoleWriter consoleWriter)
     {
         return _moduleEventHandlers.Count == 0
             ? Task.CompletedTask
             : _eventHandlerInvoker.InvokeReadyHandlersAsync(
                 _moduleEventHandlers,
-                CreateModuleHookContext(moduleState));
+                CreateModuleHookContext(moduleState, consoleWriter));
     }
 
     public Task OnModuleStartAsync(ModuleState moduleState)
@@ -103,7 +104,9 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
         return _moduleContextProvider.GetModuleContext();
     }
 
-    private ModuleHookContext CreateModuleHookContext(ModuleState moduleState)
+    private ModuleHookContext CreateModuleHookContext(
+        ModuleState moduleState,
+        IConsoleWriter? consoleWriter = null)
     {
         var moduleType = moduleState.ModuleType;
         var moduleAttributes = _attributeEventService.GetAttributes(moduleType);
@@ -115,6 +118,7 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
             startTime,
             moduleState.Result,
             GetPipelineContext(),
-            _metadataRegistry);
+            _metadataRegistry,
+            consoleWriter);
     }
 }

--- a/src/ModularPipelines/IPipelineContext.cs
+++ b/src/ModularPipelines/IPipelineContext.cs
@@ -35,6 +35,12 @@ public interface IPipelineContext
     ILogger Logger { get; }
 
     /// <summary>
+    /// Gets the module-aware console writer. Output is buffered with the current module
+    /// and secrets are obfuscated before rendering.
+    /// </summary>
+    IConsoleWriter Console { get; }
+
+    /// <summary>
     /// Gets the command execution capabilities.
     /// </summary>
     IShellContext Shell { get; }

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -37,7 +37,7 @@ internal class ConsoleWriter : IConsoleWriter
         try
         {
             AnsiConsole.Write(new SecretObfuscatedRenderable(
-                CreateObfuscatedMarkup(value),
+                ObfuscatedMarkup.Create(value, _secretObfuscator),
                 _secretObfuscator));
             AnsiConsole.WriteLine();
         }
@@ -66,21 +66,5 @@ internal class ConsoleWriter : IConsoleWriter
     {
         consoleWriter = ModuleLogger.Values.Value as IConsoleWriter;
         return consoleWriter is not null;
-    }
-
-    private Markup CreateObfuscatedMarkup(string value)
-    {
-        var obfuscatedSource = _secretObfuscator.Obfuscate(value, null);
-        try
-        {
-            return new Markup(obfuscatedSource);
-        }
-        catch (InvalidOperationException) when (!string.Equals(
-            obfuscatedSource,
-            value,
-            StringComparison.Ordinal))
-        {
-            return new Markup(value);
-        }
     }
 }

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -10,11 +10,16 @@ namespace ModularPipelines.Logging;
 internal class ConsoleWriter : IConsoleWriter
 {
     private readonly ISecretObfuscator _secretObfuscator;
+    private readonly ISecretProvider _secretProvider;
     private readonly IAnsiConsole _ansiConsole;
 
-    public ConsoleWriter(ISecretObfuscator secretObfuscator, IAnsiConsole ansiConsole)
+    public ConsoleWriter(
+        ISecretObfuscator secretObfuscator,
+        ISecretProvider secretProvider,
+        IAnsiConsole ansiConsole)
     {
         _secretObfuscator = secretObfuscator;
+        _secretProvider = secretProvider;
         _ansiConsole = ansiConsole;
     }
 
@@ -26,7 +31,7 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
-        _ansiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
+        ExecuteWithStableSecrets(value, WriteLineCore);
     }
 
     public void WriteMarkupLine(string value)
@@ -37,17 +42,7 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
-        try
-        {
-            _ansiConsole.Write(ObfuscatedMarkup.Create(value, _secretObfuscator));
-            _ansiConsole.WriteLine();
-        }
-        catch (InvalidOperationException)
-        {
-            // Fall back to plain console output if markup parsing fails
-            // (e.g., unbalanced or invalid markup characters)
-            _ansiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
-        }
+        ExecuteWithStableSecrets(value, WriteMarkupLineCore);
     }
 
     public void Write(IRenderable renderable)
@@ -58,7 +53,39 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
+        ExecuteWithStableSecrets(renderable, WriteCore);
+    }
+
+    private void WriteLineCore(string value) =>
+        _ansiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
+
+    private void WriteMarkupLineCore(string value)
+    {
+        try
+        {
+            _ansiConsole.Write(ObfuscatedMarkup.Create(value, _secretObfuscator));
+            _ansiConsole.WriteLine();
+        }
+        catch (InvalidOperationException)
+        {
+            // Fall back to plain console output if markup parsing fails
+            // (e.g., unbalanced or invalid markup characters)
+            WriteLineCore(value);
+        }
+    }
+
+    private void WriteCore(IRenderable renderable) =>
         _ansiConsole.Write(new SecretObfuscatedRenderable(renderable, _secretObfuscator));
+
+    private void ExecuteWithStableSecrets<TState>(TState state, Action<TState> write)
+    {
+        if (_secretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(state, write);
+            return;
+        }
+
+        write(state);
     }
 
     private static bool TryGetModuleConsoleWriter(

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -1,18 +1,28 @@
 using System.Diagnostics.CodeAnalysis;
-using ModularPipelines.Logging;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
-namespace ModularPipelines;
+namespace ModularPipelines.Logging;
 
 [ExcludeFromCodeCoverage]
 internal class ConsoleWriter : IConsoleWriter
 {
-    public void LogToConsole(string value)
+    public void WriteLine(string value)
     {
         if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
         {
-            moduleConsoleWriter.LogToConsole(value);
+            moduleConsoleWriter.WriteLine(value);
+            return;
+        }
+
+        AnsiConsole.WriteLine(value);
+    }
+
+    public void WriteMarkupLine(string value)
+    {
+        if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
+        {
+            moduleConsoleWriter.WriteMarkupLine(value);
             return;
         }
 

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -9,19 +9,10 @@ namespace ModularPipelines.Logging;
 internal class ConsoleWriter : IConsoleWriter
 {
     private readonly ISecretObfuscator _secretObfuscator;
-    private readonly object _renderLock = new();
-    private readonly StringWriter _renderWriter;
-    private readonly IAnsiConsole _renderConsole;
 
     public ConsoleWriter(ISecretObfuscator secretObfuscator)
     {
         _secretObfuscator = secretObfuscator;
-        _renderWriter = new StringWriter();
-        _renderConsole = AnsiConsole.Create(new AnsiConsoleSettings
-        {
-            Out = new AnsiConsoleOutput(_renderWriter),
-            Ansi = AnsiSupport.No,
-        });
     }
 
     public void WriteLine(string value)
@@ -43,17 +34,16 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
-        var obfuscated = _secretObfuscator.Obfuscate(value, null);
-
         try
         {
-            AnsiConsole.MarkupLine(obfuscated);
+            AnsiConsole.Write(new SecretObfuscatedRenderable(new Markup(value), _secretObfuscator));
+            AnsiConsole.WriteLine();
         }
         catch (InvalidOperationException)
         {
             // Fall back to plain console output if markup parsing fails
             // (e.g., unbalanced or invalid markup characters)
-            System.Console.WriteLine(obfuscated);
+            System.Console.WriteLine(_secretObfuscator.Obfuscate(value, null));
         }
     }
 
@@ -65,15 +55,8 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
-        string rendered;
-        lock (_renderLock)
-        {
-            _renderWriter.GetStringBuilder().Clear();
-            _renderConsole.Write(renderable);
-            rendered = _renderWriter.ToString();
-        }
-
-        AnsiConsole.WriteLine(_secretObfuscator.Obfuscate(rendered, null));
+        AnsiConsole.Write(new SecretObfuscatedRenderable(renderable, _secretObfuscator));
+        AnsiConsole.WriteLine();
     }
 
     private static bool TryGetModuleConsoleWriter(

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -36,9 +36,7 @@ internal class ConsoleWriter : IConsoleWriter
 
         try
         {
-            AnsiConsole.Write(new SecretObfuscatedRenderable(
-                ObfuscatedMarkup.Create(value, _secretObfuscator),
-                _secretObfuscator));
+            AnsiConsole.Write(ObfuscatedMarkup.Create(value, _secretObfuscator));
             AnsiConsole.WriteLine();
         }
         catch (InvalidOperationException)

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Engine;
+using ModularPipelines.Secrets;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -36,14 +36,16 @@ internal class ConsoleWriter : IConsoleWriter
 
         try
         {
-            AnsiConsole.Write(new SecretObfuscatedRenderable(new Markup(value), _secretObfuscator));
+            AnsiConsole.Write(new SecretObfuscatedRenderable(
+                CreateObfuscatedMarkup(value),
+                _secretObfuscator));
             AnsiConsole.WriteLine();
         }
         catch (InvalidOperationException)
         {
             // Fall back to plain console output if markup parsing fails
             // (e.g., unbalanced or invalid markup characters)
-            System.Console.WriteLine(_secretObfuscator.Obfuscate(value, null));
+            AnsiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
         }
     }
 
@@ -64,5 +66,21 @@ internal class ConsoleWriter : IConsoleWriter
     {
         consoleWriter = ModuleLogger.Values.Value as IConsoleWriter;
         return consoleWriter is not null;
+    }
+
+    private Markup CreateObfuscatedMarkup(string value)
+    {
+        var obfuscatedSource = _secretObfuscator.Obfuscate(value, null);
+        try
+        {
+            return new Markup(obfuscatedSource);
+        }
+        catch (InvalidOperationException) when (!string.Equals(
+            obfuscatedSource,
+            value,
+            StringComparison.Ordinal))
+        {
+            return new Markup(value);
+        }
     }
 }

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Engine;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -7,45 +8,78 @@ namespace ModularPipelines.Logging;
 [ExcludeFromCodeCoverage]
 internal class ConsoleWriter : IConsoleWriter
 {
+    private readonly ISecretObfuscator _secretObfuscator;
+    private readonly object _renderLock = new();
+    private readonly StringWriter _renderWriter;
+    private readonly IAnsiConsole _renderConsole;
+
+    public ConsoleWriter(ISecretObfuscator secretObfuscator)
+    {
+        _secretObfuscator = secretObfuscator;
+        _renderWriter = new StringWriter();
+        _renderConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(_renderWriter),
+            Ansi = AnsiSupport.No,
+        });
+    }
+
     public void WriteLine(string value)
     {
-        if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
+        if (TryGetModuleConsoleWriter(out var moduleConsoleWriter))
         {
             moduleConsoleWriter.WriteLine(value);
             return;
         }
 
-        AnsiConsole.WriteLine(value);
+        AnsiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
     }
 
     public void WriteMarkupLine(string value)
     {
-        if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
+        if (TryGetModuleConsoleWriter(out var moduleConsoleWriter))
         {
             moduleConsoleWriter.WriteMarkupLine(value);
             return;
         }
 
+        var obfuscated = _secretObfuscator.Obfuscate(value, null);
+
         try
         {
-            AnsiConsole.MarkupLine(value);
+            AnsiConsole.MarkupLine(obfuscated);
         }
         catch (InvalidOperationException)
         {
             // Fall back to plain console output if markup parsing fails
             // (e.g., unbalanced or invalid markup characters)
-            System.Console.WriteLine(value);
+            System.Console.WriteLine(obfuscated);
         }
     }
 
     public void Write(IRenderable renderable)
     {
-        if (ModuleLogger.Values.Value is IConsoleWriter moduleConsoleWriter)
+        if (TryGetModuleConsoleWriter(out var moduleConsoleWriter))
         {
             moduleConsoleWriter.Write(renderable);
             return;
         }
 
-        AnsiConsole.Write(renderable);
+        string rendered;
+        lock (_renderLock)
+        {
+            _renderWriter.GetStringBuilder().Clear();
+            _renderConsole.Write(renderable);
+            rendered = _renderWriter.ToString();
+        }
+
+        AnsiConsole.WriteLine(_secretObfuscator.Obfuscate(rendered, null));
+    }
+
+    private static bool TryGetModuleConsoleWriter(
+        [NotNullWhen(true)] out IConsoleWriter? consoleWriter)
+    {
+        consoleWriter = ModuleLogger.Values.Value as IConsoleWriter;
+        return consoleWriter is not null;
     }
 }

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -10,10 +10,12 @@ namespace ModularPipelines.Logging;
 internal class ConsoleWriter : IConsoleWriter
 {
     private readonly ISecretObfuscator _secretObfuscator;
+    private readonly IAnsiConsole _ansiConsole;
 
-    public ConsoleWriter(ISecretObfuscator secretObfuscator)
+    public ConsoleWriter(ISecretObfuscator secretObfuscator, IAnsiConsole ansiConsole)
     {
         _secretObfuscator = secretObfuscator;
+        _ansiConsole = ansiConsole;
     }
 
     public void WriteLine(string value)
@@ -24,7 +26,7 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
-        AnsiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
+        _ansiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
     }
 
     public void WriteMarkupLine(string value)
@@ -37,14 +39,14 @@ internal class ConsoleWriter : IConsoleWriter
 
         try
         {
-            AnsiConsole.Write(ObfuscatedMarkup.Create(value, _secretObfuscator));
-            AnsiConsole.WriteLine();
+            _ansiConsole.Write(ObfuscatedMarkup.Create(value, _secretObfuscator));
+            _ansiConsole.WriteLine();
         }
         catch (InvalidOperationException)
         {
             // Fall back to plain console output if markup parsing fails
             // (e.g., unbalanced or invalid markup characters)
-            AnsiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
+            _ansiConsole.WriteLine(_secretObfuscator.Obfuscate(value, null));
         }
     }
 
@@ -56,7 +58,7 @@ internal class ConsoleWriter : IConsoleWriter
             return;
         }
 
-        AnsiConsole.Write(new SecretObfuscatedRenderable(renderable, _secretObfuscator));
+        _ansiConsole.Write(new SecretObfuscatedRenderable(renderable, _secretObfuscator));
     }
 
     private static bool TryGetModuleConsoleWriter(

--- a/src/ModularPipelines/Logging/ConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/ConsoleWriter.cs
@@ -58,7 +58,6 @@ internal class ConsoleWriter : IConsoleWriter
         }
 
         AnsiConsole.Write(new SecretObfuscatedRenderable(renderable, _secretObfuscator));
-        AnsiConsole.WriteLine();
     }
 
     private static bool TryGetModuleConsoleWriter(

--- a/src/ModularPipelines/Logging/IConsoleWriter.cs
+++ b/src/ModularPipelines/Logging/IConsoleWriter.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Rendering;
 namespace ModularPipelines.Logging;
 
 /// <summary>
-/// Provides direct console output with Spectre.Console markup support.
+/// Provides module-aware plain text, Spectre.Console markup, and rich console output.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -19,18 +19,24 @@ namespace ModularPipelines.Logging;
 /// <para><b>Example usage:</b></para>
 /// <code>
 /// // Rich console output with markup
-/// consoleWriter.LogToConsole("[green]Build succeeded![/]");
-/// consoleWriter.LogToConsole("[red]Error:[/] Something went wrong");
+/// consoleWriter.WriteLine("Build succeeded!");
+/// consoleWriter.WriteMarkupLine("[red]Error:[/] Something went wrong");
 /// </code>
 /// </remarks>
 /// <seealso cref="ILogger"/>
 public interface IConsoleWriter
 {
     /// <summary>
-    /// Writes a value to the console.
+    /// Writes a plain-text line to the console.
     /// </summary>
     /// <param name="value">The value to write.</param>
-    void LogToConsole(string value);
+    void WriteLine(string value);
+
+    /// <summary>
+    /// Writes a line containing Spectre.Console markup to the console.
+    /// </summary>
+    /// <param name="value">The markup value to write.</param>
+    void WriteMarkupLine(string value);
 
     /// <summary>
     /// Writes a Spectre.Console renderable to the console.

--- a/src/ModularPipelines/Logging/IInternalModuleLogger.cs
+++ b/src/ModularPipelines/Logging/IInternalModuleLogger.cs
@@ -16,4 +16,10 @@ internal interface IInternalModuleLogger : IModuleLogger
     /// Sets the final module status used when rendering buffered output.
     /// </summary>
     void SetStatus(ModuleStatus status);
+
+    /// <summary>
+    /// Prevents this scoped logger from completing the shared module output buffer.
+    /// Used when scheduling defers the module before execution starts.
+    /// </summary>
+    void PreserveBufferForDeferredExecution();
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -56,7 +56,9 @@ internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter, IA
 
     public abstract ValueTask DisposeAsync();
 
-    public abstract void LogToConsole(string value);
+    public abstract void WriteLine(string value);
+
+    public abstract void WriteMarkupLine(string value);
 
     public abstract void Write(IRenderable renderable);
 
@@ -258,7 +260,13 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             typeof(T).Name);
     }
 
-    public override void LogToConsole(string value)
+    public override void WriteLine(string value)
+    {
+        var obfuscated = _secretObfuscator.Obfuscate(value, null) ?? value;
+        _buffer.WriteLine(Markup.Escape(obfuscated));
+    }
+
+    public override void WriteMarkupLine(string value)
     {
         var obfuscated = _secretObfuscator.Obfuscate(value, null) ?? value;
         _buffer.WriteLine(obfuscated);

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -268,7 +268,18 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void WriteMarkupLine(string value)
     {
-        WriteRenderable(new Markup(value));
+        Markup markup;
+        try
+        {
+            markup = new Markup(value);
+        }
+        catch (InvalidOperationException)
+        {
+            WriteLine(value);
+            return;
+        }
+
+        WriteRenderable(markup);
     }
 
     public override void Write(IRenderable renderable)

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -287,15 +287,15 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             return;
         }
 
-        WriteRenderable(markup);
+        WriteRenderable(markup, appendNewLine: true);
     }
 
     public override void Write(IRenderable renderable)
     {
-        WriteRenderable(renderable);
+        WriteRenderable(renderable, appendNewLine: false);
     }
 
-    private void WriteRenderable(IRenderable renderable)
+    private void WriteRenderable(IRenderable renderable, bool appendNewLine)
     {
         var obfuscatedRenderable = new SecretObfuscatedRenderable(renderable, _secretObfuscator);
         var snapshot = obfuscatedRenderable.Snapshot(
@@ -309,6 +309,6 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             rendered = _renderWriter.ToString();
         }
 
-        _buffer.WriteRenderable(snapshot, rendered);
+        _buffer.WriteRenderable(snapshot, rendered, appendNewLine);
     }
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -279,7 +279,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         Markup markup;
         try
         {
-            markup = CreateObfuscatedMarkup(value);
+            markup = ObfuscatedMarkup.Create(value, _secretObfuscator);
         }
         catch (InvalidOperationException)
         {
@@ -310,21 +310,5 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         }
 
         _buffer.WriteRenderable(snapshot, rendered);
-    }
-
-    private Markup CreateObfuscatedMarkup(string value)
-    {
-        var obfuscatedSource = _secretObfuscator.Obfuscate(value, null);
-        try
-        {
-            return new Markup(obfuscatedSource);
-        }
-        catch (InvalidOperationException) when (!string.Equals(
-            obfuscatedSource,
-            value,
-            StringComparison.Ordinal))
-        {
-            return new Markup(value);
-        }
     }
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -86,6 +86,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
     private readonly IFormattedLogValuesObfuscator _formattedLogValuesObfuscator;
     private readonly IModuleOutputBuffer _buffer;
     private readonly IOutputCoordinator _outputCoordinator;
+    private readonly IAnsiConsole _ansiConsole;
     private readonly object _renderLock = new();
     private readonly StringWriter _renderWriter;
     private readonly IAnsiConsole _renderConsole;
@@ -98,13 +99,15 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         ISecretObfuscator secretObfuscator,
         IFormattedLogValuesObfuscator formattedLogValuesObfuscator,
         IConsoleCoordinator consoleCoordinator,
-        IOutputCoordinator outputCoordinator)
+        IOutputCoordinator outputCoordinator,
+        IAnsiConsole? ansiConsole = null)
     {
         _defaultLogger = defaultLogger;
         _secretObfuscator = secretObfuscator;
         _formattedLogValuesObfuscator = formattedLogValuesObfuscator;
         _buffer = consoleCoordinator.GetModuleBuffer(typeof(T));
         _outputCoordinator = outputCoordinator;
+        _ansiConsole = ansiConsole ?? DelegatingAnsiConsole.Instance;
         _renderWriter = new StringWriter();
         _renderConsole = AnsiConsole.Create(new AnsiConsoleSettings
         {
@@ -298,12 +301,14 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
     private void WriteRenderable(IRenderable renderable, bool appendNewLine)
     {
         var obfuscatedRenderable = new SecretObfuscatedRenderable(renderable, _secretObfuscator);
+        var renderWidth = _ansiConsole.Profile.Width;
         var snapshot = obfuscatedRenderable.Snapshot(
-            RenderOptions.Create(_renderConsole),
-            _renderConsole.Profile.Width);
+            RenderOptions.Create(_ansiConsole),
+            renderWidth);
         string rendered;
         lock (_renderLock)
         {
+            _renderConsole.Profile.Width = renderWidth;
             _renderWriter.GetStringBuilder().Clear();
             _renderConsole.Write(snapshot);
             rendered = _renderWriter.ToString();

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -317,6 +317,6 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             rendered = _renderWriter.ToString();
         }
 
-        _buffer.WriteRenderable(snapshot, rendered, appendNewLine);
+        _buffer.WriteRenderable(obfuscatedRenderable, rendered, appendNewLine);
     }
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -268,21 +268,25 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void WriteMarkupLine(string value)
     {
-        var obfuscated = _secretObfuscator.Obfuscate(value, null) ?? value;
-        _buffer.WriteLine(obfuscated);
+        WriteRenderable(new Markup(value));
     }
 
     public override void Write(IRenderable renderable)
     {
+        WriteRenderable(renderable);
+    }
+
+    private void WriteRenderable(IRenderable renderable)
+    {
+        var obfuscatedRenderable = new SecretObfuscatedRenderable(renderable, _secretObfuscator);
         string rendered;
         lock (_renderLock)
         {
             _renderWriter.GetStringBuilder().Clear();
-            _renderConsole.Write(renderable);
+            _renderConsole.Write(obfuscatedRenderable);
             rendered = _renderWriter.ToString();
         }
 
-        var obfuscated = _secretObfuscator.Obfuscate(rendered, null) ?? rendered;
-        _buffer.WriteLine(obfuscated);
+        _buffer.WriteRenderable(obfuscatedRenderable, rendered);
     }
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -44,6 +44,7 @@ internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter, IA
     protected readonly object _disposeLock = new();
     protected Exception? _exception;
     protected ModuleStatus _status = ModuleStatus.Succeeded;
+    protected bool _preserveBufferForDeferredExecution;
 
     public abstract void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
 
@@ -70,6 +71,11 @@ internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter, IA
     public void SetStatus(ModuleStatus status)
     {
         _status = status;
+    }
+
+    public void PreserveBufferForDeferredExecution()
+    {
+        _preserveBufferForDeferredExecution = true;
     }
 }
 
@@ -165,14 +171,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             }
 
             _isDisposed = true;
-
-            if (_exception != null)
-            {
-                _buffer.SetException(_exception);
-            }
-
-            _buffer.SetStatus(_status);
-            _buffer.MarkComplete();
+            CompleteBuffer();
         }
 
         GC.SuppressFinalize(this);
@@ -190,15 +189,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             }
 
             _isDisposed = true;
-
-            if (_exception != null)
-            {
-                _buffer.SetException(_exception);
-            }
-
-            _buffer.SetStatus(_status);
-            _buffer.MarkComplete();
-            shouldFlush = true;
+            shouldFlush = CompleteBuffer();
         }
 
         if (shouldFlush)
@@ -225,6 +216,23 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         }
 
         GC.SuppressFinalize(this);
+    }
+
+    private bool CompleteBuffer()
+    {
+        if (_preserveBufferForDeferredExecution)
+        {
+            return false;
+        }
+
+        if (_exception != null)
+        {
+            _buffer.SetException(_exception);
+        }
+
+        _buffer.SetStatus(_status);
+        _buffer.MarkComplete();
+        return true;
     }
 
     private void LogFlushTimeout()
@@ -263,7 +271,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
     public override void WriteLine(string value)
     {
         var obfuscated = _secretObfuscator.Obfuscate(value, null) ?? value;
-        _buffer.WriteLine(Markup.Escape(obfuscated));
+        _buffer.WriteRenderable(new Markup(Markup.Escape(obfuscated)), obfuscated);
     }
 
     public override void WriteMarkupLine(string value)
@@ -271,7 +279,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         Markup markup;
         try
         {
-            markup = new Markup(value);
+            markup = CreateObfuscatedMarkup(value);
         }
         catch (InvalidOperationException)
         {
@@ -290,14 +298,33 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
     private void WriteRenderable(IRenderable renderable)
     {
         var obfuscatedRenderable = new SecretObfuscatedRenderable(renderable, _secretObfuscator);
+        var snapshot = obfuscatedRenderable.Snapshot(
+            RenderOptions.Create(_renderConsole),
+            _renderConsole.Profile.Width);
         string rendered;
         lock (_renderLock)
         {
             _renderWriter.GetStringBuilder().Clear();
-            _renderConsole.Write(obfuscatedRenderable);
+            _renderConsole.Write(snapshot);
             rendered = _renderWriter.ToString();
         }
 
-        _buffer.WriteRenderable(obfuscatedRenderable, rendered);
+        _buffer.WriteRenderable(snapshot, rendered);
+    }
+
+    private Markup CreateObfuscatedMarkup(string value)
+    {
+        var obfuscatedSource = _secretObfuscator.Obfuscate(value, null);
+        try
+        {
+            return new Markup(obfuscatedSource);
+        }
+        catch (InvalidOperationException) when (!string.Equals(
+            obfuscatedSource,
+            value,
+            StringComparison.Ordinal))
+        {
+            return new Markup(value);
+        }
     }
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -279,7 +279,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void WriteMarkupLine(string value)
     {
-        Markup markup;
+        SecretObfuscatedRenderable markup;
         try
         {
             markup = ObfuscatedMarkup.Create(value, _secretObfuscator);
@@ -300,7 +300,10 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     private void WriteRenderable(IRenderable renderable, bool appendNewLine)
     {
-        var obfuscatedRenderable = new SecretObfuscatedRenderable(renderable, _secretObfuscator);
+        var obfuscatedRenderable = renderable as SecretObfuscatedRenderable
+                                   ?? new SecretObfuscatedRenderable(
+                                       renderable,
+                                       _secretObfuscator);
         var renderWidth = _ansiConsole.Profile.Width;
         var snapshot = obfuscatedRenderable.Snapshot(
             RenderOptions.Create(_ansiConsole),

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -279,10 +279,12 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void WriteMarkupLine(string value)
     {
-        SecretObfuscatedRenderable markup;
+        Markup markup;
+        string plainText;
         try
         {
-            markup = ObfuscatedMarkup.Create(value, _secretObfuscator);
+            markup = new Markup(value);
+            plainText = Markup.Remove(value);
         }
         catch (InvalidOperationException)
         {
@@ -290,7 +292,10 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             return;
         }
 
-        WriteRenderable(markup, appendNewLine: true);
+        WriteRenderable(
+            new SecretObfuscatedRenderable(markup, _secretObfuscator),
+            appendNewLine: true,
+            plainText: plainText);
     }
 
     public override void Write(IRenderable renderable)
@@ -298,7 +303,10 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         WriteRenderable(renderable, appendNewLine: false);
     }
 
-    private void WriteRenderable(IRenderable renderable, bool appendNewLine)
+    private void WriteRenderable(
+        IRenderable renderable,
+        bool appendNewLine,
+        string? plainText = null)
     {
         var obfuscatedRenderable = renderable as SecretObfuscatedRenderable
                                    ?? new SecretObfuscatedRenderable(
@@ -317,6 +325,6 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             rendered = _renderWriter.ToString();
         }
 
-        _buffer.WriteRenderable(obfuscatedRenderable, rendered, appendNewLine);
+        _buffer.WriteRenderable(obfuscatedRenderable, plainText ?? rendered, appendNewLine);
     }
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -273,8 +273,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void WriteLine(string value)
     {
-        var obfuscated = _secretObfuscator.Obfuscate(value, null) ?? value;
-        _buffer.WriteRenderable(new Markup(Markup.Escape(obfuscated)), obfuscated);
+        _buffer.WriteRenderable(new Markup(Markup.Escape(value)), value);
     }
 
     public override void WriteMarkupLine(string value)

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using ModularPipelines.Engine;
+using ModularPipelines.Secrets;
 using Spectre.Console;
 
 namespace ModularPipelines.Logging;

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -7,12 +7,14 @@ namespace ModularPipelines.Logging;
 
 internal static partial class ObfuscatedMarkup
 {
-    internal static Markup Create(string value, ISecretObfuscator secretObfuscator)
+    internal static SecretObfuscatedRenderable Create(
+        string value,
+        ISecretObfuscator secretObfuscator)
     {
         var safeSource = CreateSafeSourceCore(value, secretObfuscator);
         if (safeSource.WasChanged)
         {
-            return new Markup(safeSource.Value);
+            return CreateRenderable(safeSource.Value, secretObfuscator);
         }
 
         var obfuscatedSource = secretObfuscator.Obfuscate(value, null);
@@ -21,11 +23,16 @@ internal static partial class ObfuscatedMarkup
             match => secretObfuscator.Obfuscate(match.Value, null));
         if (string.Equals(tagObfuscatedSource, obfuscatedSource, StringComparison.Ordinal))
         {
-            return new Markup(value);
+            return CreateRenderable(value, secretObfuscator);
         }
 
-        return new Markup(obfuscatedSource);
+        return CreateRenderable(obfuscatedSource, secretObfuscator);
     }
+
+    private static SecretObfuscatedRenderable CreateRenderable(
+        string value,
+        ISecretObfuscator secretObfuscator) =>
+        SecretObfuscatedRenderable.FromPreObfuscated(new Markup(value), secretObfuscator);
 
     internal static string CreateSafeSource(
         string value,

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -9,61 +9,108 @@ internal static partial class ObfuscatedMarkup
 {
     internal static Markup Create(string value, ISecretObfuscator secretObfuscator)
     {
-        var obfuscatedSource = secretObfuscator.Obfuscate(value, null);
-        try
+        var safeSource = CreateSafeSourceCore(value, secretObfuscator);
+        if (safeSource.WasChanged)
         {
-            return new Markup(obfuscatedSource);
+            return new Markup(safeSource.Value);
         }
-        catch (InvalidOperationException) when (!string.Equals(
-            obfuscatedSource,
-            value,
-            StringComparison.Ordinal))
-        {
-            var tagObfuscatedSource = MarkupTagRegex().Replace(
-                value,
-                match => secretObfuscator.Obfuscate(match.Value, null));
-            if (!string.Equals(tagObfuscatedSource, obfuscatedSource, StringComparison.Ordinal))
-            {
-                throw;
-            }
 
-            return new Markup(ObfuscateText(value, secretObfuscator));
+        var obfuscatedSource = secretObfuscator.Obfuscate(value, null);
+        var tagObfuscatedSource = MarkupTagRegex().Replace(
+            value,
+            match => secretObfuscator.Obfuscate(match.Value, null));
+        if (string.Equals(tagObfuscatedSource, obfuscatedSource, StringComparison.Ordinal))
+        {
+            return new Markup(value);
         }
+
+        return new Markup(obfuscatedSource);
     }
 
     internal static string CreateSafeSource(
         string value,
+        ISecretObfuscator secretObfuscator) =>
+        CreateSafeSourceCore(value, secretObfuscator).Value;
+
+    private static SafeSource CreateSafeSourceCore(
+        string value,
         ISecretObfuscator secretObfuscator)
     {
-        var output = new StringBuilder(value.Length);
-        var sourceOffset = 0;
-        foreach (Match match in MarkupTagRegex().Matches(value))
+        var matches = MarkupTagRegex().Matches(value).Cast<Match>().ToArray();
+        var visibleText = GetVisibleText(value, matches);
+        string obfuscatedText;
+        Func<int, int, string> getObfuscatedSlice;
+        if (secretObfuscator is SecretObfuscator concreteObfuscator)
         {
-            output.Append(Markup.Escape(
-                secretObfuscator.Obfuscate(value[sourceOffset..match.Index], null)));
-            output.Append(match.Value);
-            sourceOffset = match.Index + match.Length;
+            var mappedOutput = concreteObfuscator.ObfuscateWithSourceMap(
+                visibleText,
+                concreteObfuscator.CanSafelyPreserveRegisteredMasks());
+            var outputBytes = Encoding.UTF8.GetBytes(mappedOutput.Value);
+            obfuscatedText = mappedOutput.Value;
+            getObfuscatedSlice = (start, end) => Encoding.UTF8.GetString(
+                outputBytes,
+                mappedOutput.SourceToOutputByteOffsets[start],
+                mappedOutput.SourceToOutputByteOffsets[end]
+                - mappedOutput.SourceToOutputByteOffsets[start]);
+        }
+        else
+        {
+            obfuscatedText = secretObfuscator.Obfuscate(visibleText, null);
+            getObfuscatedSlice = (start, end) => obfuscatedText[
+                ScaleOffset(start, visibleText.Length, obfuscatedText)..
+                ScaleOffset(end, visibleText.Length, obfuscatedText)];
         }
 
-        output.Append(Markup.Escape(
-            secretObfuscator.Obfuscate(value[sourceOffset..], null)));
-        return output.ToString();
+        var wasChanged = !string.Equals(visibleText, obfuscatedText, StringComparison.Ordinal);
+
+        var output = new StringBuilder(value.Length);
+        var sourceOffset = 0;
+        var visibleOffset = 0;
+        foreach (var match in matches)
+        {
+            var textLength = match.Index - sourceOffset;
+            output.Append(Markup.Escape(getObfuscatedSlice(
+                visibleOffset,
+                visibleOffset + textLength)));
+            output.Append(match.Value);
+            sourceOffset = match.Index + match.Length;
+            visibleOffset += textLength;
+        }
+
+        output.Append(Markup.Escape(getObfuscatedSlice(visibleOffset, visibleText.Length)));
+        return new SafeSource(output.ToString(), wasChanged);
     }
 
-    private static string ObfuscateText(string value, ISecretObfuscator secretObfuscator)
+    private static string GetVisibleText(string value, IReadOnlyList<Match> matches)
     {
         var output = new StringBuilder(value.Length);
         var sourceOffset = 0;
-        foreach (Match match in MarkupTagRegex().Matches(value))
+        foreach (var match in matches)
         {
-            output.Append(secretObfuscator.Obfuscate(value[sourceOffset..match.Index], null));
-            output.Append(match.Value);
+            output.Append(value[sourceOffset..match.Index]);
             sourceOffset = match.Index + match.Length;
         }
 
-        output.Append(secretObfuscator.Obfuscate(value[sourceOffset..], null));
+        output.Append(value[sourceOffset..]);
         return output.ToString();
     }
+
+    private static int ScaleOffset(int sourceOffset, int sourceLength, string output)
+    {
+        if (sourceOffset >= sourceLength)
+        {
+            return output.Length;
+        }
+
+        var outputOffset = (int)((long) sourceOffset * output.Length / sourceLength);
+        return outputOffset > 0
+               && outputOffset < output.Length
+               && char.IsLowSurrogate(output[outputOffset])
+            ? outputOffset + 1
+            : outputOffset;
+    }
+
+    private readonly record struct SafeSource(string Value, bool WasChanged);
 
     [GeneratedRegex(@"\[[^\]\r\n]+\]", RegexOptions.CultureInvariant)]
     private static partial Regex MarkupTagRegex();

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -68,7 +68,8 @@ internal static partial class ObfuscatedMarkup
         var visibleOffset = 0;
         foreach (var match in matches)
         {
-            var textLength = match.Index - sourceOffset;
+            var visibleFragment = DecodeEscapedBrackets(value[sourceOffset..match.Index]);
+            var textLength = visibleFragment.Length;
             output.Append(Markup.Escape(getObfuscatedSlice(
                 visibleOffset,
                 visibleOffset + textLength)));
@@ -87,13 +88,17 @@ internal static partial class ObfuscatedMarkup
         var sourceOffset = 0;
         foreach (var match in matches)
         {
-            output.Append(value[sourceOffset..match.Index]);
+            output.Append(DecodeEscapedBrackets(value[sourceOffset..match.Index]));
             sourceOffset = match.Index + match.Length;
         }
 
-        output.Append(value[sourceOffset..]);
+        output.Append(DecodeEscapedBrackets(value[sourceOffset..]));
         return output.ToString();
     }
+
+    private static string DecodeEscapedBrackets(string value) => value
+        .Replace("[[", "[", StringComparison.Ordinal)
+        .Replace("]]", "]", StringComparison.Ordinal);
 
     private static int ScaleOffset(int sourceOffset, int sourceLength, string output)
     {
@@ -112,6 +117,6 @@ internal static partial class ObfuscatedMarkup
 
     private readonly record struct SafeSource(string Value, bool WasChanged);
 
-    [GeneratedRegex(@"\[[^\]\r\n]+\]", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"(?<!\[)\[(?!\[)[^\]\r\n]+\](?!\])", RegexOptions.CultureInvariant)]
     private static partial Regex MarkupTagRegex();
 }

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -31,6 +31,25 @@ internal static partial class ObfuscatedMarkup
         }
     }
 
+    internal static string CreateSafeSource(
+        string value,
+        ISecretObfuscator secretObfuscator)
+    {
+        var output = new StringBuilder(value.Length);
+        var sourceOffset = 0;
+        foreach (Match match in MarkupTagRegex().Matches(value))
+        {
+            output.Append(Markup.Escape(
+                secretObfuscator.Obfuscate(value[sourceOffset..match.Index], null)));
+            output.Append(match.Value);
+            sourceOffset = match.Index + match.Length;
+        }
+
+        output.Append(Markup.Escape(
+            secretObfuscator.Obfuscate(value[sourceOffset..], null)));
+        return output.ToString();
+    }
+
     private static string ObfuscateText(string value, ISecretObfuscator secretObfuscator)
     {
         var output = new StringBuilder(value.Length);

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using ModularPipelines.Engine;
+using Spectre.Console;
+
+namespace ModularPipelines.Logging;
+
+internal static partial class ObfuscatedMarkup
+{
+    internal static Markup Create(string value, ISecretObfuscator secretObfuscator)
+    {
+        var obfuscatedSource = secretObfuscator.Obfuscate(value, null);
+        try
+        {
+            return new Markup(obfuscatedSource);
+        }
+        catch (InvalidOperationException) when (!string.Equals(
+            obfuscatedSource,
+            value,
+            StringComparison.Ordinal))
+        {
+            var tagObfuscatedSource = MarkupTagRegex().Replace(
+                value,
+                match => secretObfuscator.Obfuscate(match.Value, null));
+            if (!string.Equals(tagObfuscatedSource, obfuscatedSource, StringComparison.Ordinal))
+            {
+                throw;
+            }
+
+            return new Markup(ObfuscateText(value, secretObfuscator));
+        }
+    }
+
+    private static string ObfuscateText(string value, ISecretObfuscator secretObfuscator)
+    {
+        var output = new StringBuilder(value.Length);
+        var sourceOffset = 0;
+        foreach (Match match in MarkupTagRegex().Matches(value))
+        {
+            output.Append(secretObfuscator.Obfuscate(value[sourceOffset..match.Index], null));
+            output.Append(match.Value);
+            sourceOffset = match.Index + match.Length;
+        }
+
+        output.Append(secretObfuscator.Obfuscate(value[sourceOffset..], null));
+        return output.ToString();
+    }
+
+    [GeneratedRegex(@"\[[^\]\r\n]+\]", RegexOptions.CultureInvariant)]
+    private static partial Regex MarkupTagRegex();
+}

--- a/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedMarkup.cs
@@ -65,8 +65,7 @@ internal static partial class ObfuscatedMarkup
         {
             obfuscatedText = secretObfuscator.Obfuscate(visibleText, null);
             getObfuscatedSlice = (start, end) => obfuscatedText[
-                ScaleOffset(start, visibleText.Length, obfuscatedText)..
-                ScaleOffset(end, visibleText.Length, obfuscatedText)];
+                ObfuscatedTextOffset.Scale(start, visibleText.Length, obfuscatedText)..ObfuscatedTextOffset.Scale(end, visibleText.Length, obfuscatedText)];
         }
 
         var wasChanged = !string.Equals(visibleText, obfuscatedText, StringComparison.Ordinal);
@@ -107,21 +106,6 @@ internal static partial class ObfuscatedMarkup
     private static string DecodeEscapedBrackets(string value) => value
         .Replace("[[", "[", StringComparison.Ordinal)
         .Replace("]]", "]", StringComparison.Ordinal);
-
-    private static int ScaleOffset(int sourceOffset, int sourceLength, string output)
-    {
-        if (sourceOffset >= sourceLength)
-        {
-            return output.Length;
-        }
-
-        var outputOffset = (int)((long) sourceOffset * output.Length / sourceLength);
-        return outputOffset > 0
-               && outputOffset < output.Length
-               && char.IsLowSurrogate(output[outputOffset])
-            ? outputOffset + 1
-            : outputOffset;
-    }
 
     private readonly record struct SafeSource(string Value, bool WasChanged);
 

--- a/src/ModularPipelines/Logging/ObfuscatedTextOffset.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedTextOffset.cs
@@ -1,0 +1,19 @@
+namespace ModularPipelines.Logging;
+
+internal static class ObfuscatedTextOffset
+{
+    internal static int Scale(int sourceOffset, int sourceLength, string output)
+    {
+        if (sourceOffset >= sourceLength)
+        {
+            return output.Length;
+        }
+
+        var outputOffset = (int) ((long) sourceOffset * output.Length / sourceLength);
+        return outputOffset > 0
+               && outputOffset < output.Length
+               && char.IsLowSurrogate(output[outputOffset])
+            ? outputOffset + 1
+            : outputOffset;
+    }
+}

--- a/src/ModularPipelines/Logging/ObfuscatedTextOffset.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedTextOffset.cs
@@ -9,7 +9,8 @@ internal static class ObfuscatedTextOffset
             return output.Length;
         }
 
-        var outputOffset = (int) ((long) sourceOffset * output.Length / sourceLength);
+        var scaledOffset = (long) sourceOffset * output.Length / sourceLength;
+        var outputOffset = (int) scaledOffset;
         return outputOffset > 0
                && outputOffset < output.Length
                && char.IsLowSurrogate(output[outputOffset])

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -28,7 +28,13 @@ internal sealed class SecretObfuscatedRenderable(
     public Measurement Measure(RenderOptions options, int maxWidth)
     {
         var innerMeasurement = _prepared.Renderable.Measure(options, maxWidth);
-        return MeasureSegments(GetSegments(options, maxWidth), maxWidth, innerMeasurement);
+        var segments = GetSegments(options, maxWidth, out var originalSegments);
+        return MeasureSegments(
+            segments,
+            originalSegments,
+            options,
+            maxWidth,
+            innerMeasurement);
     }
 
     public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
@@ -37,13 +43,21 @@ internal sealed class SecretObfuscatedRenderable(
     internal IRenderable Snapshot(RenderOptions options, int maxWidth)
     {
         var innerMeasurement = _prepared.Renderable.Measure(options, maxWidth);
-        return new SegmentSnapshotRenderable(GetSegments(options, maxWidth), innerMeasurement);
+        var segments = GetSegments(options, maxWidth, out var originalSegments);
+        return new SegmentSnapshotRenderable(segments, originalSegments, innerMeasurement);
     }
 
-    private Segment[] GetSegments(RenderOptions options, int maxWidth)
+    private Segment[] GetSegments(RenderOptions options, int maxWidth) =>
+        GetSegments(options, maxWidth, out _);
+
+    private Segment[] GetSegments(
+        RenderOptions options,
+        int maxWidth,
+        out Segment[] originalSegments)
     {
-        var segments = SanitizeControlCodes(
+        originalSegments = SanitizeControlCodes(
             _prepared.Renderable.Render(options, maxWidth).ToArray());
+        var segments = originalSegments;
         if (_prepared.IsObfuscatedBeforeRender)
         {
             return ObfuscateLinks(segments);
@@ -598,6 +612,8 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static Measurement MeasureSegments(
         Segment[] segments,
+        Segment[] originalSegments,
+        RenderOptions options,
         int maxWidth,
         Measurement innerMeasurement)
     {
@@ -608,17 +624,51 @@ internal sealed class SecretObfuscatedRenderable(
         width = Math.Min(width, maxWidth);
         var innerMaximumWidth = Math.Min(innerMeasurement.Max, maxWidth);
         var innerMinimumWidth = Math.Min(innerMeasurement.Min, innerMaximumWidth);
-        var widthChange = width - innerMaximumWidth;
-        var minimumWidth = Math.Clamp(innerMinimumWidth + widthChange, 0, width);
+        var originalText = GetVisibleText(originalSegments);
+        var transformedText = GetVisibleText(segments);
+        var minimumWidth = string.Equals(originalText, transformedText, StringComparison.Ordinal)
+            ? Math.Min(innerMinimumWidth, width)
+            : GetTransformedMinimumWidth(
+                originalText,
+                transformedText,
+                options,
+                maxWidth,
+                innerMinimumWidth,
+                width);
         return new Measurement(minimumWidth, width);
+    }
+
+    private static string GetVisibleText(IEnumerable<Segment> segments) =>
+        string.Concat(segments
+            .Where(static segment => !segment.IsControlCode)
+            .Select(static segment => segment.Text));
+
+    private static int GetTransformedMinimumWidth(
+        string originalText,
+        string transformedText,
+        RenderOptions options,
+        int maxWidth,
+        int innerMinimumWidth,
+        int transformedMaximumWidth)
+    {
+        var originalTextMinimumWidth = ((IRenderable) new Text(originalText))
+            .Measure(options, maxWidth).Min;
+        var transformedTextMinimumWidth = ((IRenderable) new Text(transformedText))
+            .Measure(options, maxWidth).Min;
+        var structuralMinimumWidth = Math.Max(0, innerMinimumWidth - originalTextMinimumWidth);
+        return Math.Clamp(
+            structuralMinimumWidth + transformedTextMinimumWidth,
+            0,
+            transformedMaximumWidth);
     }
 
     private sealed class SegmentSnapshotRenderable(
         Segment[] segments,
+        Segment[] originalSegments,
         Measurement innerMeasurement) : IRenderable
     {
         public Measurement Measure(RenderOptions options, int maxWidth) =>
-            MeasureSegments(segments, maxWidth, innerMeasurement);
+            MeasureSegments(segments, originalSegments, options, maxWidth, innerMeasurement);
 
         public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) => segments;
     }

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -799,15 +799,41 @@ internal sealed class SecretObfuscatedRenderable(
     }
 
     private Segment[] SanitizeControlCodes(Segment[] segments) =>
-        segments.Any(segment => segment.IsControlCode && !IsSafeControlCode(segment))
+        ContainsUnsafeControlCodeStream(segments)
             ? [.. segments.Where(static segment => !segment.IsControlCode)]
             : segments;
 
-    private bool IsSafeControlCode(Segment segment) =>
-        string.Equals(
-            ObfuscateMetadata(segment.Text, secretObfuscator),
-            segment.Text,
+    private bool ContainsUnsafeControlCodeStream(Segment[] segments)
+    {
+        var controlCodeStream = new StringBuilder();
+
+        foreach (var segment in segments)
+        {
+            if (segment.IsControlCode)
+            {
+                controlCodeStream.Append(segment.Text);
+                continue;
+            }
+
+            if (controlCodeStream.Length > 0 && !IsSafeControlCodeStream(controlCodeStream))
+            {
+                return true;
+            }
+
+            controlCodeStream.Clear();
+        }
+
+        return controlCodeStream.Length > 0 && !IsSafeControlCodeStream(controlCodeStream);
+    }
+
+    private bool IsSafeControlCodeStream(StringBuilder controlCodeStream)
+    {
+        var controlCodeText = controlCodeStream.ToString();
+        return string.Equals(
+            ObfuscateMetadata(controlCodeText, secretObfuscator),
+            controlCodeText,
             StringComparison.Ordinal);
+    }
 
     private static Link? ObfuscateLink(
         Link? link,

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -40,7 +40,10 @@ internal sealed class SecretObfuscatedRenderable(
                 concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks));
         }
 
-        return MapFallbackSegments(segments);
+        return MapFallbackSegments(
+            segments,
+            secretObfuscator.Obfuscate(visibleText, null),
+            visibleText.Length);
     }
 
     private Segment[] MapSegments(
@@ -75,14 +78,51 @@ internal sealed class SecretObfuscatedRenderable(
         return [.. output];
     }
 
-    private Segment[] MapFallbackSegments(Segment[] segments)
+    private Segment[] MapFallbackSegments(
+        Segment[] segments,
+        string obfuscatedText,
+        int sourceLength)
     {
-        return [.. segments.Select(segment => segment.IsControlCode
-            ? segment
-            : new Segment(
-                secretObfuscator.Obfuscate(segment.Text, null),
-                segment.Style,
-                ObfuscateLink(segment.Link)))];
+        var output = new List<Segment>(segments.Length);
+        var sourceOffset = 0;
+        foreach (var segment in segments)
+        {
+            if (segment.IsControlCode)
+            {
+                output.Add(segment);
+                continue;
+            }
+
+            var segmentEnd = sourceOffset + segment.Text.Length;
+            var outputStart = ScaleOffset(sourceOffset, sourceLength, obfuscatedText);
+            var outputEnd = ScaleOffset(segmentEnd, sourceLength, obfuscatedText);
+            sourceOffset = segmentEnd;
+
+            if (outputEnd > outputStart)
+            {
+                output.Add(new Segment(
+                    obfuscatedText[outputStart..outputEnd],
+                    segment.Style,
+                    ObfuscateLink(segment.Link)));
+            }
+        }
+
+        return [.. output];
+    }
+
+    private static int ScaleOffset(int sourceOffset, int sourceLength, string output)
+    {
+        if (sourceOffset >= sourceLength)
+        {
+            return output.Length;
+        }
+
+        var outputOffset = (int) ((long) sourceOffset * output.Length / sourceLength);
+        return outputOffset > 0
+               && outputOffset < output.Length
+               && char.IsLowSurrogate(output[outputOffset])
+            ? outputOffset + 1
+            : outputOffset;
     }
 
     private Segment[] ObfuscateLinks(Segment[] segments) =>

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -171,6 +171,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             Align align => PrepareAlign(align, secretObfuscator),
             Columns columns => PrepareColumns(columns, secretObfuscator),
+            FigletText figletText => PrepareFigletText(figletText, secretObfuscator),
             Grid grid => PrepareGrid(grid, secretObfuscator),
             Layout layout => PrepareLayout(layout, secretObfuscator),
             Padder padder => PreparePadder(padder, secretObfuscator),
@@ -199,6 +200,18 @@ internal sealed class SecretObfuscatedRenderable(
         {
             Expand = columns.Expand,
             Padding = columns.Padding,
+        };
+
+    private static FigletText PrepareFigletText(
+        FigletText figletText,
+        ISecretObfuscator secretObfuscator) => new(
+        GetFigletFont(figletText),
+        secretObfuscator.Obfuscate(GetFigletText(figletText), null))
+        {
+            Color = figletText.Color,
+            Justification = figletText.Justification,
+            LayoutMode = figletText.LayoutMode,
+            Pad = figletText.Pad,
         };
 
     private static Grid PrepareGrid(Grid grid, ISecretObfuscator secretObfuscator)
@@ -415,6 +428,12 @@ internal sealed class SecretObfuscatedRenderable(
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_items")]
     private static extern ref readonly List<IRenderable> GetColumnItems(Columns columns);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_font")]
+    private static extern ref readonly FigletFont GetFigletFont(FigletText figletText);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_text")]
+    private static extern ref readonly string GetFigletText(FigletText figletText);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_child")]
     private static extern ref readonly IRenderable GetPadderChild(Padder padder);

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -366,8 +367,8 @@ internal sealed class SecretObfuscatedRenderable(
         return preparedChart;
     }
 
-    private static Func<double, System.Globalization.CultureInfo, string>? PrepareValueFormatter(
-        Func<double, System.Globalization.CultureInfo, string>? formatter,
+    private static Func<double, CultureInfo, string>? PrepareValueFormatter(
+        Func<double, CultureInfo, string>? formatter,
         ISecretObfuscator secretObfuscator,
         bool snapshot) => formatter is null
         ? null
@@ -378,25 +379,43 @@ internal sealed class SecretObfuscatedRenderable(
                 secretObfuscator,
                 snapshot: false);
 
-    private static Func<double, System.Globalization.CultureInfo, string> SnapshotValueFormatter(
-        Func<double, System.Globalization.CultureInfo, string> formatter)
+    internal static Func<double, CultureInfo, string> SnapshotValueFormatter(
+        Func<double, CultureInfo, string> formatter)
     {
-        var values = new Dictionary<double, string>();
+        var values = new Dictionary<ValueFormatterSnapshotKey, string>();
         var snapshotLock = new object();
         return (value, culture) =>
         {
+            var key = new ValueFormatterSnapshotKey(BitConverter.DoubleToInt64Bits(value), culture);
             lock (snapshotLock)
             {
-                if (values.TryGetValue(value, out var formattedValue))
+                if (values.TryGetValue(key, out var formattedValue))
                 {
                     return formattedValue;
                 }
 
                 formattedValue = formatter(value, culture);
-                values.Add(value, formattedValue);
+                values.Add(key, formattedValue);
                 return formattedValue;
             }
         };
+    }
+
+    private readonly struct ValueFormatterSnapshotKey(long valueBits, CultureInfo culture)
+        : IEquatable<ValueFormatterSnapshotKey>
+    {
+        private long ValueBits { get; } = valueBits;
+
+        private CultureInfo Culture { get; } = culture;
+
+        public bool Equals(ValueFormatterSnapshotKey other) =>
+            ValueBits == other.ValueBits && ReferenceEquals(Culture, other.Culture);
+
+        public override bool Equals(object? obj) =>
+            obj is ValueFormatterSnapshotKey other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(ValueBits, RuntimeHelpers.GetHashCode(Culture));
     }
 
     private static Columns PrepareColumns(

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -168,19 +168,19 @@ internal sealed class SecretObfuscatedRenderable(
     private static IRenderable PrepareCompositeLayout(
         IRenderable renderable,
         ISecretObfuscator secretObfuscator) => renderable switch
-    {
-        Align align => PrepareAlign(align, secretObfuscator),
-        Columns columns => PrepareColumns(columns, secretObfuscator),
-        Grid grid => PrepareGrid(grid, secretObfuscator),
-        Layout layout => PrepareLayout(layout, secretObfuscator),
-        Padder padder => PreparePadder(padder, secretObfuscator),
-        Panel panel => PreparePanel(panel, secretObfuscator),
-        Rule rule => PrepareRule(rule, secretObfuscator),
-        Rows rows => PrepareRows(rows, secretObfuscator),
-        Table table => PrepareTable(table, secretObfuscator),
-        Tree tree => PrepareTree(tree, secretObfuscator),
-        _ => renderable,
-    };
+        {
+            Align align => PrepareAlign(align, secretObfuscator),
+            Columns columns => PrepareColumns(columns, secretObfuscator),
+            Grid grid => PrepareGrid(grid, secretObfuscator),
+            Layout layout => PrepareLayout(layout, secretObfuscator),
+            Padder padder => PreparePadder(padder, secretObfuscator),
+            Panel panel => PreparePanel(panel, secretObfuscator),
+            Rule rule => PrepareRule(rule, secretObfuscator),
+            Rows rows => PrepareRows(rows, secretObfuscator),
+            Table table => PrepareTable(table, secretObfuscator),
+            Tree tree => PrepareTree(tree, secretObfuscator),
+            _ => renderable,
+        };
 
     private static Align PrepareAlign(Align align, ISecretObfuscator secretObfuscator) =>
         new(new SecretObfuscatedRenderable(GetAlignChild(align), secretObfuscator),
@@ -196,10 +196,10 @@ internal sealed class SecretObfuscatedRenderable(
         ISecretObfuscator secretObfuscator) => new(
         GetColumnItems(columns).Select(
             item => new SecretObfuscatedRenderable(item, secretObfuscator)))
-    {
-        Expand = columns.Expand,
-        Padding = columns.Padding,
-    };
+        {
+            Expand = columns.Expand,
+            Padding = columns.Padding,
+        };
 
     private static Grid PrepareGrid(Grid grid, ISecretObfuscator secretObfuscator)
     {
@@ -234,22 +234,25 @@ internal sealed class SecretObfuscatedRenderable(
         ISecretObfuscator secretObfuscator) => new(
         new SecretObfuscatedRenderable(GetPadderChild(padder), secretObfuscator),
         padder.Padding)
-    {
-        Expand = padder.Expand,
-    };
+        {
+            Expand = padder.Expand,
+        };
 
     private static Layout PrepareLayout(
         Layout layout,
         ISecretObfuscator secretObfuscator)
     {
-        var preparedLayout = new Layout(
-            layout.Name,
-            new SecretObfuscatedRenderable(GetLayoutRenderable(layout), secretObfuscator))
+        var preparedLayout = new Layout(layout.Name)
         {
             IsVisible = layout.IsVisible,
             Ratio = layout.Ratio,
             Size = layout.Size,
         };
+        if (GetLayoutRenderable(layout) is { } renderable)
+        {
+            preparedLayout.Update(new SecretObfuscatedRenderable(renderable, secretObfuscator));
+        }
+
         if (layout.MinimumSize > 0)
         {
             preparedLayout.MinimumSize = layout.MinimumSize;
@@ -277,16 +280,16 @@ internal sealed class SecretObfuscatedRenderable(
         Panel panel,
         ISecretObfuscator secretObfuscator) => new(
         new SecretObfuscatedRenderable(GetPanelChild(panel), secretObfuscator))
-    {
-        Border = panel.Border,
-        BorderStyle = panel.BorderStyle,
-        Expand = panel.Expand,
-        Header = ObfuscateHeader(panel.Header, secretObfuscator),
-        Height = panel.Height,
-        Padding = panel.Padding,
-        UseSafeBorder = panel.UseSafeBorder,
-        Width = panel.Width,
-    };
+        {
+            Border = panel.Border,
+            BorderStyle = panel.BorderStyle,
+            Expand = panel.Expand,
+            Header = ObfuscateHeader(panel.Header, secretObfuscator),
+            Height = panel.Height,
+            Padding = panel.Padding,
+            UseSafeBorder = panel.UseSafeBorder,
+            Width = panel.Width,
+        };
 
     private static Rows PrepareRows(Rows rows, ISecretObfuscator secretObfuscator) => new(
         GetRowChildren(rows).Select(
@@ -423,7 +426,7 @@ internal sealed class SecretObfuscatedRenderable(
     private static extern ref readonly Layout[] GetLayoutChildren(Layout layout);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderable")]
-    private static extern ref readonly IRenderable GetLayoutRenderable(Layout layout);
+    private static extern ref readonly IRenderable? GetLayoutRenderable(Layout layout);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_children")]
     private static extern ref readonly List<IRenderable> GetRowChildren(Rows rows);

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -232,7 +232,7 @@ internal sealed class SecretObfuscatedRenderable(
             : ObfuscatedMarkup.CreateSafeSource(rule.Title, secretObfuscator),
     };
 
-    private static Table PrepareTable(Table table, ISecretObfuscator secretObfuscator)
+    private static IRenderable PrepareTable(Table table, ISecretObfuscator secretObfuscator)
     {
         var title = ObfuscateTitle(table.Title, secretObfuscator);
         var caption = ObfuscateTitle(table.Caption, secretObfuscator);
@@ -247,7 +247,7 @@ internal sealed class SecretObfuscatedRenderable(
             ShowRowSeparators = table.ShowRowSeparators,
             Title = title,
             UseSafeBorder = table.UseSafeBorder,
-            Width = table.Width ?? GetTitleWidth(title, caption),
+            Width = table.Width,
         };
 
         foreach (var column in table.Columns)
@@ -271,7 +271,10 @@ internal sealed class SecretObfuscatedRenderable(
                 cell => new SecretObfuscatedRenderable(cell, secretObfuscator)));
         }
 
-        return preparedTable;
+        var titleWidth = GetTitleWidth(title, caption);
+        return table.Width is null && titleWidth is not null
+            ? new AutoSizedTable(preparedTable, titleWidth.Value)
+            : preparedTable;
     }
 
     private static int? GetTitleWidth(TableTitle? title, TableTitle? caption)
@@ -391,5 +394,35 @@ internal sealed class SecretObfuscatedRenderable(
             MeasureSegments(segments, maxWidth);
 
         public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) => segments;
+    }
+
+    private sealed class AutoSizedTable(Table table, int minimumWidth) : IRenderable
+    {
+        private readonly object _renderLock = new();
+
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            lock (_renderLock)
+            {
+                SetWidth(options, maxWidth);
+                return ((IRenderable) table).Measure(options, maxWidth);
+            }
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            lock (_renderLock)
+            {
+                SetWidth(options, maxWidth);
+                return ((IRenderable) table).Render(options, maxWidth).ToArray();
+            }
+        }
+
+        private void SetWidth(RenderOptions options, int maxWidth)
+        {
+            table.Width = null;
+            var contentWidth = ((IRenderable) table).Measure(options, maxWidth).Max;
+            table.Width = Math.Min(maxWidth, Math.Max(contentWidth, minimumWidth));
+        }
     }
 }

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -72,33 +72,10 @@ internal sealed class SecretObfuscatedRenderable(
         var segments = originalSegments;
         if (prepared.IsObfuscatedBeforeRender)
         {
-            return ObfuscateLinks(segments);
+            return ObfuscateLinks(segments, secretObfuscator);
         }
 
-        var visibleText = string.Concat(
-            segments.Where(static segment => !segment.IsControlCode).Select(static segment => segment.Text));
-
-        if (visibleText.Length == 0)
-        {
-            return ObfuscateLinks(segments);
-        }
-
-        if (secretObfuscator is SecretObfuscator concreteObfuscator)
-        {
-            var preserveMasks = concreteObfuscator.CanSafelyPreserveRegisteredMasks();
-            return ReflowSegments(
-                MapSegments(
-                    segments,
-                    concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks)),
-                maxWidth);
-        }
-
-        return ReflowSegments(
-            MapFallbackSegments(
-                segments,
-                secretObfuscator.Obfuscate(visibleText, null),
-                visibleText.Length),
-            maxWidth);
+        return ReflowSegments(ObfuscateSegments(segments, secretObfuscator), maxWidth);
     }
 
     private static Segment[] ReflowSegments(Segment[] segments, int maxWidth)
@@ -127,9 +104,10 @@ internal sealed class SecretObfuscatedRenderable(
         return [.. output];
     }
 
-    private Segment[] MapSegments(
+    private static Segment[] MapSegments(
         Segment[] segments,
-        SecretObfuscator.MappedObfuscatedOutput mappedOutput)
+        SecretObfuscator.MappedObfuscatedOutput mappedOutput,
+        ISecretObfuscator secretObfuscator)
     {
         var output = new List<Segment>(segments.Length);
         var outputBytes = Encoding.UTF8.GetBytes(mappedOutput.Value);
@@ -152,17 +130,18 @@ internal sealed class SecretObfuscatedRenderable(
                 output.Add(new Segment(
                     Encoding.UTF8.GetString(outputBytes, outputStart, outputEnd - outputStart),
                     segment.Style,
-                    ObfuscateLink(segment.Link)));
+                    ObfuscateLink(segment.Link, secretObfuscator)));
             }
         }
 
         return [.. output];
     }
 
-    private Segment[] MapFallbackSegments(
+    private static Segment[] MapFallbackSegments(
         Segment[] segments,
         string obfuscatedText,
-        int sourceLength)
+        int sourceLength,
+        ISecretObfuscator secretObfuscator)
     {
         var output = new List<Segment>(segments.Length);
         var sourceOffset = 0;
@@ -184,7 +163,7 @@ internal sealed class SecretObfuscatedRenderable(
                 output.Add(new Segment(
                     obfuscatedText[outputStart..outputEnd],
                     segment.Style,
-                    ObfuscateLink(segment.Link)));
+                    ObfuscateLink(segment.Link, secretObfuscator)));
             }
         }
 
@@ -221,11 +200,23 @@ internal sealed class SecretObfuscatedRenderable(
             FigletText figletText => Prepared(PrepareFigletText(figletText, secretObfuscator, snapshot)),
             Grid grid => Prepared(PrepareGrid(grid, secretObfuscator, snapshot)),
             Layout layout => Prepared(PrepareLayout(layout, secretObfuscator, snapshot)),
+            Markup markup => Prepared(PrepareParagraph(
+                GetMarkupParagraph(markup),
+                secretObfuscator,
+                snapshot)),
             Padder padder => Prepared(PreparePadder(padder, secretObfuscator, snapshot)),
+            Paragraph paragraph => Prepared(PrepareParagraph(
+                paragraph,
+                secretObfuscator,
+                snapshot)),
             Panel panel => Prepared(PreparePanel(panel, secretObfuscator, snapshot)),
             Rule rule => Prepared(PrepareRule(rule, secretObfuscator, snapshot)),
             Rows rows => Prepared(PrepareRows(rows, secretObfuscator, snapshot)),
             Table table => Prepared(PrepareTable(table, secretObfuscator, snapshot)),
+            Text text => Prepared(PrepareParagraph(
+                GetTextParagraph(text),
+                secretObfuscator,
+                snapshot)),
             Tree tree => Prepared(PrepareTree(tree, secretObfuscator, snapshot)),
             _ => new PreparedRenderable(renderable, IsObfuscatedBeforeRender: false),
         };
@@ -255,6 +246,64 @@ internal sealed class SecretObfuscatedRenderable(
         bool snapshot) => snapshot
         ? value
         : secretObfuscator.Obfuscate(value, null);
+
+    private static Paragraph PrepareParagraph(
+        Paragraph paragraph,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
+    {
+        var sourceSegments = GetParagraphLines(paragraph)
+            .SelectMany(static (line, index) => index == 0
+                ? line
+                : new[] { Segment.LineBreak }.Concat(line))
+            .ToArray();
+        var preparedSegments = snapshot
+            ? sourceSegments
+            : ObfuscateSegments(sourceSegments, secretObfuscator);
+        var preparedParagraph = new Paragraph
+        {
+            Justification = paragraph.Justification,
+            Overflow = paragraph.Overflow,
+        };
+        foreach (var segment in preparedSegments)
+        {
+            if (segment.IsLineBreak)
+            {
+                preparedParagraph.Append("\n");
+                continue;
+            }
+
+            preparedParagraph.Append(segment.Text, segment.Style, segment.Link);
+        }
+
+        return preparedParagraph;
+    }
+
+    private static Segment[] ObfuscateSegments(
+        Segment[] segments,
+        ISecretObfuscator secretObfuscator)
+    {
+        var visibleText = GetVisibleText(segments);
+        if (visibleText.Length == 0)
+        {
+            return ObfuscateLinks(segments, secretObfuscator);
+        }
+
+        if (secretObfuscator is SecretObfuscator concreteObfuscator)
+        {
+            var preserveMasks = concreteObfuscator.CanSafelyPreserveRegisteredMasks();
+            return MapSegments(
+                segments,
+                concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks),
+                secretObfuscator);
+        }
+
+        return MapFallbackSegments(
+            segments,
+            secretObfuscator.Obfuscate(visibleText, null),
+            visibleText.Length,
+            secretObfuscator);
+    }
 
     private static PreparedRenderable Prepared(IRenderable renderable) =>
         new(renderable, IsObfuscatedBeforeRender: true);
@@ -598,6 +647,15 @@ internal sealed class SecretObfuscatedRenderable(
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderable")]
     private static extern ref readonly IRenderable GetAlignChild(Align align);
 
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_paragraph")]
+    private static extern ref readonly Paragraph GetMarkupParagraph(Markup markup);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_lines")]
+    private static extern ref readonly List<SegmentLine> GetParagraphLines(Paragraph paragraph);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_paragraph")]
+    private static extern ref readonly Paragraph GetTextParagraph(Text text);
+
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_items")]
     private static extern ref readonly List<IRenderable> GetColumnItems(Columns columns);
 
@@ -637,7 +695,9 @@ internal sealed class SecretObfuscatedRenderable(
         BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new MissingFieldException(typeof(Layout).FullName, "_splitter");
 
-    private Segment[] ObfuscateLinks(Segment[] segments)
+    private static Segment[] ObfuscateLinks(
+        Segment[] segments,
+        ISecretObfuscator secretObfuscator)
     {
         var output = new List<Segment>(segments.Length);
         foreach (var segment in segments)
@@ -650,7 +710,10 @@ internal sealed class SecretObfuscatedRenderable(
             {
                 output.Add(segment.Link is null
                     ? segment
-                    : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)));
+                    : new Segment(
+                        segment.Text,
+                        segment.Style,
+                        ObfuscateLink(segment.Link, secretObfuscator)));
             }
         }
 
@@ -664,24 +727,28 @@ internal sealed class SecretObfuscatedRenderable(
 
     private bool IsSafeControlCode(Segment segment) =>
         string.Equals(
-            ObfuscateMetadata(segment.Text),
+            ObfuscateMetadata(segment.Text, secretObfuscator),
             segment.Text,
             StringComparison.Ordinal);
 
-    private Link? ObfuscateLink(Link? link)
+    private static Link? ObfuscateLink(
+        Link? link,
+        ISecretObfuscator secretObfuscator)
     {
         if (link is null)
         {
             return null;
         }
 
-        var obfuscatedUrl = ObfuscateMetadata(link.Url);
+        var obfuscatedUrl = ObfuscateMetadata(link.Url, secretObfuscator);
         return string.Equals(obfuscatedUrl, link.Url, StringComparison.Ordinal)
             ? link
             : new Link(obfuscatedUrl);
     }
 
-    private string ObfuscateMetadata(string value) =>
+    private static string ObfuscateMetadata(
+        string value,
+        ISecretObfuscator secretObfuscator) =>
         secretObfuscator is SecretObfuscator concreteObfuscator
             ? concreteObfuscator.ObfuscateWithSourceMap(
                 value,

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -60,7 +60,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                output.Add(segment);
+                output.Add(ObfuscateControlCode(segment));
                 continue;
             }
 
@@ -92,7 +92,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                output.Add(segment);
+                output.Add(ObfuscateControlCode(segment));
                 continue;
             }
 
@@ -326,9 +326,14 @@ internal sealed class SecretObfuscatedRenderable(
     private static extern IRenderable GetTreeNodeRenderable(TreeNode node);
 
     private Segment[] ObfuscateLinks(Segment[] segments) =>
-        [.. segments.Select(segment => segment.IsControlCode || segment.Link is null
-            ? segment
-            : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)))];
+        [.. segments.Select(segment => segment.IsControlCode
+            ? ObfuscateControlCode(segment)
+            : segment.Link is null
+                ? segment
+                : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)))];
+
+    private Segment ObfuscateControlCode(Segment segment) =>
+        Segment.Control(secretObfuscator.Obfuscate(segment.Text, null));
 
     private Link? ObfuscateLink(Link? link)
     {

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using ModularPipelines.Engine;
+using ModularPipelines.Secrets;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -900,7 +900,10 @@ internal sealed class SecretObfuscatedRenderable(
         {
             table.Width = null;
             var contentWidth = ((IRenderable) table).Measure(options, maxWidth).Max;
-            table.Width = Math.Min(maxWidth, Math.Max(contentWidth, minimumWidth));
+            if (minimumWidth > contentWidth)
+            {
+                table.Width = Math.Min(maxWidth, minimumWidth);
+            }
         }
     }
 }

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -15,7 +15,8 @@ namespace ModularPipelines.Logging;
 internal sealed class SecretObfuscatedRenderable(
     IRenderable inner,
     ISecretObfuscator secretObfuscator,
-    bool isObfuscatedBeforeRender = false) : IRenderable
+    bool isObfuscatedBeforeRender = false,
+    bool sanitizeControlCodes = true) : IRenderable
 {
     private readonly IRenderable _source = isObfuscatedBeforeRender
         ? inner
@@ -68,8 +69,10 @@ internal sealed class SecretObfuscatedRenderable(
         int maxWidth,
         out Segment[] originalSegments)
     {
-        originalSegments = SanitizeControlCodes(
-            prepared.Renderable.Render(options, maxWidth).ToArray());
+        var renderedSegments = prepared.Renderable.Render(options, maxWidth).ToArray();
+        originalSegments = sanitizeControlCodes
+            ? SanitizeControlCodes(renderedSegments)
+            : renderedSegments;
         var segments = originalSegments;
         if (prepared.IsObfuscatedBeforeRender)
         {
@@ -225,7 +228,10 @@ internal sealed class SecretObfuscatedRenderable(
         ISecretObfuscator secretObfuscator,
         bool snapshot) => snapshot
         ? SnapshotRenderable(renderable, secretObfuscator)
-        : new SecretObfuscatedRenderable(renderable, secretObfuscator);
+        : new SecretObfuscatedRenderable(
+            renderable,
+            secretObfuscator,
+            sanitizeControlCodes: false);
 
     private static string PrepareMarkup(
         string value,
@@ -321,7 +327,7 @@ internal sealed class SecretObfuscatedRenderable(
     {
         var preparedChart = new BarChart
         {
-            Culture = barChart.Culture,
+            Culture = PrepareCulture(barChart.Culture, snapshot),
             Label = barChart.Label is null
                 ? null
                 : PrepareMarkup(barChart.Label, secretObfuscator, snapshot),
@@ -350,7 +356,7 @@ internal sealed class SecretObfuscatedRenderable(
         var preparedChart = new BreakdownChart
         {
             Compact = breakdownChart.Compact,
-            Culture = breakdownChart.Culture,
+            Culture = PrepareCulture(breakdownChart.Culture, snapshot),
             Expand = breakdownChart.Expand,
             ShowTags = breakdownChart.ShowTags,
             ShowTagValues = breakdownChart.ShowTagValues,
@@ -368,6 +374,9 @@ internal sealed class SecretObfuscatedRenderable(
             item.Color)));
         return preparedChart;
     }
+
+    private static CultureInfo? PrepareCulture(CultureInfo? culture, bool snapshot) =>
+        snapshot && culture is not null ? (CultureInfo) culture.Clone() : culture;
 
     private static Func<double, CultureInfo, string>? PrepareValueFormatter(
         Func<double, CultureInfo, string>? formatter,

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -44,15 +44,45 @@ internal sealed class SecretObfuscatedRenderable(
         if (secretObfuscator is SecretObfuscator concreteObfuscator)
         {
             var preserveMasks = concreteObfuscator.CanSafelyPreserveRegisteredMasks();
-            return MapSegments(
-                segments,
-                concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks));
+            return ReflowSegments(
+                MapSegments(
+                    segments,
+                    concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks)),
+                maxWidth);
         }
 
-        return MapFallbackSegments(
-            segments,
-            secretObfuscator.Obfuscate(visibleText, null),
-            visibleText.Length);
+        return ReflowSegments(
+            MapFallbackSegments(
+                segments,
+                secretObfuscator.Obfuscate(visibleText, null),
+                visibleText.Length),
+            maxWidth);
+    }
+
+    private static Segment[] ReflowSegments(Segment[] segments, int maxWidth)
+    {
+        if (maxWidth <= 0)
+        {
+            return [.. segments.Where(static segment => segment.IsControlCode)];
+        }
+
+        if (Segment.SplitLines(segments).All(line => line.CellCount() <= maxWidth))
+        {
+            return segments;
+        }
+
+        var lines = Segment.SplitLines(segments, maxWidth);
+        var output = new List<Segment>(segments.Length + lines.Count - 1);
+        for (var index = 0; index < lines.Count; index++)
+        {
+            output.AddRange(lines[index]);
+            if (index < lines.Count - 1)
+            {
+                output.Add(Segment.LineBreak);
+            }
+        }
+
+        return [.. output];
     }
 
     private Segment[] MapSegments(

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -154,8 +154,14 @@ internal sealed class SecretObfuscatedRenderable(
             }
 
             var segmentEnd = sourceOffset + segment.Text.Length;
-            var outputStart = ScaleOffset(sourceOffset, sourceLength, obfuscatedText);
-            var outputEnd = ScaleOffset(segmentEnd, sourceLength, obfuscatedText);
+            var outputStart = ObfuscatedTextOffset.Scale(
+                sourceOffset,
+                sourceLength,
+                obfuscatedText);
+            var outputEnd = ObfuscatedTextOffset.Scale(
+                segmentEnd,
+                sourceLength,
+                obfuscatedText);
             sourceOffset = segmentEnd;
 
             if (outputEnd > outputStart)
@@ -168,21 +174,6 @@ internal sealed class SecretObfuscatedRenderable(
         }
 
         return [.. output];
-    }
-
-    private static int ScaleOffset(int sourceOffset, int sourceLength, string output)
-    {
-        if (sourceOffset >= sourceLength)
-        {
-            return output.Length;
-        }
-
-        var outputOffset = (int)((long) sourceOffset * output.Length / sourceLength);
-        return outputOffset > 0
-               && outputOffset < output.Length
-               && char.IsLowSurrogate(output[outputOffset])
-            ? outputOffset + 1
-            : outputOffset;
     }
 
     private static PreparedRenderable PrepareRenderable(
@@ -516,22 +507,22 @@ internal sealed class SecretObfuscatedRenderable(
         bool snapshot) => new(
         GetRowChildren(rows).Select(
             child => PrepareChild(child, secretObfuscator, snapshot)))
-    {
-        Expand = rows.Expand,
-    };
+        {
+            Expand = rows.Expand,
+        };
 
     private static Rule PrepareRule(
         Rule rule,
         ISecretObfuscator secretObfuscator,
         bool snapshot) => new()
-    {
-        Border = rule.Border,
-        Justification = rule.Justification,
-        Style = rule.Style,
-        Title = rule.Title is null
+        {
+            Border = rule.Border,
+            Justification = rule.Justification,
+            Style = rule.Style,
+            Title = rule.Title is null
             ? null
             : PrepareMarkup(rule.Title, secretObfuscator, snapshot),
-    };
+        };
 
     private static IRenderable PrepareTable(
         Table table,
@@ -689,13 +680,16 @@ internal sealed class SecretObfuscatedRenderable(
     private static extern IRenderable GetTreeNodeRenderable(TreeNode node);
 
     private static object GetLayoutSplitter(Layout layout) =>
-        LayoutSplitterField.GetValue(layout)
+        LayoutReflection.SplitterField.GetValue(layout)
         ?? throw new InvalidOperationException("Spectre layout has no splitter.");
 
-    private static readonly FieldInfo LayoutSplitterField = typeof(Layout).GetField(
-        "_splitter",
-        BindingFlags.Instance | BindingFlags.NonPublic)
-        ?? throw new MissingFieldException(typeof(Layout).FullName, "_splitter");
+    private static class LayoutReflection
+    {
+        internal static readonly FieldInfo SplitterField = typeof(Layout).GetField(
+            "_splitter",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(typeof(Layout).FullName, "_splitter");
+    }
 
     private static Segment[] ObfuscateLinks(
         Segment[] segments,
@@ -812,7 +806,7 @@ internal sealed class SecretObfuscatedRenderable(
     private sealed class DeferredSegmentSnapshotRenderable(IRenderable inner) : IRenderable
     {
         private readonly object _snapshotLock = new();
-        private RawSnapshot? _snapshot;
+        private readonly Dictionary<int, RawSnapshot> _snapshots = [];
 
         public Measurement Measure(RenderOptions options, int maxWidth)
         {
@@ -828,9 +822,16 @@ internal sealed class SecretObfuscatedRenderable(
         {
             lock (_snapshotLock)
             {
-                return _snapshot ??= new RawSnapshot(
+                if (_snapshots.TryGetValue(maxWidth, out var snapshot))
+                {
+                    return snapshot;
+                }
+
+                snapshot = new RawSnapshot(
                     inner.Measure(options, maxWidth),
                     inner.Render(options, maxWidth).ToArray());
+                _snapshots.Add(maxWidth, snapshot);
+                return snapshot;
             }
         }
 

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -176,6 +176,9 @@ internal sealed class SecretObfuscatedRenderable(
         {
             Align align => Prepared(PrepareAlign(align, secretObfuscator)),
             BarChart barChart => Prepared(PrepareBarChart(barChart, secretObfuscator)),
+            BreakdownChart breakdownChart => Prepared(PrepareBreakdownChart(
+                breakdownChart,
+                secretObfuscator)),
             Columns columns => Prepared(PrepareColumns(columns, secretObfuscator)),
             FigletText figletText => Prepared(PrepareFigletText(figletText, secretObfuscator)),
             Grid grid => Prepared(PrepareGrid(grid, secretObfuscator)),
@@ -218,6 +221,30 @@ internal sealed class SecretObfuscatedRenderable(
             Width = barChart.Width,
         };
         preparedChart.Data.AddRange(barChart.Data.Select(item => new BarChartItem(
+            ObfuscatedMarkup.CreateSafeSource(item.Label, secretObfuscator),
+            item.Value,
+            item.Color)));
+        return preparedChart;
+    }
+
+    private static BreakdownChart PrepareBreakdownChart(
+        BreakdownChart breakdownChart,
+        ISecretObfuscator secretObfuscator)
+    {
+        var preparedChart = new BreakdownChart
+        {
+            Compact = breakdownChart.Compact,
+            Culture = breakdownChart.Culture,
+            Expand = breakdownChart.Expand,
+            ShowTags = breakdownChart.ShowTags,
+            ShowTagValues = breakdownChart.ShowTagValues,
+            ValueColor = breakdownChart.ValueColor,
+            ValueFormatter = PrepareValueFormatter(
+                breakdownChart.ValueFormatter,
+                secretObfuscator),
+            Width = breakdownChart.Width,
+        };
+        preparedChart.Data.AddRange(breakdownChart.Data.Select(item => new BreakdownChartItem(
             ObfuscatedMarkup.CreateSafeSource(item.Label, secretObfuscator),
             item.Value,
             item.Color)));

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -805,34 +805,50 @@ internal sealed class SecretObfuscatedRenderable(
 
     private bool ContainsUnsafeControlCodeStream(Segment[] segments)
     {
-        var controlCodeStream = new StringBuilder();
+        if (!segments.Any(static segment => segment.IsControlCode))
+        {
+            return false;
+        }
+
+        var emittedText = string.Concat(segments.Select(static segment => segment.Text));
+        if (secretObfuscator is not SecretObfuscator concreteObfuscator)
+        {
+            return !string.Equals(
+                secretObfuscator.Obfuscate(emittedText, null),
+                emittedText,
+                StringComparison.Ordinal);
+        }
+
+        var mappedOutput = concreteObfuscator.ObfuscateWithSourceMap(
+            emittedText,
+            concreteObfuscator.CanSafelyPreserveRegisteredMasks());
+        var outputBytes = Encoding.UTF8.GetBytes(mappedOutput.Value);
+        var sourceOffset = 0;
 
         foreach (var segment in segments)
         {
-            if (segment.IsControlCode)
+            var segmentEnd = sourceOffset + segment.Text.Length;
+            if (!segment.IsControlCode)
             {
-                controlCodeStream.Append(segment.Text);
+                sourceOffset = segmentEnd;
                 continue;
             }
 
-            if (controlCodeStream.Length > 0 && !IsSafeControlCodeStream(controlCodeStream))
+            var outputStart = mappedOutput.SourceToOutputByteOffsets[sourceOffset];
+            var outputEnd = mappedOutput.SourceToOutputByteOffsets[segmentEnd];
+            var mappedControlCode = Encoding.UTF8.GetString(
+                outputBytes,
+                outputStart,
+                outputEnd - outputStart);
+            if (!string.Equals(mappedControlCode, segment.Text, StringComparison.Ordinal))
             {
                 return true;
             }
 
-            controlCodeStream.Clear();
+            sourceOffset = segmentEnd;
         }
 
-        return controlCodeStream.Length > 0 && !IsSafeControlCodeStream(controlCodeStream);
-    }
-
-    private bool IsSafeControlCodeStream(StringBuilder controlCodeStream)
-    {
-        var controlCodeText = controlCodeStream.ToString();
-        return string.Equals(
-            ObfuscateMetadata(controlCodeText, secretObfuscator),
-            controlCodeText,
-            StringComparison.Ordinal);
+        return false;
     }
 
     private static Link? ObfuscateLink(
@@ -914,7 +930,7 @@ internal sealed class SecretObfuscatedRenderable(
     private sealed class DeferredSegmentSnapshotRenderable(IRenderable inner) : IRenderable
     {
         private readonly object _snapshotLock = new();
-        private readonly Dictionary<int, RawSnapshot> _snapshots = [];
+        private RawSnapshot? _snapshot;
 
         public Measurement Measure(RenderOptions options, int maxWidth)
         {
@@ -930,16 +946,15 @@ internal sealed class SecretObfuscatedRenderable(
         {
             lock (_snapshotLock)
             {
-                if (_snapshots.TryGetValue(maxWidth, out var snapshot))
+                if (_snapshot is not null)
                 {
-                    return snapshot;
+                    return _snapshot;
                 }
 
-                snapshot = new RawSnapshot(
+                _snapshot = new RawSnapshot(
                     inner.Measure(options, maxWidth),
                     inner.Render(options, maxWidth).ToArray());
-                _snapshots.Add(maxWidth, snapshot);
-                return snapshot;
+                return _snapshot;
             }
         }
 

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -12,6 +12,8 @@ internal sealed class SecretObfuscatedRenderable(
     IRenderable inner,
     ISecretObfuscator secretObfuscator) : IRenderable
 {
+    private readonly IRenderable _inner = PrepareCompositeLayout(inner, secretObfuscator);
+
     public Measurement Measure(RenderOptions options, int maxWidth) =>
         MeasureSegments(GetSegments(options, maxWidth), maxWidth);
 
@@ -23,7 +25,7 @@ internal sealed class SecretObfuscatedRenderable(
 
     private Segment[] GetSegments(RenderOptions options, int maxWidth)
     {
-        var segments = inner.Render(options, maxWidth).ToArray();
+        var segments = _inner.Render(options, maxWidth).ToArray();
         var visibleText = string.Concat(
             segments.Where(static segment => !segment.IsControlCode).Select(static segment => segment.Text));
 
@@ -37,10 +39,7 @@ internal sealed class SecretObfuscatedRenderable(
             var preserveMasks = concreteObfuscator.CanSafelyPreserveRegisteredMasks();
             return MapSegments(
                 segments,
-                concreteObfuscator.ObfuscateWithSourceMap(
-                    visibleText,
-                    preserveMasks,
-                    FitMaskToSourceWidth));
+                concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks));
         }
 
         return MapFallbackSegments(
@@ -128,28 +127,58 @@ internal sealed class SecretObfuscatedRenderable(
             : outputOffset;
     }
 
-    private static string FitMaskToSourceWidth(string source, string mask)
+    private static IRenderable PrepareCompositeLayout(
+        IRenderable renderable,
+        ISecretObfuscator secretObfuscator)
     {
-        var targetWidth = new Segment(source).CellCount();
-        if (targetWidth == 0)
+        if (renderable is not Table table)
         {
-            return string.Empty;
+            return renderable;
         }
 
-        var maskUnit = string.IsNullOrEmpty(mask) || new Segment(mask).CellCount() == 0
-            ? "*"
-            : mask;
-        var maskWidth = new Segment(maskUnit).CellCount();
-        var repeatedMask = string.Concat(Enumerable.Repeat(
-            maskUnit,
-            (targetWidth / maskWidth) + 2));
-        var fittedMask = Segment.Truncate(new Segment(repeatedMask), targetWidth)?.Text
-                         ?? string.Empty;
-        var paddingWidth = targetWidth - new Segment(fittedMask).CellCount();
-        return paddingWidth == 0
-            ? fittedMask
-            : fittedMask + new string('*', paddingWidth);
+        var preparedTable = new Table
+        {
+            Border = table.Border,
+            BorderStyle = table.BorderStyle,
+            Caption = ObfuscateTitle(table.Caption, secretObfuscator),
+            Expand = table.Expand,
+            ShowFooters = table.ShowFooters,
+            ShowHeaders = table.ShowHeaders,
+            ShowRowSeparators = table.ShowRowSeparators,
+            Title = ObfuscateTitle(table.Title, secretObfuscator),
+            UseSafeBorder = table.UseSafeBorder,
+            Width = table.Width,
+        };
+
+        foreach (var column in table.Columns)
+        {
+            preparedTable.AddColumn(new TableColumn(
+                new SecretObfuscatedRenderable(column.Header, secretObfuscator))
+            {
+                Alignment = column.Alignment,
+                Footer = column.Footer is null
+                    ? null
+                    : new SecretObfuscatedRenderable(column.Footer, secretObfuscator),
+                NoWrap = column.NoWrap,
+                Padding = column.Padding,
+                Width = column.Width,
+            });
+        }
+
+        foreach (var row in table.Rows)
+        {
+            preparedTable.Rows.Add(row.Select(
+                cell => new SecretObfuscatedRenderable(cell, secretObfuscator)));
+        }
+
+        return preparedTable;
     }
+
+    private static TableTitle? ObfuscateTitle(
+        TableTitle? title,
+        ISecretObfuscator secretObfuscator) => title is null
+        ? null
+        : new TableTitle(secretObfuscator.Obfuscate(title.Text, null), title.Style);
 
     private Segment[] ObfuscateLinks(Segment[] segments) =>
         [.. segments.Select(segment => segment.IsControlCode || segment.Link is null

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -188,7 +188,7 @@ internal sealed class SecretObfuscatedRenderable(
             return output.Length;
         }
 
-        var outputOffset = (int) ((long) sourceOffset * output.Length / sourceLength);
+        var outputOffset = (int)((long) sourceOffset * output.Length / sourceLength);
         return outputOffset > 0
                && outputOffset < output.Length
                && char.IsLowSurrogate(output[outputOffset])

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -37,7 +37,10 @@ internal sealed class SecretObfuscatedRenderable(
             var preserveMasks = concreteObfuscator.CanSafelyPreserveRegisteredMasks();
             return MapSegments(
                 segments,
-                concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks));
+                concreteObfuscator.ObfuscateWithSourceMap(
+                    visibleText,
+                    preserveMasks,
+                    FitMaskToSourceWidth));
         }
 
         return MapFallbackSegments(
@@ -123,6 +126,29 @@ internal sealed class SecretObfuscatedRenderable(
                && char.IsLowSurrogate(output[outputOffset])
             ? outputOffset + 1
             : outputOffset;
+    }
+
+    private static string FitMaskToSourceWidth(string source, string mask)
+    {
+        var targetWidth = new Segment(source).CellCount();
+        if (targetWidth == 0)
+        {
+            return string.Empty;
+        }
+
+        var maskUnit = string.IsNullOrEmpty(mask) || new Segment(mask).CellCount() == 0
+            ? "*"
+            : mask;
+        var maskWidth = new Segment(maskUnit).CellCount();
+        var repeatedMask = string.Concat(Enumerable.Repeat(
+            maskUnit,
+            (targetWidth / maskWidth) + 2));
+        var fittedMask = Segment.Truncate(new Segment(repeatedMask), targetWidth)?.Text
+                         ?? string.Empty;
+        var paddingWidth = targetWidth - new Segment(fittedMask).CellCount();
+        return paddingWidth == 0
+            ? fittedMask
+            : fittedMask + new string('*', paddingWidth);
     }
 
     private Segment[] ObfuscateLinks(Segment[] segments) =>

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using ModularPipelines.Engine;
@@ -171,6 +172,7 @@ internal sealed class SecretObfuscatedRenderable(
         Align align => PrepareAlign(align, secretObfuscator),
         Columns columns => PrepareColumns(columns, secretObfuscator),
         Grid grid => PrepareGrid(grid, secretObfuscator),
+        Layout layout => PrepareLayout(layout, secretObfuscator),
         Padder padder => PreparePadder(padder, secretObfuscator),
         Panel panel => PreparePanel(panel, secretObfuscator),
         Rule rule => PrepareRule(rule, secretObfuscator),
@@ -235,6 +237,41 @@ internal sealed class SecretObfuscatedRenderable(
     {
         Expand = padder.Expand,
     };
+
+    private static Layout PrepareLayout(
+        Layout layout,
+        ISecretObfuscator secretObfuscator)
+    {
+        var preparedLayout = new Layout(
+            layout.Name,
+            new SecretObfuscatedRenderable(GetLayoutRenderable(layout), secretObfuscator))
+        {
+            IsVisible = layout.IsVisible,
+            Ratio = layout.Ratio,
+            Size = layout.Size,
+        };
+        if (layout.MinimumSize > 0)
+        {
+            preparedLayout.MinimumSize = layout.MinimumSize;
+        }
+
+        var children = GetLayoutChildren(layout)
+            .Select(child => PrepareLayout(child, secretObfuscator))
+            .ToArray();
+
+        if (children.Length == 0)
+        {
+            return preparedLayout;
+        }
+
+        return GetLayoutSplitter(layout).GetType().Name switch
+        {
+            "RowSplitter" => preparedLayout.SplitRows(children),
+            "ColumnSplitter" => preparedLayout.SplitColumns(children),
+            var splitter => throw new InvalidOperationException(
+                $"Unsupported Spectre layout splitter '{splitter}'."),
+        };
+    }
 
     private static Panel PreparePanel(
         Panel panel,
@@ -383,6 +420,12 @@ internal sealed class SecretObfuscatedRenderable(
     private static extern ref readonly IRenderable GetPanelChild(Panel panel);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_children")]
+    private static extern ref readonly Layout[] GetLayoutChildren(Layout layout);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderable")]
+    private static extern ref readonly IRenderable GetLayoutRenderable(Layout layout);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_children")]
     private static extern ref readonly List<IRenderable> GetRowChildren(Rows rows);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_root")]
@@ -390,6 +433,15 @@ internal sealed class SecretObfuscatedRenderable(
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Renderable")]
     private static extern IRenderable GetTreeNodeRenderable(TreeNode node);
+
+    private static object GetLayoutSplitter(Layout layout) =>
+        LayoutSplitterField.GetValue(layout)
+        ?? throw new InvalidOperationException("Spectre layout has no splitter.");
+
+    private static readonly FieldInfo LayoutSplitterField = typeof(Layout).GetField(
+        "_splitter",
+        BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new MissingFieldException(typeof(Layout).FullName, "_splitter");
 
     private Segment[] ObfuscateLinks(Segment[] segments) =>
         [.. segments.Select(segment => segment.IsControlCode

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using ModularPipelines.Engine;
+using Spectre.Console;
 using Spectre.Console.Rendering;
 
 namespace ModularPipelines.Logging;
@@ -80,7 +81,7 @@ internal sealed class SecretObfuscatedRenderable(
             else if (!hasWrittenVisibleText)
             {
                 hasWrittenVisibleText = true;
-                yield return new Segment(obfuscated, segment.Style, segment.Link);
+                yield return new Segment(obfuscated, Style.Plain);
             }
         }
     }

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -42,7 +42,8 @@ internal sealed class SecretObfuscatedRenderable(
 
     private Segment[] GetSegments(RenderOptions options, int maxWidth)
     {
-        var segments = _prepared.Renderable.Render(options, maxWidth).ToArray();
+        var segments = SanitizeControlCodes(
+            _prepared.Renderable.Render(options, maxWidth).ToArray());
         if (_prepared.IsObfuscatedBeforeRender)
         {
             return ObfuscateLinks(segments);
@@ -111,7 +112,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                AddSafeControlCode(output, segment);
+                output.Add(segment);
                 continue;
             }
 
@@ -143,7 +144,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                AddSafeControlCode(output, segment);
+                output.Add(segment);
                 continue;
             }
 
@@ -551,7 +552,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                AddSafeControlCode(output, segment);
+                output.Add(segment);
             }
             else
             {
@@ -564,14 +565,16 @@ internal sealed class SecretObfuscatedRenderable(
         return [.. output];
     }
 
-    private void AddSafeControlCode(List<Segment> output, Segment segment)
-    {
-        var obfuscatedMetadata = ObfuscateMetadata(segment.Text);
-        if (string.Equals(obfuscatedMetadata, segment.Text, StringComparison.Ordinal))
-        {
-            output.Add(segment);
-        }
-    }
+    private Segment[] SanitizeControlCodes(Segment[] segments) =>
+        segments.Any(segment => segment.IsControlCode && !IsSafeControlCode(segment))
+            ? [.. segments.Where(static segment => !segment.IsControlCode)]
+            : segments;
+
+    private bool IsSafeControlCode(Segment segment) =>
+        string.Equals(
+            ObfuscateMetadata(segment.Text),
+            segment.Text,
+            StringComparison.Ordinal);
 
     private Link? ObfuscateLink(Link? link)
     {

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -120,7 +120,7 @@ internal sealed class SecretObfuscatedRenderable(
             return output.Length;
         }
 
-        var outputOffset = (int) ((long) sourceOffset * output.Length / sourceLength);
+        var outputOffset = (int)((long) sourceOffset * output.Length / sourceLength);
         return outputOffset > 0
                && outputOffset < output.Length
                && char.IsLowSurrogate(output[outputOffset])

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -1,0 +1,87 @@
+using System.Text;
+using ModularPipelines.Engine;
+using Spectre.Console.Rendering;
+
+namespace ModularPipelines.Logging;
+
+/// <summary>
+/// Obfuscates visible renderable text while retaining Spectre segment styling and control codes.
+/// </summary>
+internal sealed class SecretObfuscatedRenderable(
+    IRenderable inner,
+    ISecretObfuscator secretObfuscator) : IRenderable
+{
+    public Measurement Measure(RenderOptions options, int maxWidth) => inner.Measure(options, maxWidth);
+
+    public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        var segments = inner.Render(options, maxWidth).ToArray();
+        var visibleText = string.Concat(
+            segments.Where(static segment => !segment.IsControlCode).Select(static segment => segment.Text));
+
+        if (visibleText.Length == 0)
+        {
+            return segments;
+        }
+
+        if (secretObfuscator is SecretObfuscator concreteObfuscator)
+        {
+            return MapSegments(
+                segments,
+                concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(visibleText));
+        }
+
+        var obfuscated = secretObfuscator.Obfuscate(visibleText, null);
+        return string.Equals(obfuscated, visibleText, StringComparison.Ordinal)
+            ? segments
+            : MapFallbackSegments(segments, obfuscated);
+    }
+
+    private static IEnumerable<Segment> MapSegments(
+        IReadOnlyList<Segment> segments,
+        SecretObfuscator.MappedObfuscatedOutput mappedOutput)
+    {
+        var outputBytes = Encoding.UTF8.GetBytes(mappedOutput.Value);
+        var sourceOffset = 0;
+        foreach (var segment in segments)
+        {
+            if (segment.IsControlCode)
+            {
+                yield return segment;
+                continue;
+            }
+
+            var segmentEnd = sourceOffset + segment.Text.Length;
+            var outputStart = mappedOutput.SourceToOutputByteOffsets[sourceOffset];
+            var outputEnd = mappedOutput.SourceToOutputByteOffsets[segmentEnd];
+            sourceOffset = segmentEnd;
+
+            if (outputEnd > outputStart)
+            {
+                yield return new Segment(
+                    Encoding.UTF8.GetString(outputBytes, outputStart, outputEnd - outputStart),
+                    segment.Style,
+                    segment.Link);
+            }
+        }
+    }
+
+    private static IEnumerable<Segment> MapFallbackSegments(
+        IReadOnlyList<Segment> segments,
+        string obfuscated)
+    {
+        var hasWrittenVisibleText = false;
+        foreach (var segment in segments)
+        {
+            if (segment.IsControlCode)
+            {
+                yield return segment;
+            }
+            else if (!hasWrittenVisibleText)
+            {
+                hasWrittenVisibleText = true;
+                yield return new Segment(obfuscated, segment.Style, segment.Link);
+            }
+        }
+    }
+}

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -20,6 +20,8 @@ internal sealed class SecretObfuscatedRenderable(
         ? Prepared(inner)
         : PrepareRenderable(inner, secretObfuscator);
 
+    internal bool RequiresPostRenderObfuscation => isObfuscatedBeforeRender;
+
     internal static SecretObfuscatedRenderable FromPreObfuscated(
         IRenderable renderable,
         ISecretObfuscator secretObfuscator) =>
@@ -186,7 +188,7 @@ internal sealed class SecretObfuscatedRenderable(
             return output.Length;
         }
 
-        var outputOffset = (int)((long) sourceOffset * output.Length / sourceLength);
+        var outputOffset = (int) ((long) sourceOffset * output.Length / sourceLength);
         return outputOffset > 0
                && outputOffset < output.Length
                && char.IsLowSurrogate(output[outputOffset])

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -12,9 +12,16 @@ internal sealed class SecretObfuscatedRenderable(
     IRenderable inner,
     ISecretObfuscator secretObfuscator) : IRenderable
 {
-    public Measurement Measure(RenderOptions options, int maxWidth) => inner.Measure(options, maxWidth);
+    public Measurement Measure(RenderOptions options, int maxWidth) =>
+        MeasureSegments(GetSegments(options, maxWidth), maxWidth);
 
-    public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
+        GetSegments(options, maxWidth);
+
+    internal IRenderable Snapshot(RenderOptions options, int maxWidth) =>
+        new SegmentSnapshotRenderable(GetSegments(options, maxWidth));
+
+    private Segment[] GetSegments(RenderOptions options, int maxWidth)
     {
         var segments = inner.Render(options, maxWidth).ToArray();
         var visibleText = string.Concat(
@@ -22,33 +29,32 @@ internal sealed class SecretObfuscatedRenderable(
 
         if (visibleText.Length == 0)
         {
-            return segments;
+            return ObfuscateLinks(segments);
         }
 
         if (secretObfuscator is SecretObfuscator concreteObfuscator)
         {
+            var preserveMasks = concreteObfuscator.CanSafelyPreserveRegisteredMasks();
             return MapSegments(
                 segments,
-                concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(visibleText));
+                concreteObfuscator.ObfuscateWithSourceMap(visibleText, preserveMasks));
         }
 
-        var obfuscated = secretObfuscator.Obfuscate(visibleText, null);
-        return string.Equals(obfuscated, visibleText, StringComparison.Ordinal)
-            ? segments
-            : MapFallbackSegments(segments, obfuscated);
+        return MapFallbackSegments(segments);
     }
 
-    private static IEnumerable<Segment> MapSegments(
-        IReadOnlyList<Segment> segments,
+    private Segment[] MapSegments(
+        Segment[] segments,
         SecretObfuscator.MappedObfuscatedOutput mappedOutput)
     {
+        var output = new List<Segment>(segments.Length);
         var outputBytes = Encoding.UTF8.GetBytes(mappedOutput.Value);
         var sourceOffset = 0;
         foreach (var segment in segments)
         {
             if (segment.IsControlCode)
             {
-                yield return segment;
+                output.Add(segment);
                 continue;
             }
 
@@ -59,30 +65,59 @@ internal sealed class SecretObfuscatedRenderable(
 
             if (outputEnd > outputStart)
             {
-                yield return new Segment(
+                output.Add(new Segment(
                     Encoding.UTF8.GetString(outputBytes, outputStart, outputEnd - outputStart),
                     segment.Style,
-                    segment.Link);
+                    ObfuscateLink(segment.Link)));
             }
         }
+
+        return [.. output];
     }
 
-    private static IEnumerable<Segment> MapFallbackSegments(
-        IReadOnlyList<Segment> segments,
-        string obfuscated)
+    private Segment[] MapFallbackSegments(Segment[] segments)
     {
-        var hasWrittenVisibleText = false;
-        foreach (var segment in segments)
+        return [.. segments.Select(segment => segment.IsControlCode
+            ? segment
+            : new Segment(
+                secretObfuscator.Obfuscate(segment.Text, null),
+                segment.Style,
+                ObfuscateLink(segment.Link)))];
+    }
+
+    private Segment[] ObfuscateLinks(Segment[] segments) =>
+        [.. segments.Select(segment => segment.IsControlCode || segment.Link is null
+            ? segment
+            : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)))];
+
+    private Link? ObfuscateLink(Link? link)
+    {
+        if (link is null)
         {
-            if (segment.IsControlCode)
-            {
-                yield return segment;
-            }
-            else if (!hasWrittenVisibleText)
-            {
-                hasWrittenVisibleText = true;
-                yield return new Segment(obfuscated, Style.Plain);
-            }
+            return null;
         }
+
+        var obfuscatedUrl = secretObfuscator.Obfuscate(link.Url, null);
+        return string.Equals(obfuscatedUrl, link.Url, StringComparison.Ordinal)
+            ? link
+            : new Link(obfuscatedUrl);
+    }
+
+    private static Measurement MeasureSegments(Segment[] segments, int maxWidth)
+    {
+        var width = Segment.SplitLines(segments)
+            .Select(static line => line.CellCount())
+            .DefaultIfEmpty(0)
+            .Max();
+        width = Math.Min(width, maxWidth);
+        return new Measurement(width, width);
+    }
+
+    private sealed class SegmentSnapshotRenderable(Segment[] segments) : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth) =>
+            MeasureSegments(segments, maxWidth);
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) => segments;
     }
 }

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -16,9 +16,9 @@ internal sealed class SecretObfuscatedRenderable(
     ISecretObfuscator secretObfuscator,
     bool isObfuscatedBeforeRender = false) : IRenderable
 {
-    private readonly PreparedRenderable _prepared = isObfuscatedBeforeRender
-        ? Prepared(inner)
-        : PrepareRenderable(inner, secretObfuscator);
+    private readonly IRenderable _source = isObfuscatedBeforeRender
+        ? inner
+        : SnapshotRenderable(inner, secretObfuscator);
 
     internal bool RequiresPostRenderObfuscation => isObfuscatedBeforeRender;
 
@@ -29,8 +29,9 @@ internal sealed class SecretObfuscatedRenderable(
 
     public Measurement Measure(RenderOptions options, int maxWidth)
     {
-        var innerMeasurement = _prepared.Renderable.Measure(options, maxWidth);
-        var segments = GetSegments(options, maxWidth, out var originalSegments);
+        var prepared = GetPrepared();
+        var innerMeasurement = prepared.Renderable.Measure(options, maxWidth);
+        var segments = GetSegments(prepared, options, maxWidth, out var originalSegments);
         return MeasureSegments(
             segments,
             originalSegments,
@@ -40,27 +41,36 @@ internal sealed class SecretObfuscatedRenderable(
     }
 
     public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
-        GetSegments(options, maxWidth);
+        GetSegments(GetPrepared(), options, maxWidth);
 
     internal IRenderable Snapshot(RenderOptions options, int maxWidth)
     {
-        var innerMeasurement = _prepared.Renderable.Measure(options, maxWidth);
-        var segments = GetSegments(options, maxWidth, out var originalSegments);
+        var prepared = GetPrepared();
+        var innerMeasurement = prepared.Renderable.Measure(options, maxWidth);
+        var segments = GetSegments(prepared, options, maxWidth, out var originalSegments);
         return new SegmentSnapshotRenderable(segments, originalSegments, innerMeasurement);
     }
 
-    private Segment[] GetSegments(RenderOptions options, int maxWidth) =>
-        GetSegments(options, maxWidth, out _);
+    private PreparedRenderable GetPrepared() => isObfuscatedBeforeRender
+        ? Prepared(_source)
+        : PrepareRenderable(_source, secretObfuscator);
 
     private Segment[] GetSegments(
+        PreparedRenderable prepared,
+        RenderOptions options,
+        int maxWidth) =>
+        GetSegments(prepared, options, maxWidth, out _);
+
+    private Segment[] GetSegments(
+        PreparedRenderable prepared,
         RenderOptions options,
         int maxWidth,
         out Segment[] originalSegments)
     {
         originalSegments = SanitizeControlCodes(
-            _prepared.Renderable.Render(options, maxWidth).ToArray());
+            prepared.Renderable.Render(options, maxWidth).ToArray());
         var segments = originalSegments;
-        if (_prepared.IsObfuscatedBeforeRender)
+        if (prepared.IsObfuscatedBeforeRender)
         {
             return ObfuscateLinks(segments);
         }
@@ -198,31 +208,62 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static PreparedRenderable PrepareRenderable(
         IRenderable renderable,
-        ISecretObfuscator secretObfuscator) => renderable switch
+        ISecretObfuscator secretObfuscator,
+        bool snapshot = false) => renderable switch
         {
-            Align align => Prepared(PrepareAlign(align, secretObfuscator)),
-            BarChart barChart => Prepared(PrepareBarChart(barChart, secretObfuscator)),
+            Align align => Prepared(PrepareAlign(align, secretObfuscator, snapshot)),
+            BarChart barChart => Prepared(PrepareBarChart(barChart, secretObfuscator, snapshot)),
             BreakdownChart breakdownChart => Prepared(PrepareBreakdownChart(
                 breakdownChart,
-                secretObfuscator)),
-            Columns columns => Prepared(PrepareColumns(columns, secretObfuscator)),
-            FigletText figletText => Prepared(PrepareFigletText(figletText, secretObfuscator)),
-            Grid grid => Prepared(PrepareGrid(grid, secretObfuscator)),
-            Layout layout => Prepared(PrepareLayout(layout, secretObfuscator)),
-            Padder padder => Prepared(PreparePadder(padder, secretObfuscator)),
-            Panel panel => Prepared(PreparePanel(panel, secretObfuscator)),
-            Rule rule => Prepared(PrepareRule(rule, secretObfuscator)),
-            Rows rows => Prepared(PrepareRows(rows, secretObfuscator)),
-            Table table => Prepared(PrepareTable(table, secretObfuscator)),
-            Tree tree => Prepared(PrepareTree(tree, secretObfuscator)),
+                secretObfuscator,
+                snapshot)),
+            Columns columns => Prepared(PrepareColumns(columns, secretObfuscator, snapshot)),
+            FigletText figletText => Prepared(PrepareFigletText(figletText, secretObfuscator, snapshot)),
+            Grid grid => Prepared(PrepareGrid(grid, secretObfuscator, snapshot)),
+            Layout layout => Prepared(PrepareLayout(layout, secretObfuscator, snapshot)),
+            Padder padder => Prepared(PreparePadder(padder, secretObfuscator, snapshot)),
+            Panel panel => Prepared(PreparePanel(panel, secretObfuscator, snapshot)),
+            Rule rule => Prepared(PrepareRule(rule, secretObfuscator, snapshot)),
+            Rows rows => Prepared(PrepareRows(rows, secretObfuscator, snapshot)),
+            Table table => Prepared(PrepareTable(table, secretObfuscator, snapshot)),
+            Tree tree => Prepared(PrepareTree(tree, secretObfuscator, snapshot)),
             _ => new PreparedRenderable(renderable, IsObfuscatedBeforeRender: false),
         };
+
+    private static IRenderable SnapshotRenderable(
+        IRenderable renderable,
+        ISecretObfuscator secretObfuscator) =>
+        PrepareRenderable(renderable, secretObfuscator, snapshot: true).Renderable;
+
+    private static IRenderable PrepareChild(
+        IRenderable renderable,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => snapshot
+        ? SnapshotRenderable(renderable, secretObfuscator)
+        : new SecretObfuscatedRenderable(renderable, secretObfuscator);
+
+    private static string PrepareMarkup(
+        string value,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => snapshot
+        ? value
+        : ObfuscatedMarkup.CreateSafeSource(value, secretObfuscator);
+
+    private static string PreparePlainText(
+        string value,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => snapshot
+        ? value
+        : secretObfuscator.Obfuscate(value, null);
 
     private static PreparedRenderable Prepared(IRenderable renderable) =>
         new(renderable, IsObfuscatedBeforeRender: true);
 
-    private static Align PrepareAlign(Align align, ISecretObfuscator secretObfuscator) =>
-        new(new SecretObfuscatedRenderable(GetAlignChild(align), secretObfuscator),
+    private static Align PrepareAlign(
+        Align align,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) =>
+        new(PrepareChild(GetAlignChild(align), secretObfuscator, snapshot),
             align.Horizontal,
             align.Vertical)
         {
@@ -232,22 +273,26 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static BarChart PrepareBarChart(
         BarChart barChart,
-        ISecretObfuscator secretObfuscator)
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
         var preparedChart = new BarChart
         {
             Culture = barChart.Culture,
             Label = barChart.Label is null
                 ? null
-                : ObfuscatedMarkup.CreateSafeSource(barChart.Label, secretObfuscator),
+                : PrepareMarkup(barChart.Label, secretObfuscator, snapshot),
             LabelAlignment = barChart.LabelAlignment,
             MaxValue = barChart.MaxValue,
             ShowValues = barChart.ShowValues,
-            ValueFormatter = PrepareValueFormatter(barChart.ValueFormatter, secretObfuscator),
+            ValueFormatter = PrepareValueFormatter(
+                barChart.ValueFormatter,
+                secretObfuscator,
+                snapshot),
             Width = barChart.Width,
         };
         preparedChart.Data.AddRange(barChart.Data.Select(item => new BarChartItem(
-            ObfuscatedMarkup.CreateSafeSource(item.Label, secretObfuscator),
+            PrepareMarkup(item.Label, secretObfuscator, snapshot),
             item.Value,
             item.Color)));
         return preparedChart;
@@ -255,7 +300,8 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static BreakdownChart PrepareBreakdownChart(
         BreakdownChart breakdownChart,
-        ISecretObfuscator secretObfuscator)
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
         var preparedChart = new BreakdownChart
         {
@@ -267,11 +313,12 @@ internal sealed class SecretObfuscatedRenderable(
             ValueColor = breakdownChart.ValueColor,
             ValueFormatter = PrepareValueFormatter(
                 breakdownChart.ValueFormatter,
-                secretObfuscator),
+                secretObfuscator,
+                snapshot),
             Width = breakdownChart.Width,
         };
         preparedChart.Data.AddRange(breakdownChart.Data.Select(item => new BreakdownChartItem(
-            ObfuscatedMarkup.CreateSafeSource(item.Label, secretObfuscator),
+            PrepareMarkup(item.Label, secretObfuscator, snapshot),
             item.Value,
             item.Color)));
         return preparedChart;
@@ -279,17 +326,22 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static Func<double, System.Globalization.CultureInfo, string>? PrepareValueFormatter(
         Func<double, System.Globalization.CultureInfo, string>? formatter,
-        ISecretObfuscator secretObfuscator) => formatter is null
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => formatter is null
         ? null
-        : (value, culture) => ObfuscatedMarkup.CreateSafeSource(
-            formatter(value, culture),
-            secretObfuscator);
+        : snapshot
+            ? formatter
+            : (value, culture) => PrepareMarkup(
+                formatter(value, culture),
+                secretObfuscator,
+                snapshot: false);
 
     private static Columns PrepareColumns(
         Columns columns,
-        ISecretObfuscator secretObfuscator) => new(
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => new(
         GetColumnItems(columns).Select(
-            item => new SecretObfuscatedRenderable(item, secretObfuscator)))
+            item => PrepareChild(item, secretObfuscator, snapshot)))
         {
             Expand = columns.Expand,
             Padding = columns.Padding,
@@ -297,9 +349,10 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static FigletText PrepareFigletText(
         FigletText figletText,
-        ISecretObfuscator secretObfuscator) => new(
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => new(
         GetFigletFont(figletText),
-        secretObfuscator.Obfuscate(GetFigletText(figletText), null))
+        PreparePlainText(GetFigletText(figletText), secretObfuscator, snapshot))
         {
             Color = figletText.Color,
             Justification = figletText.Justification,
@@ -307,7 +360,10 @@ internal sealed class SecretObfuscatedRenderable(
             Pad = figletText.Pad,
         };
 
-    private static Grid PrepareGrid(Grid grid, ISecretObfuscator secretObfuscator)
+    private static Grid PrepareGrid(
+        Grid grid,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
         var preparedGrid = new Grid
         {
@@ -328,7 +384,7 @@ internal sealed class SecretObfuscatedRenderable(
         foreach (var row in grid.Rows)
         {
             preparedGrid.AddRow(row.Select(
-                    cell => new SecretObfuscatedRenderable(cell, secretObfuscator))
+                    cell => PrepareChild(cell, secretObfuscator, snapshot))
                 .ToArray());
         }
 
@@ -337,8 +393,9 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static Padder PreparePadder(
         Padder padder,
-        ISecretObfuscator secretObfuscator) => new(
-        new SecretObfuscatedRenderable(GetPadderChild(padder), secretObfuscator),
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => new(
+        PrepareChild(GetPadderChild(padder), secretObfuscator, snapshot),
         padder.Padding)
         {
             Expand = padder.Expand,
@@ -346,20 +403,21 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static Layout PrepareLayout(
         Layout layout,
-        ISecretObfuscator secretObfuscator)
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
         var preparedLayout = new Layout
         {
             IsVisible = layout.IsVisible,
             Name = layout.Name is null
                 ? null
-                : ObfuscatedMarkup.CreateSafeSource(layout.Name, secretObfuscator),
+                : PrepareMarkup(layout.Name, secretObfuscator, snapshot),
             Ratio = layout.Ratio,
             Size = layout.Size,
         };
         if (GetLayoutRenderable(layout) is { } renderable)
         {
-            preparedLayout.Update(new SecretObfuscatedRenderable(renderable, secretObfuscator));
+            preparedLayout.Update(PrepareChild(renderable, secretObfuscator, snapshot));
         }
 
         if (layout.MinimumSize > 0)
@@ -368,7 +426,7 @@ internal sealed class SecretObfuscatedRenderable(
         }
 
         var children = GetLayoutChildren(layout)
-            .Select(child => PrepareLayout(child, secretObfuscator))
+            .Select(child => PrepareLayout(child, secretObfuscator, snapshot))
             .ToArray();
 
         if (children.Length == 0)
@@ -387,40 +445,50 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static Panel PreparePanel(
         Panel panel,
-        ISecretObfuscator secretObfuscator) => new(
-        new SecretObfuscatedRenderable(GetPanelChild(panel), secretObfuscator))
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => new(
+        PrepareChild(GetPanelChild(panel), secretObfuscator, snapshot))
         {
             Border = panel.Border,
             BorderStyle = panel.BorderStyle,
             Expand = panel.Expand,
-            Header = ObfuscateHeader(panel.Header, secretObfuscator),
+            Header = ObfuscateHeader(panel.Header, secretObfuscator, snapshot),
             Height = panel.Height,
             Padding = panel.Padding,
             UseSafeBorder = panel.UseSafeBorder,
             Width = panel.Width,
         };
 
-    private static Rows PrepareRows(Rows rows, ISecretObfuscator secretObfuscator) => new(
+    private static Rows PrepareRows(
+        Rows rows,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => new(
         GetRowChildren(rows).Select(
-            child => new SecretObfuscatedRenderable(child, secretObfuscator)))
+            child => PrepareChild(child, secretObfuscator, snapshot)))
     {
         Expand = rows.Expand,
     };
 
-    private static Rule PrepareRule(Rule rule, ISecretObfuscator secretObfuscator) => new()
+    private static Rule PrepareRule(
+        Rule rule,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => new()
     {
         Border = rule.Border,
         Justification = rule.Justification,
         Style = rule.Style,
         Title = rule.Title is null
             ? null
-            : ObfuscatedMarkup.CreateSafeSource(rule.Title, secretObfuscator),
+            : PrepareMarkup(rule.Title, secretObfuscator, snapshot),
     };
 
-    private static IRenderable PrepareTable(Table table, ISecretObfuscator secretObfuscator)
+    private static IRenderable PrepareTable(
+        Table table,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
-        var title = ObfuscateTitle(table.Title, secretObfuscator);
-        var caption = ObfuscateTitle(table.Caption, secretObfuscator);
+        var title = ObfuscateTitle(table.Title, secretObfuscator, snapshot);
+        var caption = ObfuscateTitle(table.Caption, secretObfuscator, snapshot);
         var preparedTable = new Table
         {
             Border = table.Border,
@@ -438,12 +506,12 @@ internal sealed class SecretObfuscatedRenderable(
         foreach (var column in table.Columns)
         {
             preparedTable.AddColumn(new TableColumn(
-                new SecretObfuscatedRenderable(column.Header, secretObfuscator))
+                PrepareChild(column.Header, secretObfuscator, snapshot))
             {
                 Alignment = column.Alignment,
                 Footer = column.Footer is null
                     ? null
-                    : new SecretObfuscatedRenderable(column.Footer, secretObfuscator),
+                    : PrepareChild(column.Footer, secretObfuscator, snapshot),
                 NoWrap = column.NoWrap,
                 Padding = column.Padding,
                 Width = column.Width,
@@ -453,11 +521,11 @@ internal sealed class SecretObfuscatedRenderable(
         foreach (var row in table.Rows)
         {
             preparedTable.Rows.Add(row.Select(
-                cell => new SecretObfuscatedRenderable(cell, secretObfuscator)));
+                cell => PrepareChild(cell, secretObfuscator, snapshot)));
         }
 
         var titleWidth = GetTitleWidth(title, caption);
-        return table.Width is null && titleWidth is not null
+        return !snapshot && table.Width is null && titleWidth is not null
             ? new AutoSizedTable(preparedTable, titleWidth.Value)
             : preparedTable;
     }
@@ -472,51 +540,59 @@ internal sealed class SecretObfuscatedRenderable(
         return contentWidth == 0 ? null : contentWidth + 2;
     }
 
-    private static Tree PrepareTree(Tree tree, ISecretObfuscator secretObfuscator)
+    private static Tree PrepareTree(
+        Tree tree,
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
         var root = GetTreeRoot(tree);
-        var preparedTree = new Tree(new SecretObfuscatedRenderable(
+        var preparedTree = new Tree(PrepareChild(
             GetTreeNodeRenderable(root),
-            secretObfuscator))
+            secretObfuscator,
+            snapshot))
         {
             Expanded = tree.Expanded,
             Guide = tree.Guide,
             Style = tree.Style,
         };
         preparedTree.Nodes.AddRange(root.Nodes.Select(
-            node => PrepareTreeNode(node, secretObfuscator)));
+            node => PrepareTreeNode(node, secretObfuscator, snapshot)));
         return preparedTree;
     }
 
     private static TreeNode PrepareTreeNode(
         TreeNode node,
-        ISecretObfuscator secretObfuscator)
+        ISecretObfuscator secretObfuscator,
+        bool snapshot)
     {
-        var preparedNode = new TreeNode(new SecretObfuscatedRenderable(
+        var preparedNode = new TreeNode(PrepareChild(
             GetTreeNodeRenderable(node),
-            secretObfuscator))
+            secretObfuscator,
+            snapshot))
         {
             Expanded = node.Expanded,
         };
         preparedNode.Nodes.AddRange(node.Nodes.Select(
-            child => PrepareTreeNode(child, secretObfuscator)));
+            child => PrepareTreeNode(child, secretObfuscator, snapshot)));
         return preparedNode;
     }
 
     private static TableTitle? ObfuscateTitle(
         TableTitle? title,
-        ISecretObfuscator secretObfuscator) => title is null
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => title is null
         ? null
         : new TableTitle(
-            ObfuscatedMarkup.CreateSafeSource(title.Text, secretObfuscator),
+            PrepareMarkup(title.Text, secretObfuscator, snapshot),
             title.Style);
 
     private static PanelHeader? ObfuscateHeader(
         PanelHeader? header,
-        ISecretObfuscator secretObfuscator) => header is null
+        ISecretObfuscator secretObfuscator,
+        bool snapshot) => header is null
         ? null
         : new PanelHeader(
-            ObfuscatedMarkup.CreateSafeSource(header.Text, secretObfuscator),
+            PrepareMarkup(header.Text, secretObfuscator, snapshot),
             header.Justification);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderable")]

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -218,7 +218,9 @@ internal sealed class SecretObfuscatedRenderable(
                 secretObfuscator,
                 snapshot)),
             Tree tree => Prepared(PrepareTree(tree, secretObfuscator, snapshot)),
-            _ => new PreparedRenderable(renderable, IsObfuscatedBeforeRender: false),
+            _ => new PreparedRenderable(
+                snapshot ? new DeferredSegmentSnapshotRenderable(renderable) : renderable,
+                IsObfuscatedBeforeRender: false),
         };
 
     private static IRenderable SnapshotRenderable(
@@ -805,6 +807,34 @@ internal sealed class SecretObfuscatedRenderable(
             structuralMinimumWidth + transformedTextMinimumWidth,
             0,
             transformedMaximumWidth);
+    }
+
+    private sealed class DeferredSegmentSnapshotRenderable(IRenderable inner) : IRenderable
+    {
+        private readonly object _snapshotLock = new();
+        private RawSnapshot? _snapshot;
+
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            var measurement = GetSnapshot(options, maxWidth).Measurement;
+            var maximumWidth = Math.Min(measurement.Max, maxWidth);
+            return new Measurement(Math.Min(measurement.Min, maximumWidth), maximumWidth);
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
+            GetSnapshot(options, maxWidth).Segments;
+
+        private RawSnapshot GetSnapshot(RenderOptions options, int maxWidth)
+        {
+            lock (_snapshotLock)
+            {
+                return _snapshot ??= new RawSnapshot(
+                    inner.Measure(options, maxWidth),
+                    inner.Render(options, maxWidth).ToArray());
+            }
+        }
+
+        private sealed record RawSnapshot(Measurement Measurement, Segment[] Segments);
     }
 
     private sealed class SegmentSnapshotRenderable(

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -8,7 +8,7 @@ using Spectre.Console.Rendering;
 namespace ModularPipelines.Logging;
 
 /// <summary>
-/// Obfuscates visible renderable text while retaining Spectre segment styling and control codes.
+/// Obfuscates visible renderable text while retaining Spectre segment styling and safe control codes.
 /// </summary>
 internal sealed class SecretObfuscatedRenderable(
     IRenderable inner,
@@ -102,7 +102,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                output.Add(ObfuscateControlCode(segment));
+                AddSafeControlCode(output, segment);
                 continue;
             }
 
@@ -134,7 +134,7 @@ internal sealed class SecretObfuscatedRenderable(
         {
             if (segment.IsControlCode)
             {
-                output.Add(ObfuscateControlCode(segment));
+                AddSafeControlCode(output, segment);
                 continue;
             }
 
@@ -508,15 +508,34 @@ internal sealed class SecretObfuscatedRenderable(
         BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new MissingFieldException(typeof(Layout).FullName, "_splitter");
 
-    private Segment[] ObfuscateLinks(Segment[] segments) =>
-        [.. segments.Select(segment => segment.IsControlCode
-            ? ObfuscateControlCode(segment)
-            : segment.Link is null
-                ? segment
-                : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)))];
+    private Segment[] ObfuscateLinks(Segment[] segments)
+    {
+        var output = new List<Segment>(segments.Length);
+        foreach (var segment in segments)
+        {
+            if (segment.IsControlCode)
+            {
+                AddSafeControlCode(output, segment);
+            }
+            else
+            {
+                output.Add(segment.Link is null
+                    ? segment
+                    : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)));
+            }
+        }
 
-    private Segment ObfuscateControlCode(Segment segment) =>
-        Segment.Control(ObfuscateMetadata(segment.Text));
+        return [.. output];
+    }
+
+    private void AddSafeControlCode(List<Segment> output, Segment segment)
+    {
+        var obfuscatedMetadata = ObfuscateMetadata(segment.Text);
+        if (string.Equals(obfuscatedMetadata, segment.Text, StringComparison.Ordinal))
+        {
+            output.Add(segment);
+        }
+    }
 
     private Link? ObfuscateLink(Link? link)
     {

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -12,9 +12,17 @@ namespace ModularPipelines.Logging;
 /// </summary>
 internal sealed class SecretObfuscatedRenderable(
     IRenderable inner,
-    ISecretObfuscator secretObfuscator) : IRenderable
+    ISecretObfuscator secretObfuscator,
+    bool isObfuscatedBeforeRender = false) : IRenderable
 {
-    private readonly PreparedRenderable _prepared = PrepareRenderable(inner, secretObfuscator);
+    private readonly PreparedRenderable _prepared = isObfuscatedBeforeRender
+        ? Prepared(inner)
+        : PrepareRenderable(inner, secretObfuscator);
+
+    internal static SecretObfuscatedRenderable FromPreObfuscated(
+        IRenderable renderable,
+        ISecretObfuscator secretObfuscator) =>
+        new(renderable, secretObfuscator, isObfuscatedBeforeRender: true);
 
     public Measurement Measure(RenderOptions options, int maxWidth)
     {

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -36,7 +36,7 @@ internal sealed class SecretObfuscatedRenderable(
         var segments = _prepared.Renderable.Render(options, maxWidth).ToArray();
         if (_prepared.IsObfuscatedBeforeRender)
         {
-            return segments;
+            return ObfuscateLinks(segments);
         }
 
         var visibleText = string.Concat(

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -15,14 +15,20 @@ internal sealed class SecretObfuscatedRenderable(
 {
     private readonly IRenderable _inner = PrepareCompositeLayout(inner, secretObfuscator);
 
-    public Measurement Measure(RenderOptions options, int maxWidth) =>
-        MeasureSegments(GetSegments(options, maxWidth), maxWidth);
+    public Measurement Measure(RenderOptions options, int maxWidth)
+    {
+        var innerMeasurement = ((IRenderable) _inner).Measure(options, maxWidth);
+        return MeasureSegments(GetSegments(options, maxWidth), maxWidth, innerMeasurement);
+    }
 
     public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) =>
         GetSegments(options, maxWidth);
 
-    internal IRenderable Snapshot(RenderOptions options, int maxWidth) =>
-        new SegmentSnapshotRenderable(GetSegments(options, maxWidth));
+    internal IRenderable Snapshot(RenderOptions options, int maxWidth)
+    {
+        var innerMeasurement = ((IRenderable) _inner).Measure(options, maxWidth);
+        return new SegmentSnapshotRenderable(GetSegments(options, maxWidth), innerMeasurement);
+    }
 
     private Segment[] GetSegments(RenderOptions options, int maxWidth)
     {
@@ -363,7 +369,7 @@ internal sealed class SecretObfuscatedRenderable(
                 : new Segment(segment.Text, segment.Style, ObfuscateLink(segment.Link)))];
 
     private Segment ObfuscateControlCode(Segment segment) =>
-        Segment.Control(secretObfuscator.Obfuscate(segment.Text, null));
+        Segment.Control(ObfuscateMetadata(segment.Text));
 
     private Link? ObfuscateLink(Link? link)
     {
@@ -372,26 +378,42 @@ internal sealed class SecretObfuscatedRenderable(
             return null;
         }
 
-        var obfuscatedUrl = secretObfuscator.Obfuscate(link.Url, null);
+        var obfuscatedUrl = ObfuscateMetadata(link.Url);
         return string.Equals(obfuscatedUrl, link.Url, StringComparison.Ordinal)
             ? link
             : new Link(obfuscatedUrl);
     }
 
-    private static Measurement MeasureSegments(Segment[] segments, int maxWidth)
+    private string ObfuscateMetadata(string value) =>
+        secretObfuscator is SecretObfuscator concreteObfuscator
+            ? concreteObfuscator.ObfuscateWithSourceMap(
+                value,
+                concreteObfuscator.CanSafelyPreserveRegisteredMasks()).Value
+            : secretObfuscator.Obfuscate(value, null);
+
+    private static Measurement MeasureSegments(
+        Segment[] segments,
+        int maxWidth,
+        Measurement innerMeasurement)
     {
         var width = Segment.SplitLines(segments)
             .Select(static line => line.CellCount())
             .DefaultIfEmpty(0)
             .Max();
         width = Math.Min(width, maxWidth);
-        return new Measurement(width, width);
+        var innerMaximumWidth = Math.Min(innerMeasurement.Max, maxWidth);
+        var innerMinimumWidth = Math.Min(innerMeasurement.Min, innerMaximumWidth);
+        var widthChange = width - innerMaximumWidth;
+        var minimumWidth = Math.Clamp(innerMinimumWidth + widthChange, 0, width);
+        return new Measurement(minimumWidth, width);
     }
 
-    private sealed class SegmentSnapshotRenderable(Segment[] segments) : IRenderable
+    private sealed class SegmentSnapshotRenderable(
+        Segment[] segments,
+        Measurement innerMeasurement) : IRenderable
     {
         public Measurement Measure(RenderOptions options, int maxWidth) =>
-            MeasureSegments(segments, maxWidth);
+            MeasureSegments(segments, maxWidth, innerMeasurement);
 
         public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) => segments;
     }

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -14,11 +14,11 @@ internal sealed class SecretObfuscatedRenderable(
     IRenderable inner,
     ISecretObfuscator secretObfuscator) : IRenderable
 {
-    private readonly IRenderable _inner = PrepareCompositeLayout(inner, secretObfuscator);
+    private readonly PreparedRenderable _prepared = PrepareRenderable(inner, secretObfuscator);
 
     public Measurement Measure(RenderOptions options, int maxWidth)
     {
-        var innerMeasurement = ((IRenderable) _inner).Measure(options, maxWidth);
+        var innerMeasurement = _prepared.Renderable.Measure(options, maxWidth);
         return MeasureSegments(GetSegments(options, maxWidth), maxWidth, innerMeasurement);
     }
 
@@ -27,13 +27,18 @@ internal sealed class SecretObfuscatedRenderable(
 
     internal IRenderable Snapshot(RenderOptions options, int maxWidth)
     {
-        var innerMeasurement = ((IRenderable) _inner).Measure(options, maxWidth);
+        var innerMeasurement = _prepared.Renderable.Measure(options, maxWidth);
         return new SegmentSnapshotRenderable(GetSegments(options, maxWidth), innerMeasurement);
     }
 
     private Segment[] GetSegments(RenderOptions options, int maxWidth)
     {
-        var segments = _inner.Render(options, maxWidth).ToArray();
+        var segments = _prepared.Renderable.Render(options, maxWidth).ToArray();
+        if (_prepared.IsObfuscatedBeforeRender)
+        {
+            return segments;
+        }
+
         var visibleText = string.Concat(
             segments.Where(static segment => !segment.IsControlCode).Select(static segment => segment.Text));
 
@@ -165,23 +170,27 @@ internal sealed class SecretObfuscatedRenderable(
             : outputOffset;
     }
 
-    private static IRenderable PrepareCompositeLayout(
+    private static PreparedRenderable PrepareRenderable(
         IRenderable renderable,
         ISecretObfuscator secretObfuscator) => renderable switch
         {
-            Align align => PrepareAlign(align, secretObfuscator),
-            Columns columns => PrepareColumns(columns, secretObfuscator),
-            FigletText figletText => PrepareFigletText(figletText, secretObfuscator),
-            Grid grid => PrepareGrid(grid, secretObfuscator),
-            Layout layout => PrepareLayout(layout, secretObfuscator),
-            Padder padder => PreparePadder(padder, secretObfuscator),
-            Panel panel => PreparePanel(panel, secretObfuscator),
-            Rule rule => PrepareRule(rule, secretObfuscator),
-            Rows rows => PrepareRows(rows, secretObfuscator),
-            Table table => PrepareTable(table, secretObfuscator),
-            Tree tree => PrepareTree(tree, secretObfuscator),
-            _ => renderable,
+            Align align => Prepared(PrepareAlign(align, secretObfuscator)),
+            BarChart barChart => Prepared(PrepareBarChart(barChart, secretObfuscator)),
+            Columns columns => Prepared(PrepareColumns(columns, secretObfuscator)),
+            FigletText figletText => Prepared(PrepareFigletText(figletText, secretObfuscator)),
+            Grid grid => Prepared(PrepareGrid(grid, secretObfuscator)),
+            Layout layout => Prepared(PrepareLayout(layout, secretObfuscator)),
+            Padder padder => Prepared(PreparePadder(padder, secretObfuscator)),
+            Panel panel => Prepared(PreparePanel(panel, secretObfuscator)),
+            Rule rule => Prepared(PrepareRule(rule, secretObfuscator)),
+            Rows rows => Prepared(PrepareRows(rows, secretObfuscator)),
+            Table table => Prepared(PrepareTable(table, secretObfuscator)),
+            Tree tree => Prepared(PrepareTree(tree, secretObfuscator)),
+            _ => new PreparedRenderable(renderable, IsObfuscatedBeforeRender: false),
         };
+
+    private static PreparedRenderable Prepared(IRenderable renderable) =>
+        new(renderable, IsObfuscatedBeforeRender: true);
 
     private static Align PrepareAlign(Align align, ISecretObfuscator secretObfuscator) =>
         new(new SecretObfuscatedRenderable(GetAlignChild(align), secretObfuscator),
@@ -191,6 +200,37 @@ internal sealed class SecretObfuscatedRenderable(
             Height = align.Height,
             Width = align.Width,
         };
+
+    private static BarChart PrepareBarChart(
+        BarChart barChart,
+        ISecretObfuscator secretObfuscator)
+    {
+        var preparedChart = new BarChart
+        {
+            Culture = barChart.Culture,
+            Label = barChart.Label is null
+                ? null
+                : ObfuscatedMarkup.CreateSafeSource(barChart.Label, secretObfuscator),
+            LabelAlignment = barChart.LabelAlignment,
+            MaxValue = barChart.MaxValue,
+            ShowValues = barChart.ShowValues,
+            ValueFormatter = PrepareValueFormatter(barChart.ValueFormatter, secretObfuscator),
+            Width = barChart.Width,
+        };
+        preparedChart.Data.AddRange(barChart.Data.Select(item => new BarChartItem(
+            ObfuscatedMarkup.CreateSafeSource(item.Label, secretObfuscator),
+            item.Value,
+            item.Color)));
+        return preparedChart;
+    }
+
+    private static Func<double, System.Globalization.CultureInfo, string>? PrepareValueFormatter(
+        Func<double, System.Globalization.CultureInfo, string>? formatter,
+        ISecretObfuscator secretObfuscator) => formatter is null
+        ? null
+        : (value, culture) => ObfuscatedMarkup.CreateSafeSource(
+            formatter(value, culture),
+            secretObfuscator);
 
     private static Columns PrepareColumns(
         Columns columns,
@@ -258,7 +298,9 @@ internal sealed class SecretObfuscatedRenderable(
         var preparedLayout = new Layout
         {
             IsVisible = layout.IsVisible,
-            Name = layout.Name,
+            Name = layout.Name is null
+                ? null
+                : ObfuscatedMarkup.CreateSafeSource(layout.Name, secretObfuscator),
             Ratio = layout.Ratio,
             Size = layout.Size,
         };
@@ -522,6 +564,10 @@ internal sealed class SecretObfuscatedRenderable(
 
         public IEnumerable<Segment> Render(RenderOptions options, int maxWidth) => segments;
     }
+
+    private readonly record struct PreparedRenderable(
+        IRenderable Renderable,
+        bool IsObfuscatedBeforeRender);
 
     private sealed class AutoSizedTable(Table table, int minimumWidth) : IRenderable
     {

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -372,11 +372,32 @@ internal sealed class SecretObfuscatedRenderable(
         bool snapshot) => formatter is null
         ? null
         : snapshot
-            ? formatter
+            ? SnapshotValueFormatter(formatter)
             : (value, culture) => PrepareMarkup(
                 formatter(value, culture),
                 secretObfuscator,
                 snapshot: false);
+
+    private static Func<double, System.Globalization.CultureInfo, string> SnapshotValueFormatter(
+        Func<double, System.Globalization.CultureInfo, string> formatter)
+    {
+        var values = new Dictionary<double, string>();
+        var snapshotLock = new object();
+        return (value, culture) =>
+        {
+            lock (snapshotLock)
+            {
+                if (values.TryGetValue(value, out var formattedValue))
+                {
+                    return formattedValue;
+                }
+
+                formattedValue = formatter(value, culture);
+                values.Add(value, formattedValue);
+                return formattedValue;
+            }
+        };
+    }
 
     private static Columns PrepareColumns(
         Columns columns,

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -255,9 +255,10 @@ internal sealed class SecretObfuscatedRenderable(
         Layout layout,
         ISecretObfuscator secretObfuscator)
     {
-        var preparedLayout = new Layout(layout.Name)
+        var preparedLayout = new Layout
         {
             IsVisible = layout.IsVisible,
+            Name = layout.Name,
             Ratio = layout.Ratio,
             Size = layout.Size,
         };

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using ModularPipelines.Engine;
 using Spectre.Console;
@@ -129,13 +130,99 @@ internal sealed class SecretObfuscatedRenderable(
 
     private static IRenderable PrepareCompositeLayout(
         IRenderable renderable,
-        ISecretObfuscator secretObfuscator)
+        ISecretObfuscator secretObfuscator) => renderable switch
     {
-        if (renderable is not Table table)
+        Align align => PrepareAlign(align, secretObfuscator),
+        Columns columns => PrepareColumns(columns, secretObfuscator),
+        Grid grid => PrepareGrid(grid, secretObfuscator),
+        Padder padder => PreparePadder(padder, secretObfuscator),
+        Panel panel => PreparePanel(panel, secretObfuscator),
+        Rows rows => PrepareRows(rows, secretObfuscator),
+        Table table => PrepareTable(table, secretObfuscator),
+        Tree tree => PrepareTree(tree, secretObfuscator),
+        _ => renderable,
+    };
+
+    private static Align PrepareAlign(Align align, ISecretObfuscator secretObfuscator) =>
+        new(new SecretObfuscatedRenderable(GetAlignChild(align), secretObfuscator),
+            align.Horizontal,
+            align.Vertical)
         {
-            return renderable;
+            Height = align.Height,
+            Width = align.Width,
+        };
+
+    private static Columns PrepareColumns(
+        Columns columns,
+        ISecretObfuscator secretObfuscator) => new(
+        GetColumnItems(columns).Select(
+            item => new SecretObfuscatedRenderable(item, secretObfuscator)))
+    {
+        Expand = columns.Expand,
+        Padding = columns.Padding,
+    };
+
+    private static Grid PrepareGrid(Grid grid, ISecretObfuscator secretObfuscator)
+    {
+        var preparedGrid = new Grid
+        {
+            Expand = grid.Expand,
+            Width = grid.Width,
+        };
+        foreach (var column in grid.Columns)
+        {
+            preparedGrid.AddColumn(new GridColumn
+            {
+                Alignment = column.Alignment,
+                NoWrap = column.NoWrap,
+                Padding = column.Padding,
+                Width = column.Width,
+            });
         }
 
+        foreach (var row in grid.Rows)
+        {
+            preparedGrid.AddRow(row.Select(
+                    cell => new SecretObfuscatedRenderable(cell, secretObfuscator))
+                .ToArray());
+        }
+
+        return preparedGrid;
+    }
+
+    private static Padder PreparePadder(
+        Padder padder,
+        ISecretObfuscator secretObfuscator) => new(
+        new SecretObfuscatedRenderable(GetPadderChild(padder), secretObfuscator),
+        padder.Padding)
+    {
+        Expand = padder.Expand,
+    };
+
+    private static Panel PreparePanel(
+        Panel panel,
+        ISecretObfuscator secretObfuscator) => new(
+        new SecretObfuscatedRenderable(GetPanelChild(panel), secretObfuscator))
+    {
+        Border = panel.Border,
+        BorderStyle = panel.BorderStyle,
+        Expand = panel.Expand,
+        Header = ObfuscateHeader(panel.Header, secretObfuscator),
+        Height = panel.Height,
+        Padding = panel.Padding,
+        UseSafeBorder = panel.UseSafeBorder,
+        Width = panel.Width,
+    };
+
+    private static Rows PrepareRows(Rows rows, ISecretObfuscator secretObfuscator) => new(
+        GetRowChildren(rows).Select(
+            child => new SecretObfuscatedRenderable(child, secretObfuscator)))
+    {
+        Expand = rows.Expand,
+    };
+
+    private static Table PrepareTable(Table table, ISecretObfuscator secretObfuscator)
+    {
         var preparedTable = new Table
         {
             Border = table.Border,
@@ -174,11 +261,69 @@ internal sealed class SecretObfuscatedRenderable(
         return preparedTable;
     }
 
+    private static Tree PrepareTree(Tree tree, ISecretObfuscator secretObfuscator)
+    {
+        var root = GetTreeRoot(tree);
+        var preparedTree = new Tree(new SecretObfuscatedRenderable(
+            GetTreeNodeRenderable(root),
+            secretObfuscator))
+        {
+            Expanded = tree.Expanded,
+            Guide = tree.Guide,
+            Style = tree.Style,
+        };
+        preparedTree.Nodes.AddRange(root.Nodes.Select(
+            node => PrepareTreeNode(node, secretObfuscator)));
+        return preparedTree;
+    }
+
+    private static TreeNode PrepareTreeNode(
+        TreeNode node,
+        ISecretObfuscator secretObfuscator)
+    {
+        var preparedNode = new TreeNode(new SecretObfuscatedRenderable(
+            GetTreeNodeRenderable(node),
+            secretObfuscator))
+        {
+            Expanded = node.Expanded,
+        };
+        preparedNode.Nodes.AddRange(node.Nodes.Select(
+            child => PrepareTreeNode(child, secretObfuscator)));
+        return preparedNode;
+    }
+
     private static TableTitle? ObfuscateTitle(
         TableTitle? title,
         ISecretObfuscator secretObfuscator) => title is null
         ? null
         : new TableTitle(secretObfuscator.Obfuscate(title.Text, null), title.Style);
+
+    private static PanelHeader? ObfuscateHeader(
+        PanelHeader? header,
+        ISecretObfuscator secretObfuscator) => header is null
+        ? null
+        : new PanelHeader(secretObfuscator.Obfuscate(header.Text, null), header.Justification);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderable")]
+    private static extern ref readonly IRenderable GetAlignChild(Align align);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_items")]
+    private static extern ref readonly List<IRenderable> GetColumnItems(Columns columns);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_child")]
+    private static extern ref readonly IRenderable GetPadderChild(Padder padder);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_child")]
+    private static extern ref readonly IRenderable GetPanelChild(Panel panel);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_children")]
+    private static extern ref readonly List<IRenderable> GetRowChildren(Rows rows);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_root")]
+    private static extern ref readonly TreeNode GetTreeRoot(Tree tree);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Renderable")]
+    private static extern IRenderable GetTreeNodeRenderable(TreeNode node);
 
     private Segment[] ObfuscateLinks(Segment[] segments) =>
         [.. segments.Select(segment => segment.IsControlCode || segment.Link is null

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -331,7 +331,8 @@ internal sealed class SecretObfuscatedRenderable(
             ValueFormatter = PrepareValueFormatter(
                 barChart.ValueFormatter,
                 secretObfuscator,
-                snapshot),
+                snapshot,
+                barChart.Data.Select(static item => item.Value)),
             Width = barChart.Width,
         };
         preparedChart.Data.AddRange(barChart.Data.Select(item => new BarChartItem(
@@ -357,7 +358,8 @@ internal sealed class SecretObfuscatedRenderable(
             ValueFormatter = PrepareValueFormatter(
                 breakdownChart.ValueFormatter,
                 secretObfuscator,
-                snapshot),
+                snapshot,
+                breakdownChart.Data.Select(static item => item.Value)),
             Width = breakdownChart.Width,
         };
         preparedChart.Data.AddRange(breakdownChart.Data.Select(item => new BreakdownChartItem(
@@ -370,35 +372,66 @@ internal sealed class SecretObfuscatedRenderable(
     private static Func<double, CultureInfo, string>? PrepareValueFormatter(
         Func<double, CultureInfo, string>? formatter,
         ISecretObfuscator secretObfuscator,
-        bool snapshot) => formatter is null
+        bool snapshot,
+        IEnumerable<double> values) => formatter is null
         ? null
         : snapshot
-            ? SnapshotValueFormatter(formatter)
+            ? SnapshotValueFormatter(formatter, values)
             : (value, culture) => PrepareMarkup(
                 formatter(value, culture),
                 secretObfuscator,
                 snapshot: false);
 
     internal static Func<double, CultureInfo, string> SnapshotValueFormatter(
-        Func<double, CultureInfo, string> formatter)
+        Func<double, CultureInfo, string> formatter) =>
+        SnapshotValueFormatter(formatter, []);
+
+    internal static Func<double, CultureInfo, string> SnapshotValueFormatter(
+        Func<double, CultureInfo, string> formatter,
+        IEnumerable<double> values)
     {
-        var values = new Dictionary<ValueFormatterSnapshotKey, string>();
+        var occurrenceCounts = values
+            .GroupBy(static value => BitConverter.DoubleToInt64Bits(value))
+            .ToDictionary(static group => group.Key, static group => group.Count());
+        var snapshots = new Dictionary<ValueFormatterSnapshotKey, ValueFormatterSnapshot>();
         var snapshotLock = new object();
         return (value, culture) =>
         {
-            var key = new ValueFormatterSnapshotKey(BitConverter.DoubleToInt64Bits(value), culture);
+            var valueBits = BitConverter.DoubleToInt64Bits(value);
+            var key = new ValueFormatterSnapshotKey(valueBits, culture);
             lock (snapshotLock)
             {
-                if (values.TryGetValue(key, out var formattedValue))
+                if (!snapshots.TryGetValue(key, out var snapshot))
                 {
-                    return formattedValue;
+                    snapshot = new ValueFormatterSnapshot(
+                        occurrenceCounts.GetValueOrDefault(valueBits, 1));
+                    snapshots.Add(key, snapshot);
                 }
 
-                formattedValue = formatter(value, culture);
-                values.Add(key, formattedValue);
-                return formattedValue;
+                return snapshot.GetNext(() => formatter(value, culture));
             }
         };
+    }
+
+    private sealed class ValueFormatterSnapshot(int occurrenceCount)
+    {
+        private readonly List<string> _values = new(occurrenceCount);
+        private int _nextIndex;
+
+        public string GetNext(Func<string> format)
+        {
+            if (_values.Count < occurrenceCount)
+            {
+                var formattedValue = format();
+                _values.Add(formattedValue);
+                _nextIndex = _values.Count % occurrenceCount;
+                return formattedValue;
+            }
+
+            var value = _values[_nextIndex];
+            _nextIndex = (_nextIndex + 1) % occurrenceCount;
+            return value;
+        }
     }
 
     private readonly struct ValueFormatterSnapshotKey(long valueBits, CultureInfo culture)

--- a/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
+++ b/src/ModularPipelines/Logging/SecretObfuscatedRenderable.cs
@@ -137,6 +137,7 @@ internal sealed class SecretObfuscatedRenderable(
         Grid grid => PrepareGrid(grid, secretObfuscator),
         Padder padder => PreparePadder(padder, secretObfuscator),
         Panel panel => PreparePanel(panel, secretObfuscator),
+        Rule rule => PrepareRule(rule, secretObfuscator),
         Rows rows => PrepareRows(rows, secretObfuscator),
         Table table => PrepareTable(table, secretObfuscator),
         Tree tree => PrepareTree(tree, secretObfuscator),
@@ -221,20 +222,32 @@ internal sealed class SecretObfuscatedRenderable(
         Expand = rows.Expand,
     };
 
+    private static Rule PrepareRule(Rule rule, ISecretObfuscator secretObfuscator) => new()
+    {
+        Border = rule.Border,
+        Justification = rule.Justification,
+        Style = rule.Style,
+        Title = rule.Title is null
+            ? null
+            : ObfuscatedMarkup.CreateSafeSource(rule.Title, secretObfuscator),
+    };
+
     private static Table PrepareTable(Table table, ISecretObfuscator secretObfuscator)
     {
+        var title = ObfuscateTitle(table.Title, secretObfuscator);
+        var caption = ObfuscateTitle(table.Caption, secretObfuscator);
         var preparedTable = new Table
         {
             Border = table.Border,
             BorderStyle = table.BorderStyle,
-            Caption = ObfuscateTitle(table.Caption, secretObfuscator),
+            Caption = caption,
             Expand = table.Expand,
             ShowFooters = table.ShowFooters,
             ShowHeaders = table.ShowHeaders,
             ShowRowSeparators = table.ShowRowSeparators,
-            Title = ObfuscateTitle(table.Title, secretObfuscator),
+            Title = title,
             UseSafeBorder = table.UseSafeBorder,
-            Width = table.Width,
+            Width = table.Width ?? GetTitleWidth(title, caption),
         };
 
         foreach (var column in table.Columns)
@@ -259,6 +272,16 @@ internal sealed class SecretObfuscatedRenderable(
         }
 
         return preparedTable;
+    }
+
+    private static int? GetTitleWidth(TableTitle? title, TableTitle? caption)
+    {
+        var contentWidth = new[] { title, caption }
+            .Where(static item => item is not null)
+            .Select(static item => new Segment(Markup.Remove(item!.Text)).CellCount())
+            .DefaultIfEmpty(0)
+            .Max();
+        return contentWidth == 0 ? null : contentWidth + 2;
     }
 
     private static Tree PrepareTree(Tree tree, ISecretObfuscator secretObfuscator)
@@ -296,13 +319,17 @@ internal sealed class SecretObfuscatedRenderable(
         TableTitle? title,
         ISecretObfuscator secretObfuscator) => title is null
         ? null
-        : new TableTitle(secretObfuscator.Obfuscate(title.Text, null), title.Style);
+        : new TableTitle(
+            ObfuscatedMarkup.CreateSafeSource(title.Text, secretObfuscator),
+            title.Style);
 
     private static PanelHeader? ObfuscateHeader(
         PanelHeader? header,
         ISecretObfuscator secretObfuscator) => header is null
         ? null
-        : new PanelHeader(secretObfuscator.Obfuscate(header.Text, null), header.Justification);
+        : new PanelHeader(
+            ObfuscatedMarkup.CreateSafeSource(header.Text, secretObfuscator),
+            header.Justification);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderable")]
     private static extern ref readonly IRenderable GetAlignChild(Align align);

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1745,6 +1745,7 @@ ModularPipelines.IModuleContext.RunSubModuleAsync(string! name, System.Func<Syst
 ModularPipelines.IModuleContext.RunSubModuleAsync<T>(string! name, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
 ModularPipelines.IPipelineContext
 ModularPipelines.IPipelineContext.Artifacts.get -> ModularPipelines.Distributed.IArtifactContext!
+ModularPipelines.IPipelineContext.Console.get -> ModularPipelines.Logging.IConsoleWriter!
 ModularPipelines.IPipelineContext.Data.get -> ModularPipelines.Context.IDataContext!
 ModularPipelines.IPipelineContext.Environment.get -> ModularPipelines.Context.IEnvironmentContext!
 ModularPipelines.IPipelineContext.Files.get -> ModularPipelines.Context.IFilesContext!
@@ -1762,8 +1763,9 @@ ModularPipelines.IRunCondition
 ModularPipelines.IRunCondition.EvaluateAsync(ModularPipelines.IPipelineContext! context) -> System.Threading.Tasks.Task<bool>!
 ModularPipelines.IRunCondition.EvaluateAsync(ModularPipelines.IPipelineContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 ModularPipelines.Logging.IConsoleWriter
-ModularPipelines.Logging.IConsoleWriter.LogToConsole(string! value) -> void
 ModularPipelines.Logging.IConsoleWriter.Write(Spectre.Console.Rendering.IRenderable! renderable) -> void
+ModularPipelines.Logging.IConsoleWriter.WriteLine(string! value) -> void
+ModularPipelines.Logging.IConsoleWriter.WriteMarkupLine(string! value) -> void
 ModularPipelines.Logging.IModuleLoggerAccessor
 ModularPipelines.Logging.IModuleLoggerAccessor.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 ModularPipelines.Logging.ISummaryLogReader

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -290,9 +290,21 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             }
         }
 
-        for (var codePoint = char.MinValue; codePoint <= char.MaxValue; codePoint++)
+        var safeCharacter = FindSafeFallbackMaskCharacter(character =>
+            IsSafeMask(new string(character, 10), secrets, comparison));
+        if (safeCharacter is not null)
         {
-            var character = (char)codePoint;
+            return new string(safeCharacter.Value, 10);
+        }
+
+        throw new InvalidOperationException("No non-secret masking characters remain available.");
+    }
+
+    internal static char? FindSafeFallbackMaskCharacter(Func<char, bool> isSafe)
+    {
+        for (var codePoint = (int) char.MinValue; codePoint <= char.MaxValue; codePoint++)
+        {
+            var character = (char) codePoint;
             if (char.IsControl(character)
                 || char.IsSurrogate(character)
                 || char.IsWhiteSpace(character))
@@ -300,14 +312,13 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
                 continue;
             }
 
-            var candidate = new string(character, 10);
-            if (IsSafeMask(candidate, secrets, comparison))
+            if (isSafe(character))
             {
-                return candidate;
+                return character;
             }
         }
 
-        throw new InvalidOperationException("No non-secret masking characters remain available.");
+        return null;
     }
 
     private static bool IsSafeMask(

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -178,8 +178,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         var comparison = CaseInsensitive
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
-        return secrets.All(secret =>
-            string.IsNullOrEmpty(secret) || !maskValue.Contains(secret, comparison));
+        return IsSafeMask(maskValue, secrets, comparison);
     }
 
     internal bool CanSafelyPreserveRegisteredMasks()
@@ -334,9 +333,19 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
     private static bool IsSafeMask(
         string candidate,
         IReadOnlyList<string> secrets,
-        StringComparison comparison) =>
-        secrets.All(secret =>
-            string.IsNullOrEmpty(secret) || !candidate.Contains(secret, comparison));
+        StringComparison comparison)
+    {
+        var maximumSecretLength = secrets
+            .Where(secret => !string.IsNullOrEmpty(secret))
+            .Select(secret => secret.Length)
+            .DefaultIfEmpty()
+            .Max();
+        var repetitionCount = (maximumSecretLength / candidate.Length) + 2;
+        var repeatedCandidate = string.Concat(Enumerable.Repeat(candidate, repetitionCount));
+
+        return secrets.All(secret =>
+            string.IsNullOrEmpty(secret) || !repeatedCandidate.Contains(secret, comparison));
+    }
 
     private static SecretCache CreateSecretCache(
         IEnumerable<string> secrets,

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -130,7 +130,8 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
     internal MappedObfuscatedOutput ObfuscateWithSourceMap(
         string input,
-        bool preserveExistingMasks)
+        bool preserveExistingMasks,
+        Func<string, string, string>? transformMask = null)
     {
         if (string.IsNullOrEmpty(input))
         {
@@ -167,7 +168,8 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             secretCache.SearchValues,
             maskValue,
             comparison,
-            preserveExistingMasks);
+            preserveExistingMasks,
+            transformMask);
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -365,7 +367,8 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         SearchValues<string> searchValues,
         string maskValue,
         StringComparison comparison,
-        bool preserveExistingMasks)
+        bool preserveExistingMasks,
+        Func<string, string, string>? transformMask)
     {
         var existingMaskRanges = preserveExistingMasks
             ? GetMaskRanges(input, maskValue)
@@ -419,8 +422,9 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
                     sourceToOutputByteOffsets[index] = outputByteCount;
                 }
 
-                result.Append(maskValue);
-                outputByteCount += Encoding.UTF8.GetByteCount(maskValue);
+                var transformedMask = transformMask?.Invoke(matchedSecret, maskValue) ?? maskValue;
+                result.Append(transformedMask);
+                outputByteCount += Encoding.UTF8.GetByteCount(transformedMask);
                 sourceToOutputByteOffsets[matchEnd] = outputByteCount;
             }
 

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -130,8 +130,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
     internal MappedObfuscatedOutput ObfuscateWithSourceMap(
         string input,
-        bool preserveExistingMasks,
-        Func<string, string, string>? transformMask = null)
+        bool preserveExistingMasks)
     {
         if (string.IsNullOrEmpty(input))
         {
@@ -151,9 +150,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         var comparison = caseInsensitive
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
-        if (!preserveExistingMasks
-            && secretCache.Secrets.Any(secret =>
-                !string.IsNullOrEmpty(secret) && maskValue.Contains(secret, comparison)))
+        if (!preserveExistingMasks && !CanSafelyPreserveMasks(secretCache.Secrets))
         {
             const string safeMask = "[MASKED]";
             maskValue = secretCache.Secrets.Any(secret =>
@@ -168,8 +165,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             secretCache.SearchValues,
             maskValue,
             comparison,
-            preserveExistingMasks,
-            transformMask);
+            preserveExistingMasks);
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -367,8 +363,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         SearchValues<string> searchValues,
         string maskValue,
         StringComparison comparison,
-        bool preserveExistingMasks,
-        Func<string, string, string>? transformMask)
+        bool preserveExistingMasks)
     {
         var existingMaskRanges = preserveExistingMasks
             ? GetMaskRanges(input, maskValue)
@@ -422,9 +417,8 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
                     sourceToOutputByteOffsets[index] = outputByteCount;
                 }
 
-                var transformedMask = transformMask?.Invoke(matchedSecret, maskValue) ?? maskValue;
-                result.Append(transformedMask);
-                outputByteCount += Encoding.UTF8.GetByteCount(transformedMask);
+                result.Append(maskValue);
+                outputByteCount += Encoding.UTF8.GetByteCount(maskValue);
                 sourceToOutputByteOffsets[matchEnd] = outputByteCount;
             }
 

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -1,9 +1,11 @@
 using System.Buffers;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Initialization.Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Options;
+using Spectre.Console;
 
 namespace ModularPipelines.Secrets;
 
@@ -305,9 +307,17 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         for (var codePoint = (int) char.MinValue; codePoint <= char.MaxValue; codePoint++)
         {
             var character = (char) codePoint;
+            var category = char.GetUnicodeCategory(character);
             if (char.IsControl(character)
                 || char.IsSurrogate(character)
-                || char.IsWhiteSpace(character))
+                || char.IsWhiteSpace(character)
+                || category is UnicodeCategory.Format
+                    or UnicodeCategory.NonSpacingMark
+                    or UnicodeCategory.SpacingCombiningMark
+                    or UnicodeCategory.EnclosingMark
+                    or UnicodeCategory.PrivateUse
+                    or UnicodeCategory.OtherNotAssigned
+                || character.GetCellWidth() <= 0)
             {
                 continue;
             }

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -152,11 +152,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             : StringComparison.Ordinal;
         if (!preserveExistingMasks && !CanSafelyPreserveMasks(secretCache.Secrets))
         {
-            const string safeMask = "[MASKED]";
-            maskValue = secretCache.Secrets.Any(secret =>
-                !string.IsNullOrEmpty(secret) && safeMask.Contains(secret, comparison))
-                ? string.Empty
-                : safeMask;
+            maskValue = GetSafeFallbackMask(secretCache.Secrets, comparison);
         }
 
         return ObfuscateMatchesWithSourceMap(
@@ -280,6 +276,46 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
     private static string GetMaskValue(SecretMaskingOptions options) =>
         string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
+
+    private static string GetSafeFallbackMask(
+        IReadOnlyList<string> secrets,
+        StringComparison comparison)
+    {
+        string[] preferredMasks = ["[MASKED]", "[REDACTED]", "**********", "##########"];
+        foreach (var candidate in preferredMasks)
+        {
+            if (IsSafeMask(candidate, secrets, comparison))
+            {
+                return candidate;
+            }
+        }
+
+        for (var codePoint = char.MinValue; codePoint <= char.MaxValue; codePoint++)
+        {
+            var character = (char)codePoint;
+            if (char.IsControl(character)
+                || char.IsSurrogate(character)
+                || char.IsWhiteSpace(character))
+            {
+                continue;
+            }
+
+            var candidate = new string(character, 10);
+            if (IsSafeMask(candidate, secrets, comparison))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException("No non-secret masking characters remain available.");
+    }
+
+    private static bool IsSafeMask(
+        string candidate,
+        IReadOnlyList<string> secrets,
+        StringComparison comparison) =>
+        secrets.All(secret =>
+            string.IsNullOrEmpty(secret) || !candidate.Contains(secret, comparison));
 
     private static SecretCache CreateSecretCache(
         IEnumerable<string> secrets,

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -126,6 +126,11 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
     }
 
     internal MappedObfuscatedOutput ObfuscatePreservingMasksWithSourceMap(string input)
+        => ObfuscateWithSourceMap(input, preserveExistingMasks: true);
+
+    internal MappedObfuscatedOutput ObfuscateWithSourceMap(
+        string input,
+        bool preserveExistingMasks)
     {
         if (string.IsNullOrEmpty(input))
         {
@@ -142,12 +147,27 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             return CreateUnchangedSourceMap(input);
         }
 
+        var comparison = caseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!preserveExistingMasks
+            && secretCache.Secrets.Any(secret =>
+                !string.IsNullOrEmpty(secret) && maskValue.Contains(secret, comparison)))
+        {
+            const string safeMask = "[MASKED]";
+            maskValue = secretCache.Secrets.Any(secret =>
+                !string.IsNullOrEmpty(secret) && safeMask.Contains(secret, comparison))
+                ? string.Empty
+                : safeMask;
+        }
+
         return ObfuscateMatchesWithSourceMap(
             input,
             secretCache.Secrets,
             secretCache.SearchValues,
             maskValue,
-            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+            comparison,
+            preserveExistingMasks);
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -164,6 +184,12 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             : StringComparison.Ordinal;
         return secrets.All(secret =>
             string.IsNullOrEmpty(secret) || !maskValue.Contains(secret, comparison));
+    }
+
+    internal bool CanSafelyPreserveRegisteredMasks()
+    {
+        var options = _maskingOptions.Value;
+        return CanSafelyPreserveMasks(GetRegisteredSecretCache(options.CaseInsensitive).Secrets);
     }
 
     internal SecretCache GetSecretCache(
@@ -338,9 +364,12 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         IReadOnlyList<string> secrets,
         SearchValues<string> searchValues,
         string maskValue,
-        StringComparison comparison)
+        StringComparison comparison,
+        bool preserveExistingMasks)
     {
-        var existingMaskRanges = GetMaskRanges(input, maskValue);
+        var existingMaskRanges = preserveExistingMasks
+            ? GetMaskRanges(input, maskValue)
+            : [];
         var maskRangeIndex = 0;
         var sourceToOutputByteOffsets = new int[input.Length + 1];
         var result = new StringBuilder(input.Length);

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -93,12 +93,31 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             return new SecretObfuscationResult(input, 0);
         }
 
-        return ObfuscateMatches(
+        var comparison = caseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var output = ObfuscateMatches(
             input,
             secretCache.Secrets,
             secretCache.SearchValues,
             maskValue,
-            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+            comparison);
+        if (!output.Output.AsSpan().ContainsAny(secretCache.SearchValues))
+        {
+            return output;
+        }
+
+        return ObfuscateWithSafeFallbackMask(
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            comparison,
+            candidate => ObfuscateMatches(
+                input,
+                secretCache.Secrets,
+                secretCache.SearchValues,
+                candidate,
+                comparison),
+            static result => result.Output);
     }
 
     internal string ObfuscatePreservingMasks(string input)
@@ -152,18 +171,30 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         var comparison = caseInsensitive
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
-        if (!preserveExistingMasks && !CanSafelyPreserveMasks(secretCache.Secrets))
-        {
-            maskValue = GetSafeFallbackMask(secretCache.Secrets, comparison);
-        }
-
-        return ObfuscateMatchesWithSourceMap(
+        var output = ObfuscateMatchesWithSourceMap(
             input,
             secretCache.Secrets,
             secretCache.SearchValues,
             maskValue,
             comparison,
             preserveExistingMasks);
+        if (preserveExistingMasks || !output.Value.AsSpan().ContainsAny(secretCache.SearchValues))
+        {
+            return output;
+        }
+
+        return ObfuscateWithSafeFallbackMask(
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            comparison,
+            candidate => ObfuscateMatchesWithSourceMap(
+                input,
+                secretCache.Secrets,
+                secretCache.SearchValues,
+                candidate,
+                comparison,
+                preserveExistingMasks: false),
+            static result => result.Value);
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -278,27 +309,39 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
     private static string GetMaskValue(SecretMaskingOptions options) =>
         string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
 
-    private static string GetSafeFallbackMask(
+    private static TResult ObfuscateWithSafeFallbackMask<TResult>(
         IReadOnlyList<string> secrets,
-        StringComparison comparison)
+        SearchValues<string> searchValues,
+        StringComparison comparison,
+        Func<string, TResult> obfuscate,
+        Func<TResult, string> getOutput)
+        where TResult : notnull
     {
         string[] preferredMasks = ["[MASKED]", "[REDACTED]", "**********", "##########"];
         foreach (var candidate in preferredMasks)
         {
-            if (IsSafeMask(candidate, secrets, comparison))
+            if (TryObfuscate(candidate, out var output))
             {
-                return candidate;
+                return output;
             }
         }
 
+        var safeOutput = default(TResult);
         var safeCharacter = FindSafeFallbackMaskCharacter(character =>
-            IsSafeMask(new string(character, 10), secrets, comparison));
+            TryObfuscate(new string(character, 10), out safeOutput));
         if (safeCharacter is not null)
         {
-            return new string(safeCharacter.Value, 10);
+            return safeOutput!;
         }
 
         throw new InvalidOperationException("No non-secret masking characters remain available.");
+
+        bool TryObfuscate(string maskValue, out TResult output)
+        {
+            output = obfuscate(maskValue);
+            return IsSafeMask(maskValue, secrets, comparison)
+                   && !getOutput(output).AsSpan().ContainsAny(searchValues);
+        }
     }
 
     internal static char? FindSafeFallbackMaskCharacter(Func<char, bool> isSafe)

--- a/src/ModularPipelines/Secrets/SecretObfuscator.cs
+++ b/src/ModularPipelines/Secrets/SecretObfuscator.cs
@@ -137,13 +137,32 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             return input;
         }
 
-        return ObfuscateMatches(
+        var comparison = caseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var output = ObfuscateMatches(
             input,
             secretCache.Secrets,
             secretCache.SearchValues,
             maskValue,
-            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal,
-            preserveExistingMasks: true).Output;
+            comparison,
+            preserveExistingMasks: true);
+        if (!output.Output.AsSpan().ContainsAny(secretCache.SearchValues))
+        {
+            return output.Output;
+        }
+
+        return ObfuscateWithSafeFallbackMask(
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            comparison,
+            candidate => ObfuscateMatches(
+                input,
+                secretCache.Secrets,
+                secretCache.SearchValues,
+                candidate,
+                comparison),
+            static result => result.Output).Output;
     }
 
     internal MappedObfuscatedOutput ObfuscatePreservingMasksWithSourceMap(string input)
@@ -178,7 +197,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             maskValue,
             comparison,
             preserveExistingMasks);
-        if (preserveExistingMasks || !output.Value.AsSpan().ContainsAny(secretCache.SearchValues))
+        if (!output.Value.AsSpan().ContainsAny(secretCache.SearchValues))
         {
             return output;
         }

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -1,4 +1,3 @@
-using ModularPipelines.Logging;
 using ModularPipelines.Reporting;
 using ModularPipelines.Events;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -12,6 +12,7 @@ using ModularPipelines.Enums;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Interfaces;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -36,7 +37,12 @@ public class PipelineCommandLineTests
 
         public List<string> Messages { get; } = [];
 
-        public void LogToConsole(string value)
+        public void WriteLine(string value)
+        {
+            Messages.Add(value);
+        }
+
+        public void WriteMarkupLine(string value)
         {
             Messages.Add(value);
         }

--- a/test/ModularPipelines.UnitTests/Console/BufferedSecretRemaskerTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/BufferedSecretRemaskerTests.cs
@@ -1,0 +1,160 @@
+using ModularPipelines.Console;
+using ModularPipelines.Enums;
+using ModularPipelines.Options;
+using ModularPipelines.Secrets;
+using Moq;
+using Spectre.Console;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class BufferedSecretRemaskerTests
+{
+    [Test]
+    public async Task IncrementalFlush_Retains_Unterminated_Maskable_Tail()
+    {
+        var remasker = CreateRemasker("token");
+        BufferedOutput[] outputs =
+        [
+            BufferedOutput.FromString(
+                "to",
+                ModuleOutputStream.StandardOutput,
+                appendNewLine: false),
+        ];
+
+        var count = remasker.GetIncrementalFlushableOutputCount(outputs);
+
+        await Assert.That(count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryWrite_Masks_Secret_Split_Across_Fragments()
+    {
+        var remasker = CreateRemasker("token");
+        BufferedOutput[] outputs =
+        [
+            BufferedOutput.FromString(
+                "to",
+                ModuleOutputStream.StandardOutput,
+                appendNewLine: false),
+            BufferedOutput.FromString("ken"),
+        ];
+        using var writer = new StringWriter();
+
+        var count = remasker.TryWrite(CreateConsole(writer), outputs, 0);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(count).IsEqualTo(2);
+            await Assert.That(writer.ToString()).Contains("**********");
+            await Assert.That(writer.ToString()).DoesNotContain("token");
+        }
+    }
+
+    [Test]
+    public async Task TryWrite_Masks_Secret_Split_Across_Line_Boundary()
+    {
+        var secret = $"to{Environment.NewLine}ken";
+        var remasker = CreateRemasker(secret);
+        BufferedOutput[] outputs =
+        [
+            BufferedOutput.FromString("to"),
+            BufferedOutput.FromString("ken"),
+        ];
+        using var writer = new StringWriter();
+
+        var count = remasker.TryWrite(CreateConsole(writer), outputs, 0);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(count).IsEqualTo(2);
+            await Assert.That(writer.ToString()).Contains("**********");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+        }
+    }
+
+    [Test]
+    public async Task TryWrite_Stops_After_Completed_NonSecret_Line()
+    {
+        var remasker = CreateRemasker("token");
+        BufferedOutput[] outputs =
+        [
+            BufferedOutput.FromString("ordinary"),
+            BufferedOutput.FromString("token"),
+        ];
+        using var writer = new StringWriter();
+
+        var count = remasker.TryWrite(CreateConsole(writer), outputs, 0);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(count).IsEqualTo(1);
+            await Assert.That(writer.ToString()).Contains("ordinary");
+            await Assert.That(writer.ToString()).DoesNotContain("**********");
+        }
+    }
+
+    [Test]
+    public async Task TryWrite_Remasks_Only_Registered_Secrets_In_PreObfuscated_Output()
+    {
+        const string secret = "secret";
+        var provider = CreateSecretProvider(secret);
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input switch
+            {
+                "secret" => "masked",
+                "masked" => "masked-twice",
+                _ => input ?? string.Empty,
+            });
+        var remasker = new BufferedSecretRemasker(obfuscator.Object, provider.Object);
+        BufferedOutput[] outputs =
+        [
+            BufferedOutput.FromString(
+                "masked ",
+                ModuleOutputStream.StandardOutput,
+                appendNewLine: false,
+                isPreObfuscated: true),
+            BufferedOutput.FromString(
+                secret,
+                ModuleOutputStream.StandardOutput,
+                appendNewLine: true,
+                isPreObfuscated: true),
+        ];
+        using var writer = new StringWriter();
+
+        var count = remasker.TryWrite(CreateConsole(writer), outputs, 0);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(count).IsEqualTo(2);
+            await Assert.That(writer.ToString()).Contains("masked masked");
+            await Assert.That(writer.ToString()).DoesNotContain("masked-twice");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+        }
+    }
+
+    private static BufferedSecretRemasker CreateRemasker(string secret)
+    {
+        var provider = CreateSecretProvider(secret);
+        return new BufferedSecretRemasker(
+            new SecretObfuscator(
+                provider.Object,
+                Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions())),
+            provider.Object);
+    }
+
+    private static Mock<ISecretProvider> CreateSecretProvider(string secret)
+    {
+        var provider = new Mock<ISecretProvider>();
+        provider.SetupGet(x => x.Version).Returns(0);
+        provider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, [secret]));
+        return provider;
+    }
+
+    private static IAnsiConsole CreateConsole(TextWriter writer) =>
+        AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+        });
+}

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -575,6 +575,32 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_PreservesEmptyLayoutRegions()
+    {
+        var layout = new Layout("root")
+            .SplitColumns(
+                new Layout("left", new Text("tiny")).Size(10),
+                new Layout("spacer").Size(10));
+        var renderable = new SecretObfuscatedRenderable(
+            layout,
+            CreateSecretObfuscator("tiny"));
+
+        var lines = Segment.SplitLines(renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                20))
+            .Select(static line => string.Concat(line.Select(segment => segment.Text)))
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(lines).Count().IsEqualTo(24);
+            await Assert.That(lines[0]).StartsWith("**********");
+            await Assert.That(lines.All(line => new Segment(line).CellCount() == 20))
+                .IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Write_EscapesConfiguredMaskInTableTitle()
     {
         var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -110,11 +110,23 @@ public class ConsoleWriterTests
         }
     }
 
-    private sealed class WriteReadyOutputReceiver : IModuleEventReceiver
+    private sealed class WriteLifecycleOutputReceiver : IModuleEventReceiver
     {
         public Task OnModuleReadyAsync(IModuleHookContext context)
         {
             context.Console.WriteLine("receiver ready output");
+            return Task.CompletedTask;
+        }
+
+        public Task OnModuleStartAsync(IModuleHookContext context)
+        {
+            context.Console.WriteLine("receiver start output");
+            return Task.CompletedTask;
+        }
+
+        public Task OnModuleEndAsync(IModuleHookContext context)
+        {
+            context.Console.WriteLine("receiver end output");
             return Task.CompletedTask;
         }
     }
@@ -242,13 +254,15 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task ReadyHooks_UseModuleConsoleWriter()
+    public async Task LifecycleHooks_UseModuleConsoleWriter()
     {
         var output = await RunAsync<ReadyOutputModule>(
-            builder => builder.AddModuleEventReceiver<WriteReadyOutputReceiver>());
+            builder => builder.AddModuleEventReceiver<WriteLifecycleOutputReceiver>());
 
         await Assert.That(output).Contains("attribute ready output");
         await Assert.That(output).Contains("receiver ready output");
+        await Assert.That(output).Contains("receiver start output");
+        await Assert.That(output).Contains("receiver end output");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -254,6 +254,22 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task WriteMarkupLine_EscapesBracketedMaskWithoutDroppingMarkup()
+    {
+        var output = CaptureFallbackOutput(
+            writer => writer.WriteMarkupLine("[red]secret[/]"),
+            CreateSecretObfuscator("secret", "[REDACTED]"),
+            AnsiSupport.Yes);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("\u001b[");
+            await Assert.That(output).Contains("[REDACTED]");
+            await Assert.That(output).DoesNotContain("secret");
+        }
+    }
+
+    [Test]
     public async Task Write_ObfuscatesWithoutAmbientModule()
     {
         var output = CaptureFallbackOutput(writer => writer.Write(new Markup("[green]a secret value[/]")));
@@ -504,6 +520,47 @@ public class ConsoleWriterTests
             await Assert.That(Segment.SplitLines(segments).Max(static line => line.CellCount()))
                 .IsEqualTo(24);
         }
+    }
+
+    [Test]
+    public async Task Write_PreparesRuleTitleWithSecretSplitAcrossTags()
+    {
+        var obfuscator = CreateSecretObfuscator("abc123", "[REDACTED]");
+        var renderable = new SecretObfuscatedRenderable(
+            new Rule("[red]abc[/][blue]123[/]"),
+            obfuscator);
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                24)
+            .ToArray();
+        var renderedText = string.Concat(segments.Select(static segment => segment.Text));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(renderedText).Contains("[REDACTED]");
+            await Assert.That(renderedText).DoesNotContain("abc");
+            await Assert.That(renderedText).DoesNotContain("123");
+            await Assert.That(Segment.SplitLines(segments).Max(static line => line.CellCount()))
+                .IsEqualTo(24);
+        }
+    }
+
+    [Test]
+    public async Task Write_AutoSizedTableAccountsForColumnContentWithTitle()
+    {
+        var table = new Table()
+            .AddColumn("Value")
+            .AddRow("substantially wider column content");
+        table.Title = new TableTitle("Short");
+        var renderable = new SecretObfuscatedRenderable(
+            table,
+            CreateSecretObfuscator("unrelated"));
+
+        var measurement = renderable.Measure(
+            RenderOptions.Create(AnsiConsole.Console),
+            80);
+
+        await Assert.That(measurement.Max).IsGreaterThan(20);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -376,6 +376,28 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_ObfuscatesHyperlinkTargetInPreparedTableTitle()
+    {
+        var table = new Table().AddColumn("Value").AddRow("content");
+        table.Title = new TableTitle("[link=https://host/token]label[/]");
+        var renderable = new SecretObfuscatedRenderable(
+            table,
+            CreateSecretObfuscator("token"));
+
+        var url = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .Select(static segment => segment.Link?.Url)
+            .First(static value => value is not null)!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(url).Contains("**********");
+            await Assert.That(url).DoesNotContain("token");
+        }
+    }
+
+    [Test]
     public async Task Write_RemovesControlSegmentContainingSecret()
     {
         var renderable = new SecretObfuscatedRenderable(

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,5 +1,6 @@
 using ModularPipelines.Logging;
 using ModularPipelines.Context;
+using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 using Spectre.Console;
@@ -10,13 +11,24 @@ namespace ModularPipelines.UnitTests.Console;
 [TUnit.Core.NotInParallel(nameof(ConsoleWriterTests))]
 public class ConsoleWriterTests
 {
-    private sealed class LogToConsoleModule(IConsoleWriter consoleWriter) : Module<bool>
+    private sealed class WriteMarkupLineModule(IConsoleWriter consoleWriter) : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken)
         {
-            consoleWriter.LogToConsole("[green]module output[/]");
+            consoleWriter.WriteMarkupLine("[green]module output[/]");
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class WriteLineModule(IConsoleWriter consoleWriter) : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            consoleWriter.WriteLine("[green]module output[/]");
             return Task.FromResult(true);
         }
     }
@@ -34,11 +46,19 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task LogToConsole_UsesAmbientModuleConsoleWriter()
+    public async Task WriteMarkupLine_UsesAmbientModuleConsoleWriter()
     {
-        var output = await RunAsync<LogToConsoleModule>();
+        var output = await RunAsync<WriteMarkupLineModule>();
 
         await Assert.That(output).Contains("module output");
+    }
+
+    [Test]
+    public async Task WriteLine_EscapesMarkup()
+    {
+        var output = await RunAsync<WriteLineModule>();
+
+        await Assert.That(output).Contains("[[green]]module output[[/]]");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -992,6 +992,29 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task ChartValueFormatterSnapshotPreservesDuplicateValueInvocations()
+    {
+        var formatterCalls = 0;
+        var formatter = SecretObfuscatedRenderable.SnapshotValueFormatter(
+            (_, _) => $"call-{++formatterCalls}",
+            [42, 42]);
+
+        var first = formatter(42, CultureInfo.InvariantCulture);
+        var second = formatter(42, CultureInfo.InvariantCulture);
+        var replayedFirst = formatter(42, CultureInfo.InvariantCulture);
+        var replayedSecond = formatter(42, CultureInfo.InvariantCulture);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(first).IsEqualTo("call-1");
+            await Assert.That(second).IsEqualTo("call-2");
+            await Assert.That(replayedFirst).IsEqualTo(first);
+            await Assert.That(replayedSecond).IsEqualTo(second);
+            await Assert.That(formatterCalls).IsEqualTo(2);
+        }
+    }
+
+    [Test]
     public async Task Write_EscapesConfiguredMaskInTableTitle()
     {
         var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,8 +1,10 @@
 using ModularPipelines.Logging;
 using ModularPipelines.Context;
+using ModularPipelines.Engine;
 using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
+using Moq;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -69,6 +71,30 @@ public class ConsoleWriterTests
         await Assert.That(output).Contains("module output");
     }
 
+    [Test]
+    public async Task WriteLine_ObfuscatesWithoutAmbientModule()
+    {
+        var output = CaptureFallbackOutput(writer => writer.WriteLine("a secret value"));
+
+        await AssertFallbackOutputIsObfuscated(output);
+    }
+
+    [Test]
+    public async Task WriteMarkupLine_ObfuscatesWithoutAmbientModule()
+    {
+        var output = CaptureFallbackOutput(writer => writer.WriteMarkupLine("[green]a secret value[/]"));
+
+        await AssertFallbackOutputIsObfuscated(output);
+    }
+
+    [Test]
+    public async Task Write_ObfuscatesWithoutAmbientModule()
+    {
+        var output = CaptureFallbackOutput(writer => writer.Write(new Markup("[green]a secret value[/]")));
+
+        await AssertFallbackOutputIsObfuscated(output);
+    }
+
     private static async Task<string> RunAsync<TModule>()
         where TModule : class, IModule
     {
@@ -86,5 +112,38 @@ public class ConsoleWriterTests
         var summary = await builder.RunAsync();
 
         return summary.RunReport!.Modules.Single().Output!.StdoutTail ?? string.Empty;
+    }
+
+    private static string CaptureFallbackOutput(Action<ConsoleWriter> write)
+    {
+        var originalConsole = AnsiConsole.Console;
+        using var output = new StringWriter();
+
+        try
+        {
+            AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Out = new AnsiConsoleOutput(output),
+                Ansi = AnsiSupport.No,
+            });
+
+            var secretObfuscator = new Mock<ISecretObfuscator>();
+            secretObfuscator
+                .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+                .Returns((string? input, object? _) => input!.Replace("secret", "********"));
+
+            write(new ConsoleWriter(secretObfuscator.Object));
+            return output.ToString();
+        }
+        finally
+        {
+            AnsiConsole.Console = originalConsole;
+        }
+    }
+
+    private static async Task AssertFallbackOutputIsObfuscated(string output)
+    {
+        await Assert.That(output).Contains("********");
+        await Assert.That(output).DoesNotContain("secret");
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1042,7 +1042,11 @@ public class ConsoleWriterTests
             RenderOptions.Create(AnsiConsole.Console),
             80);
 
-        await Assert.That(measurement.Max).IsGreaterThan(20);
+        using (Assert.Multiple())
+        {
+            await Assert.That(measurement.Min).IsLessThan(measurement.Max);
+            await Assert.That(measurement.Max).IsGreaterThan(20);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -859,6 +859,40 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_SnapshotsChartValueFormatterResults()
+    {
+        var formattedValue = "write-time";
+        var formatterCalls = 0;
+        var chart = new BreakdownChart
+        {
+            ValueFormatter = (_, _) =>
+            {
+                formatterCalls++;
+                return formattedValue;
+            },
+            Width = 24,
+        }.AddItem("item", 100, Color.Red);
+        var renderable = new SecretObfuscatedRenderable(
+            chart,
+            CreateSecretObfuscator("unrelated"));
+        var options = RenderOptions.Create(AnsiConsole.Console);
+
+        var writeTimeOutput = string.Concat(renderable.Render(options, 24)
+            .Select(static segment => segment.Text));
+        formattedValue = "flush-time";
+        var flushOutput = string.Concat(renderable.Render(options, 24)
+            .Select(static segment => segment.Text));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writeTimeOutput).Contains("write-time");
+            await Assert.That(flushOutput).Contains("write-time");
+            await Assert.That(flushOutput).DoesNotContain("flush-time");
+            await Assert.That(formatterCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
     public async Task Write_EscapesConfiguredMaskInTableTitle()
     {
         var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");
@@ -1029,18 +1063,22 @@ public class ConsoleWriterTests
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(x => x.Version).Returns(0);
         secretProvider.Setup(x => x.GetSnapshot())
-            .Returns(new SecretSnapshot(0, ["REDACT"]));
+            .Returns(new SecretSnapshot(0, ["MASK"]));
         var obfuscator = new SecretObfuscator(
             secretProvider.Object,
             Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
             {
-                MaskValue = "[REDACTED]",
+                MaskValue = "[MASK]",
             }));
         var output = CaptureFallbackOutput(
-            writer => writer.Write(new Text("[REDACTED]")),
+            writer => writer.Write(new Text("MASK")),
             obfuscator);
 
-        await Assert.That(output).DoesNotContain("REDACT");
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).IsNotEmpty();
+            await Assert.That(output).DoesNotContain("MASK");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -245,7 +245,7 @@ public class ConsoleWriterTests
             writer => writer.WriteMarkupLine("[red]abc[/][blue]123[/]"),
             CreateSecretObfuscator("abc123"));
 
-        await Assert.That(output).Contains("**********");
+        await Assert.That(output).Contains("******");
         await Assert.That(output).DoesNotContain("abc");
         await Assert.That(output).DoesNotContain("123");
     }
@@ -326,7 +326,7 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task Write_MeasuresObfuscatedWidth()
+    public async Task Write_PreservesRenderableWidthWhileObfuscating()
     {
         var renderable = new SecretObfuscatedRenderable(
             new Text("tiny"),
@@ -336,7 +336,31 @@ public class ConsoleWriterTests
             RenderOptions.Create(AnsiConsole.Console),
             80);
 
-        await Assert.That(measurement.Max).IsEqualTo(10);
+        await Assert.That(measurement.Max).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task Write_PreservesCompositeLayoutWhenMaskWidthDiffers()
+    {
+        var table = new Table()
+            .AddColumn("Value")
+            .AddRow("tiny");
+
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(table),
+            CreateSecretObfuscator("tiny"));
+        var lineWidths = output
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => new Segment(line).CellCount())
+            .Distinct()
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("****");
+            await Assert.That(output).DoesNotContain("tiny");
+            await Assert.That(lineWidths).Count().IsEqualTo(1);
+        }
     }
 
     [Test]
@@ -364,7 +388,7 @@ public class ConsoleWriterTests
     {
         var output = await RunAsync<WriteSplitSecretModule>();
 
-        await Assert.That(output).Contains("**********");
+        await Assert.That(output).Contains("******");
         await Assert.That(output).DoesNotContain("abc");
         await Assert.That(output).DoesNotContain("123");
     }

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using ModularPipelines;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
@@ -889,6 +890,32 @@ public class ConsoleWriterTests
             await Assert.That(flushOutput).Contains("write-time");
             await Assert.That(flushOutput).DoesNotContain("flush-time");
             await Assert.That(formatterCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task ChartValueFormatterSnapshotDistinguishesSignedZeroAndCulture()
+    {
+        var formatterCalls = 0;
+        var formatter = SecretObfuscatedRenderable.SnapshotValueFormatter((value, culture) =>
+        {
+            formatterCalls++;
+            return $"{BitConverter.DoubleToInt64Bits(value)}:{culture.Name}";
+        });
+        var invariantCulture = CultureInfo.InvariantCulture;
+        var frenchCulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        var positiveZero = formatter(+0.0, invariantCulture);
+        var negativeZero = formatter(-0.0, invariantCulture);
+        var frenchPositiveZero = formatter(+0.0, frenchCulture);
+        var cachedPositiveZero = formatter(+0.0, invariantCulture);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(positiveZero).IsNotEqualTo(negativeZero);
+            await Assert.That(positiveZero).IsNotEqualTo(frenchPositiveZero);
+            await Assert.That(cachedPositiveZero).IsEqualTo(positiveZero);
+            await Assert.That(formatterCalls).IsEqualTo(3);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -70,6 +70,23 @@ public class ConsoleWriterTests
         }
     }
 
+    private sealed class ControlAndVisibleRenderable(
+        string controlText = "to",
+        string visibleText = "ken") : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            var width = Math.Min(visibleText.Length, maxWidth);
+            return new Measurement(width, width);
+        }
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            yield return Segment.Control(controlText);
+            yield return new Segment(visibleText);
+        }
+    }
+
     private sealed class WidthSensitiveRenderable : IRenderable
     {
         public List<int> RenderWidths { get; } = [];
@@ -628,6 +645,46 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_RemovesSecretSplitAcrossControlAndVisibleSegments()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlAndVisibleRenderable(),
+            CreateSecretObfuscator("token"));
+
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(segments.Any(static segment => segment.IsControlCode)).IsFalse();
+            await Assert.That(string.Concat(segments.Select(static segment => segment.Text)))
+                .DoesNotContain("token");
+        }
+    }
+
+    [Test]
+    public async Task Write_PreservesUnrelatedControlBeforeVisibleSecret()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlAndVisibleRenderable("\u001b[31m", "token"),
+            CreateSecretObfuscator("token"));
+
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(segments.Any(static segment => segment.IsControlCode)).IsTrue();
+            await Assert.That(string.Concat(segments.Select(static segment => segment.Text)))
+                .DoesNotContain("token");
+        }
+    }
+
+    [Test]
     public async Task Write_RemovesRelatedControlSequencesAcrossNestedChildren()
     {
         var renderable = new SecretObfuscatedRenderable(
@@ -817,7 +874,7 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task Write_SnapshotsUnhandledRenderablePerWidth()
+    public async Task Write_SnapshotsUnhandledRenderableBeforeUnseenWidths()
     {
         var source = new WidthSensitiveRenderable();
         var renderable = new SecretObfuscatedRenderable(
@@ -831,8 +888,8 @@ public class ConsoleWriterTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(output).IsEqualTo("5");
-            await Assert.That(source.RenderWidths).IsEquivalentTo([20, 5]);
+            await Assert.That(output).IsEqualTo("20");
+            await Assert.That(source.RenderWidths).IsEquivalentTo([20]);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -703,6 +703,32 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_PreparesBreakdownChartContentBeforeLayout()
+    {
+        var options = RenderOptions.Create(AnsiConsole.Console);
+        var chart = new BreakdownChart
+        {
+            ValueFormatter = static (_, _) => "tiny",
+            Width = 24,
+        }.AddItem("tiny", 100, Color.Red);
+        var renderable = new SecretObfuscatedRenderable(
+            chart,
+            CreateSecretObfuscator("tiny"));
+        var expectedChart = new BreakdownChart
+        {
+            ValueFormatter = static (_, _) => "**********",
+            Width = 24,
+        }.AddItem("**********", 100, Color.Red);
+
+        var actual = string.Concat(renderable.Render(options, 24)
+            .Select(static segment => segment.Text));
+        var expected = string.Concat(((IRenderable)expectedChart).Render(options, 24)
+            .Select(static segment => segment.Text));
+
+        await Assert.That(actual).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task Write_EscapesConfiguredMaskInTableTitle()
     {
         var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -613,6 +613,21 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_RemovesSecretSplitAcrossControlSegments()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlRenderable("to", "ken"),
+            CreateSecretObfuscator("token"));
+
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        await Assert.That(segments).IsEmpty();
+    }
+
+    [Test]
     public async Task Write_RemovesRelatedControlSequencesAcrossNestedChildren()
     {
         var renderable = new SecretObfuscatedRenderable(

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -19,13 +19,16 @@ namespace ModularPipelines.UnitTests.Console;
 [TUnit.Core.NotInParallel]
 public class ConsoleWriterTests
 {
-    private sealed class ControlRenderable(string value) : IRenderable
+    private sealed class ControlRenderable(params string[] values) : IRenderable
     {
         public Measurement Measure(RenderOptions options, int maxWidth) => new(0, 0);
 
         public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
         {
-            yield return Segment.Control(value);
+            foreach (var value in values)
+            {
+                yield return Segment.Control(value);
+            }
         }
     }
 
@@ -473,6 +476,21 @@ public class ConsoleWriterTests
         var renderable = new SecretObfuscatedRenderable(
             new ControlRenderable("\u001b[31m"),
             CreateSecretObfuscator("31"));
+
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        await Assert.That(segments).IsEmpty();
+    }
+
+    [Test]
+    public async Task Write_RemovesRelatedControlSequencesTogether()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlRenderable("\u001b[?25l", "\u001b[?25h"),
+            CreateSecretObfuscator("25h"));
 
         var segments = renderable.Render(
                 RenderOptions.Create(AnsiConsole.Console),

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -63,6 +63,18 @@ public class ConsoleWriterTests
         }
     }
 
+    private sealed class WriteFragmentsModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            context.Console.Write(new Text("prefix"));
+            context.Console.Write(new Text("suffix"));
+            return Task.FromResult(true);
+        }
+    }
+
     private sealed class WriteSplitSecretModule(
         IConsoleWriter consoleWriter,
         ISecretRegistry secretRegistry) : Module<bool>
@@ -160,6 +172,18 @@ public class ConsoleWriterTests
         var output = await RunAsync<WriteModule>();
 
         await Assert.That(output).Contains("module output");
+    }
+
+    [Test]
+    public async Task Write_UsesAmbientModuleConsoleWriterWithoutAppendingLineBreaks()
+    {
+        var output = await RunAsync<WriteFragmentsModule>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("prefixsuffix");
+            await Assert.That(output).DoesNotContain($"prefix{Environment.NewLine}suffix");
+        }
     }
 
     [Test]
@@ -386,6 +410,31 @@ public class ConsoleWriterTests
         using (Assert.Multiple())
         {
             await Assert.That(output).Contains("[REDACTED]");
+            await Assert.That(output).DoesNotContain("tiny");
+            await Assert.That(lineWidths).Count().IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Write_PreservesNestedCompositeLayoutWhenMaskWidthDiffers()
+    {
+        var grid = new Grid()
+            .AddColumn()
+            .AddRow("tiny");
+        var panel = new Panel(grid);
+
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(panel),
+            CreateSecretObfuscator("tiny"));
+        var lineWidths = output
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => new Segment(line).CellCount())
+            .Distinct()
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("**********");
             await Assert.That(output).DoesNotContain("tiny");
             await Assert.That(lineWidths).Count().IsEqualTo(1);
         }

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -213,6 +213,27 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task WriteMarkupLine_DoesNotApplyCustomObfuscatorTwice()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input switch
+            {
+                "secret" => "masked",
+                "masked" => "masked-twice",
+                _ => input ?? string.Empty,
+            });
+
+        var output = CaptureFallbackOutput(
+            writer => writer.WriteMarkupLine("[green]secret[/]"),
+            secretObfuscator.Object);
+
+        await Assert.That(output).Contains("masked");
+        await Assert.That(output).DoesNotContain("masked-twice");
+    }
+
+    [Test]
     public async Task WriteMarkupLine_InvalidMarkupUsesConfiguredConsole()
     {
         var output = CaptureFallbackOutput(writer => writer.WriteMarkupLine("[green]unclosed"));

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -868,6 +868,42 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_MeasureDerivesMinimumFromLongerMask()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Text("tiny abcdefghij"),
+            CreateSecretObfuscator("tiny", "[REDACTED]"));
+
+        var measurement = renderable.Measure(
+            RenderOptions.Create(AnsiConsole.Console),
+            80);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(measurement.Min).IsEqualTo(10);
+            await Assert.That(measurement.Max).IsEqualTo(21);
+        }
+    }
+
+    [Test]
+    public async Task Write_MeasureDerivesMinimumFromShorterMask()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Text("1234567890 abcdefghij"),
+            CreateSecretObfuscator("1234567890", "x"));
+
+        var measurement = renderable.Measure(
+            RenderOptions.Create(AnsiConsole.Console),
+            80);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(measurement.Min).IsEqualTo(10);
+            await Assert.That(measurement.Max).IsEqualTo(12);
+        }
+    }
+
+    [Test]
     public async Task Write_AutoSizedTableAccountsForColumnContentWithTitle()
     {
         var table = new Table()

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -199,6 +199,28 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task WriteMarkupLine_InvalidObfuscatedMarkupNeverFallsBackToRawSecret()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, ["[red]secret[/]"]));
+        var obfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = "[REDACTED]",
+            }));
+
+        var output = CaptureFallbackOutput(
+            writer => writer.WriteMarkupLine("value: [red]secret[/]"),
+            obfuscator);
+
+        await Assert.That(output).Contains("[REDACTED]");
+        await Assert.That(output).DoesNotContain("secret");
+    }
+
+    [Test]
     public async Task Write_ObfuscatesWithoutAmbientModule()
     {
         var output = CaptureFallbackOutput(writer => writer.Write(new Markup("[green]a secret value[/]")));

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -524,6 +524,32 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_DoesNotReapplyCustomObfuscatorToPreparedComposite()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns("masked");
+        var table = new Table()
+            .AddColumn("Value")
+            .AddRow("tiny");
+
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(table),
+            secretObfuscator.Object);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("masked");
+            await Assert.That(output).Contains("┌");
+            await Assert.That(output.Split(
+                    Environment.NewLine,
+                    StringSplitOptions.RemoveEmptyEntries))
+                .Count().IsGreaterThan(1);
+        }
+    }
+
+    [Test]
     public async Task Write_PreservesNestedCompositeLayoutWhenMaskWidthDiffers()
     {
         var grid = new Grid()
@@ -580,10 +606,10 @@ public class ConsoleWriterTests
         var layout = new Layout("root")
             .SplitColumns(
                 new Layout("left", new Text("tiny")).Size(10),
-                new Layout("spacer").Size(10));
+                new Layout("secret").Size(10));
         var renderable = new SecretObfuscatedRenderable(
             layout,
-            CreateSecretObfuscator("tiny"));
+            CreateSecretObfuscator(["tiny", "secret"], maskValue: null));
 
         var lines = Segment.SplitLines(renderable.Render(
                 RenderOptions.Create(AnsiConsole.Console),
@@ -595,6 +621,7 @@ public class ConsoleWriterTests
         {
             await Assert.That(lines).Count().IsEqualTo(24);
             await Assert.That(lines[0]).StartsWith("**********");
+            await Assert.That(string.Concat(lines)).DoesNotContain("secret");
             await Assert.That(lines.All(line => new Segment(line).CellCount() == 20))
                 .IsTrue();
         }
@@ -620,6 +647,32 @@ public class ConsoleWriterTests
             await Assert.That(actual).IsEqualTo(expected);
             await Assert.That(actual).IsNotEqualTo(unmasked);
         }
+    }
+
+    [Test]
+    public async Task Write_PreparesBarChartLabelsBeforeLayout()
+    {
+        var options = RenderOptions.Create(AnsiConsole.Console);
+        var chart = new BarChart
+        {
+            ShowValues = false,
+            Width = 24,
+        }.AddItem("tiny", 100, Color.Red);
+        var renderable = new SecretObfuscatedRenderable(
+            chart,
+            CreateSecretObfuscator("tiny"));
+        var expectedChart = new BarChart
+        {
+            ShowValues = false,
+            Width = 24,
+        }.AddItem("**********", 100, Color.Red);
+
+        var actual = string.Concat(renderable.Render(options, 24)
+            .Select(static segment => segment.Text));
+        var expected = string.Concat(((IRenderable)expectedChart).Render(options, 24)
+            .Select(static segment => segment.Text));
+
+        await Assert.That(actual).IsEqualTo(expected);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -8,6 +8,7 @@ using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
+using ModularPipelines.Secrets;
 using ModularPipelines.TestHelpers;
 using Moq;
 using Spectre.Console;

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -326,7 +326,7 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task Write_PreservesRenderableWidthWhileObfuscating()
+    public async Task Write_UsesConfiguredMaskWidthWhileObfuscating()
     {
         var renderable = new SecretObfuscatedRenderable(
             new Text("tiny"),
@@ -336,7 +336,7 @@ public class ConsoleWriterTests
             RenderOptions.Create(AnsiConsole.Console),
             80);
 
-        await Assert.That(measurement.Max).IsEqualTo(4);
+        await Assert.That(measurement.Max).IsEqualTo(10);
     }
 
     [Test]
@@ -357,10 +357,50 @@ public class ConsoleWriterTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(output).Contains("****");
+            await Assert.That(output).Contains("**********");
             await Assert.That(output).DoesNotContain("tiny");
             await Assert.That(lineWidths).Count().IsEqualTo(1);
         }
+    }
+
+    [Test]
+    public async Task Write_CustomObfuscatorPreservesCompositeLayout()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input!.Replace("tiny", "[REDACTED]"));
+        var table = new Table()
+            .AddColumn("Value")
+            .AddRow("tiny");
+
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(table),
+            secretObfuscator.Object);
+        var lineWidths = output
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => new Segment(line).CellCount())
+            .Distinct()
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("[REDACTED]");
+            await Assert.That(output).DoesNotContain("tiny");
+            await Assert.That(lineWidths).Count().IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Write_DoesNotAppendLineBreak()
+    {
+        var output = CaptureFallbackOutput(writer =>
+        {
+            writer.Write(new Text("prefix"));
+            writer.Write(new Text("suffix"));
+        });
+
+        await Assert.That(output).IsEqualTo("prefixsuffix");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -470,6 +470,43 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_EscapesConfiguredMaskInTableTitle()
+    {
+        var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");
+        var table = new Table()
+            .AddColumn("Value")
+            .AddRow("value");
+        table.Title = new TableTitle("secret");
+
+        var output = CaptureFallbackOutput(writer => writer.Write(table), obfuscator);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("[REDACTED]");
+            await Assert.That(output).DoesNotContain("secret");
+        }
+    }
+
+    [Test]
+    public async Task Write_PreparesRuleTitleBeforeLayout()
+    {
+        var obfuscator = CreateSecretObfuscator("tiny", "[REDACTED]");
+        var renderable = new SecretObfuscatedRenderable(new Rule("tiny"), obfuscator);
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                24)
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(string.Concat(segments.Select(static segment => segment.Text)))
+                .Contains("[REDACTED]");
+            await Assert.That(Segment.SplitLines(segments).Max(static line => line.CellCount()))
+                .IsEqualTo(24);
+        }
+    }
+
+    [Test]
     public async Task Write_DoesNotAppendLineBreak()
     {
         var output = CaptureFallbackOutput(writer =>
@@ -592,13 +629,24 @@ public class ConsoleWriterTests
     }
 
     private static ISecretObfuscator CreateSecretObfuscator(params string[] secrets)
+        => CreateSecretObfuscator(secrets, maskValue: null);
+
+    private static ISecretObfuscator CreateSecretObfuscator(string secret, string maskValue)
+        => CreateSecretObfuscator([secret], maskValue);
+
+    private static ISecretObfuscator CreateSecretObfuscator(
+        string[] secrets,
+        string? maskValue)
     {
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(x => x.Version).Returns(0);
         secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, secrets));
         return new SecretObfuscator(
             secretProvider.Object,
-            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = maskValue ?? "**********",
+            }));
     }
 
     private static async Task AssertFallbackOutputIsObfuscated(string output)

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -448,6 +448,30 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_ReflowsExpandedMaskToRenderWidth()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Text("tiny"),
+            CreateSecretObfuscator("tiny"));
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                5)
+            .ToArray();
+        var lines = Segment.SplitLines(segments);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(lines).Count().IsEqualTo(2);
+            await Assert.That(lines.Max(static line => line.CellCount())).IsLessThanOrEqualTo(5);
+            await Assert.That(string.Concat(lines.SelectMany(static line => line)
+                    .Select(static segment => segment.Text)))
+                .IsEqualTo("**********");
+            await Assert.That(renderable.Measure(RenderOptions.Create(AnsiConsole.Console), 5).Max)
+                .IsEqualTo(5);
+        }
+    }
+
+    [Test]
     public async Task Write_PreservesCompositeLayoutWhenMaskWidthDiffers()
     {
         var table = new Table()

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -549,6 +549,32 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_PreparesLayoutChildrenBeforeSizingRegions()
+    {
+        var layout = new Layout("root")
+            .SplitColumns(
+                new Layout("left", new Text("tiny")).Size(10),
+                new Layout("right", new Text("next")).Size(10));
+        var renderable = new SecretObfuscatedRenderable(
+            layout,
+            CreateSecretObfuscator("tiny"));
+
+        var lines = Segment.SplitLines(renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                20))
+            .Select(static line => string.Concat(line.Select(segment => segment.Text)))
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(lines).Count().IsEqualTo(24);
+            await Assert.That(lines[0]).IsEqualTo("**********next      ");
+            await Assert.That(lines.All(line => new Segment(line).CellCount() == 20))
+                .IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Write_EscapesConfiguredMaskInTableTitle()
     {
         var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -20,6 +20,43 @@ namespace ModularPipelines.UnitTests.Console;
 [TUnit.Core.NotInParallel]
 public class ConsoleWriterTests
 {
+    private sealed class TrackingSecretProvider : ISecretProvider, ISecretEmissionGuard
+    {
+        private int _executionDepth;
+
+        public int ExecutionCount { get; private set; }
+
+        public bool IsExecuting => _executionDepth > 0;
+
+        public long Version => 0;
+
+        public IEnumerable<string> Secrets => [];
+
+        public SecretSnapshot GetSnapshot() => new(0, []);
+
+        public bool TryExecuteIfVersionCurrent(long expectedVersion, Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IEnumerable<string> GetSecretsInObject(object? value) => [];
+
+        public void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput)
+        {
+            ExecutionCount++;
+            _executionDepth++;
+            try
+            {
+                processOutput(state);
+            }
+            finally
+            {
+                _executionDepth--;
+            }
+        }
+    }
+
     private sealed class ControlRenderable(params string[] values) : IRenderable
     {
         public Measurement Measure(RenderOptions options, int maxWidth) => new(0, 0);
@@ -223,6 +260,38 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Direct_Writes_Obfuscate_And_Emit_With_Stable_Secrets()
+    {
+        var secretProvider = new TrackingSecretProvider();
+        var guardedObfuscations = new List<bool>();
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) =>
+            {
+                guardedObfuscations.Add(secretProvider.IsExecuting);
+                return input ?? string.Empty;
+            });
+
+        CaptureFallbackOutput(
+            writer =>
+            {
+                writer.WriteLine("plain text");
+                writer.WriteMarkupLine("[green]markup text[/]");
+                writer.Write(new Text("renderable text"));
+            },
+            secretObfuscator.Object,
+            secretProvider: secretProvider);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(secretProvider.ExecutionCount).IsEqualTo(3);
+            await Assert.That(guardedObfuscations).IsNotEmpty();
+            await Assert.That(guardedObfuscations.All(static isGuarded => isGuarded)).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task WriteLine_UsesInjectedConsoleWithoutAmbientModule()
     {
         var originalConsole = AnsiConsole.Console;
@@ -233,7 +302,10 @@ public class ConsoleWriterTests
             AnsiConsole.Console = CreateConsole(globalOutput);
             var injectedConsole = CreateConsole(injectedOutput);
 
-            new ConsoleWriter(CreateMockSecretObfuscator(), injectedConsole)
+            new ConsoleWriter(
+                    CreateMockSecretObfuscator(),
+                    new Mock<ISecretProvider>().Object,
+                    injectedConsole)
                 .WriteLine("injected output");
 
             using (Assert.Multiple())
@@ -1166,7 +1238,8 @@ public class ConsoleWriterTests
     private static string CaptureFallbackOutput(
         Action<ConsoleWriter> write,
         ISecretObfuscator? secretObfuscator = null,
-        AnsiSupport ansiSupport = AnsiSupport.No)
+        AnsiSupport ansiSupport = AnsiSupport.No,
+        ISecretProvider? secretProvider = null)
     {
         var originalConsole = AnsiConsole.Console;
         using var output = new StringWriter();
@@ -1183,8 +1256,9 @@ public class ConsoleWriterTests
             });
 
             secretObfuscator ??= CreateMockSecretObfuscator();
+            secretProvider ??= new Mock<ISecretProvider>().Object;
 
-            write(new ConsoleWriter(secretObfuscator, AnsiConsole.Console));
+            write(new ConsoleWriter(secretObfuscator, secretProvider, AnsiConsole.Console));
             return output.ToString();
         }
         finally

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -18,6 +18,16 @@ namespace ModularPipelines.UnitTests.Console;
 [TUnit.Core.NotInParallel(nameof(ConsoleWriterTests))]
 public class ConsoleWriterTests
 {
+    private sealed class ControlRenderable(string value) : IRenderable
+    {
+        public Measurement Measure(RenderOptions options, int maxWidth) => new(0, 0);
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            yield return Segment.Control(value);
+        }
+    }
+
     private sealed class WriteMarkupLineModule(IConsoleWriter consoleWriter) : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
@@ -347,6 +357,25 @@ public class ConsoleWriterTests
             .First(static value => value is not null)!;
         await Assert.That(url).Contains("**********");
         await Assert.That(url).DoesNotContain("token");
+    }
+
+    [Test]
+    public async Task Write_ObfuscatesSecretInControlSegment()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlRenderable("secret"),
+            CreateSecretObfuscator("secret"));
+        var segment = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(segment.IsControlCode).IsTrue();
+            await Assert.That(segment.Text).Contains("**********");
+            await Assert.That(segment.Text).DoesNotContain("secret");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -613,6 +613,23 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_RemovesRelatedControlSequencesAcrossNestedChildren()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Rows(
+                new ControlRenderable("\u001b[?25l"),
+                new ControlRenderable("\u001b[?25h")),
+            CreateSecretObfuscator("25h"));
+
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        await Assert.That(segments.Any(static segment => segment.IsControlCode)).IsFalse();
+    }
+
+    [Test]
     public async Task Write_UsesConfiguredMaskWidthWhileObfuscating()
     {
         var renderable = new SecretObfuscatedRenderable(
@@ -962,6 +979,51 @@ public class ConsoleWriterTests
             await Assert.That(flushOutput).Contains("write-time");
             await Assert.That(flushOutput).DoesNotContain("flush-time");
             await Assert.That(formatterCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Write_SnapshotsChartCultures()
+    {
+        var culture = new CultureInfo("en-US");
+        string FormatValue(double _, CultureInfo valueCulture) =>
+            valueCulture.NumberFormat.NumberDecimalSeparator == "."
+                ? "original-culture"
+                : "mutated-culture";
+        IRenderable[] charts =
+        [
+            new BarChart
+            {
+                Culture = culture,
+                ValueFormatter = FormatValue,
+                Width = 24,
+            }.AddItem("item", 100, Color.Red),
+            new BreakdownChart
+            {
+                Culture = culture,
+                ValueFormatter = FormatValue,
+                Width = 24,
+            }.AddItem("item", 100, Color.Red),
+        ];
+        var renderables = charts.Select(chart => new SecretObfuscatedRenderable(
+                chart,
+                CreateSecretObfuscator("unrelated")))
+            .ToArray();
+
+        culture.NumberFormat.NumberDecimalSeparator = ",";
+
+        foreach (var renderable in renderables)
+        {
+            var output = string.Concat(renderable.Render(
+                    RenderOptions.Create(AnsiConsole.Console),
+                    24)
+                .Select(static segment => segment.Text));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(output).Contains("original-culture");
+                await Assert.That(output).DoesNotContain("mutated-culture");
+            }
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -395,6 +395,45 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_UsesSafeMaskForSecretsInHyperlinkMetadata()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Markup("[link=https://example.test/token]label[/]"),
+            CreateSecretObfuscator(["token", "REDACT"], "[REDACTED]"));
+        var url = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .Select(static segment => segment.Link?.Url)
+            .First(static value => value is not null)!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(url).Contains("[MASKED]");
+            await Assert.That(url).DoesNotContain("token");
+            await Assert.That(url).DoesNotContain("REDACT");
+        }
+    }
+
+    [Test]
+    public async Task Write_UsesSafeMaskForSecretsInControlMetadata()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlRenderable("token"),
+            CreateSecretObfuscator(["token", "REDACT"], "[REDACTED]"));
+        var segment = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(segment.Text).Contains("[MASKED]");
+            await Assert.That(segment.Text).DoesNotContain("token");
+            await Assert.That(segment.Text).DoesNotContain("REDACT");
+        }
+    }
+
+    [Test]
     public async Task Write_UsesConfiguredMaskWidthWhileObfuscating()
     {
         var renderable = new SecretObfuscatedRenderable(
@@ -542,6 +581,45 @@ public class ConsoleWriterTests
             await Assert.That(renderedText).DoesNotContain("123");
             await Assert.That(Segment.SplitLines(segments).Max(static line => line.CellCount()))
                 .IsEqualTo(24);
+        }
+    }
+
+    [Test]
+    public async Task Write_PreparesEscapedBracketTextBeforeRuleLayout()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Rule("[[tiny]]"),
+            CreateSecretObfuscator("tiny", "[REDACTED]"));
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                24)
+            .ToArray();
+        var renderedText = string.Concat(segments.Select(static segment => segment.Text));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(renderedText).Contains("[REDACTED]");
+            await Assert.That(renderedText).DoesNotContain("tiny");
+            await Assert.That(Segment.SplitLines(segments).Max(static line => line.CellCount()))
+                .IsEqualTo(24);
+        }
+    }
+
+    [Test]
+    public async Task Write_MeasurePreservesFlexibleMinimumWidth()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Text("1234567890 abcdefghij"),
+            CreateSecretObfuscator("unrelated"));
+
+        var measurement = renderable.Measure(
+            RenderOptions.Create(AnsiConsole.Console),
+            80);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(measurement.Min).IsEqualTo(10);
+            await Assert.That(measurement.Max).IsEqualTo(21);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -41,6 +41,17 @@ public class ConsoleWriterTests
         }
     }
 
+    private sealed class WriteInvalidMarkupModule(IConsoleWriter consoleWriter) : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            consoleWriter.WriteMarkupLine("[green]unclosed");
+            return Task.FromResult(true);
+        }
+    }
+
     private sealed class WriteModule(IConsoleWriter consoleWriter) : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
@@ -125,6 +136,14 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task WriteMarkupLine_InvalidMarkupFallsBackToPlainModuleOutput()
+    {
+        var output = await RunAsync<WriteInvalidMarkupModule>();
+
+        await Assert.That(output).Contains("[[green]]unclosed");
+    }
+
+    [Test]
     public async Task Write_UsesAmbientModuleConsoleWriter()
     {
         var output = await RunAsync<WriteModule>();
@@ -189,6 +208,27 @@ public class ConsoleWriterTests
 
         await Assert.That(output).Contains("\u001b[");
         await Assert.That(output).Contains("styled");
+    }
+
+    [Test]
+    public async Task Write_CustomObfuscatorUsesPlainFallbackStyle()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns("masked");
+
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(new Markup("[red]abc[/][blue]123[/]")),
+            secretObfuscator.Object,
+            AnsiSupport.Yes);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("masked");
+            await Assert.That(output).DoesNotContain("\u001b[31m");
+            await Assert.That(output).DoesNotContain("\u001b[34m");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -15,7 +15,7 @@ using Spectre.Console.Rendering;
 
 namespace ModularPipelines.UnitTests.Console;
 
-[TUnit.Core.NotInParallel(nameof(ConsoleWriterTests))]
+[TUnit.Core.NotInParallel]
 public class ConsoleWriterTests
 {
     private sealed class ControlRenderable(string value) : IRenderable

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -376,22 +376,17 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task Write_ObfuscatesSecretInControlSegment()
+    public async Task Write_RemovesControlSegmentContainingSecret()
     {
         var renderable = new SecretObfuscatedRenderable(
             new ControlRenderable("secret"),
             CreateSecretObfuscator("secret"));
-        var segment = renderable.Render(
+        var segments = renderable.Render(
                 RenderOptions.Create(AnsiConsole.Console),
                 80)
-            .Single();
+            .ToArray();
 
-        using (Assert.Multiple())
-        {
-            await Assert.That(segment.IsControlCode).IsTrue();
-            await Assert.That(segment.Text).Contains("**********");
-            await Assert.That(segment.Text).DoesNotContain("secret");
-        }
+        await Assert.That(segments).IsEmpty();
     }
 
     [Test]
@@ -415,22 +410,32 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task Write_UsesSafeMaskForSecretsInControlMetadata()
+    public async Task Write_RemovesUnsafeControlMetadataMask()
     {
         var renderable = new SecretObfuscatedRenderable(
             new ControlRenderable("token"),
             CreateSecretObfuscator(["token", "REDACT"], "[REDACTED]"));
-        var segment = renderable.Render(
+        var segments = renderable.Render(
                 RenderOptions.Create(AnsiConsole.Console),
                 80)
-            .Single();
+            .ToArray();
 
-        using (Assert.Multiple())
-        {
-            await Assert.That(segment.Text).Contains("[MASKED]");
-            await Assert.That(segment.Text).DoesNotContain("token");
-            await Assert.That(segment.Text).DoesNotContain("REDACT");
-        }
+        await Assert.That(segments).IsEmpty();
+    }
+
+    [Test]
+    public async Task Write_RemovesAnsiSequenceContainingSecret()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new ControlRenderable("\u001b[31m"),
+            CreateSecretObfuscator("31"));
+
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        await Assert.That(segments).IsEmpty();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,10 +1,9 @@
 using ModularPipelines;
-using ModularPipelines.Attributes.Events;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Events;
 using ModularPipelines.Extensions;
-using ModularPipelines.Interfaces;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -110,7 +109,7 @@ public class ConsoleWriterTests
         }
     }
 
-    private sealed class WriteLifecycleOutputReceiver : IModuleEventReceiver
+    private sealed class WriteLifecycleOutputHandler : IModuleEventHandler
     {
         public Task OnModuleReadyAsync(IModuleHookContext context)
         {
@@ -124,7 +123,7 @@ public class ConsoleWriterTests
             return Task.CompletedTask;
         }
 
-        public Task OnModuleEndAsync(IModuleHookContext context)
+        public Task OnModuleEndAsync(IModuleHookContext context, IModuleResult result)
         {
             context.Console.WriteLine("receiver end output");
             return Task.CompletedTask;
@@ -271,16 +270,41 @@ public class ConsoleWriterTests
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns("masked");
 
+        var renderable = new SecretObfuscatedRenderable(
+            new Markup("[red]abc[/][blue]123[/]"),
+            secretObfuscator.Object);
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .Where(static segment => !segment.IsControlCode)
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(string.Concat(segments.Select(static segment => segment.Text)))
+                .IsEqualTo("masked");
+            await Assert.That(segments).Count().IsEqualTo(2);
+            await Assert.That(segments[0].Style).IsNotEqualTo(segments[1].Style);
+        }
+    }
+
+    [Test]
+    public async Task Write_CustomObfuscatorMasksSecretSplitAcrossStyledSegments()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input!.Replace("abc123", "masked"));
+
         var output = CaptureFallbackOutput(
             writer => writer.Write(new Markup("[red]abc[/][blue]123[/]")),
-            secretObfuscator.Object,
-            AnsiSupport.Yes);
+            secretObfuscator.Object);
 
         using (Assert.Multiple())
         {
             await Assert.That(output).Contains("masked");
-            await Assert.That(output).Contains("\u001b[");
-            await Assert.That(output.Split("masked").Length - 1).IsEqualTo(2);
+            await Assert.That(output).DoesNotContain("abc");
+            await Assert.That(output).DoesNotContain("123");
         }
     }
 
@@ -349,7 +373,7 @@ public class ConsoleWriterTests
     public async Task LifecycleHooks_UseModuleConsoleWriter()
     {
         var output = await RunAsync<ReadyOutputModule>(
-            builder => builder.AddModuleEventReceiver<WriteLifecycleOutputReceiver>());
+            builder => builder.AddModuleEventHandler<WriteLifecycleOutputHandler>());
 
         await Assert.That(output).Contains("attribute ready output");
         await Assert.That(output).Contains("receiver ready output");

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -1,8 +1,14 @@
-using ModularPipelines.Logging;
+using ModularPipelines;
+using ModularPipelines.Attributes.Events;
+using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Extensions;
+using ModularPipelines.Interfaces;
 using ModularPipelines.Logging;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using Moq;
 using Spectre.Console;
@@ -44,6 +50,61 @@ public class ConsoleWriterTests
             IRenderable table = new Table().AddColumn("Value").AddRow("module output");
             consoleWriter.Write(table);
             return Task.FromResult(true);
+        }
+    }
+
+    private sealed class WriteSplitSecretModule(
+        IConsoleWriter consoleWriter,
+        ISecretRegistry secretRegistry) : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            secretRegistry.AddSecret("abc123");
+            consoleWriter.WriteMarkupLine("[red]abc[/][blue]123[/]");
+            return Task.FromResult(true);
+        }
+    }
+
+    [WriteReadyOutput]
+    private sealed class ReadyOutputModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class PlanningOutputModule : Module<bool>
+    {
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithSkipWhen(context =>
+            {
+                context.Console.WriteLine("planning condition output");
+                return SkipDecision.DoNotSkip;
+            });
+
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class WriteReadyOutputAttribute : Attribute, IModuleReadyHandler
+    {
+        public Task OnModuleReadyAsync(IModuleHookContext context)
+        {
+            context.Console.WriteLine("attribute ready output");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class WriteReadyOutputReceiver : IModuleEventReceiver
+    {
+        public Task OnModuleReadyAsync(IModuleHookContext context)
+        {
+            context.Console.WriteLine("receiver ready output");
+            return Task.CompletedTask;
         }
     }
 
@@ -95,7 +156,71 @@ public class ConsoleWriterTests
         await AssertFallbackOutputIsObfuscated(output);
     }
 
-    private static async Task<string> RunAsync<TModule>()
+    [Test]
+    public async Task WriteMarkupLine_PreservesTagsThatMatchSecrets()
+    {
+        var output = CaptureFallbackOutput(
+            writer => writer.WriteMarkupLine("[green]visible[/]"),
+            CreateSecretObfuscator("green"));
+
+        await Assert.That(output).Contains("visible");
+        await Assert.That(output).DoesNotContain("**********");
+    }
+
+    [Test]
+    public async Task WriteMarkupLine_ObfuscatesSecretSplitAcrossTags()
+    {
+        var output = CaptureFallbackOutput(
+            writer => writer.WriteMarkupLine("[red]abc[/][blue]123[/]"),
+            CreateSecretObfuscator("abc123"));
+
+        await Assert.That(output).Contains("**********");
+        await Assert.That(output).DoesNotContain("abc");
+        await Assert.That(output).DoesNotContain("123");
+    }
+
+    [Test]
+    public async Task Write_PreservesRenderableStylesWithoutAmbientModule()
+    {
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(new Markup("[red]styled[/]")),
+            CreateSecretObfuscator("unrelated"),
+            AnsiSupport.Yes);
+
+        await Assert.That(output).Contains("\u001b[");
+        await Assert.That(output).Contains("styled");
+    }
+
+    [Test]
+    public async Task WriteMarkupLine_ObfuscatesSplitSecretInModuleBuffer()
+    {
+        var output = await RunAsync<WriteSplitSecretModule>();
+
+        await Assert.That(output).Contains("**********");
+        await Assert.That(output).DoesNotContain("abc");
+        await Assert.That(output).DoesNotContain("123");
+    }
+
+    [Test]
+    public async Task ReadyHooks_UseModuleConsoleWriter()
+    {
+        var output = await RunAsync<ReadyOutputModule>(
+            builder => builder.AddModuleEventReceiver<WriteReadyOutputReceiver>());
+
+        await Assert.That(output).Contains("attribute ready output");
+        await Assert.That(output).Contains("receiver ready output");
+    }
+
+    [Test]
+    public async Task PlanningCondition_UsesModuleConsoleWriter()
+    {
+        var output = await RunAsync<PlanningOutputModule>();
+
+        await Assert.That(output).Contains("planning condition output");
+    }
+
+    private static async Task<string> RunAsync<TModule>(
+        Action<PipelineBuilder>? configure = null)
         where TModule : class, IModule
     {
         var builder = TestPipelineBuilder.Create();
@@ -108,13 +233,17 @@ public class ConsoleWriterTests
             },
         });
         builder.AddModule<TModule>();
+        configure?.Invoke(builder);
 
         var summary = await builder.RunAsync();
 
         return summary.RunReport!.Modules.Single().Output!.StdoutTail ?? string.Empty;
     }
 
-    private static string CaptureFallbackOutput(Action<ConsoleWriter> write)
+    private static string CaptureFallbackOutput(
+        Action<ConsoleWriter> write,
+        ISecretObfuscator? secretObfuscator = null,
+        AnsiSupport ansiSupport = AnsiSupport.No)
     {
         var originalConsole = AnsiConsole.Console;
         using var output = new StringWriter();
@@ -124,21 +253,40 @@ public class ConsoleWriterTests
             AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
             {
                 Out = new AnsiConsoleOutput(output),
-                Ansi = AnsiSupport.No,
+                Ansi = ansiSupport,
+                ColorSystem = ansiSupport is AnsiSupport.Yes
+                    ? ColorSystemSupport.Standard
+                    : ColorSystemSupport.NoColors,
             });
 
-            var secretObfuscator = new Mock<ISecretObfuscator>();
-            secretObfuscator
-                .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
-                .Returns((string? input, object? _) => input!.Replace("secret", "********"));
+            secretObfuscator ??= CreateMockSecretObfuscator();
 
-            write(new ConsoleWriter(secretObfuscator.Object));
+            write(new ConsoleWriter(secretObfuscator));
             return output.ToString();
         }
         finally
         {
             AnsiConsole.Console = originalConsole;
         }
+    }
+
+    private static ISecretObfuscator CreateMockSecretObfuscator()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input!.Replace("secret", "********"));
+        return secretObfuscator.Object;
+    }
+
+    private static ISecretObfuscator CreateSecretObfuscator(params string[] secrets)
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, secrets));
+        return new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
     }
 
     private static async Task AssertFallbackOutputIsObfuscated(string output)

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -32,6 +32,19 @@ public class ConsoleWriterTests
         }
     }
 
+    private sealed class WidthSensitiveRenderable : IRenderable
+    {
+        public List<int> RenderWidths { get; } = [];
+
+        public Measurement Measure(RenderOptions options, int maxWidth) => new(1, maxWidth);
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            RenderWidths.Add(maxWidth);
+            yield return new Segment(maxWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+    }
+
     private sealed class WriteMarkupLineModule(IConsoleWriter consoleWriter) : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
@@ -206,6 +219,32 @@ public class ConsoleWriterTests
         var output = CaptureFallbackOutput(writer => writer.WriteLine("a secret value"));
 
         await AssertFallbackOutputIsObfuscated(output);
+    }
+
+    [Test]
+    public async Task WriteLine_UsesInjectedConsoleWithoutAmbientModule()
+    {
+        var originalConsole = AnsiConsole.Console;
+        using var globalOutput = new StringWriter();
+        using var injectedOutput = new StringWriter();
+        try
+        {
+            AnsiConsole.Console = CreateConsole(globalOutput);
+            var injectedConsole = CreateConsole(injectedOutput);
+
+            new ConsoleWriter(CreateMockSecretObfuscator(), injectedConsole)
+                .WriteLine("injected output");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(injectedOutput.ToString()).Contains("injected output");
+                await Assert.That(globalOutput.ToString()).DoesNotContain("injected output");
+            }
+        }
+        finally
+        {
+            AnsiConsole.Console = originalConsole;
+        }
     }
 
     [Test]
@@ -642,6 +681,57 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_PreparesEveryUnsafeAccessorBackedRenderable()
+    {
+        var tree = new Tree("secret");
+        tree.AddNode("secret");
+        IRenderable[] renderables =
+        [
+            new Align(new Text("secret"), HorizontalAlignment.Left, VerticalAlignment.Top),
+            new Columns(new Text("secret")),
+            new Padder(new Text("secret"), new Padding(1)),
+            new Rows(new Text("secret")),
+            tree,
+        ];
+        var options = RenderOptions.Create(AnsiConsole.Console);
+        var obfuscator = CreateSecretObfuscator("secret");
+
+        foreach (var source in renderables)
+        {
+            var output = string.Concat(new SecretObfuscatedRenderable(source, obfuscator)
+                .Render(options, 80)
+                .Where(static segment => !segment.IsControlCode)
+                .Select(static segment => segment.Text));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(output).Contains("**********");
+                await Assert.That(output).DoesNotContain("secret");
+            }
+        }
+    }
+
+    [Test]
+    public async Task Write_SnapshotsUnhandledRenderablePerWidth()
+    {
+        var source = new WidthSensitiveRenderable();
+        var renderable = new SecretObfuscatedRenderable(
+            source,
+            CreateMockSecretObfuscator());
+        var options = RenderOptions.Create(AnsiConsole.Console);
+
+        _ = renderable.Measure(options, 20);
+        var output = string.Concat(renderable.Render(options, 5)
+            .Select(static segment => segment.Text));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).IsEqualTo("5");
+            await Assert.That(source.RenderWidths).IsEquivalentTo([20, 5]);
+        }
+    }
+
+    [Test]
     public async Task Write_PreparesLayoutChildrenBeforeSizingRegions()
     {
         var layout = new Layout("root")
@@ -704,9 +794,9 @@ public class ConsoleWriterTests
 
         var actual = string.Concat(renderable.Render(options, 120)
             .Select(static segment => segment.Text));
-        var expected = string.Concat(((IRenderable)new FigletText("**********")).Render(options, 120)
+        var expected = string.Concat(((IRenderable) new FigletText("**********")).Render(options, 120)
             .Select(static segment => segment.Text));
-        var unmasked = string.Concat(((IRenderable)new FigletText("secret")).Render(options, 120)
+        var unmasked = string.Concat(((IRenderable) new FigletText("secret")).Render(options, 120)
             .Select(static segment => segment.Text));
 
         using (Assert.Multiple())
@@ -736,7 +826,7 @@ public class ConsoleWriterTests
 
         var actual = string.Concat(renderable.Render(options, 24)
             .Select(static segment => segment.Text));
-        var expected = string.Concat(((IRenderable)expectedChart).Render(options, 24)
+        var expected = string.Concat(((IRenderable) expectedChart).Render(options, 24)
             .Select(static segment => segment.Text));
 
         await Assert.That(actual).IsEqualTo(expected);
@@ -762,7 +852,7 @@ public class ConsoleWriterTests
 
         var actual = string.Concat(renderable.Render(options, 24)
             .Select(static segment => segment.Text));
-        var expected = string.Concat(((IRenderable)expectedChart).Render(options, 24)
+        var expected = string.Concat(((IRenderable) expectedChart).Render(options, 24)
             .Select(static segment => segment.Text));
 
         await Assert.That(actual).IsEqualTo(expected);
@@ -1025,7 +1115,7 @@ public class ConsoleWriterTests
 
             secretObfuscator ??= CreateMockSecretObfuscator();
 
-            write(new ConsoleWriter(secretObfuscator));
+            write(new ConsoleWriter(secretObfuscator, AnsiConsole.Console));
             return output.ToString();
         }
         finally
@@ -1033,6 +1123,14 @@ public class ConsoleWriterTests
             AnsiConsole.Console = originalConsole;
         }
     }
+
+    private static IAnsiConsole CreateConsole(TextWriter output) =>
+        AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(output),
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+        });
 
     private static ISecretObfuscator CreateMockSecretObfuscator()
     {

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -144,7 +144,7 @@ public class ConsoleWriterTests
     {
         var output = await RunAsync<WriteLineModule>();
 
-        await Assert.That(output).Contains("[[green]]module output[[/]]");
+        await Assert.That(output).Contains("[green]module output[/]");
     }
 
     [Test]
@@ -152,7 +152,7 @@ public class ConsoleWriterTests
     {
         var output = await RunAsync<WriteInvalidMarkupModule>();
 
-        await Assert.That(output).Contains("[[green]]unclosed");
+        await Assert.That(output).Contains("[green]unclosed");
     }
 
     [Test]
@@ -177,6 +177,25 @@ public class ConsoleWriterTests
         var output = CaptureFallbackOutput(writer => writer.WriteMarkupLine("[green]a secret value[/]"));
 
         await AssertFallbackOutputIsObfuscated(output);
+    }
+
+    [Test]
+    public async Task WriteMarkupLine_InvalidMarkupUsesConfiguredConsole()
+    {
+        var output = CaptureFallbackOutput(writer => writer.WriteMarkupLine("[green]unclosed"));
+
+        await Assert.That(output).Contains("[green]unclosed");
+    }
+
+    [Test]
+    public async Task WriteMarkupLine_ObfuscatesMarkupWrappedSecret()
+    {
+        var output = CaptureFallbackOutput(
+            writer => writer.WriteMarkupLine("[red]secret[/]"),
+            CreateSecretObfuscator("[red]secret[/]"));
+
+        await Assert.That(output).Contains("**********");
+        await Assert.That(output).DoesNotContain("secret");
     }
 
     [Test]
@@ -223,7 +242,7 @@ public class ConsoleWriterTests
     }
 
     [Test]
-    public async Task Write_CustomObfuscatorUsesPlainFallbackStyle()
+    public async Task Write_CustomObfuscatorPreservesSegmentStyles()
     {
         var secretObfuscator = new Mock<ISecretObfuscator>();
         secretObfuscator
@@ -238,9 +257,60 @@ public class ConsoleWriterTests
         using (Assert.Multiple())
         {
             await Assert.That(output).Contains("masked");
-            await Assert.That(output).DoesNotContain("\u001b[31m");
-            await Assert.That(output).DoesNotContain("\u001b[34m");
+            await Assert.That(output).Contains("\u001b[");
+            await Assert.That(output.Split("masked").Length - 1).IsEqualTo(2);
         }
+    }
+
+    [Test]
+    public async Task Write_ObfuscatesSecretInHyperlinkTarget()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Markup("[link=https://example.test/token]label[/]"),
+            CreateSecretObfuscator("token"));
+        var segments = renderable.Render(
+                RenderOptions.Create(AnsiConsole.Console),
+                80)
+            .ToArray();
+
+        var url = segments.Select(static segment => segment.Link?.Url)
+            .First(static value => value is not null)!;
+        await Assert.That(url).Contains("**********");
+        await Assert.That(url).DoesNotContain("token");
+    }
+
+    [Test]
+    public async Task Write_MeasuresObfuscatedWidth()
+    {
+        var renderable = new SecretObfuscatedRenderable(
+            new Text("tiny"),
+            CreateSecretObfuscator("tiny"));
+
+        var measurement = renderable.Measure(
+            RenderOptions.Create(AnsiConsole.Console),
+            80);
+
+        await Assert.That(measurement.Max).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task Write_DoesNotPreserveMaskContainingSecret()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, ["REDACT"]));
+        var obfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = "[REDACTED]",
+            }));
+        var output = CaptureFallbackOutput(
+            writer => writer.Write(new Text("[REDACTED]")),
+            obfuscator);
+
+        await Assert.That(output).DoesNotContain("REDACT");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleWriterTests.cs
@@ -601,6 +601,28 @@ public class ConsoleWriterTests
     }
 
     [Test]
+    public async Task Write_MasksFigletTextBeforeRendering()
+    {
+        var options = RenderOptions.Create(AnsiConsole.Console);
+        var renderable = new SecretObfuscatedRenderable(
+            new FigletText("secret"),
+            CreateSecretObfuscator("secret"));
+
+        var actual = string.Concat(renderable.Render(options, 120)
+            .Select(static segment => segment.Text));
+        var expected = string.Concat(((IRenderable)new FigletText("**********")).Render(options, 120)
+            .Select(static segment => segment.Text));
+        var unmasked = string.Concat(((IRenderable)new FigletText("secret")).Render(options, 120)
+            .Select(static segment => segment.Text));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(actual).IsEqualTo(expected);
+            await Assert.That(actual).IsNotEqualTo(unmasked);
+        }
+    }
+
+    [Test]
     public async Task Write_EscapesConfiguredMaskInTableTitle()
     {
         var obfuscator = CreateSecretObfuscator("secret", "[REDACTED]");

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -271,6 +271,99 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_RemasksLateInterceptedSecretWithoutReobfuscatingSafeText()
+    {
+        const string secret = "secret";
+        var redactSecret = false;
+        var secretProvider = new TrackingSecretProvider();
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => redactSecret
+                ? (input ?? string.Empty)
+                    .Replace("masked", "masked-twice", StringComparison.Ordinal)
+                    .Replace(secret, "masked", StringComparison.Ordinal)
+                : input ?? string.Empty);
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator.Object,
+            renderableSecretProvider: secretProvider);
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(buffer);
+        using var coordinatedWriter = new CoordinatedTextWriter(
+            coordinator.Object,
+            writer,
+            () => true,
+            secretObfuscator.Object,
+            secretProvider);
+        coordinatedWriter.Write("masked secret");
+        coordinatedWriter.Flush();
+
+        secretProvider.RegisteredSecrets = [secret];
+        redactSecret = true;
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("masked masked");
+            await Assert.That(writer.ToString()).DoesNotContain("masked-twice");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+        }
+    }
+
+    [Test]
+    public async Task Flush_AdjacentRichWritesApplyCustomObfuscatorOnce()
+    {
+        const string secret = "secret";
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => (input ?? string.Empty)
+                .Replace("masked", "masked-twice", StringComparison.Ordinal)
+                .Replace(secret, "masked", StringComparison.Ordinal));
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator.Object,
+            renderableSecretProvider: Mock.Of<ISecretProvider>());
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
+            .Returns(buffer);
+        var logger = new ModuleLogger<ModuleOutputBufferTests>(
+            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+        logger.Write(new Text(secret));
+        logger.Write(new Text(secret));
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("maskedmasked");
+            await Assert.That(writer.ToString()).DoesNotContain("masked-twice");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+        }
+    }
+
+    [Test]
     public async Task IncrementalFlush_RetainsSecretPrefixUntilRenderableLineCompletes()
     {
         var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer("token");
@@ -2029,11 +2122,13 @@ public class ModuleOutputBufferTests
 
         public bool IsExecuting => _executionDepth > 0;
 
+        public IReadOnlyList<string> RegisteredSecrets { get; set; } = [];
+
         public long Version => 0;
 
-        public IEnumerable<string> Secrets => [];
+        public IEnumerable<string> Secrets => RegisteredSecrets;
 
-        public SecretSnapshot GetSnapshot() => new(0, []);
+        public SecretSnapshot GetSnapshot() => new(0, RegisteredSecrets);
 
         public bool TryExecuteIfVersionCurrent(long expectedVersion, Action action)
         {

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -9,8 +9,10 @@ using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Enums;
+using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using Moq;
+using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Console;
 
@@ -44,6 +46,42 @@ public class ModuleOutputBufferTests
         buffer.WriteLine("ordinary output");
 
         await Assert.That(buffer.GetOutputExcerpt()).IsNull();
+    }
+
+    [Test]
+    public async Task Flush_RemasksRenderableWithSecretsRegisteredAfterBuffering()
+    {
+        const string secret = "late-registered-secret";
+        long version = 0;
+        IReadOnlyList<string> secrets = [];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider
+            .Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, secrets));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator,
+            renderableSecretProvider: secretProvider.Object);
+        buffer.WriteRenderable(new Text(secret), secret, appendNewLine: false);
+
+        secrets = [secret];
+        version++;
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(writer.ToString()).Contains("**********");
+        await Assert.That(writer.ToString()).DoesNotContain(secret);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -329,6 +329,32 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task IncrementalFlush_RetainsMultilinePrefixAcrossGroupSeparator()
+    {
+        var secret = $"to{Environment.NewLine}{Environment.NewLine}ken";
+        var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer(secret);
+        buffer.WriteLine("to");
+
+        await buffer.FlushToAsync(
+            writer,
+            new AppVeyorFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+        await Assert.That(writer.ToString()).DoesNotContain("to");
+
+        buffer.WriteLine("ken");
+        await buffer.FlushToAsync(
+            writer,
+            new AppVeyorFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(writer.ToString()).DoesNotContain(secret);
+    }
+
+    [Test]
     public async Task Flush_CustomObfuscatorRemasksLateSecretUnderEmissionGuard()
     {
         const string secret = "late-custom-secret";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.UnitTests.Console;
 public class ModuleOutputBufferTests
 {
     [Test]
-    public async Task DirectConsole_UsesConfiguredRenderableWidth()
+    public async Task DirectConsole_UsesConfiguredRenderableDimensions()
     {
         using var profileWriter = new StringWriter();
         var configuredConsole = AnsiConsole.Create(new AnsiConsoleSettings
@@ -29,6 +29,7 @@ public class ModuleOutputBufferTests
             Out = new AnsiConsoleOutput(profileWriter),
         });
         configuredConsole.Profile.Width = 24;
+        configuredConsole.Profile.Height = 12;
         using var outputWriter = new StringWriter();
         var buffer = new ModuleOutputBuffer(
             typeof(ModuleOutputBufferTests),
@@ -37,6 +38,7 @@ public class ModuleOutputBufferTests
         var directConsole = buffer.GetDirectConsole(outputWriter);
 
         await Assert.That(directConsole.Profile.Width).IsEqualTo(24);
+        await Assert.That(directConsole.Profile.Height).IsEqualTo(12);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -14,11 +14,31 @@ using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using Moq;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace ModularPipelines.UnitTests.Console;
 
 public class ModuleOutputBufferTests
 {
+    [Test]
+    public async Task DirectConsole_UsesConfiguredRenderableWidth()
+    {
+        using var profileWriter = new StringWriter();
+        var configuredConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(profileWriter),
+        });
+        configuredConsole.Profile.Width = 24;
+        using var outputWriter = new StringWriter();
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableConsole: configuredConsole);
+
+        var directConsole = buffer.GetDirectConsole(outputWriter);
+
+        await Assert.That(directConsole.Profile.Width).IsEqualTo(24);
+    }
+
     [Test]
     public async Task OutputExcerptSurvivesConsoleFlush()
     {
@@ -131,6 +151,46 @@ public class ModuleOutputBufferTests
         var output = writer.ToString();
         await Assert.That(output).Contains("**********");
         await Assert.That(output).DoesNotContain(secret[..20]);
+    }
+
+    [Test]
+    public async Task Flush_SnapshotsUnhandledRenderableAtWriteTime()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
+            .Returns(buffer);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+        var logger = new ModuleLogger<ModuleOutputBufferTests>(
+            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+        var renderable = new MutableRenderable("first");
+
+        logger.Write(renderable);
+        renderable.Value = "second";
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("first");
+            await Assert.That(writer.ToString()).DoesNotContain("second");
+            await Assert.That(renderable.RenderCount).IsEqualTo(1);
+        }
     }
 
     [Test]
@@ -1677,6 +1737,22 @@ public class ModuleOutputBufferTests
             var message = formatter(state, exception);
             Entries.Add(message);
             writer.WriteLine(message);
+        }
+    }
+
+    private sealed class MutableRenderable(string value) : IRenderable
+    {
+        public string Value { get; set; } = value;
+
+        public int RenderCount { get; private set; }
+
+        public Measurement Measure(RenderOptions options, int maxWidth) =>
+            new(Math.Min(Value.Length, maxWidth), Math.Min(Value.Length, maxWidth));
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            RenderCount++;
+            yield return new Segment(Value);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -157,6 +157,76 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_MasksSecretSplitAcrossLineTerminators()
+    {
+        var secret = $"to{Environment.NewLine}ken";
+        var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer(secret);
+        buffer.WriteLine("to");
+        buffer.WriteLine("ken");
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("**********");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+        }
+    }
+
+    [Test]
+    public async Task Flush_PreservesPreObfuscatedPrefixWhileMaskingMixedBoundarySecret()
+    {
+        const string secret = "secret";
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(0);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(0, [secret]));
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(obfuscator => obfuscator.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => (input ?? string.Empty)
+                .Replace("masked", "masked-twice", StringComparison.Ordinal)
+                .Replace(secret, "masked", StringComparison.Ordinal));
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator.Object,
+            renderableSecretProvider: secretProvider.Object);
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(buffer);
+        using var coordinatedWriter = new CoordinatedTextWriter(
+            coordinator.Object,
+            writer,
+            () => true,
+            secretObfuscator.Object,
+            secretProvider.Object);
+        coordinatedWriter.Write("secret se");
+        coordinatedWriter.Flush();
+        buffer.WriteRenderable(new Text("cret"), "cret", appendNewLine: true);
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("masked masked");
+            await Assert.That(writer.ToString()).DoesNotContain("masked-twice");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+        }
+    }
+
+    [Test]
     public async Task Flush_ModuleLoggerWriteLineAppliesCustomObfuscatorOnce()
     {
         var secretObfuscator = new Mock<ISecretObfuscator>();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -136,6 +136,118 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_CustomObfuscatorRemasksLateSecretUnderEmissionGuard()
+    {
+        const string secret = "late-custom-secret";
+        var redactSecret = false;
+        var guardedObfuscations = new List<bool>();
+        var secretProvider = new TrackingSecretProvider();
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) =>
+            {
+                if (redactSecret)
+                {
+                    guardedObfuscations.Add(secretProvider.IsExecuting);
+                }
+
+                return redactSecret
+                    ? value?.Replace(secret, "***", StringComparison.Ordinal) ?? string.Empty
+                    : value ?? string.Empty;
+            });
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator.Object,
+            renderableSecretProvider: secretProvider);
+        buffer.WriteRenderable(new Text(secret), secret, appendNewLine: false);
+
+        redactSecret = true;
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("***");
+            await Assert.That(writer.ToString()).DoesNotContain(secret);
+            await Assert.That(secretProvider.ExecutionCount).IsGreaterThan(0);
+            await Assert.That(guardedObfuscations).IsNotEmpty();
+            await Assert.That(guardedObfuscations.All(static guarded => guarded)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Flush_MasksLateMarkupSecretBeforeNarrowLayout()
+    {
+        const string secret = "alpha-bravo-charlie";
+        long version = 0;
+        IReadOnlyList<string> secrets = [];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider
+            .Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, secrets));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        using var profileWriter = new StringWriter();
+        var narrowConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(profileWriter),
+        });
+        narrowConsole.Profile.Width = 8;
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            outputExcerptMaximumBytes: 1024,
+            outputExcerptSecretObfuscator: secretObfuscator,
+            outputExcerptSecretProvider: secretProvider.Object,
+            renderableSecretObfuscator: secretObfuscator,
+            renderableSecretProvider: secretProvider.Object,
+            renderableConsole: narrowConsole);
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
+            .Returns(buffer);
+        var logger = new ModuleLogger<ModuleOutputBufferTests>(
+            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
+            secretObfuscator,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>(),
+            narrowConsole);
+        logger.WriteMarkupLine($"[green]{secret}[/]");
+
+        secrets = [secret];
+        version++;
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        var excerpt = buffer.GetOutputExcerpt();
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("********");
+            await Assert.That(output).DoesNotContain("alpha");
+            await Assert.That(excerpt).IsNotNull();
+            await Assert.That(excerpt!.StdoutTail).DoesNotContain("alpha");
+        }
+    }
+
+    [Test]
     public async Task Flush_MasksLeafSourcesBeforeOverflow()
     {
         var secret = string.Concat(Enumerable.Repeat("late-registered-secret-", 8));
@@ -1663,6 +1775,43 @@ public class ModuleOutputBufferTests
     private sealed class PassthroughSecretObfuscator : ISecretObfuscator
     {
         public string Obfuscate(string? input, object? optionsObject) => input ?? string.Empty;
+    }
+
+    private sealed class TrackingSecretProvider : ISecretProvider, ISecretEmissionGuard
+    {
+        private int _executionDepth;
+
+        public int ExecutionCount { get; private set; }
+
+        public bool IsExecuting => _executionDepth > 0;
+
+        public long Version => 0;
+
+        public IEnumerable<string> Secrets => [];
+
+        public SecretSnapshot GetSnapshot() => new(0, []);
+
+        public bool TryExecuteIfVersionCurrent(long expectedVersion, Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IEnumerable<string> GetSecretsInObject(object? value) => [];
+
+        public void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput)
+        {
+            ExecutionCount++;
+            _executionDepth++;
+            try
+            {
+                processOutput(state);
+            }
+            finally
+            {
+                _executionDepth--;
+            }
+        }
     }
 
     private sealed class RedactingSecretObfuscator : ISecretObfuscator

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -9,6 +9,7 @@ using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Enums;
+using ModularPipelines.Logging;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using Moq;
@@ -82,6 +83,54 @@ public class ModuleOutputBufferTests
 
         await Assert.That(writer.ToString()).Contains("**********");
         await Assert.That(writer.ToString()).DoesNotContain(secret);
+    }
+
+    [Test]
+    public async Task Flush_RelayoutsCompositeWhenLateSecretMaskExpands()
+    {
+        const string secret = "tiny";
+        long version = 0;
+        IReadOnlyList<string> secrets = [];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider
+            .Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, secrets));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator,
+            renderableSecretProvider: secretProvider.Object);
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
+            .Returns(buffer);
+        var logger = new ModuleLogger<ModuleOutputBufferTests>(
+            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
+            secretObfuscator,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+
+        logger.Write(new Table().AddColumn("Value").AddRow(secret));
+        logger.WriteMarkupLine($"[green]{secret}[/]");
+        secrets = [secret];
+        version++;
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("│ ********** │");
+        await Assert.That(output).DoesNotContain(secret);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -86,6 +86,54 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_MasksLeafSourcesBeforeOverflow()
+    {
+        var secret = string.Concat(Enumerable.Repeat("late-registered-secret-", 8));
+        long version = 0;
+        IReadOnlyList<string> secrets = [];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider
+            .Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, secrets));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator,
+            renderableSecretProvider: secretProvider.Object);
+        buffer.WriteRenderable(
+            new SecretObfuscatedRenderable(
+                new Text(secret) { Overflow = Overflow.Ellipsis },
+                secretObfuscator),
+            secret,
+            appendNewLine: true);
+        buffer.WriteRenderable(
+            new SecretObfuscatedRenderable(
+                new Markup($"[green]{secret}[/]") { Overflow = Overflow.Ellipsis },
+                secretObfuscator),
+            secret,
+            appendNewLine: false);
+
+        secrets = [secret];
+        version++;
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("**********");
+        await Assert.That(output).DoesNotContain(secret[..20]);
+    }
+
+    [Test]
     public async Task Flush_RelayoutsCompositeWhenLateSecretMaskExpands()
     {
         const string secret = "tiny";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -116,7 +116,11 @@ public class ModuleOutputBufferTests
             consoleCoordinator.Object,
             Mock.Of<IOutputCoordinator>());
 
-        logger.Write(new Table().AddColumn("Value").AddRow(secret));
+        logger.Write(new Table
+        {
+            Title = new TableTitle(secret),
+            Caption = new TableTitle(secret),
+        }.AddColumn("Value").AddRow(secret));
         logger.WriteMarkupLine($"[green]{secret}[/]");
         secrets = [secret];
         version++;

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -136,22 +136,11 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task Flush_MasksSecretSplitAcrossAdjacentRenderables()
+    public async Task Flush_MasksSecretSplitAcrossRenderableAndString()
     {
-        var (buffer, writer, loggerControl, secretObfuscator) =
-            CreateSecretMaskingBuffer("token");
-        var consoleCoordinator = new Mock<IConsoleCoordinator>();
-        consoleCoordinator
-            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
-            .Returns(buffer);
-        var logger = new ModuleLogger<ModuleOutputBufferTests>(
-            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
-            secretObfuscator,
-            Mock.Of<IFormattedLogValuesObfuscator>(),
-            consoleCoordinator.Object,
-            Mock.Of<IOutputCoordinator>());
-        logger.Write(new Text("to"));
-        logger.WriteLine("ken");
+        var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer("token");
+        buffer.WriteRenderable(new Text("to"), "to", appendNewLine: false);
+        buffer.WriteLine("ken");
 
         await buffer.FlushToAsync(
             writer,
@@ -168,10 +157,83 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_ModuleLoggerWriteLineAppliesCustomObfuscatorOnce()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input switch
+            {
+                "secret" => "masked",
+                "masked" => "masked-twice",
+                _ => input ?? string.Empty,
+            });
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableSecretObfuscator: secretObfuscator.Object,
+            renderableSecretProvider: Mock.Of<ISecretProvider>());
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
+            .Returns(buffer);
+        var logger = new ModuleLogger<ModuleOutputBufferTests>(
+            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+
+        logger.WriteLine("secret");
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("masked");
+            await Assert.That(writer.ToString()).DoesNotContain("masked-twice");
+        }
+    }
+
+    [Test]
     public async Task IncrementalFlush_RetainsSecretPrefixUntilRenderableLineCompletes()
     {
         var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer("token");
         buffer.WriteRenderable(new Text("to"), "to", appendNewLine: false);
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+        await Assert.That(writer.ToString()).DoesNotContain("to");
+
+        buffer.WriteRenderable(new Text("ken"), "ken", appendNewLine: true);
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("**********");
+            await Assert.That(writer.ToString()).DoesNotContain("token");
+        }
+    }
+
+    [Test]
+    public async Task IncrementalFlush_RetainsStringPrefixUntilRenderableLineCompletes()
+    {
+        var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer("token");
+        buffer.Write("to");
 
         await buffer.FlushToAsync(
             writer,

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -42,6 +42,34 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task DirectConsole_RefreshesConfiguredRenderableDimensions()
+    {
+        using var profileWriter = new StringWriter();
+        var configuredConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(profileWriter),
+        });
+        configuredConsole.Profile.Width = 24;
+        configuredConsole.Profile.Height = 12;
+        using var outputWriter = new StringWriter();
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            renderableConsole: configuredConsole);
+
+        var directConsole = buffer.GetDirectConsole(outputWriter);
+        configuredConsole.Profile.Width = 48;
+        configuredConsole.Profile.Height = 20;
+        var refreshedConsole = buffer.GetDirectConsole(outputWriter);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(refreshedConsole).IsSameReferenceAs(directConsole);
+            await Assert.That(refreshedConsole.Profile.Width).IsEqualTo(48);
+            await Assert.That(refreshedConsole.Profile.Height).IsEqualTo(20);
+        }
+    }
+
+    [Test]
     public async Task OutputExcerptSurvivesConsoleFlush()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -136,6 +136,67 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_MasksSecretSplitAcrossAdjacentRenderables()
+    {
+        var (buffer, writer, loggerControl, secretObfuscator) =
+            CreateSecretMaskingBuffer("token");
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleOutputBufferTests)))
+            .Returns(buffer);
+        var logger = new ModuleLogger<ModuleOutputBufferTests>(
+            Mock.Of<ILogger<ModuleOutputBufferTests>>(),
+            secretObfuscator,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+        logger.Write(new Text("to"));
+        logger.WriteLine("ken");
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("**********");
+            await Assert.That(writer.ToString()).DoesNotContain("token");
+        }
+    }
+
+    [Test]
+    public async Task IncrementalFlush_RetainsSecretPrefixUntilRenderableLineCompletes()
+    {
+        var (buffer, writer, loggerControl, _) = CreateSecretMaskingBuffer("token");
+        buffer.WriteRenderable(new Text("to"), "to", appendNewLine: false);
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+        await Assert.That(writer.ToString()).DoesNotContain("to");
+
+        buffer.WriteRenderable(new Text("ken"), "ken", appendNewLine: true);
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(writer.ToString()).Contains("**********");
+            await Assert.That(writer.ToString()).DoesNotContain("token");
+        }
+    }
+
+    [Test]
     public async Task Flush_CustomObfuscatorRemasksLateSecretUnderEmissionGuard()
     {
         const string secret = "late-custom-secret";
@@ -1742,6 +1803,31 @@ public class ModuleOutputBufferTests
         await Assert.That(fallbackLogger.Entries).HasSingleItem();
         await Assert.That(CountOccurrences(writer.ToString(), "[INFO] retry structured log"))
             .IsEqualTo(1);
+    }
+
+    private static (
+        ModuleOutputBuffer Buffer,
+        StringWriter Writer,
+        SynchronousLoggerControl LoggerControl,
+        SecretObfuscator SecretObfuscator) CreateSecretMaskingBuffer(string secret)
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider
+            .Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, [secret]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var writer = new StringWriter();
+        return (
+            new ModuleOutputBuffer(
+                typeof(ModuleOutputBufferTests),
+                renderableSecretObfuscator: secretObfuscator,
+                renderableSecretProvider: secretProvider.Object),
+            writer,
+            new SynchronousLoggerControl(writer),
+            secretObfuscator);
     }
 
     private static ModuleOutputBuffer CreateBufferWithStructuredLog(

--- a/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
@@ -39,6 +39,12 @@ public class ContextHierarchyTests
         await Assert.That(loggerProperty!.PropertyType).IsEqualTo(typeof(ILogger))
             .Because("Logger should expose the standard ILogger contract");
 
+        var consoleProperty = contextType.GetProperty("Console");
+        await Assert.That(consoleProperty).IsNotNull()
+            .Because("IPipelineContext should have Console property");
+        await Assert.That(consoleProperty!.PropertyType).IsEqualTo(typeof(IConsoleWriter))
+            .Because("Console should be of type IConsoleWriter");
+
         var shellProperty = contextType.GetProperty("Shell");
         await Assert.That(shellProperty).IsNotNull()
             .Because("IPipelineContext should have Shell property");

--- a/test/ModularPipelines.UnitTests/Context/PipelineContextModuleLookupTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/PipelineContextModuleLookupTests.cs
@@ -92,18 +92,30 @@ public class PipelineContextModuleLookupTests
             .IsEquivalentTo([typeof(ConcreteBaseLookupModule), typeof(DerivedConcreteLookupModule)]);
     }
 
+    [Test]
+    public async Task Console_ReturnsInjectedWriterWithoutResolvingPipelineLogger()
+    {
+        var consoleWriter = Mock.Of<IConsoleWriter>();
+        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
+        var context = CreateContext(CreateModuleLookup([]), engineCancellationToken, consoleWriter);
+
+        await Assert.That(context.Console).IsSameReferenceAs(consoleWriter);
+    }
+
     private static ModuleLookup CreateModuleLookup(IReadOnlyList<IModule> modules) =>
         new(modules);
 
     private static PipelineContext CreateContext(
         ModuleLookup moduleLookup,
-        EngineCancellationToken engineCancellationToken)
+        EngineCancellationToken engineCancellationToken,
+        IConsoleWriter? consoleWriter = null)
     {
         return new PipelineContext(
             moduleLookup,
             Mock.Of<IDependencyCollisionDetector>(),
             Mock.Of<IModuleResultRepository>(),
             Mock.Of<IInternalModuleLoggerAccessor>(),
+            consoleWriter ?? Mock.Of<IConsoleWriter>(),
             engineCancellationToken,
             Mock.Of<IShellContext>(),
             Mock.Of<IFilesContext>(),

--- a/test/ModularPipelines.UnitTests/Engine/DependencyPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyPrinterTests.cs
@@ -1,0 +1,58 @@
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using Moq;
+using Spectre.Console;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class DependencyPrinterTests
+{
+    private sealed class TestModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    [Test]
+    public void PrintDependencyChains_RendersLocalGroupCommandsAsMarkup()
+    {
+        const string startCommand = "[bold cyan]start[/]";
+        const string endCommand = "[bold cyan]end[/]";
+        var dependencyModel = new ModuleDependencyModel(new TestModule());
+        var chainProvider = new Mock<IDependencyChainProvider>();
+        chainProvider.SetupGet(x => x.ModuleDependencyModels).Returns([dependencyModel]);
+
+        var consoleWriter = new Mock<IConsoleWriter>();
+        var formatter = new Mock<IBuildSystemFormatter>();
+        formatter.SetupGet(x => x.UsesRawCommands).Returns(false);
+        formatter.Setup(x => x.GetStartBlockCommand("Module Dependencies")).Returns(startCommand);
+        formatter.Setup(x => x.GetEndBlockCommand("Module Dependencies")).Returns(endCommand);
+
+        var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
+        formatterProvider.Setup(x => x.GetFormatter()).Returns(formatter.Object);
+
+        var tree = new Tree("Module Dependencies");
+        var treeFormatter = new Mock<IDependencyTreeFormatter>();
+        treeFormatter.Setup(x => x.FormatTree(It.IsAny<IEnumerable<ModuleDependencyModel>>())).Returns(tree);
+
+        var printer = new DependencyPrinter(
+            chainProvider.Object,
+            consoleWriter.Object,
+            Mock.Of<IBuildSystemCommandWriter>(),
+            formatterProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            treeFormatter.Object);
+
+        printer.PrintDependencyChains();
+
+        consoleWriter.Verify(x => x.WriteMarkupLine(startCommand), Times.Once);
+        consoleWriter.Verify(x => x.WriteMarkupLine(endCommand), Times.Once);
+        consoleWriter.Verify(x => x.Write(tree), Times.Once);
+        consoleWriter.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -128,6 +128,29 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
+    public async Task ModuleRunner_PreservesLoggerForEveryConstraintDeferral()
+    {
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.Setup(x => x.MarkModuleStarted(typeof(TestModule))).Returns(false);
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        var ambientLogger = new Mock<IInternalModuleLogger>();
+
+        await using (new ModuleLoggerScope(ambientLogger.Object, typeof(TestModule)))
+        {
+            await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
+            await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
+        }
+
+        ambientLogger.Verify(
+            logger => logger.PreserveBufferForDeferredExecution(),
+            Times.Exactly(2));
+    }
+
+    [Test]
     public async Task ModuleRunner_PreservesAlwaysRunDuringCancelledLimiterWaits()
     {
         var observedTokens = new List<CancellationToken>();

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Configuration;
+using ModularPipelines.Console;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
@@ -112,12 +113,17 @@ public class ParallelLimitHandlerTests
         await executionTask;
 
         scheduler.Verify(x => x.MarkModuleStarted(typeof(ReadyTestModule)), Times.Once);
+        var outputBuffer = host.Services
+            .GetRequiredService<IConsoleCoordinator>()
+            .GetModuleBuffer(typeof(ReadyTestModule));
+        await Assert.That(outputBuffer.IsComplete).IsFalse();
 
         await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
 
         handler.Verify(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()), Times.Once);
         await Assert.That(TrackingReadyAttribute.InvocationCount).IsEqualTo(1);
         scheduler.Verify(x => x.MarkModuleStarted(typeof(ReadyTestModule)), Times.Exactly(2));
+        await Assert.That(outputBuffer.IsComplete).IsFalse();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -453,6 +453,57 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
+    public async Task ModuleRunner_CompletesPreservedReadyOutputWhenRescheduledLimiterFails()
+    {
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .SetupSequence(x => x.AcquireParallelLimitAsync(
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<IDisposable>())
+            .ThrowsAsync(new InvalidOperationException("Limiter failure"));
+        parallelLimitHandler
+            .Setup(x => x.AcquireExecutionHintLimitAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<IDisposable>());
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(TestModule)))
+            .Returns(outputBuffer.Object);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                outputBuffer.Object,
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        builder.Services.AddSingleton(consoleCoordinator.Object);
+        builder.Services.AddSingleton(outputCoordinator.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.Setup(x => x.MarkModuleStarted(typeof(TestModule))).Returns(false);
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+
+        await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None));
+
+        outputBuffer.Verify(x => x.SetException(It.IsAny<InvalidOperationException>()), Times.Once);
+        outputBuffer.Verify(x => x.SetStatus(It.IsAny<ModuleStatus>()), Times.Once);
+        outputBuffer.Verify(x => x.MarkComplete(), Times.Once);
+        outputCoordinator.Verify(x => x.OnModuleCompletedAsync(
+            outputBuffer.Object,
+            typeof(TestModule),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
     public async Task ModuleRunner_PreservesWorkerTokenForCancelledLinkedLimiterWait()
     {
         var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -11,6 +11,7 @@ using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
+using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
@@ -370,10 +371,24 @@ public class ParallelLimitHandlerTests
                 It.IsAny<ModuleCompletedNotification>(),
                 It.IsAny<CancellationToken>()))
             .Returns(ValueTask.CompletedTask);
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ThrowingReadyTestModule)))
+            .Returns(outputBuffer.Object);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                outputBuffer.Object,
+                typeof(ThrowingReadyTestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
         var builder = TestPipelineBuilder.Create()
             .AddModule<ThrowingReadyTestModule>();
         builder.Services.AddSingleton<IModuleEventHandler>(handler);
         builder.Services.AddSingleton(mediator.Object);
+        builder.Services.AddSingleton(consoleCoordinator.Object);
+        builder.Services.AddSingleton(outputCoordinator.Object);
         await using var host = await builder.BuildAsync();
         var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
         var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
@@ -398,6 +413,43 @@ public class ParallelLimitHandlerTests
                 notification.ModuleState.ModuleType == typeof(ThrowingReadyTestModule)
                 && !notification.IsSuccessful),
             It.IsAny<CancellationToken>()), Times.Once);
+        outputBuffer.Verify(x => x.SetException(It.IsAny<InvalidOperationException>()), Times.Once);
+        outputBuffer.Verify(x => x.SetStatus(ModuleStatus.Failed), Times.Once);
+    }
+
+    [Test]
+    public async Task ModuleRunner_ReusesAmbientLoggerForLifecycleContexts()
+    {
+        IConsoleWriter? readyWriter = null;
+        IConsoleWriter? startWriter = null;
+        var handler = new Mock<IModuleEventHandler>();
+        handler.Setup(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()))
+            .Callback<IModuleHookContext>(context => readyWriter = context.Console)
+            .Returns(Task.CompletedTask);
+        handler.Setup(x => x.OnModuleStartAsync(It.IsAny<IModuleHookContext>()))
+            .Callback<IModuleHookContext>(context => startWriter = context.Console)
+            .Returns(Task.CompletedTask);
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        builder.Services.AddSingleton<IModuleEventHandler>(handler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.Setup(x => x.MarkModuleStarted(typeof(TestModule))).Returns(true);
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        var ambientLogger = new Mock<IInternalModuleLogger>();
+        var ambientWriter = ambientLogger.As<IConsoleWriter>().Object;
+
+        await using (new ModuleLoggerScope(ambientLogger.Object, typeof(TestModule)))
+        {
+            await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
+        }
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(readyWriter).IsSameReferenceAs(ambientWriter);
+            await Assert.That(startWriter).IsSameReferenceAs(ambientWriter);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
@@ -6,6 +6,7 @@ using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Events;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
+using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 using Moq;
 
@@ -70,7 +71,9 @@ public class PipelineSetupExecutorTests
         var module = new TestModule();
         CountingAttribute.InstanceCount = 0;
 
-        await executor.OnModuleReadyAsync(new ModuleState(module, module.GetType()));
+        await executor.OnModuleReadyAsync(
+            new ModuleState(module, module.GetType()),
+            Mock.Of<IConsoleWriter>());
 
         await Assert.That(CountingAttribute.InstanceCount).IsEqualTo(0);
     }
@@ -93,7 +96,9 @@ public class PipelineSetupExecutorTests
             attributeEventService);
         var module = new TestModule();
 
-        await executor.OnModuleReadyAsync(new ModuleState(module, module.GetType()));
+        await executor.OnModuleReadyAsync(
+            new ModuleState(module, module.GetType()),
+            Mock.Of<IConsoleWriter>());
 
         await Assert.That(ReferenceEquals(
                 handlerAttributes,

--- a/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
@@ -129,7 +129,9 @@ public class PipelineSetupExecutorTests
         var module = new TestModule();
 
         await executor.OnPipelineStartAsync();
-        await executor.OnModuleReadyAsync(new ModuleState(module, module.GetType()));
+        await executor.OnModuleReadyAsync(
+            new ModuleState(module, module.GetType()),
+            Mock.Of<IConsoleWriter>());
 
         var expected = new[]
         {
@@ -168,13 +170,61 @@ public class PipelineSetupExecutorTests
         var result = Mock.Of<IModuleResult>();
         var exception = new InvalidOperationException("Expected failure");
         var skipDecision = SkipDecision.Skip("Expected skip");
+        var writer = Mock.Of<IConsoleWriter>();
 
-        await executor.OnModuleEndAsync(moduleState, result);
-        await executor.OnModuleFailureAsync(moduleState, exception);
-        await executor.OnModuleSkippedAsync(moduleState, skipDecision);
+        await executor.OnModuleEndAsync(moduleState, result, writer);
+        await executor.OnModuleFailureAsync(moduleState, exception, writer);
+        await executor.OnModuleSkippedAsync(moduleState, skipDecision, writer);
 
         handler.Verify(x => x.OnModuleEndAsync(It.IsAny<IModuleHookContext>(), result), Times.Once);
         handler.Verify(x => x.OnModuleFailureAsync(It.IsAny<IModuleHookContext>(), exception), Times.Once);
         handler.Verify(x => x.OnModuleSkippedAsync(It.IsAny<IModuleHookContext>(), skipDecision), Times.Once);
+    }
+
+    [Test]
+    public async Task ModuleEvents_UseProvidedConsoleWriter()
+    {
+        var receivedWriters = new List<IConsoleWriter>();
+        var handler = new Mock<IModuleEventHandler>();
+        handler.Setup(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()))
+            .Callback<IModuleHookContext>(context => receivedWriters.Add(context.Console))
+            .Returns(Task.CompletedTask);
+        handler.Setup(x => x.OnModuleStartAsync(It.IsAny<IModuleHookContext>()))
+            .Callback<IModuleHookContext>(context => receivedWriters.Add(context.Console))
+            .Returns(Task.CompletedTask);
+        handler.Setup(x => x.OnModuleEndAsync(It.IsAny<IModuleHookContext>(), It.IsAny<IModuleResult>()))
+            .Callback<IModuleHookContext, IModuleResult>((context, _) => receivedWriters.Add(context.Console))
+            .Returns(Task.CompletedTask);
+        handler.Setup(x => x.OnModuleFailureAsync(It.IsAny<IModuleHookContext>(), It.IsAny<Exception>()))
+            .Callback<IModuleHookContext, Exception>((context, _) => receivedWriters.Add(context.Console))
+            .Returns(Task.CompletedTask);
+        handler.Setup(x => x.OnModuleSkippedAsync(It.IsAny<IModuleHookContext>(), It.IsAny<SkipDecision>()))
+            .Callback<IModuleHookContext, SkipDecision>((context, _) => receivedWriters.Add(context.Console))
+            .Returns(Task.CompletedTask);
+        var executor = new PipelineSetupExecutor(
+            [],
+            [handler.Object],
+            new EventHandlerInvoker(Mock.Of<ILogger<EventHandlerInvoker>>()),
+            Mock.Of<IPipelineContextProvider>(),
+            Mock.Of<IModuleMetadataRegistry>(),
+            new ModuleAttributeEventService());
+        var module = new TestModule();
+        var state = new ModuleState(module, module.GetType());
+        var result = Mock.Of<IModuleResult>();
+        var exception = new InvalidOperationException("Expected failure");
+        var skipDecision = SkipDecision.Skip("Expected skip");
+        var writer = Mock.Of<IConsoleWriter>();
+
+        await executor.OnModuleReadyAsync(state, writer);
+        await executor.OnModuleStartAsync(state, writer);
+        await executor.OnModuleEndAsync(state, result, writer);
+        await executor.OnModuleFailureAsync(state, exception, writer);
+        await executor.OnModuleSkippedAsync(state, skipDecision, writer);
+
+        await Assert.That(receivedWriters.Count).IsEqualTo(5);
+        foreach (var receivedWriter in receivedWriters)
+        {
+            await Assert.That(receivedWriter).IsSameReferenceAs(writer);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -458,6 +458,39 @@ public class ModuleLoggerTests
     }
 
     [Test]
+    public async Task WriteMarkupLine_DoesNotApplyCustomObfuscatorTwice()
+    {
+        string? renderedOutput = null;
+        var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
+        moduleOutputBuffer
+            .Setup(x => x.WriteRenderable(
+                It.IsAny<IRenderable>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>()))
+            .Callback<IRenderable, string, bool>((_, rendered, _) => renderedOutput = rendered);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? input, object? _) => input switch
+            {
+                "secret" => "masked",
+                "masked" => "masked-twice",
+                _ => input ?? string.Empty,
+            });
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            Mock.Of<ILogger<ModuleLoggerTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            CreateConsoleCoordinator(moduleOutputBuffer.Object).Object,
+            Mock.Of<IOutputCoordinator>());
+
+        logger.WriteMarkupLine("[green]secret[/]");
+
+        await Assert.That(renderedOutput).Contains("masked");
+        await Assert.That(renderedOutput).DoesNotContain("masked-twice");
+    }
+
+    [Test]
     public async Task Write_SnapshotsRenderableAtConfiguredConsoleWidth()
     {
         string? renderedOutput = null;

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -26,9 +26,9 @@ public class ModuleLoggerTests
     {
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            ((IConsoleWriter) context.Logger).LogToConsole(RandomString);
+            context.Console.WriteLine(RandomString);
 
-            ((IConsoleWriter) context.Logger).LogToConsole(new MySecrets().Value1!);
+            context.Console.WriteLine(new MySecrets().Value1!);
 
             await Task.Yield();
             return true;
@@ -58,9 +58,9 @@ public class ModuleLoggerTests
     }
 
     [Test]
-    public async Task LogToConsole_Does_Not_Write_To_File_Logger()
+    public async Task ConsoleWriteLine_Does_Not_Write_To_File_Logger()
     {
-        // This test verifies that LogToConsole output goes to console buffers,
+        // This test verifies that console output goes to console buffers,
         // NOT to file loggers. The console output itself is verified implicitly
         // through the full integration tests.
         var file = FilePath.GetNewTemporaryFilePath();
@@ -77,7 +77,7 @@ public class ModuleLoggerTests
 
         await host.DisposeAsync();
 
-        // The key behavior: LogToConsole output should NOT appear in file logs
+        // The key behavior: console output should NOT appear in file logs
         await Assert.That(await file.ReadAsync()).DoesNotContain(RandomString);
     }
 

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -460,14 +460,19 @@ public class ModuleLoggerTests
     [Test]
     public async Task WriteMarkupLine_DoesNotApplyCustomObfuscatorTwice()
     {
-        string? renderedOutput = null;
+        IRenderable? bufferedRenderable = null;
+        string? bufferedPlainText = null;
         var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
         moduleOutputBuffer
             .Setup(x => x.WriteRenderable(
                 It.IsAny<IRenderable>(),
                 It.IsAny<string>(),
                 It.IsAny<bool>()))
-            .Callback<IRenderable, string, bool>((_, rendered, _) => renderedOutput = rendered);
+            .Callback<IRenderable, string, bool>((renderable, plainText, _) =>
+            {
+                bufferedRenderable = renderable;
+                bufferedPlainText = plainText;
+            });
         var secretObfuscator = new Mock<ISecretObfuscator>();
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
@@ -486,8 +491,20 @@ public class ModuleLoggerTests
 
         logger.WriteMarkupLine("[green]secret[/]");
 
-        await Assert.That(renderedOutput).Contains("masked");
-        await Assert.That(renderedOutput).DoesNotContain("masked-twice");
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+            Ansi = AnsiSupport.No,
+        });
+        console.Write(bufferedRenderable!);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bufferedPlainText).IsEqualTo("secret");
+            await Assert.That(writer.ToString()).Contains("masked");
+            await Assert.That(writer.ToString()).DoesNotContain("masked-twice");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -458,6 +458,42 @@ public class ModuleLoggerTests
     }
 
     [Test]
+    public async Task Write_SnapshotsRenderableAtConfiguredConsoleWidth()
+    {
+        string? renderedOutput = null;
+        var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
+        moduleOutputBuffer
+            .Setup(x => x.WriteRenderable(
+                It.IsAny<IRenderable>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>()))
+            .Callback<IRenderable, string, bool>((_, rendered, _) => renderedOutput = rendered);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+        using var consoleWriter = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(consoleWriter),
+            Ansi = AnsiSupport.No,
+        });
+        console.Profile.Width = 24;
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            Mock.Of<ILogger<ModuleLoggerTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            CreateConsoleCoordinator(moduleOutputBuffer.Object).Object,
+            Mock.Of<IOutputCoordinator>(),
+            console);
+
+        logger.Write(new Rule("Title"));
+
+        await Assert.That(renderedOutput).IsNotNull();
+        await Assert.That(renderedOutput!.TrimEnd('\r', '\n').Length).IsEqualTo(24);
+    }
+
+    [Test]
     public async Task Write_SnapshotsMutableRenderableBeforeBuffering()
     {
         var snapshots = new List<IRenderable>();

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -13,6 +13,7 @@ using ModularPipelines.TestHelpers;
 using Moq;
 using NReco.Logging.File;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using ModularPipelines.FileSystem;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using ModularPipelines.Enums;
@@ -431,8 +432,8 @@ public class ModuleLoggerTests
         var renderedLines = new List<string>();
         var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
         moduleOutputBuffer
-            .Setup(x => x.WriteLine(It.IsAny<string>()))
-            .Callback<string>(renderedLines.Add);
+            .Setup(x => x.WriteRenderable(It.IsAny<IRenderable>(), It.IsAny<string>()))
+            .Callback<IRenderable, string>((_, rendered) => renderedLines.Add(rendered));
         var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer.Object);
         var secretObfuscator = new Mock<ISecretObfuscator>();
         secretObfuscator
@@ -451,6 +452,43 @@ public class ModuleLoggerTests
         await Assert.That(renderedLines).Count().IsEqualTo(2);
         await Assert.That(renderedLines[1]).Contains("second");
         await Assert.That(renderedLines[1]).DoesNotContain("first");
+    }
+
+    [Test]
+    public async Task Write_SnapshotsMutableRenderableBeforeBuffering()
+    {
+        var snapshots = new List<IRenderable>();
+        var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
+        moduleOutputBuffer
+            .Setup(x => x.WriteRenderable(It.IsAny<IRenderable>(), It.IsAny<string>()))
+            .Callback<IRenderable, string>((renderable, _) => snapshots.Add(renderable));
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            Mock.Of<ILogger<ModuleLoggerTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            CreateConsoleCoordinator(moduleOutputBuffer.Object).Object,
+            Mock.Of<IOutputCoordinator>());
+        var table = new Table().AddColumn("Value").AddRow("first");
+
+        logger.Write(table);
+        table.AddRow("second");
+        logger.Write(table);
+
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+            Ansi = AnsiSupport.No,
+        });
+        console.Write(snapshots[0]);
+        var firstSnapshot = writer.ToString();
+
+        await Assert.That(firstSnapshot).Contains("first");
+        await Assert.That(firstSnapshot).DoesNotContain("second");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -432,8 +432,11 @@ public class ModuleLoggerTests
         var renderedLines = new List<string>();
         var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
         moduleOutputBuffer
-            .Setup(x => x.WriteRenderable(It.IsAny<IRenderable>(), It.IsAny<string>()))
-            .Callback<IRenderable, string>((_, rendered) => renderedLines.Add(rendered));
+            .Setup(x => x.WriteRenderable(
+                It.IsAny<IRenderable>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>()))
+            .Callback<IRenderable, string, bool>((_, rendered, _) => renderedLines.Add(rendered));
         var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer.Object);
         var secretObfuscator = new Mock<ISecretObfuscator>();
         secretObfuscator
@@ -460,8 +463,11 @@ public class ModuleLoggerTests
         var snapshots = new List<IRenderable>();
         var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
         moduleOutputBuffer
-            .Setup(x => x.WriteRenderable(It.IsAny<IRenderable>(), It.IsAny<string>()))
-            .Callback<IRenderable, string>((renderable, _) => snapshots.Add(renderable));
+            .Setup(x => x.WriteRenderable(
+                It.IsAny<IRenderable>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>()))
+            .Callback<IRenderable, string, bool>((renderable, _, _) => snapshots.Add(renderable));
         var secretObfuscator = new Mock<ISecretObfuscator>();
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
@@ -319,6 +319,53 @@ public class SecretMaskingTests
     }
 
     [Test]
+    public async Task FallbackMaskAndSourceText_DoNotReconstructARegisteredSecret()
+    {
+        string[] secrets = ["MASK", "[REDACTED]B"];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, secrets));
+        var obfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = "[MASK]",
+            }));
+
+        var output = obfuscator.ObfuscateWithSourceMap(
+            "[REDACTED]BB",
+            preserveExistingMasks: false).Value;
+
+        await Assert.That(output).DoesNotContain("[REDACTED]B");
+    }
+
+    [Test]
+    public async Task ConfiguredMaskAndSourceText_DoNotReconstructARegisteredSecret()
+    {
+        string[] secrets = ["AB"];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, secrets));
+        var obfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = "A",
+            }));
+
+        var mappedOutput = obfuscator.ObfuscateWithSourceMap(
+            "ABB",
+            preserveExistingMasks: false).Value;
+        var plainOutput = obfuscator.Obfuscate("ABB", optionsObject: null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mappedOutput).DoesNotContain("AB");
+            await Assert.That(plainOutput).DoesNotContain("AB");
+        }
+    }
+
+    [Test]
     public async Task MultipleSecrets_AllAreMasked()
     {
         var stringBuilder = new StringBuilder();

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
@@ -10,6 +10,7 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Logging;
 
@@ -294,6 +295,27 @@ public class SecretMaskingTests
         var result = SecretObfuscator.FindSafeFallbackMaskCharacter(character => character >= '\u00AD');
 
         await Assert.That(result).IsEqualTo('\u00AE');
+    }
+
+    [Test]
+    public async Task AdjacentFallbackMasks_DoNotReconstructARegisteredSecret()
+    {
+        string[] secrets = ["MASK", "D][R", "AA"];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, secrets));
+        var obfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = "[MASK]",
+            }));
+
+        var output = obfuscator.ObfuscateWithSourceMap(
+            "AAAA",
+            preserveExistingMasks: false).Value;
+
+        await Assert.That(output).DoesNotContain("D][R");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
@@ -274,18 +274,26 @@ public class SecretMaskingTests
     #region Edge Cases Tests
 
     [Test]
-    public async Task FallbackMaskCharacterScan_TerminatesAfterMaximumCharacter()
+    public async Task FallbackMaskCharacterScan_TerminatesWhenNoCharacterIsSafe()
     {
-        var inspectedMaximumCharacter = false;
+        var inspectedCharacterCount = 0;
 
         var result = SecretObfuscator.FindSafeFallbackMaskCharacter(character =>
         {
-            inspectedMaximumCharacter |= character == char.MaxValue;
+            inspectedCharacterCount++;
             return false;
         });
 
         await Assert.That(result).IsNull();
-        await Assert.That(inspectedMaximumCharacter).IsTrue();
+        await Assert.That(inspectedCharacterCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task FallbackMaskCharacterScan_SkipsInvisibleCharacters()
+    {
+        var result = SecretObfuscator.FindSafeFallbackMaskCharacter(character => character >= '\u00AD');
+
+        await Assert.That(result).IsEqualTo('\u00AE');
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
@@ -366,6 +366,32 @@ public class SecretMaskingTests
     }
 
     [Test]
+    public async Task PreservedMaskAndSourceText_DoNotReconstructARegisteredSecret()
+    {
+        string[] secrets = ["AAAA", "***B"];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(0);
+        secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, secrets));
+        var obfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MaskValue = "***",
+            }));
+
+        var mappedOutput = obfuscator.ObfuscateWithSourceMap(
+            "AAAAB",
+            preserveExistingMasks: true).Value;
+        var plainOutput = obfuscator.ObfuscatePreservingMasks("AAAAB");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mappedOutput).DoesNotContain("***B");
+            await Assert.That(plainOutput).DoesNotContain("***B");
+        }
+    }
+
+    [Test]
     public async Task MultipleSecrets_AllAreMasked()
     {
         var stringBuilder = new StringBuilder();

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingTests.cs
@@ -274,6 +274,21 @@ public class SecretMaskingTests
     #region Edge Cases Tests
 
     [Test]
+    public async Task FallbackMaskCharacterScan_TerminatesAfterMaximumCharacter()
+    {
+        var inspectedMaximumCharacter = false;
+
+        var result = SecretObfuscator.FindSafeFallbackMaskCharacter(character =>
+        {
+            inspectedMaximumCharacter |= character == char.MaxValue;
+            return false;
+        });
+
+        await Assert.That(result).IsNull();
+        await Assert.That(inspectedMaximumCharacter).IsTrue();
+    }
+
+    [Test]
     public async Task MultipleSecrets_AllAreMasked()
     {
         var stringBuilder = new StringBuilder();

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -72,7 +72,7 @@ public class SecretObfuscatorCachingTests
     [Test]
     [Arguments(false)]
     [Arguments(true)]
-    public async Task DoesNotRescanMaskReplacement(bool caseInsensitive)
+    public async Task UnsafeMaskReplacementUsesSafeFallback(bool caseInsensitive)
     {
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.Setup(x => x.GetSnapshot())
@@ -84,7 +84,7 @@ public class SecretObfuscatorCachingTests
 
         var result = obfuscator.Obfuscate(caseInsensitive ? "SECRET" : "secret", null);
 
-        await Assert.That(result).IsEqualTo("***");
+        await Assert.That(result).IsEqualTo("[MASKED]");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
+using ModularPipelines.Logging;
 using ModularPipelines.TestHelpers;
 using ModularPipelines.UnitTests.Models;
 using Moq;
@@ -25,7 +26,7 @@ public class SecretObfuscatorTests
         _buildSystemMock = new Mock<IBuildSystemDetector>();
 
         _consoleWriterMock = new Mock<IConsoleWriter>();
-        _consoleWriterMock.Setup(x => x.LogToConsole(It.IsAny<string>()))
+        _consoleWriterMock.Setup(x => x.WriteLine(It.IsAny<string>()))
             .Callback<string>(value => _consoleOutput.AppendLine(value));
 
         _commandWriterMock = new Mock<IBuildSystemCommandWriter>();
@@ -53,7 +54,7 @@ public class SecretObfuscatorTests
         await RunAsync();
 
         _consoleWriterMock.Verify(
-            writer => writer.LogToConsole(It.Is<string>(
+            writer => writer.WriteLine(It.Is<string>(
                 value => value.StartsWith("::add-mask::", StringComparison.Ordinal))),
             Times.Never);
         await Assert.That(_consoleOutput.ToString())

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
@@ -1,5 +1,5 @@
 using ModularPipelines.Context;
-using ModularPipelines.Logging;
+using ModularPipelines.Secrets;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Engine;


### PR DESCRIPTION
Closes #4231  ## Summary - expose module-aware console output through `IPipelineContext.Console` - split plain text (`WriteLine`) from Spectre markup (`WriteMarkupLine`) - move `IConsoleWriter` into `ModularPipelines.Logging` and make the raw implementation internal - preserve module logger buffers across every scheduler constraint deferral - keep auto-sized tables flexible when content is wider than the title-derived minimum - key chart formatter snapshots by exact IEEE-754 bits and culture identity - update call sites, API baselines, release notes, docs, and focused tests  ## Validation - `ModularPipelines.slnx` Release build: 0 errors (4 existing RS0026 warnings) - `ConsoleWriterTests`: 54/54 - `ParallelLimitHandlerTests`: 13/13 - `ModuleLoggerTests`: 12/12 - `ContextHierarchyTests`: 6/6 - `SecretObfuscatorTests`: 3/3
- fallback mask exhaustion regression: 1/1
- invisible fallback mask regression: 1/1 at `ebc6aa856f`
- `ModularPipelines.Tests.slnf` Release build after review fix: 0 errors (existing warnings only) - `PipelineCommandLineTests`: 77/77 - scoped formatter run: passed - `git diff --check`: passed  Full `ModularPipelines.Tests.slnf` format verification hit the agent 2 GB guard while reporting unrelated existing formatting debt in `ScaleTests.cs` and `ZipCentralDirectory.cs`; touched-file formatting and whitespace checks pass. The build pipeline was not run per repository agent constraints.  ## Spectre.Console compatibility `Spectre.Console` is pinned exactly to `0.57.2`. Private-field access is needed to clone renderable structure and mask secrets before layout; post-render masking can expose secret-dependent metadata or alter layout. `ConsoleWriterTests` instantiate and render every supported accessor-backed type (including align, markup, paragraph/text, columns, figlet, padder, layout, rows, tree/tree node, and table), so an incompatible package shape fails the focused suite. 