### PR TITLE
Preserve CLI forwarding enum ordinals

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliCompatibilityForwardingKindTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliCompatibilityForwardingKindTests.cs
@@ -1,0 +1,27 @@
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Models;
+
+public class CliCompatibilityForwardingKindTests
+{
+    [Test]
+    public async Task Established_Member_Ordinals_Remain_Stable()
+    {
+        var ordinals = Enum.GetValues<CliCompatibilityForwardingKind>()
+            .Select(value => $"{value}:{(int) value}");
+
+        await Assert.That(ordinals).IsEquivalentTo([
+            "Direct:0",
+            "ScalarToCollection:1",
+            "NullableInt32ToString:2",
+            "NullableBooleanToString:3",
+            "NullableStringToRequiredString:4",
+            "NullableInt32ToRequiredString:5",
+            "NullableInt32ToStringCollection:6",
+            "NullableStringToCliOptionValue:7",
+            "NullableInt32ToCliOptionValue:8",
+            "NullableBooleanToStringCollection:9",
+            "NullableBooleanToLocalBackendString:10",
+        ]);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -257,19 +257,23 @@ public record CliCompatibilityProperty
 /// <summary>
 /// Supported conversions for generated compatibility-property forwarding.
 /// </summary>
+/// <remarks>
+/// Numeric values are a compatibility contract. Do not renumber existing members;
+/// assign new members an unused value and update the ordinal contract test.
+/// </remarks>
 public enum CliCompatibilityForwardingKind
 {
-    Direct,
-    ScalarToCollection,
-    NullableInt32ToString,
-    NullableBooleanToString,
-    NullableBooleanToLocalBackendString,
-    NullableStringToRequiredString,
-    NullableInt32ToRequiredString,
-    NullableInt32ToStringCollection,
-    NullableStringToCliOptionValue,
-    NullableInt32ToCliOptionValue,
-    NullableBooleanToStringCollection,
+    Direct = 0,
+    ScalarToCollection = 1,
+    NullableInt32ToString = 2,
+    NullableBooleanToString = 3,
+    NullableStringToRequiredString = 4,
+    NullableInt32ToRequiredString = 5,
+    NullableInt32ToStringCollection = 6,
+    NullableStringToCliOptionValue = 7,
+    NullableInt32ToCliOptionValue = 8,
+    NullableBooleanToStringCollection = 9,
+    NullableBooleanToLocalBackendString = 10,
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- assign explicit stable values to `CliCompatibilityForwardingKind`
- append `NullableBooleanToLocalBackendString` at ordinal 10
- add a complete enum ordinal contract regression and document the compatibility policy

## Validation
- `CliCompatibilityForwardingKindTests`: 1/1 passed
- `ModularPipelines.OptionsGenerator.slnx` Release build: 0 warnings, 0 errors
- full OptionsGenerator test project exceeded the mandated 2 GB local agent limit (exit 137); not retried with a higher limit

Closes #4342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved compatibility for command-line option forwarding values by assigning stable numeric identifiers.
  * Corrected the nullable Boolean forwarding value to avoid conflicts with existing enum values.

* **Tests**
  * Added coverage verifying that all forwarding kinds retain their expected names and numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->