### PR TITLE
Normalize PowerShell casing across core APIs

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -1,5 +1,17 @@
 # ModularPipelines V4 Release Notes
 
+## PowerShell casing
+
+PowerShell types now use the product's canonical casing:
+
+- `PowershellOptions` is now `PowerShellOptions`.
+- `PowershellScriptOptions` is now `PowerShellScriptOptions`.
+- `PowershellFileOptions` is now `PowerShellFileOptions`.
+
+The internal implementation class also follows the `PowerShell` casing. The former
+`Powershell7Async` predefined installer was removed with the rest of the predefined
+installer surface; use the dedicated installation integrations instead.
+
 ## Installers
 
 The core installer surface now contains only generic local and web installation:

--- a/docs/docs/why.md
+++ b/docs/docs/why.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 
 - The .NET ecosystem is rich with features and libraries. You can utilize what already exists and not have to re-invent the wheel.
 
-- If you're already a .NET developer, you don't have to concern yourself as much with the different features, languages or syntaxes of different build systems. No need for YAML-based pipeline definitions, Powershell scripts, bash scripts, or even just unfamiliar UI based build systems.
+- If you're already a .NET developer, you don't have to concern yourself as much with the different features, languages or syntaxes of different build systems. No need for YAML-based pipeline definitions, PowerShell scripts, bash scripts, or even just unfamiliar UI based build systems.
 
 - Strong typing - We can structure our modules with objects that we can pass around, and we know what data we then have available to use.
 

--- a/src/ModularPipelines/Context/Domains/Shell/IPowerShellContext.cs
+++ b/src/ModularPipelines/Context/Domains/Shell/IPowerShellContext.cs
@@ -41,7 +41,7 @@ public interface IPowerShellContext
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="CommandResult"/> containing the execution results.</returns>
     Task<CommandResult> RunAsync(
-        PowershellScriptOptions options,
+        PowerShellScriptOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default);
 
@@ -74,7 +74,7 @@ public interface IPowerShellContext
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="CommandResult"/> containing the execution results.</returns>
     Task<CommandResult> RunFileAsync(
-        PowershellFileOptions options,
+        PowerShellFileOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/Domains/Shell/IPowerShellContext.cs
+++ b/src/ModularPipelines/Context/Domains/Shell/IPowerShellContext.cs
@@ -28,6 +28,7 @@ public interface IPowerShellContext
     /// Console.WriteLine(result.StandardOutput);
     /// </code>
     /// </example>
+#pragma warning disable RS0026 // String and options overloads intentionally share optional execution and cancellation parameters.
     Task<CommandResult> RunAsync(
         string script,
         CommandExecutionOptions? executionOptions = null,
@@ -77,4 +78,5 @@ public interface IPowerShellContext
         PowerShellFileOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default);
+#pragma warning restore RS0026
 }

--- a/src/ModularPipelines/Context/PowerShell.cs
+++ b/src/ModularPipelines/Context/PowerShell.cs
@@ -4,11 +4,11 @@ using ModularPipelines.Options;
 
 namespace ModularPipelines.Context;
 
-internal class Powershell : IPowerShellContext
+internal class PowerShell : IPowerShellContext
 {
     private readonly ICommandContext _command;
 
-    public Powershell(ICommandContext command)
+    public PowerShell(ICommandContext command)
     {
         _command = command;
     }
@@ -18,11 +18,11 @@ internal class Powershell : IPowerShellContext
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return RunAsync(new PowershellScriptOptions(script), executionOptions, cancellationToken);
+        return RunAsync(new PowerShellScriptOptions(script), executionOptions, cancellationToken);
     }
 
     public virtual Task<CommandResult> RunAsync(
-        PowershellScriptOptions options,
+        PowerShellScriptOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
@@ -34,11 +34,11 @@ internal class Powershell : IPowerShellContext
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return RunFileAsync(new PowershellFileOptions(path), executionOptions, cancellationToken);
+        return RunFileAsync(new PowerShellFileOptions(path), executionOptions, cancellationToken);
     }
 
     public virtual Task<CommandResult> RunFileAsync(
-        PowershellFileOptions options,
+        PowerShellFileOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -150,7 +150,7 @@ internal static class DependencyInjectionSetup
             .AddScoped<ICertificatesContext, Certificates>()
             .AddScoped<IDownloaderContext, Downloader>()
             .AddScoped<IZipContext, Zip>()
-            .AddScoped<IPowerShellContext, Powershell>()
+            .AddScoped<IPowerShellContext, PowerShell>()
             .AddScoped<IBashContext, Bash>()
             .AddScoped<ModularPipelines.Context.Domains.IShellContext, ModularPipelines.Context.Domains.Implementations.ShellContext>()
             .AddScoped<IFilesContext, FilesContext>()

--- a/src/ModularPipelines/Options/BashFileOptions.cs
+++ b/src/ModularPipelines/Options/BashFileOptions.cs
@@ -3,5 +3,9 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Options;
 
+/// <summary>
+/// Options for executing a Bash script file.
+/// </summary>
+/// <param name="FilePath">The path to the Bash script file to execute.</param>
 [ExcludeFromCodeCoverage]
 public record BashFileOptions([property: CliArgument(Phase = CommandLinePhase.EarlyOperand)] string FilePath) : BashOptions;

--- a/src/ModularPipelines/Options/PowerShellFileOptions.cs
+++ b/src/ModularPipelines/Options/PowerShellFileOptions.cs
@@ -8,4 +8,4 @@ namespace ModularPipelines.Options;
 /// </summary>
 /// <param name="FilePath">The path to the PowerShell script file to execute.</param>
 [ExcludeFromCodeCoverage]
-public record PowershellFileOptions([property: CliOption("-File")] string FilePath) : PowershellOptions;
+public record PowerShellFileOptions([property: CliOption("-File")] string FilePath) : PowerShellOptions;

--- a/src/ModularPipelines/Options/PowerShellOptions.cs
+++ b/src/ModularPipelines/Options/PowerShellOptions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Options;
@@ -5,5 +6,6 @@ namespace ModularPipelines.Options;
 /// <summary>
 /// Options for executing PowerShell commands using the pwsh executable.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [CliTool("pwsh")]
-public record PowershellOptions : CommandLineToolOptions;
+public record PowerShellOptions : CommandLineToolOptions;

--- a/src/ModularPipelines/Options/PowerShellScriptOptions.cs
+++ b/src/ModularPipelines/Options/PowerShellScriptOptions.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options;
+
+/// <summary>
+/// Options for executing an inline PowerShell script.
+/// </summary>
+/// <param name="Script">The PowerShell script to execute.</param>
+[ExcludeFromCodeCoverage]
+public record PowerShellScriptOptions([property: CliOption("-Command")] string Script) : PowerShellOptions;

--- a/src/ModularPipelines/Options/PowershellScriptOptions.cs
+++ b/src/ModularPipelines/Options/PowershellScriptOptions.cs
@@ -1,5 +1,0 @@
-using ModularPipelines.Attributes;
-
-namespace ModularPipelines.Options;
-
-public record PowershellScriptOptions([property: CliOption("-Command")] string Script) : PowershellOptions;

--- a/src/ModularPipelines/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines/PublicAPI.Shipped.txt
@@ -1654,21 +1654,6 @@ ModularPipelines.Options.PipelineOptions.TargetModules.get -> System.Collections
 ModularPipelines.Options.PipelineOptions.TargetModules.init -> void
 ModularPipelines.Options.PipelineOptions.ThrowOnPipelineFailure.get -> bool
 ModularPipelines.Options.PipelineOptions.ThrowOnPipelineFailure.init -> void
-ModularPipelines.Options.PowershellFileOptions
-ModularPipelines.Options.PowershellFileOptions.Deconstruct(out string! FilePath) -> void
-ModularPipelines.Options.PowershellFileOptions.FilePath.get -> string!
-ModularPipelines.Options.PowershellFileOptions.FilePath.init -> void
-ModularPipelines.Options.PowershellFileOptions.PowershellFileOptions(ModularPipelines.Options.PowershellFileOptions! original) -> void
-ModularPipelines.Options.PowershellFileOptions.PowershellFileOptions(string! FilePath) -> void
-ModularPipelines.Options.PowershellOptions
-ModularPipelines.Options.PowershellOptions.PowershellOptions() -> void
-ModularPipelines.Options.PowershellOptions.PowershellOptions(ModularPipelines.Options.PowershellOptions! original) -> void
-ModularPipelines.Options.PowershellScriptOptions
-ModularPipelines.Options.PowershellScriptOptions.Deconstruct(out string! Script) -> void
-ModularPipelines.Options.PowershellScriptOptions.PowershellScriptOptions(ModularPipelines.Options.PowershellScriptOptions! original) -> void
-ModularPipelines.Options.PowershellScriptOptions.PowershellScriptOptions(string! Script) -> void
-ModularPipelines.Options.PowershellScriptOptions.Script.get -> string!
-ModularPipelines.Options.PowershellScriptOptions.Script.init -> void
 ModularPipelines.Options.RunReportOptions
 ModularPipelines.Options.RunReportOptions.<Clone>$() -> ModularPipelines.Options.RunReportOptions!
 ModularPipelines.Options.RunReportOptions.AutoWriteInCi.get -> bool
@@ -2030,24 +2015,6 @@ override ModularPipelines.Options.PipelineHttpOptions.ToString() -> string!
 override ModularPipelines.Options.PipelineOptions.Equals(object? obj) -> bool
 override ModularPipelines.Options.PipelineOptions.GetHashCode() -> int
 override ModularPipelines.Options.PipelineOptions.ToString() -> string!
-override ModularPipelines.Options.PowershellFileOptions.<Clone>$() -> ModularPipelines.Options.PowershellFileOptions!
-override ModularPipelines.Options.PowershellFileOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Options.PowershellFileOptions.Equals(object? obj) -> bool
-override ModularPipelines.Options.PowershellFileOptions.GetHashCode() -> int
-override ModularPipelines.Options.PowershellFileOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Options.PowershellFileOptions.ToString() -> string!
-override ModularPipelines.Options.PowershellOptions.<Clone>$() -> ModularPipelines.Options.PowershellOptions!
-override ModularPipelines.Options.PowershellOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Options.PowershellOptions.Equals(object? obj) -> bool
-override ModularPipelines.Options.PowershellOptions.GetHashCode() -> int
-override ModularPipelines.Options.PowershellOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Options.PowershellOptions.ToString() -> string!
-override ModularPipelines.Options.PowershellScriptOptions.<Clone>$() -> ModularPipelines.Options.PowershellScriptOptions!
-override ModularPipelines.Options.PowershellScriptOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Options.PowershellScriptOptions.Equals(object? obj) -> bool
-override ModularPipelines.Options.PowershellScriptOptions.GetHashCode() -> int
-override ModularPipelines.Options.PowershellScriptOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Options.PowershellScriptOptions.ToString() -> string!
 override ModularPipelines.Options.RunReportOptions.Equals(object? obj) -> bool
 override ModularPipelines.Options.RunReportOptions.GetHashCode() -> int
 override ModularPipelines.Options.RunReportOptions.ToString() -> string!
@@ -2079,9 +2046,6 @@ override sealed ModularPipelines.Options.BashCommandOptions.Equals(ModularPipeli
 override sealed ModularPipelines.Options.BashFileOptions.Equals(ModularPipelines.Options.BashOptions? other) -> bool
 override sealed ModularPipelines.Options.BashOptions.Equals(ModularPipelines.Options.CommandLineToolOptions? other) -> bool
 override sealed ModularPipelines.Options.DownloadFileOptions.Equals(ModularPipelines.Options.DownloadOptions? other) -> bool
-override sealed ModularPipelines.Options.PowershellFileOptions.Equals(ModularPipelines.Options.PowershellOptions? other) -> bool
-override sealed ModularPipelines.Options.PowershellOptions.Equals(ModularPipelines.Options.CommandLineToolOptions? other) -> bool
-override sealed ModularPipelines.Options.PowershellScriptOptions.Equals(ModularPipelines.Options.PowershellOptions? other) -> bool
 static ModularPipelines.AmbientModuleContext.CurrentModuleFullName.get -> string?
 static ModularPipelines.AmbientModuleContext.CurrentModuleName.get -> string?
 static ModularPipelines.AmbientModuleContext.CurrentModuleType.get -> System.Type?
@@ -2274,12 +2238,6 @@ static ModularPipelines.Options.PipelineHttpOptions.operator !=(ModularPipelines
 static ModularPipelines.Options.PipelineHttpOptions.operator ==(ModularPipelines.Options.PipelineHttpOptions? left, ModularPipelines.Options.PipelineHttpOptions? right) -> bool
 static ModularPipelines.Options.PipelineOptions.operator !=(ModularPipelines.Options.PipelineOptions? left, ModularPipelines.Options.PipelineOptions? right) -> bool
 static ModularPipelines.Options.PipelineOptions.operator ==(ModularPipelines.Options.PipelineOptions? left, ModularPipelines.Options.PipelineOptions? right) -> bool
-static ModularPipelines.Options.PowershellFileOptions.operator !=(ModularPipelines.Options.PowershellFileOptions? left, ModularPipelines.Options.PowershellFileOptions? right) -> bool
-static ModularPipelines.Options.PowershellFileOptions.operator ==(ModularPipelines.Options.PowershellFileOptions? left, ModularPipelines.Options.PowershellFileOptions? right) -> bool
-static ModularPipelines.Options.PowershellOptions.operator !=(ModularPipelines.Options.PowershellOptions? left, ModularPipelines.Options.PowershellOptions? right) -> bool
-static ModularPipelines.Options.PowershellOptions.operator ==(ModularPipelines.Options.PowershellOptions? left, ModularPipelines.Options.PowershellOptions? right) -> bool
-static ModularPipelines.Options.PowershellScriptOptions.operator !=(ModularPipelines.Options.PowershellScriptOptions? left, ModularPipelines.Options.PowershellScriptOptions? right) -> bool
-static ModularPipelines.Options.PowershellScriptOptions.operator ==(ModularPipelines.Options.PowershellScriptOptions? left, ModularPipelines.Options.PowershellScriptOptions? right) -> bool
 static ModularPipelines.Options.RunReportOptions.operator !=(ModularPipelines.Options.RunReportOptions? left, ModularPipelines.Options.RunReportOptions? right) -> bool
 static ModularPipelines.Options.RunReportOptions.operator ==(ModularPipelines.Options.RunReportOptions? left, ModularPipelines.Options.RunReportOptions? right) -> bool
 static ModularPipelines.Options.SchedulerOptions.operator !=(ModularPipelines.Options.SchedulerOptions? left, ModularPipelines.Options.SchedulerOptions? right) -> bool
@@ -2444,9 +2402,6 @@ virtual ModularPipelines.Options.PipelineOptions.<Clone>$() -> ModularPipelines.
 virtual ModularPipelines.Options.PipelineOptions.EqualityContract.get -> System.Type!
 virtual ModularPipelines.Options.PipelineOptions.Equals(ModularPipelines.Options.PipelineOptions? other) -> bool
 virtual ModularPipelines.Options.PipelineOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual ModularPipelines.Options.PowershellFileOptions.Equals(ModularPipelines.Options.PowershellFileOptions? other) -> bool
-virtual ModularPipelines.Options.PowershellOptions.Equals(ModularPipelines.Options.PowershellOptions? other) -> bool
-virtual ModularPipelines.Options.PowershellScriptOptions.Equals(ModularPipelines.Options.PowershellScriptOptions? other) -> bool
 virtual ModularPipelines.Options.SchedulerOptions.<Clone>$() -> ModularPipelines.Options.SchedulerOptions!
 virtual ModularPipelines.Options.SchedulerOptions.EqualityContract.get -> System.Type!
 virtual ModularPipelines.Options.SchedulerOptions.Equals(ModularPipelines.Options.SchedulerOptions? other) -> bool

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -36,9 +36,9 @@ ModularPipelines.Context.Domains.Shell.IBashContext.RunAsync(ModularPipelines.Op
 ModularPipelines.Context.Domains.Shell.IBashContext.RunAsync(string! script, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.Domains.Shell.IBashContext.RunFileAsync(ModularPipelines.Options.BashFileOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.Domains.Shell.IBashContext.RunFileAsync(string! path, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-ModularPipelines.Context.Domains.Shell.IPowerShellContext.RunAsync(ModularPipelines.Options.PowershellScriptOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Context.Domains.Shell.IPowerShellContext.RunAsync(ModularPipelines.Options.PowerShellScriptOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.Domains.Shell.IPowerShellContext.RunAsync(string! script, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-ModularPipelines.Context.Domains.Shell.IPowerShellContext.RunFileAsync(ModularPipelines.Options.PowershellFileOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Context.Domains.Shell.IPowerShellContext.RunFileAsync(ModularPipelines.Options.PowerShellFileOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.Domains.Shell.IPowerShellContext.RunFileAsync(string! path, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 ModularPipelines.Context.IModuleContext.RunSubModuleAsync(string! name, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 ModularPipelines.Context.IModuleContext.RunSubModuleAsync<T>(string! name, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
@@ -173,6 +173,21 @@ ModularPipelines.Options.FailureMode.ContinueOnFailure = 1 -> ModularPipelines.O
 ModularPipelines.Options.FailureMode.FailFast = 0 -> ModularPipelines.Options.FailureMode
 ModularPipelines.Options.PipelineOptions.FailureMode.get -> ModularPipelines.Options.FailureMode
 ModularPipelines.Options.PipelineOptions.FailureMode.init -> void
+ModularPipelines.Options.PowerShellFileOptions
+ModularPipelines.Options.PowerShellFileOptions.Deconstruct(out string! FilePath) -> void
+ModularPipelines.Options.PowerShellFileOptions.FilePath.get -> string!
+ModularPipelines.Options.PowerShellFileOptions.FilePath.init -> void
+ModularPipelines.Options.PowerShellFileOptions.PowerShellFileOptions(ModularPipelines.Options.PowerShellFileOptions! original) -> void
+ModularPipelines.Options.PowerShellFileOptions.PowerShellFileOptions(string! FilePath) -> void
+ModularPipelines.Options.PowerShellOptions
+ModularPipelines.Options.PowerShellOptions.PowerShellOptions() -> void
+ModularPipelines.Options.PowerShellOptions.PowerShellOptions(ModularPipelines.Options.PowerShellOptions! original) -> void
+ModularPipelines.Options.PowerShellScriptOptions
+ModularPipelines.Options.PowerShellScriptOptions.Deconstruct(out string! Script) -> void
+ModularPipelines.Options.PowerShellScriptOptions.PowerShellScriptOptions(ModularPipelines.Options.PowerShellScriptOptions! original) -> void
+ModularPipelines.Options.PowerShellScriptOptions.PowerShellScriptOptions(string! Script) -> void
+ModularPipelines.Options.PowerShellScriptOptions.Script.get -> string!
+ModularPipelines.Options.PowerShellScriptOptions.Script.init -> void
 ModularPipelines.PipelineBuilderSettings
 ModularPipelines.PipelineBuilderSettings.<Clone>$() -> ModularPipelines.PipelineBuilderSettings!
 ModularPipelines.PipelineBuilderSettings.ApplicationName.get -> string?
@@ -219,6 +234,24 @@ override ModularPipelines.Generated.PropertyCommandLinePart.ToString() -> string
 override ModularPipelines.Generated.SecretPropertyAccessor.Equals(object? obj) -> bool
 override ModularPipelines.Generated.SecretPropertyAccessor.GetHashCode() -> int
 override ModularPipelines.Generated.SecretPropertyAccessor.ToString() -> string!
+override ModularPipelines.Options.PowerShellFileOptions.<Clone>$() -> ModularPipelines.Options.PowerShellFileOptions!
+override ModularPipelines.Options.PowerShellFileOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Options.PowerShellFileOptions.Equals(object? obj) -> bool
+override ModularPipelines.Options.PowerShellFileOptions.GetHashCode() -> int
+override ModularPipelines.Options.PowerShellFileOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Options.PowerShellFileOptions.ToString() -> string!
+override ModularPipelines.Options.PowerShellOptions.<Clone>$() -> ModularPipelines.Options.PowerShellOptions!
+override ModularPipelines.Options.PowerShellOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Options.PowerShellOptions.Equals(object? obj) -> bool
+override ModularPipelines.Options.PowerShellOptions.GetHashCode() -> int
+override ModularPipelines.Options.PowerShellOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Options.PowerShellOptions.ToString() -> string!
+override ModularPipelines.Options.PowerShellScriptOptions.<Clone>$() -> ModularPipelines.Options.PowerShellScriptOptions!
+override ModularPipelines.Options.PowerShellScriptOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Options.PowerShellScriptOptions.Equals(object? obj) -> bool
+override ModularPipelines.Options.PowerShellScriptOptions.GetHashCode() -> int
+override ModularPipelines.Options.PowerShellScriptOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Options.PowerShellScriptOptions.ToString() -> string!
 override ModularPipelines.PipelineBuilderSettings.Equals(object? obj) -> bool
 override ModularPipelines.PipelineBuilderSettings.GetHashCode() -> int
 override ModularPipelines.PipelineBuilderSettings.ToString() -> string!
@@ -227,6 +260,9 @@ override sealed ModularPipelines.Generated.FlagPart.Equals(ModularPipelines.Gene
 override sealed ModularPipelines.Generated.OptionPart.Equals(ModularPipelines.Generated.PropertyCommandLinePart? other) -> bool
 override sealed ModularPipelines.Modules.NonGenericSyncModuleAdapter.Execute(ModularPipelines.Context.IModuleContext! context, System.Threading.CancellationToken cancellationToken) -> ModularPipelines.Models.None
 override sealed ModularPipelines.Modules.SyncModule.ExecuteWithoutResult(ModularPipelines.Context.IModuleContext! context, System.Threading.CancellationToken cancellationToken) -> void
+override sealed ModularPipelines.Options.PowerShellFileOptions.Equals(ModularPipelines.Options.PowerShellOptions? other) -> bool
+override sealed ModularPipelines.Options.PowerShellOptions.Equals(ModularPipelines.Options.CommandLineToolOptions? other) -> bool
+override sealed ModularPipelines.Options.PowerShellScriptOptions.Equals(ModularPipelines.Options.PowerShellOptions? other) -> bool
 static ModularPipelines.Extensions.CommandExtensions.WithArguments<TOptions>(this TOptions! options, params string![]! arguments) -> TOptions!
 static ModularPipelines.Extensions.CommandExtensions.WithArguments<TOptions>(this TOptions! options, string! singleArgument) -> TOptions!
 static ModularPipelines.Extensions.CommandExtensions.WithArguments<TOptions>(this TOptions! options, System.Collections.Generic.IEnumerable<string!>? arguments) -> TOptions!
@@ -272,6 +308,12 @@ static ModularPipelines.Generated.RuntimeMetadataRegistry.RegisterCommandOptions
 static ModularPipelines.Generated.RuntimeMetadataRegistry.RegisterSecrets(System.Type! objectType, System.Collections.Generic.IReadOnlyList<ModularPipelines.Generated.SecretPropertyAccessor!>! accessors) -> void
 static ModularPipelines.Generated.SecretPropertyAccessor.operator !=(ModularPipelines.Generated.SecretPropertyAccessor? left, ModularPipelines.Generated.SecretPropertyAccessor? right) -> bool
 static ModularPipelines.Generated.SecretPropertyAccessor.operator ==(ModularPipelines.Generated.SecretPropertyAccessor? left, ModularPipelines.Generated.SecretPropertyAccessor? right) -> bool
+static ModularPipelines.Options.PowerShellFileOptions.operator !=(ModularPipelines.Options.PowerShellFileOptions? left, ModularPipelines.Options.PowerShellFileOptions? right) -> bool
+static ModularPipelines.Options.PowerShellFileOptions.operator ==(ModularPipelines.Options.PowerShellFileOptions? left, ModularPipelines.Options.PowerShellFileOptions? right) -> bool
+static ModularPipelines.Options.PowerShellOptions.operator !=(ModularPipelines.Options.PowerShellOptions? left, ModularPipelines.Options.PowerShellOptions? right) -> bool
+static ModularPipelines.Options.PowerShellOptions.operator ==(ModularPipelines.Options.PowerShellOptions? left, ModularPipelines.Options.PowerShellOptions? right) -> bool
+static ModularPipelines.Options.PowerShellScriptOptions.operator !=(ModularPipelines.Options.PowerShellScriptOptions? left, ModularPipelines.Options.PowerShellScriptOptions? right) -> bool
+static ModularPipelines.Options.PowerShellScriptOptions.operator ==(ModularPipelines.Options.PowerShellScriptOptions? left, ModularPipelines.Options.PowerShellScriptOptions? right) -> bool
 static ModularPipelines.Pipeline.CreateBuilder(ModularPipelines.PipelineBuilderSettings! settings, string! sourceFilePath = "") -> ModularPipelines.PipelineBuilder!
 static ModularPipelines.Pipeline.CreateBuilder(string![]? args = null, string! sourceFilePath = "") -> ModularPipelines.PipelineBuilder!
 static ModularPipelines.PipelineBuilderExtensions.AddValidator<TValidator>(this ModularPipelines.PipelineBuilder! builder) -> ModularPipelines.PipelineBuilder!
@@ -281,3 +323,6 @@ virtual ModularPipelines.Generated.PropertyCommandLinePart.EqualityContract.get 
 virtual ModularPipelines.Generated.PropertyCommandLinePart.Equals(ModularPipelines.Generated.PropertyCommandLinePart? other) -> bool
 virtual ModularPipelines.Generated.PropertyCommandLinePart.PrintMembers(System.Text.StringBuilder! builder) -> bool
 virtual ModularPipelines.Modules.Module<T>.Configure(ModularPipelines.Configuration.ModuleConfigurationBuilder! module) -> void
+virtual ModularPipelines.Options.PowerShellFileOptions.Equals(ModularPipelines.Options.PowerShellFileOptions? other) -> bool
+virtual ModularPipelines.Options.PowerShellOptions.Equals(ModularPipelines.Options.PowerShellOptions? other) -> bool
+virtual ModularPipelines.Options.PowerShellScriptOptions.Equals(ModularPipelines.Options.PowerShellScriptOptions? other) -> bool

--- a/test/ModularPipelines.UnitTests/Api/PowerShellApiSurfaceTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/PowerShellApiSurfaceTests.cs
@@ -1,0 +1,32 @@
+using ModularPipelines.Options;
+
+namespace ModularPipelines.UnitTests.Api;
+
+public class PowerShellApiSurfaceTests
+{
+    [Test]
+    public async Task Uses_Canonical_PowerShell_Casing()
+    {
+        var assembly = typeof(PowerShellOptions).Assembly;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(assembly.GetType("ModularPipelines.Options.PowerShellOptions"))
+                .IsEqualTo(typeof(PowerShellOptions));
+            await Assert.That(assembly.GetType("ModularPipelines.Options.PowerShellScriptOptions"))
+                .IsEqualTo(typeof(PowerShellScriptOptions));
+            await Assert.That(assembly.GetType("ModularPipelines.Options.PowerShellFileOptions"))
+                .IsEqualTo(typeof(PowerShellFileOptions));
+            await Assert.That(assembly.GetType("ModularPipelines.Context.PowerShell"))
+                .IsNotNull();
+            await Assert.That(assembly.GetType("ModularPipelines.Options.PowershellOptions"))
+                .IsNull();
+            await Assert.That(assembly.GetType("ModularPipelines.Options.PowershellScriptOptions"))
+                .IsNull();
+            await Assert.That(assembly.GetType("ModularPipelines.Options.PowershellFileOptions"))
+                .IsNull();
+            await Assert.That(assembly.GetType("ModularPipelines.Context.Powershell"))
+                .IsNull();
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -77,7 +77,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var commandResult = await result.T.ExecuteCommandLineToolAsync(
-            new PowershellScriptOptions($"Write-Output '{rawOutput}'"),
+            new PowerShellScriptOptions($"Write-Output '{rawOutput}'"),
             new CommandExecutionOptions
             {
                 LogSettings = new CommandLoggingOptions
@@ -105,7 +105,7 @@ public class CommandLoggerTests : TestBase
         var command = await GetService<ICommandContext>();
 
         var result = await command.ExecuteCommandLineToolAsync(
-            new PowershellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
+            new PowerShellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
             new CommandExecutionOptions
             {
                 MaxCapturedOutputLength = 10,
@@ -132,7 +132,7 @@ public class CommandLoggerTests : TestBase
         [Matrix(true, false)] bool logExitCode,
         [Matrix(true, false)] bool logDuration)
     {
-        var file = await RunPowershellCommand("""
+        var file = await RunPowerShellCommand("""
                                         echo Hello world!
                                         throw "Error!"
                                         """, logInput, logOutput, logError, logExitCode, logDuration);
@@ -186,7 +186,7 @@ public class CommandLoggerTests : TestBase
         }
     }
 
-    private async Task<string> RunPowershellCommand(string command, bool logInput, bool logOutput, bool logError,
+    private async Task<string> RunPowerShellCommand(string command, bool logInput, bool logOutput, bool logError,
         bool logExitCode, bool logDuration)
     {
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
@@ -213,7 +213,7 @@ public class CommandLoggerTests : TestBase
         };
 
         await result.T.ExecuteCommandLineToolAsync(
-            new PowershellScriptOptions(command),
+            new PowerShellScriptOptions(command),
             new CommandExecutionOptions
             {
                 LogSettings = loggingOptions,
@@ -228,7 +228,7 @@ public class CommandLoggerTests : TestBase
     [Test]
     public async Task Silent_Verbosity_Logs_Nothing()
     {
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             "echo Hello",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Silent });
 
@@ -245,7 +245,7 @@ public class CommandLoggerTests : TestBase
     [Test]
     public async Task Minimal_Verbosity_Logs_Only_Input()
     {
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             "echo Hello",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Minimal });
 
@@ -262,7 +262,7 @@ public class CommandLoggerTests : TestBase
     [Test]
     public async Task Normal_Verbosity_Logs_Input_And_Output()
     {
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             "echo Hello",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Normal });
 
@@ -279,7 +279,7 @@ public class CommandLoggerTests : TestBase
     [Test]
     public async Task Detailed_Verbosity_Logs_Input_Output_ExitCode_Duration()
     {
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             "echo Hello",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
 
@@ -296,7 +296,7 @@ public class CommandLoggerTests : TestBase
     [Test]
     public async Task Diagnostic_Verbosity_Logs_Everything_Including_WorkingDirectory()
     {
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             "echo Hello",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Diagnostic });
 
@@ -316,7 +316,7 @@ public class CommandLoggerTests : TestBase
     public async Task Command_Logs_Complete_Output_When_Result_Is_Truncated()
     {
         const string output = "complete-output";
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             $"Write-Output '{output}'",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Normal },
             maxCapturedOutputLength: 4);
@@ -330,7 +330,7 @@ public class CommandLoggerTests : TestBase
     public async Task Failed_Fast_Command_Logs_Short_Standard_Output()
     {
         const string output = "failure-output";
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             $"Write-Output '{output}'; exit 1",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
 
@@ -339,7 +339,7 @@ public class CommandLoggerTests : TestBase
         await Assert.That(logFile).Contains("exit 1");
     }
 
-    private async Task<string> RunPowershellCommandWithLoggingOptions(
+    private async Task<string> RunPowerShellCommandWithLoggingOptions(
         string command,
         CommandLoggingOptions loggingOptions,
         int? maxCapturedOutputLength = null)
@@ -353,7 +353,7 @@ public class CommandLoggerTests : TestBase
         });
 
         await result.T.ExecuteCommandLineToolAsync(
-            new PowershellScriptOptions(command),
+            new PowerShellScriptOptions(command),
             new CommandExecutionOptions
             {
                 LogSettings = loggingOptions,
@@ -371,7 +371,7 @@ public class CommandLoggerTests : TestBase
     public async Task Command_Header_Precedes_Streamed_Output_And_Completion()
     {
         var marker = $"ordered-output-{Guid.NewGuid():N}";
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             $"Write-Output '{marker}'; Start-Sleep -Milliseconds 750",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
 
@@ -409,7 +409,7 @@ public class CommandLoggerTests : TestBase
     public async Task Failed_Command_Logs_Error_Before_Completion()
     {
         var marker = $"ordered-error-{Guid.NewGuid():N}";
-        var file = await RunPowershellCommandWithLoggingOptions(
+        var file = await RunPowerShellCommandWithLoggingOptions(
             $"[Console]::Error.WriteLine('{marker}'); Start-Sleep -Milliseconds 750; exit 7",
             new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
 
@@ -445,7 +445,7 @@ public class CommandLoggerTests : TestBase
                       while (-not (Test-Path '{{releaseFile}}')) { Start-Sleep -Milliseconds 10 }
                       """;
 
-        var commandTask = result.T.ExecuteCommandLineToolAsync(new PowershellScriptOptions(script));
+        var commandTask = result.T.ExecuteCommandLineToolAsync(new PowerShellScriptOptions(script));
 
         try
         {
@@ -474,7 +474,7 @@ public class CommandLoggerTests : TestBase
 
         var exception = await Assert.ThrowsAsync<AggregateException>(() =>
             commandContext.ExecuteCommandLineToolAsync(
-                new PowershellScriptOptions(
+                new PowerShellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
                     + $"Write-Output '{marker}'")));
@@ -503,7 +503,7 @@ public class CommandLoggerTests : TestBase
 
         var exception = await Assert.ThrowsAsync<AggregateException>(() =>
             commandContext.ExecuteCommandLineToolAsync(
-                new PowershellScriptOptions(
+                new PowerShellScriptOptions(
                     $"[System.IO.File]::WriteAllText('{sideEffectFile}', 'executed')"),
                 new CommandExecutionOptions
                 {
@@ -537,7 +537,7 @@ public class CommandLoggerTests : TestBase
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
             result.T.ExecuteCommandLineToolAsync(
-                new PowershellScriptOptions("Write-Output 'not-executed'"),
+                new PowerShellScriptOptions("Write-Output 'not-executed'"),
                 new CommandExecutionOptions
                 {
                     ExecutionTimeout = TimeSpan.FromMilliseconds(-2),
@@ -557,7 +557,7 @@ public class CommandLoggerTests : TestBase
             TestContext.WorkingDirectory,
             $"command-cancellation-{Guid.NewGuid():N}.ready");
         var commandTask = commandContext.ExecuteCommandLineToolAsync(
-            new PowershellScriptOptions(
+            new PowerShellScriptOptions(
                 "[IO.File]::WriteAllText($env:MP_COMMAND_CANCELLATION_READY_FILE, 'ready'); "
                 + "Start-Sleep -Seconds 30"),
             new CommandExecutionOptions
@@ -612,7 +612,7 @@ public class CommandLoggerTests : TestBase
 
         var exception = await Assert.ThrowsAsync<CommandException>(() =>
             commandContext.ExecuteCommandLineToolAsync(
-                new PowershellScriptOptions(
+                new PowerShellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
                     + "exit 7")));
@@ -647,7 +647,7 @@ public class CommandLoggerTests : TestBase
 
         var commandTask =
             commandContext.ExecuteCommandLineToolAsync(
-                new PowershellScriptOptions(
+                new PowerShellScriptOptions(
                     $"Write-Output '{marker}'; Start-Sleep -Seconds 30"),
                 new CommandExecutionOptions
                 {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -132,7 +132,7 @@ public class CommandTests : TestBase
     {
         var command = await GetService<ICommandContext>();
         var result = await command.ExecuteCommandLineToolAsync(
-            new PowershellScriptOptions("Write-Output '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
+            new PowerShellScriptOptions("Write-Output '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
             new CommandExecutionOptions { MaxCapturedOutputLength = 10 });
 
         using (Assert.Multiple())

--- a/test/ModularPipelines.UnitTests/Helpers/PowerShellTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/PowerShellTests.cs
@@ -9,9 +9,9 @@ using Moq;
 
 namespace ModularPipelines.UnitTests.Helpers;
 
-public class PowershellTests : TestBase
+public class PowerShellTests : TestBase
 {
-    private class PowershellEchoModule : Module<CommandResult>
+    private class PowerShellEchoModule : Module<CommandResult>
     {
         protected internal override async Task<CommandResult> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
@@ -22,7 +22,7 @@ public class PowershellTests : TestBase
     [Test]
     public async Task Has_Not_Errored()
     {
-        var moduleResult = await await RunModule<PowershellEchoModule>();
+        var moduleResult = await await RunModule<PowerShellEchoModule>();
 
         await ModuleResultAssertions.AssertSuccessWithValue(moduleResult);
     }
@@ -30,7 +30,7 @@ public class PowershellTests : TestBase
     [Test]
     public async Task Standard_Output_Equals_Foo_Bar()
     {
-        var moduleResult = await await RunModule<PowershellEchoModule>();
+        var moduleResult = await await RunModule<PowerShellEchoModule>();
 
         await ModuleResultAssertions.AssertCommandOutput(moduleResult, TestConstants.TestString);
     }
@@ -38,14 +38,14 @@ public class PowershellTests : TestBase
     [Test]
     public async Task RunAsync_Forwards_Options_Record_And_Execution_Options()
     {
-        var options = new PowershellScriptOptions("Write-Host test");
+        var options = new PowerShellScriptOptions("Write-Host test");
         var executionOptions = new CommandExecutionOptions { WorkingDirectory = "work" };
         var cancellationToken = new CancellationTokenSource().Token;
         var command = new Mock<ICommandContext>();
         command.Setup(context => context.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken))
             .ReturnsAsync(CommandResult.Ok());
 
-        await new Powershell(command.Object).RunAsync(options, executionOptions, cancellationToken);
+        await new PowerShell(command.Object).RunAsync(options, executionOptions, cancellationToken);
 
         command.VerifyAll();
     }
@@ -56,12 +56,12 @@ public class PowershellTests : TestBase
         var executionOptions = new CommandExecutionOptions { ThrowOnNonZeroExitCode = false };
         var command = new Mock<ICommandContext>();
         command.Setup(context => context.ExecuteCommandLineToolAsync(
-                It.Is<PowershellFileOptions>(options => options.FilePath == "script.ps1"),
+                It.Is<PowerShellFileOptions>(options => options.FilePath == "script.ps1"),
                 executionOptions,
                 CancellationToken.None))
             .ReturnsAsync(CommandResult.Ok());
 
-        await new Powershell(command.Object).RunFileAsync("script.ps1", executionOptions);
+        await new PowerShell(command.Object).RunFileAsync("script.ps1", executionOptions);
 
         command.VerifyAll();
     }


### PR DESCRIPTION
## Summary
- rename core `Powershell*` option records and implementation to canonical `PowerShell*` casing
- update DI, shell contracts, active docs, tests, and PublicAPI baselines
- add missing PowerShell/Bash option docs and align coverage exclusions
- document the predefined-installer interaction after its removal in #4276

## Validation
- core Release build: 0 warnings, 0 errors
- `PowerShellApiSurfaceTests`: 1/1 passed
- `PowerShellTests`: 4/4 passed
- scoped whitespace verification passed

Closes #4233