### PR TITLE
Stabilize output coordinator timing tests

### DIFF
--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -33,6 +33,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     private readonly IOutputCoordinator _outputCoordinator;
     private readonly IOptions<PipelineOptions> _options;
     private readonly ILogger<PipelineOutputCoordinator> _logger;
+    private readonly TimeProvider _timeProvider;
 
     public PipelineOutputCoordinator(
         IPrintProgressExecutor printProgressExecutor,
@@ -42,7 +43,8 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         IConsoleCoordinator consoleCoordinator,
         IOutputCoordinator outputCoordinator,
         IOptions<PipelineOptions> options,
-        ILogger<PipelineOutputCoordinator> logger)
+        ILogger<PipelineOutputCoordinator> logger,
+        TimeProvider timeProvider)
     {
         _printProgressExecutor = printProgressExecutor;
         _consolePrinter = consolePrinter;
@@ -52,6 +54,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         _outputCoordinator = outputCoordinator;
         _options = options;
         _logger = logger;
+        _timeProvider = timeProvider;
     }
 
     /// <inheritdoc />
@@ -76,7 +79,8 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             _consoleCoordinator,
             _outputCoordinator,
             liveFlushInterval,
-            _logger);
+            _logger,
+            _timeProvider);
     }
 
     /// <inheritdoc />
@@ -164,6 +168,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         private readonly IConsoleCoordinator _consoleCoordinator;
         private readonly IOutputCoordinator _outputCoordinator;
         private readonly ILogger _logger;
+        private readonly TimeProvider _timeProvider;
         private readonly CancellationTokenSource _liveFlushCancellation = new();
         private readonly Task _liveFlushTask;
 
@@ -172,12 +177,14 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             IConsoleCoordinator consoleCoordinator,
             IOutputCoordinator outputCoordinator,
             TimeSpan liveFlushInterval,
-            ILogger logger)
+            ILogger logger,
+            TimeProvider timeProvider)
         {
             _printProgressExecutor = printProgressExecutor;
             _consoleCoordinator = consoleCoordinator;
             _outputCoordinator = outputCoordinator;
             _logger = logger;
+            _timeProvider = timeProvider;
 
             _liveFlushTask = liveFlushInterval > TimeSpan.Zero
                 ? FlushPeriodicallyAsync(liveFlushInterval)
@@ -259,7 +266,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
 
         private async Task FlushPeriodicallyAsync(TimeSpan interval)
         {
-            using var timer = new PeriodicTimer(interval);
+            using var timer = new PeriodicTimer(interval, _timeProvider);
 
             try
             {

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -288,22 +288,28 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    [Timeout(30_000)]
     public async Task Completion_IsQueuedWhileIncrementalFlushOwnsOutput()
     {
-        var buffer = new BlockingIncrementalOutputBuffer();
-        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            var buffer = new BlockingIncrementalOutputBuffer();
+            var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
-        var incrementalFlush = coordinator.EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental);
-        await buffer.IncrementalFlushStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            var incrementalFlush = coordinator.EnqueueAndFlushAsync(
+                buffer,
+                OutputFlushKind.Incremental);
+            await buffer.IncrementalFlushStarted.Task;
 
-        buffer.MarkComplete();
-        var completionFlush = coordinator.OnModuleCompletedAsync(buffer, buffer.ModuleType);
+            buffer.MarkComplete();
+            var completionFlush = coordinator.OnModuleCompletedAsync(buffer, buffer.ModuleType);
 
-        buffer.ReleaseIncrementalFlush.TrySetResult();
-        await incrementalFlush;
-        await completionFlush;
+            buffer.ReleaseIncrementalFlush.TrySetResult();
+            await incrementalFlush;
+            await completionFlush;
 
-        await Assert.That(buffer.CompleteFlushCount).IsEqualTo(1);
+            await Assert.That(buffer.CompleteFlushCount).IsEqualTo(1);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using ModularPipelines.Console;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Executors;
@@ -104,7 +105,8 @@ public class PipelineOutputCoordinatorTests
             {
                 Console = new PipelineConsoleOptions { ModuleOutputFlushInterval = TimeSpan.Zero },
             }),
-            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+            Mock.Of<ILogger<PipelineOutputCoordinator>>(),
+            TimeProvider.System);
         var scope = await coordinator.InitializeAsync();
 
         await scope.DisposeAsync();
@@ -147,7 +149,8 @@ public class PipelineOutputCoordinatorTests
             {
                 Console = new PipelineConsoleOptions { ModuleOutputFlushInterval = TimeSpan.Zero },
             }),
-            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+            Mock.Of<ILogger<PipelineOutputCoordinator>>(),
+            TimeProvider.System);
         var scope = await coordinator.InitializeAsync();
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await scope.DisposeAsync());
@@ -189,7 +192,8 @@ public class PipelineOutputCoordinatorTests
             {
                 Console = new PipelineConsoleOptions { ModuleOutputFlushInterval = TimeSpan.Zero },
             }),
-            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+            Mock.Of<ILogger<PipelineOutputCoordinator>>(),
+            TimeProvider.System);
         var scope = await coordinator.InitializeAsync();
 
         var exception = await Assert.ThrowsAsync<AggregateException>(async () =>
@@ -206,50 +210,58 @@ public class PipelineOutputCoordinatorTests
     }
 
     [Test]
+    [Timeout(30_000)]
     public async Task RunningScope_PeriodicallyFlushesInProgressOutput()
     {
-        var flushObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var consoleCoordinator = new Mock<IConsoleCoordinator>();
-        consoleCoordinator
-            .Setup(x => x.FlushInProgressModuleOutputAsync(It.IsAny<CancellationToken>()))
-            .Callback(() => flushObserved.TrySetResult())
-            .Returns(Task.CompletedTask);
-        consoleCoordinator
-            .Setup(x => x.FlushPendingWritesAsync())
-            .ReturnsAsync([]);
-        consoleCoordinator
-            .Setup(x => x.FlushModuleOutputAsync())
-            .Returns(Task.CompletedTask);
-        var outputCoordinator = new Mock<IOutputCoordinator>();
-        outputCoordinator
-            .Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        outputCoordinator
-            .Setup(x => x.WaitForPendingFlushesAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        var coordinator = new PipelineOutputCoordinator(
-            new RecordingProgressExecutor([]),
-            Mock.Of<IConsolePrinter>(),
-            Mock.Of<IInternalSummaryLogger>(),
-            Mock.Of<IExceptionBuffer>(),
-            consoleCoordinator.Object,
-            outputCoordinator.Object,
-            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
-            {
-                Console = new PipelineConsoleOptions
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            var timeProvider = new FakeTimeProvider();
+            var flushObserved = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var consoleCoordinator = new Mock<IConsoleCoordinator>();
+            consoleCoordinator
+                .Setup(x => x.FlushInProgressModuleOutputAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => flushObserved.TrySetResult())
+                .Returns(Task.CompletedTask);
+            consoleCoordinator
+                .Setup(x => x.FlushPendingWritesAsync())
+                .ReturnsAsync([]);
+            consoleCoordinator
+                .Setup(x => x.FlushModuleOutputAsync())
+                .Returns(Task.CompletedTask);
+            var outputCoordinator = new Mock<IOutputCoordinator>();
+            outputCoordinator
+                .Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            outputCoordinator
+                .Setup(x => x.WaitForPendingFlushesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            var coordinator = new PipelineOutputCoordinator(
+                new RecordingProgressExecutor([]),
+                Mock.Of<IConsolePrinter>(),
+                Mock.Of<IInternalSummaryLogger>(),
+                Mock.Of<IExceptionBuffer>(),
+                consoleCoordinator.Object,
+                outputCoordinator.Object,
+                Microsoft.Extensions.Options.Options.Create(new PipelineOptions
                 {
-                    ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(10),
-                },
-            }),
-            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+                    Console = new PipelineConsoleOptions
+                    {
+                        ModuleOutputFlushInterval = TimeSpan.FromSeconds(1),
+                    },
+                }),
+                Mock.Of<ILogger<PipelineOutputCoordinator>>(),
+                timeProvider);
 
-        var scope = await coordinator.InitializeAsync();
-        await flushObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
-        await scope.DisposeAsync();
+            var scope = await coordinator.InitializeAsync();
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+            await flushObserved.Task;
+            await scope.DisposeAsync();
 
-        consoleCoordinator.Verify(
-            x => x.FlushInProgressModuleOutputAsync(It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce);
+            consoleCoordinator.Verify(
+                x => x.FlushInProgressModuleOutputAsync(It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
     }
 
     [Test]
@@ -284,7 +296,8 @@ public class PipelineOutputCoordinatorTests
                     ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(milliseconds),
                 },
             }),
-            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+            Mock.Of<ILogger<PipelineOutputCoordinator>>(),
+            TimeProvider.System);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
             await coordinator.InitializeAsync());


### PR DESCRIPTION
Closes #4346

## Summary
- inject `TimeProvider` into periodic pipeline output flushing
- replace one-second wall-clock waits with explicit coordination
- exercise both race scenarios across 25 iterations

## Validation
- `PipelineOutputCoordinatorTests`: 8 passed
- `OutputCoordinatorTests`: 19 passed
- `ModularPipelines.slnx` Release build succeeded (4 existing RS0026 warnings)
- `dotnet format ModularPipelines.Tests.slnf whitespace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and consistency of periodic output flushing by using a controlled time source.
  * Reduced timing-related flakiness in concurrent output coordination.

* **Tests**
  * Expanded concurrency coverage with repeated iterations.
  * Added deterministic time-based testing for periodic flush behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->