### PR TITLE
[Automated] Update grype CLI Options

### DIFF
--- a/src/ModularPipelines.Grype/Generated/Grype.CommandCoverage.json
+++ b/src/ModularPipelines.Grype/Generated/Grype.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "grype",
-  "toolVersion": "grype 0.117.0",
+  "toolVersion": "grype 0.118.0",
   "commandCount": 12,
   "commandTreeSha256": "b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c",
   "commands": [

--- a/src/ModularPipelines.Grype/Options/GrypeDbOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbOptions.Generated.cs
@@ -50,10 +50,7 @@ public record GrypeDbOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Grype/Options/GrypeDbSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbSearchOptions.Generated.cs
@@ -116,10 +116,7 @@ public record GrypeDbSearchOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Grype/Options/GrypeExplainOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeExplainOptions.Generated.cs
@@ -56,10 +56,7 @@ public record GrypeExplainOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    /// <summary>
-    /// The VULNERABILITY ID operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    [Obsolete("VulnerabilityId is no longer supported by the installed CLI and has no effect.")]
     public string? VulnerabilityId { get; set; }
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **grype** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- grype (grype 0.118.0): 12 commands, tree b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator