### PR TITLE
[Automated] Update buildah CLI Options

### DIFF
--- a/src/ModularPipelines.Buildah/Options/BuildahManifestOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahManifestOptions.Generated.cs
@@ -26,10 +26,7 @@ public record BuildahManifestOptions : BuildahOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.Buildah/Options/BuildahSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahSourceOptions.Generated.cs
@@ -26,10 +26,7 @@ public record BuildahSourceOptions : BuildahOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
     public string? Command { get; set; }
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **buildah** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- buildah (buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)): 37 commands, tree 40421c40371cc91f2731cecc414602c829d251cb603067ac9cbef046a69eeb90

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator