### PR TITLE
[Automated] Update winget CLI Options

### DIFF
--- a/src/ModularPipelines.WinGet/Options/WingetDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetDownloadOptions.Generated.cs
@@ -113,8 +113,8 @@ public record WingetDownloadOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -175,5 +175,12 @@ public record WingetDownloadOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetInstallOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetInstallOptions.Generated.cs
@@ -179,8 +179,8 @@ public record WingetInstallOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -241,5 +241,12 @@ public record WingetInstallOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetListOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetListOptions.Generated.cs
@@ -77,8 +77,8 @@ public record WingetListOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -139,5 +139,12 @@ public record WingetListOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetRepairOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetRepairOptions.Generated.cs
@@ -125,8 +125,8 @@ public record WingetRepairOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -181,5 +181,12 @@ public record WingetRepairOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetSearchOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetSearchOptions.Generated.cs
@@ -71,8 +71,8 @@ public record WingetSearchOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -121,5 +121,12 @@ public record WingetSearchOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetShowOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetShowOptions.Generated.cs
@@ -101,8 +101,8 @@ public record WingetShowOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -145,5 +145,12 @@ public record WingetShowOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetUninstallOptions.Generated.cs
@@ -119,8 +119,8 @@ public record WingetUninstallOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -163,5 +163,12 @@ public record WingetUninstallOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/Options/WingetUpgradeOptions.Generated.cs
+++ b/src/ModularPipelines.WinGet/Options/WingetUpgradeOptions.Generated.cs
@@ -173,8 +173,8 @@ public record WingetUpgradeOptions : WingetOptions
     /// <summary>
     /// Specify authentication window preference (silent, silentPreferred, or interactive)
     /// </summary>
-    [CliFlag("--authentication-mode")]
-    public bool? AuthenticationMode { get; set; }
+    [CliOption("--authentication-mode")]
+    public string? AuthenticationModeValue { get; set; }
 
     /// <summary>
     /// Specify the account to be used for authentication
@@ -223,5 +223,12 @@ public record WingetUpgradeOptions : WingetOptions
     /// </summary>
     [CliOption("--query", ShortForm = "-q")]
     public string? Query { get; set; }
+
+    [Obsolete("Use AuthenticationModeValue instead.")]
+    public bool? AuthenticationMode
+    {
+        get => bool.TryParse(AuthenticationModeValue, out var value) ? value : null;
+        set => AuthenticationModeValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+    }
 
 }

--- a/src/ModularPipelines.WinGet/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.WinGet/PublicAPI.Unshipped.txt
@@ -85,3 +85,19 @@ ModularPipelines.WinGet.Services.IWinget.UninstallAsync(ModularPipelines.WinGet.
 ModularPipelines.WinGet.Services.IWinget.UpgradeAsync(ModularPipelines.WinGet.Options.WingetUpgradeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.WinGet.Services.IWinget.ValidateAsync(ModularPipelines.WinGet.Options.WingetValidateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 static ModularPipelines.WinGet.Extensions.WingetExtensions.Winget(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.WinGet.Services.IWinget!
+ModularPipelines.WinGet.Options.WingetDownloadOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetDownloadOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetInstallOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetInstallOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetListOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetListOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetRepairOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetRepairOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetSearchOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetSearchOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetShowOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetShowOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetUninstallOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetUninstallOptions.AuthenticationModeValue.set -> void
+ModularPipelines.WinGet.Options.WingetUpgradeOptions.AuthenticationModeValue.get -> string?
+ModularPipelines.WinGet.Options.WingetUpgradeOptions.AuthenticationModeValue.set -> void

--- a/src/ModularPipelines.WinGet/Services/IWinget.Generated.cs
+++ b/src/ModularPipelines.WinGet/Services/IWinget.Generated.cs
@@ -27,7 +27,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigureExportAsync(WingetConfigureExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigureExportAsync(WingetConfigureExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -37,7 +37,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigureListAsync(WingetConfigureListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigureListAsync(WingetConfigureListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -47,7 +47,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigureAsync(WingetConfigureOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigureAsync(WingetConfigureOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -57,7 +57,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigureShowAsync(WingetConfigureShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigureShowAsync(WingetConfigureShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -67,7 +67,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigureTestAsync(WingetConfigureTestOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigureTestAsync(WingetConfigureTestOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -77,7 +77,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigureValidateAsync(WingetConfigureValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigureValidateAsync(WingetConfigureValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -87,7 +87,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DownloadAsync(WingetDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DownloadAsync(WingetDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -97,7 +97,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> Dscv3AdminSettingsAsync(WingetDscv3AdminSettingsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> Dscv3AdminSettingsAsync(WingetDscv3AdminSettingsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -107,7 +107,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> Dscv3Async(WingetDscv3Options? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> Dscv3Async(WingetDscv3Options? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -117,7 +117,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> Dscv3PackageAsync(WingetDscv3PackageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> Dscv3PackageAsync(WingetDscv3PackageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -127,7 +127,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> Dscv3SourceAsync(WingetDscv3SourceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> Dscv3SourceAsync(WingetDscv3SourceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -137,7 +137,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> Dscv3UserSettingsFileAsync(WingetDscv3UserSettingsFileOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> Dscv3UserSettingsFileAsync(WingetDscv3UserSettingsFileOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -147,7 +147,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExportAsync(WingetExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExportAsync(WingetExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -157,7 +157,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FeaturesAsync(WingetFeaturesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> FeaturesAsync(WingetFeaturesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -167,7 +167,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> HashAsync(WingetHashOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> HashAsync(WingetHashOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -177,7 +177,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ImportAsync(WingetImportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ImportAsync(WingetImportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -187,7 +187,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InstallAsync(WingetInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InstallAsync(WingetInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -197,7 +197,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListAsync(WingetListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ListAsync(WingetListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -207,7 +207,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> McpAsync(WingetMcpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> McpAsync(WingetMcpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -217,7 +217,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> PinAddAsync(WingetPinAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PinAddAsync(WingetPinAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -227,7 +227,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> PinListAsync(WingetPinListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PinListAsync(WingetPinListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -237,7 +237,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> PinAsync(WingetPinOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PinAsync(WingetPinOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -247,7 +247,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> PinRemoveAsync(WingetPinRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PinRemoveAsync(WingetPinRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -257,7 +257,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> PinResetAsync(WingetPinResetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PinResetAsync(WingetPinResetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -267,7 +267,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RepairAsync(WingetRepairOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RepairAsync(WingetRepairOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -277,7 +277,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SearchAsync(WingetSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SearchAsync(WingetSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -287,7 +287,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SettingsExportAsync(WingetSettingsExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SettingsExportAsync(WingetSettingsExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -297,7 +297,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SettingsAsync(WingetSettingsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SettingsAsync(WingetSettingsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -307,7 +307,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SettingsResetAsync(WingetSettingsResetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SettingsResetAsync(WingetSettingsResetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -317,7 +317,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SettingsSetAsync(WingetSettingsSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SettingsSetAsync(WingetSettingsSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -327,7 +327,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ShowAsync(WingetShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ShowAsync(WingetShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -337,7 +337,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceAddAsync(WingetSourceAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceAddAsync(WingetSourceAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -347,7 +347,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceEditAsync(WingetSourceEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceEditAsync(WingetSourceEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -357,7 +357,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceExportAsync(WingetSourceExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceExportAsync(WingetSourceExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -367,7 +367,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceListAsync(WingetSourceListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceListAsync(WingetSourceListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -377,7 +377,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceAsync(WingetSourceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceAsync(WingetSourceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -387,7 +387,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceRemoveAsync(WingetSourceRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceRemoveAsync(WingetSourceRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -397,7 +397,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceResetAsync(WingetSourceResetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceResetAsync(WingetSourceResetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -407,7 +407,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SourceUpdateAsync(WingetSourceUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SourceUpdateAsync(WingetSourceUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -417,7 +417,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UninstallAsync(WingetUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UninstallAsync(WingetUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -427,7 +427,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpgradeAsync(WingetUpgradeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpgradeAsync(WingetUpgradeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -437,7 +437,7 @@ public partial interface IWinget
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ValidateAsync(WingetValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ValidateAsync(WingetValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **winget** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- winget (v1.29.290): 42 commands, tree be6725b4f2522a990030007897738ac016f66f7f5ce700a730ea0a50070fb1bb

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator