### PR TITLE
Remove linked cancellation timing race

### DIFF
--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -244,13 +244,13 @@ public class ModuleTimeoutTests : TestBase
         using var unrelatedCancellation = new CancellationTokenSource();
 
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-            timeoutToken =>
+            async timeoutToken =>
             {
                 using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
                     timeoutToken,
                     unrelatedCancellation.Token);
-                timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
-                return Task.FromCanceled<bool>(linkedCancellation.Token);
+                await Task.Delay(Timeout.InfiniteTimeSpan, linkedCancellation.Token);
+                return true;
             },
             TimeSpan.FromMilliseconds(10),
             CancellationToken.None);


### PR DESCRIPTION
Closes #4344

## Summary
- replace the ignored one-second wait with cancellation-driven async coordination
- preserve coverage that a linked attempt token is recognized as timeout-owned cancellation

## Validation
- `ModuleTimeoutTests`: 21/21 passed
- target regression: 25/25 consecutive Debug runs passed
- target regression: Release run passed
- changed-file format verification reported only pre-existing informational diagnostics
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated timeout cancellation coverage to use asynchronous cancellation behavior.
  * Preserved validation that timed-out operations report the expected result and honor cancellation tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->