### PR TITLE
[Automated] Update syft CLI Options

### DIFF
--- a/src/ModularPipelines.Syft/Generated/Syft.CommandCoverage.json
+++ b/src/ModularPipelines.Syft/Generated/Syft.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "syft",
-  "toolVersion": "syft 1.51.0",
+  "toolVersion": "syft 1.51.1",
   "commandCount": 8,
   "commandTreeSha256": "312b56070505f8e9227e5762adaba7ae25213d326283923b5592ce0281c0c868",
   "commands": [

--- a/src/ModularPipelines.Syft/Options/SyftAttestOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftAttestOptions.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Syft.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("attest")]
 public record SyftAttestOptions(
-    [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Image
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Image
 ) : SyftOptions
 {
     /// <summary>
@@ -136,10 +136,7 @@ public record SyftAttestOptions(
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    /// <summary>
-    /// The FORMAT operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    [Obsolete("Format is no longer supported by the installed CLI and has no effect.")]
     public string? Format { get; set; }
 
 }

--- a/src/ModularPipelines.Syft/Options/SyftConvertOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftConvertOptions.Generated.cs
@@ -74,10 +74,7 @@ public record SyftConvertOptions : SyftOptions
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? SourceSbom { get; set; }
 
-    /// <summary>
-    /// The FORMAT operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    [Obsolete("Format is no longer supported by the installed CLI and has no effect.")]
     public string? Format { get; set; }
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **syft** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- syft (syft 1.51.1): 8 commands, tree 312b56070505f8e9227e5762adaba7ae25213d326283923b5592ce0281c0c868

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator