### PR TITLE
[Automated] Update pip CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/pip.md
+++ b/docs/docs/mp-packages/cli/pip.md
@@ -7,7 +7,13 @@ title: pip CLI reference
 
 `ModularPipelines.Python` provides strongly typed access to the `pip` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `pip` executable. Install it separately and ensure `pip` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Python

--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class PipExtensions
     }
 
     /// <summary>
-    /// Gets the pip service from the pipeline context.
+    /// Gets the pip service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPip"/> service for executing pip commands.</returns>

--- a/src/ModularPipelines.Python/Generated/Pip.CommandCoverage.json
+++ b/src/ModularPipelines.Python/Generated/Pip.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pip",
+  "toolVersion": "pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)",
   "commandCount": 14,
   "commandTreeSha256": "a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac",
   "commands": [

--- a/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipDownloadOptions : PipOptions
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public string? Constraint { get; set; }
+    public IEnumerable<string>? ConstraintValues { get; set; }
 
     /// <summary>
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Don't install package dependencies.
@@ -102,13 +102,13 @@ public record PipDownloadOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public string? Platform { get; set; }
+    public IEnumerable<string>? PlatformValues { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public string? Abi { get; set; }
+    public IEnumerable<string>? AbiValues { get; set; }
 
     /// <summary>
     /// Don't clean up build directories.
@@ -271,5 +271,39 @@ public record PipDownloadOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The requirement specifier operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? RequirementSpecifier { get; set; }
+
+    [Obsolete("Use ConstraintValues instead.")]
+    public string? Constraint
+    {
+        get => ConstraintValues?.FirstOrDefault();
+        set => ConstraintValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use PlatformValues instead.")]
+    public string? Platform
+    {
+        get => PlatformValues?.FirstOrDefault();
+        set => PlatformValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use AbiValues instead.")]
+    public string? Abi
+    {
+        get => AbiValues?.FirstOrDefault();
+        set => AbiValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipFreezeOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipFreezeOptions.Generated.cs
@@ -24,7 +24,7 @@ public record PipFreezeOptions : PipOptions
     /// Use the order in the given requirements file and its comments when generating output. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// If in a virtualenv that has global access, do not output globally-installed packages.
@@ -42,7 +42,7 @@ public record PipFreezeOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public string? Path { get; set; }
+    public IEnumerable<string>? PathValues { get; set; }
 
     /// <summary>
     /// Do not skip these packages in the output: pip
@@ -193,5 +193,19 @@ public record PipFreezeOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use PathValues instead.")]
+    public string? Path
+    {
+        get => PathValues?.FirstOrDefault();
+        set => PathValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipHashOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipHashOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("hash")]
-public record PipHashOptions : PipOptions
+public record PipHashOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> File
+) : PipOptions
 {
+    public PipHashOptions()
+        : this(default(IEnumerable<string>)!)
+    {
+    }
+
     /// <summary>
     /// Show help.
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipIndexOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public string? Platform { get; set; }
+    public IEnumerable<string>? PlatformValues { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public string? Abi { get; set; }
+    public IEnumerable<string>? AbiValues { get; set; }
 
     /// <summary>
     /// Ignore the Requires-Python information.
@@ -199,5 +199,19 @@ public record PipIndexOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use PlatformValues instead.")]
+    public string? Platform
+    {
+        get => PlatformValues?.FirstOrDefault();
+        set => PlatformValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use AbiValues instead.")]
+    public string? Abi
+    {
+        get => AbiValues?.FirstOrDefault();
+        set => AbiValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInspectOptions.Generated.cs
@@ -36,7 +36,7 @@ public record PipInspectOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public string? Path { get; set; }
+    public IEnumerable<string>? PathValues { get; set; }
 
     /// <summary>
     /// Show help.
@@ -169,5 +169,12 @@ public record PipInspectOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use PathValues instead.")]
+    public string? Path
+    {
+        get => PathValues?.FirstOrDefault();
+        set => PathValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipInstallOptions : PipOptions
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public string? Constraint { get; set; }
+    public IEnumerable<string>? ConstraintValues { get; set; }
 
     /// <summary>
     /// Don't install package dependencies.
@@ -66,13 +66,13 @@ public record PipInstallOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public string? Platform { get; set; }
+    public IEnumerable<string>? PlatformValues { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public string? Abi { get; set; }
+    public IEnumerable<string>? AbiValues { get; set; }
 
     /// <summary>
     /// Install to the Python user install directory for your platform. Typically ~/.local/, or %APPDATA%\Python on Windows. (See the Python documentation for site.USER_BASE for full details.)
@@ -355,5 +355,39 @@ public record PipInstallOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The requirement specifier operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? RequirementSpecifier { get; set; }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use ConstraintValues instead.")]
+    public string? Constraint
+    {
+        get => ConstraintValues?.FirstOrDefault();
+        set => ConstraintValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use PlatformValues instead.")]
+    public string? Platform
+    {
+        get => PlatformValues?.FirstOrDefault();
+        set => PlatformValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use AbiValues instead.")]
+    public string? Abi
+    {
+        get => AbiValues?.FirstOrDefault();
+        set => AbiValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
@@ -54,7 +54,7 @@ public record PipListOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public string? Path { get; set; }
+    public IEnumerable<string>? PathValues { get; set; }
 
     /// <summary>
     /// Include pre-release and development versions. By default, pip only finds stable versions.
@@ -247,5 +247,12 @@ public record PipListOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use PathValues instead.")]
+    public string? Path
+    {
+        get => PathValues?.FirstOrDefault();
+        set => PathValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipSearchOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("search")]
-public record PipSearchOptions : PipOptions
+public record PipSearchOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Query
+) : PipOptions
 {
+    public PipSearchOptions()
+        : this(default(string)!)
+    {
+    }
+
     /// <summary>
     /// Base URL of Python Package Index (default https://pypi.org/pypi)
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipShowOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipShowOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("show")]
-public record PipShowOptions : PipOptions
+public record PipShowOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Package
+) : PipOptions
 {
+    public PipShowOptions()
+        : this(default(IEnumerable<string>)!)
+    {
+    }
+
     /// <summary>
     /// Show the full list of installed files for each package.
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
@@ -24,7 +24,7 @@ public record PipUninstallOptions : PipOptions
     /// Uninstall all the packages listed in the given requirements file.  This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Don't ask for confirmation of uninstall deletions.
@@ -169,5 +169,18 @@ public record PipUninstallOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The package operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Package { get; set; }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
@@ -54,7 +54,7 @@ public record PipWheelOptions : PipOptions
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public string? Constraint { get; set; }
+    public IEnumerable<string>? ConstraintValues { get; set; }
 
     /// <summary>
     /// Install a project in editable mode (i.e. setuptools "develop mode") from a local project path or a VCS url.
@@ -66,7 +66,7 @@ public record PipWheelOptions : PipOptions
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Directory to check out editable projects into. The default in a virtualenv is "&lt;venv path&gt;/src". The default for global installs is "&lt;current dir&gt;/src".
@@ -277,5 +277,25 @@ public record PipWheelOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The requirement specifier operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? RequirementSpecifier { get; set; }
+
+    [Obsolete("Use ConstraintValues instead.")]
+    public string? Constraint
+    {
+        get => ConstraintValues?.FirstOrDefault();
+        set => ConstraintValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Python/PublicAPI.Unshipped.txt
@@ -14,6 +14,60 @@
 *REMOVED*ModularPipelines.Python.Services.IPip.UninstallAsync(ModularPipelines.Python.Options.PipUninstallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Python.Services.IPip.WheelAsync(ModularPipelines.Python.Options.PipWheelOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Python.Extensions.PipExtensions.Pip(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Python.Services.IPip!
+ModularPipelines.Python.Options.PipDownloadOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.AbiValues.set -> void
+ModularPipelines.Python.Options.PipDownloadOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.ConstraintValues.set -> void
+ModularPipelines.Python.Options.PipDownloadOptions.PlatformValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.PlatformValues.set -> void
+ModularPipelines.Python.Options.PipDownloadOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.RequirementSpecifier.set -> void
+ModularPipelines.Python.Options.PipDownloadOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.RequirementValues.set -> void
+ModularPipelines.Python.Options.PipFreezeOptions.PathValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipFreezeOptions.PathValues.set -> void
+ModularPipelines.Python.Options.PipFreezeOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipFreezeOptions.RequirementValues.set -> void
+ModularPipelines.Python.Options.PipHashOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! File) -> void
+ModularPipelines.Python.Options.PipHashOptions.File.get -> System.Collections.Generic.IEnumerable<string!>!
+ModularPipelines.Python.Options.PipHashOptions.File.init -> void
+ModularPipelines.Python.Options.PipHashOptions.PipHashOptions(System.Collections.Generic.IEnumerable<string!>! File) -> void
+ModularPipelines.Python.Options.PipIndexOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipIndexOptions.AbiValues.set -> void
+ModularPipelines.Python.Options.PipIndexOptions.PlatformValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipIndexOptions.PlatformValues.set -> void
+ModularPipelines.Python.Options.PipInspectOptions.PathValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInspectOptions.PathValues.set -> void
+ModularPipelines.Python.Options.PipInstallOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.AbiValues.set -> void
+ModularPipelines.Python.Options.PipInstallOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.ConstraintValues.set -> void
+ModularPipelines.Python.Options.PipInstallOptions.PlatformValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.PlatformValues.set -> void
+ModularPipelines.Python.Options.PipInstallOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.RequirementSpecifier.set -> void
+ModularPipelines.Python.Options.PipInstallOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.RequirementValues.set -> void
+ModularPipelines.Python.Options.PipListOptions.PathValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipListOptions.PathValues.set -> void
+ModularPipelines.Python.Options.PipSearchOptions.Deconstruct(out string! Query) -> void
+ModularPipelines.Python.Options.PipSearchOptions.PipSearchOptions(string! Query) -> void
+ModularPipelines.Python.Options.PipSearchOptions.Query.get -> string!
+ModularPipelines.Python.Options.PipSearchOptions.Query.init -> void
+ModularPipelines.Python.Options.PipShowOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! Package) -> void
+ModularPipelines.Python.Options.PipShowOptions.Package.get -> System.Collections.Generic.IEnumerable<string!>!
+ModularPipelines.Python.Options.PipShowOptions.Package.init -> void
+ModularPipelines.Python.Options.PipShowOptions.PipShowOptions(System.Collections.Generic.IEnumerable<string!>! Package) -> void
+ModularPipelines.Python.Options.PipUninstallOptions.Package.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipUninstallOptions.Package.set -> void
+ModularPipelines.Python.Options.PipUninstallOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipUninstallOptions.RequirementValues.set -> void
+ModularPipelines.Python.Options.PipWheelOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipWheelOptions.ConstraintValues.set -> void
+ModularPipelines.Python.Options.PipWheelOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipWheelOptions.RequirementSpecifier.set -> void
+ModularPipelines.Python.Options.PipWheelOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipWheelOptions.RequirementValues.set -> void
 ModularPipelines.Python.Services.IPip.CacheAsync(ModularPipelines.Python.Options.PipCacheOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.CheckAsync(ModularPipelines.Python.Options.PipCheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.ConfigAsync(ModularPipelines.Python.Options.PipConfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!

--- a/src/ModularPipelines.Python/Services/IPip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/IPip.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CacheAsync(PipCacheOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> CacheAsync(PipCacheOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Verify installed packages have compatible dependencies.
@@ -36,7 +37,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CheckAsync(PipCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> CheckAsync(PipCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Manage local and global configuration.
@@ -45,7 +47,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigAsync(PipConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> ConfigAsync(PipConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Download packages from:
@@ -54,7 +57,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DownloadAsync(PipDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> DownloadAsync(PipDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Output installed packages in requirements format.
@@ -63,7 +67,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FreezeAsync(PipFreezeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> FreezeAsync(PipFreezeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Compute a hash of a local package archive.
@@ -72,7 +77,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> HashAsync(PipHashOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> HashAsync(PipHashOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Inspect information available from package indexes.
@@ -81,7 +87,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> IndexAsync(PipIndexOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> IndexAsync(PipIndexOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Inspect the content of a Python environment and produce a report in JSON format.
@@ -90,7 +97,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InspectAsync(PipInspectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> InspectAsync(PipInspectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Install packages from:
@@ -99,7 +107,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InstallAsync(PipInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> InstallAsync(PipInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// List installed packages, including editables.
@@ -108,7 +117,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListAsync(PipListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> ListAsync(PipListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Search for PyPI packages whose name or summary contains &lt;query&gt;.
@@ -117,7 +127,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SearchAsync(PipSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> SearchAsync(PipSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Show information about one or more installed packages.
@@ -126,7 +137,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ShowAsync(PipShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> ShowAsync(PipShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Uninstall packages.
@@ -135,7 +147,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UninstallAsync(PipUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> UninstallAsync(PipUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Build Wheel archives for your requirements and dependencies.
@@ -144,7 +157,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> WheelAsync(PipWheelOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> WheelAsync(PipWheelOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pip** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pip (pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)): 14 commands, tree a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the `pip` executable is not included and must be installed separately.
  - Added guidance to make `pip` available on the system `PATH`.
  - Organized installation instructions into executable prerequisites and package installation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->