### PR TITLE
[Automated] Update argocd CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/argocd.md
+++ b/docs/docs/mp-packages/cli/argocd.md
@@ -144,7 +144,6 @@ var argoCd = context.Tools.ArgoCd;
 | `argocd proj add-destination` | `ArgoCdProjAddDestinationOptions` |
 | `argocd proj add-destination-service-account` | `ArgoCdProjAddDestinationServiceAccountOptions` |
 | `argocd proj add-orphaned-ignore` | `ArgoCdProjAddOrphanedIgnoreOptions` |
-| `argocd proj add-signature-key` | `ArgoCdProjAddSignatureKeyOptions` |
 | `argocd proj add-source` | `ArgoCdProjAddSourceOptions` |
 | `argocd proj add-source-namespace` | `ArgoCdProjAddSourceNamespaceOptions` |
 | `argocd proj allow-cluster-resource` | `ArgoCdProjAllowClusterResourceOptions` |
@@ -159,7 +158,6 @@ var argoCd = context.Tools.ArgoCd;
 | `argocd proj remove-destination` | `ArgoCdProjRemoveDestinationOptions` |
 | `argocd proj remove-destination-service-account` | `ArgoCdProjRemoveDestinationServiceAccountOptions` |
 | `argocd proj remove-orphaned-ignore` | `ArgoCdProjRemoveOrphanedIgnoreOptions` |
-| `argocd proj remove-signature-key` | `ArgoCdProjRemoveSignatureKeyOptions` |
 | `argocd proj remove-source` | `ArgoCdProjRemoveSourceOptions` |
 | `argocd proj remove-source-namespace` | `ArgoCdProjRemoveSourceNamespaceOptions` |
 | `argocd proj role` | `ArgoCdProjRoleOptions` |

--- a/src/ModularPipelines.ArgoCd/Generated/ArgoCd.CommandCoverage.json
+++ b/src/ModularPipelines.ArgoCd/Generated/ArgoCd.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "argocd",
-  "toolVersion": "argocd: v3.5.1\u002B109ca7c   BuildDate: 2026-08-12T11:51:48Z   GitCommit: 109ca7ca71139e514114499d294a492e7910a965   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64",
+  "toolVersion": "argocd: v3.5.2\u002Be258ee2   BuildDate: 2026-08-27T09:34:36Z   GitCommit: e258ee23c3e52266d407572f4bcdfe7d9ed36cb5   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64",
   "commandCount": 165,
   "commandTreeSha256": "f12af4288e7a39a4ac683d429edf0cf75b10df027963bc60b408a2f2ea0df4b2",
   "commands": [

--- a/src/ModularPipelines.ArgoCd/Options/ArgoCdProjAddSignatureKeyOptions.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Options/ArgoCdProjAddSignatureKeyOptions.Generated.cs
@@ -15,6 +15,7 @@ namespace ModularPipelines.ArgoCd.Options;
 
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
+[Obsolete("This command is no longer supported by the installed CLI and is retained only for compatibility.")]
 [CliSubCommand("proj", "add-signature-key")]
 public record ArgoCdProjAddSignatureKeyOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Project,

--- a/src/ModularPipelines.ArgoCd/Options/ArgoCdProjRemoveSignatureKeyOptions.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Options/ArgoCdProjRemoveSignatureKeyOptions.Generated.cs
@@ -15,6 +15,7 @@ namespace ModularPipelines.ArgoCd.Options;
 
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
+[Obsolete("This command is no longer supported by the installed CLI and is retained only for compatibility.")]
 [CliSubCommand("proj", "remove-signature-key")]
 public record ArgoCdProjRemoveSignatureKeyOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Project,

--- a/src/ModularPipelines.ArgoCd/Services/ArgoCdProj.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Services/ArgoCdProj.Generated.cs
@@ -114,6 +114,7 @@ public class ArgoCdProj : IArgoCdProj
     }
 
     /// <inheritdoc />
+    [Obsolete("This command is no longer supported by the installed CLI and is retained only for compatibility.")]
     public virtual async Task<CommandResult> AddSignatureKeyAsync(
         ArgoCdProjAddSignatureKeyOptions options,
         CommandExecutionOptions? executionOptions = null,
@@ -333,6 +334,7 @@ public class ArgoCdProj : IArgoCdProj
     }
 
     /// <inheritdoc />
+    [Obsolete("This command is no longer supported by the installed CLI and is retained only for compatibility.")]
     public virtual async Task<CommandResult> RemoveSignatureKeyAsync(
         ArgoCdProjRemoveSignatureKeyOptions options,
         CommandExecutionOptions? executionOptions = null,

--- a/src/ModularPipelines.ArgoCd/Services/IArgoCdProj.Generated.cs
+++ b/src/ModularPipelines.ArgoCd/Services/IArgoCdProj.Generated.cs
@@ -76,6 +76,7 @@ public interface IArgoCdProj
     public Task<CommandResult> AddOrphanedIgnoreAsync(ArgoCdProjAddOrphanedIgnoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
+    [Obsolete("This command is no longer supported by the installed CLI and is retained only for compatibility.")]
     public Task<CommandResult> AddSignatureKeyAsync(ArgoCdProjAddSignatureKeyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
@@ -219,6 +220,7 @@ public interface IArgoCdProj
     public Task<CommandResult> RemoveOrphanedIgnoreAsync(ArgoCdProjRemoveOrphanedIgnoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
+    [Obsolete("This command is no longer supported by the installed CLI and is retained only for compatibility.")]
     public Task<CommandResult> RemoveSignatureKeyAsync(ArgoCdProjRemoveSignatureKeyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **argocd** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- argocd (argocd: v3.5.2+e258ee2   BuildDate: 2026-08-27T09:34:36Z   GitCommit: e258ee23c3e52266d407572f4bcdfe7d9ed36cb5   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64): 165 commands, tree f12af4288e7a39a4ac683d429edf0cf75b10df027963bc60b408a2f2ea0df4b2

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator