### PR TITLE
[Automated] Update flux CLI Options

### DIFF
--- a/src/ModularPipelines.Flux/Options/FluxBootstrapOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapOptions.Generated.cs
@@ -369,10 +369,7 @@ public record FluxBootstrapOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBuildOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxBuildOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxCreateImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateImageOptions.Generated.cs
@@ -183,10 +183,7 @@ public record FluxCreateImageOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateOptions.Generated.cs
@@ -183,10 +183,7 @@ public record FluxCreateOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretOptions.Generated.cs
@@ -183,10 +183,7 @@ public record FluxCreateSecretOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceOptions.Generated.cs
@@ -189,10 +189,7 @@ public record FluxCreateSourceOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxDebugOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDebugOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxDebugOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteImageOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxDeleteImageOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxDeleteOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxDeleteSourceOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxDiffOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDiffOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxDiffOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxExportArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportArtifactOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxExportArtifactOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxExportImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportImageOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxExportImageOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxExportOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxExportOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceOptions.Generated.cs
@@ -177,10 +177,7 @@ public record FluxExportSourceOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxGetArtifactsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetArtifactsOptions.Generated.cs
@@ -195,10 +195,7 @@ public record FluxGetArtifactsOptions : FluxOptions
     [CliFlag("--watch", ShortForm = "-w")]
     public bool? Watch { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxGetImagesOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetImagesOptions.Generated.cs
@@ -195,10 +195,7 @@ public record FluxGetImagesOptions : FluxOptions
     [CliFlag("--watch", ShortForm = "-w")]
     public bool? Watch { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxGetOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetOptions.Generated.cs
@@ -195,10 +195,7 @@ public record FluxGetOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesOptions.Generated.cs
@@ -195,10 +195,7 @@ public record FluxGetSourcesOptions : FluxOptions
     [CliFlag("--watch", ShortForm = "-w")]
     public bool? Watch { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxListOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxListOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxListOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxPluginOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxPluginOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxPullOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPullOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxPullOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxPushOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPushOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxPushOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileImageOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxReconcileImageOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxReconcileOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxReconcileSourceOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxResumeImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeImageOptions.Generated.cs
@@ -177,10 +177,7 @@ public record FluxResumeImageOptions : FluxOptions
     [CliFlag("--wait")]
     public bool? Wait { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxResumeOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeOptions.Generated.cs
@@ -177,10 +177,7 @@ public record FluxResumeOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceOptions.Generated.cs
@@ -177,10 +177,7 @@ public record FluxResumeSourceOptions : FluxOptions
     [CliFlag("--wait")]
     public bool? Wait { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendImageOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxSuspendImageOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxSuspendOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceOptions.Generated.cs
@@ -171,10 +171,7 @@ public record FluxSuspendSourceOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxTagOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTagOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxTagOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxTreeArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTreeArtifactOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxTreeArtifactOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxTreeOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTreeOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxTreeOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Flux/Options/FluxTriggerOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTriggerOptions.Generated.cs
@@ -165,10 +165,7 @@ public record FluxTriggerOptions : FluxOptions
     [CliFlag("--verbose")]
     public bool? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **flux** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- flux (flux version 2.9.4): 173 commands, tree cce64ef09e13559016b9deee8b350b34916ce2e46c6e248c25ab24ae62a04c00

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator