### PR TITLE
Generate paired AWS boolean switches

### DIFF
--- a/src/ModularPipelines.AmazonWebServices/Options/AwsEc2RunInstancesOptions.Generated.cs
+++ b/src/ModularPipelines.AmazonWebServices/Options/AwsEc2RunInstancesOptions.Generated.cs
@@ -191,10 +191,10 @@ public record AwsEc2RunInstancesOptions : AwsOptions
     [CliOption("--maintenance-options")]
     public string? MaintenanceOptions { get; set; }
 
-    [CliFlag("--disable-api-stop")]
+    [CliFlag("--disable-api-stop", NegatedName = "--no-disable-api-stop")]
     public bool? DisableApiStop { get; set; }
 
-    [CliFlag("--enable-primary-ipv6")]
+    [CliFlag("--enable-primary-ipv6", NegatedName = "--no-enable-primary-ipv6")]
     public bool? EnablePrimaryIpv6 { get; set; }
 
     /// <summary>
@@ -215,7 +215,7 @@ public record AwsEc2RunInstancesOptions : AwsOptions
     [CliOption("--secondary-interfaces", GroupValues = true)]
     public IEnumerable<string>? SecondaryInterfaces { get; set; }
 
-    [CliFlag("--dry-run")]
+    [CliFlag("--dry-run", NegatedName = "--no-dry-run")]
     public bool? DryRun { get; set; }
 
     [CliFlag("--disable-api-termination")]
@@ -258,7 +258,7 @@ public record AwsEc2RunInstancesOptions : AwsOptions
     [CliOption("--iam-instance-profile")]
     public string? IamInstanceProfile { get; set; }
 
-    [CliFlag("--ebs-optimized")]
+    [CliFlag("--ebs-optimized", NegatedName = "--no-ebs-optimized")]
     public bool? EbsOptimized { get; set; }
 
     /// <summary>
@@ -273,7 +273,7 @@ public record AwsEc2RunInstancesOptions : AwsOptions
     [CliOption("--secondary-private-ip-address-count")]
     public string? SecondaryPrivateIpAddressCount { get; set; }
 
-    [CliFlag("--associate-public-ip-address")]
+    [CliFlag("--associate-public-ip-address", NegatedName = "--no-associate-public-ip-address")]
     public bool? AssociatePublicIpAddress { get; set; }
 
     [CliOption("--cli-input-json")]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/CliOptionCollisionAnalyzerTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/CliOptionCollisionAnalyzerTests.cs
@@ -26,6 +26,54 @@ public class CliOptionCollisionAnalyzerTests
     }
 
     [TestMethod]
+    public async Task Reports_Duplicate_Negated_Switch()
+    {
+        var source = CreateOptionsSource("""
+            [CliFlag("--feature", NegatedName = "--no-feature")]
+            public bool? Feature { get; init; }
+
+            [{|#0:CliOption("--no-feature")|}]
+            public string? Other { get; init; }
+            """);
+
+        var expected = VerifyCS.Diagnostic(CliOptionCollisionAnalyzer.DuplicateSwitchDiagnosticId)
+            .WithLocation(0)
+            .WithArguments("--no-feature", "Options.Feature", "Options.Other");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod]
+    public async Task Reports_SelfColliding_Negated_Switch()
+    {
+        var source = CreateOptionsSource("""
+            [{|#0:CliFlag("--feature", NegatedName = "--feature")|}]
+            public bool? Feature { get; init; }
+            """);
+
+        var expected = VerifyCS.Diagnostic(CliOptionCollisionAnalyzer.DuplicateSwitchDiagnosticId)
+            .WithLocation(0)
+            .WithArguments("--feature", "Options.Feature", "Options.Feature");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod]
+    public async Task Reports_Negated_Switch_Matching_ShortForm()
+    {
+        var source = CreateOptionsSource("""
+            [{|#0:CliFlag("--feature", ShortForm = "-f", NegatedName = "-f")|}]
+            public bool? Feature { get; init; }
+            """);
+
+        var expected = VerifyCS.Diagnostic(CliOptionCollisionAnalyzer.DuplicateSwitchDiagnosticId)
+            .WithLocation(0)
+            .WithArguments("-f", "Options.Feature", "Options.Feature");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod]
     public async Task Accepts_New_Property_That_Hides_Base_Property()
     {
         var source = $$"""

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/CliPropertyAttributeAnalyzerTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/CliPropertyAttributeAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<
     ModularPipelines.Analyzers.CliPropertyAttributeAnalyzer>;
@@ -7,6 +8,24 @@ namespace ModularPipelines.Analyzers.Test;
 [TestClass]
 public class CliPropertyAttributeAnalyzerTests
 {
+    [TestMethod]
+    public void Diagnostic_Ids_Are_Unique()
+    {
+        var duplicates = typeof(CliPropertyAttributeAnalyzer).Assembly
+            .GetTypes()
+            .SelectMany(static type => type.GetFields(BindingFlags.Public | BindingFlags.Static))
+            .Where(static field => field.IsLiteral
+                                   && field.FieldType == typeof(string)
+                                   && field.Name.EndsWith("DiagnosticId", StringComparison.Ordinal))
+            .Select(static field => (string)field.GetRawConstantValue()!)
+            .GroupBy(static id => id, StringComparer.Ordinal)
+            .Where(static group => group.Count() > 1)
+            .Select(static group => group.Key)
+            .ToArray();
+
+        Assert.AreEqual(0, duplicates.Length, $"Duplicate diagnostic IDs: {string.Join(", ", duplicates)}");
+    }
+
     [TestMethod]
     public async Task Reports_Invalid_Flag_Type()
     {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/CliPropertyAttributeAnalyzerTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/CliPropertyAttributeAnalyzerTests.cs
@@ -55,6 +55,33 @@ public class CliPropertyAttributeAnalyzerTests
     }
 
     [TestMethod]
+    public async Task Reports_Negated_Flag_On_NonNullable_Or_Counted_Type()
+    {
+        var source = $$"""
+            {{TestSourceConstants.StandardUsingsWithOptions}}
+
+            [CliTool("tool")]
+            public record Options : CommandLineToolOptions
+            {
+                [{|#0:CliFlag("--feature", NegatedName = "--no-feature")|}]
+                public bool Feature { get; init; }
+
+                [{|#1:CliFlag("--verbose", NegatedName = "--quiet")|}]
+                public int? Verbosity { get; init; }
+            }
+            """;
+
+        var nonNullableBoolean = VerifyCS.Diagnostic(CliPropertyAttributeAnalyzer.NegatedFlagTypeDiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Feature", "bool");
+        var countedFlag = VerifyCS.Diagnostic(CliPropertyAttributeAnalyzer.NegatedFlagTypeDiagnosticId)
+            .WithLocation(1)
+            .WithArguments("Verbosity", "int?");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, nonNullableBoolean, countedFlag);
+    }
+
+    [TestMethod]
     public async Task Reports_ValueLess_Boolean_Option_With_Reordered_Legacy_Enum()
     {
         const string source = """

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerReleases.Unshipped.md
@@ -23,6 +23,7 @@ MPCLI001 | Usage | Error | CliFlag property must be bool? or int?
 MPCLI002 | Usage | Error | Value-less bool? CliOption should use CliFlag
 MPCLI003 | Usage | Error | Multiple CLI attributes applied to one property
 MPCLI004 | Usage | Error | Duplicate CLI switch in an options hierarchy
+MPCLI005 | Usage | Error | Negated CLI flag applied to a non-nullable-Boolean or counted property
 MPCLI006 | Usage | Error | CLI attributes used outside CommandLineToolOptions
 
 ### Removed Rules

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/CliOptionCollisionAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/CliOptionCollisionAnalyzer.cs
@@ -106,7 +106,6 @@ public sealed class CliOptionCollisionAnalyzer : DiagnosticAnalyzer
             if (switches.TryGetValue(switchName, out var existingProperty))
             {
                 if (SymbolEqualityComparer.Default.Equals(property.ContainingType, analyzedType)
-                    && !SymbolEqualityComparer.Default.Equals(property, existingProperty)
                     && !Overrides(property, existingProperty))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
@@ -136,6 +135,14 @@ public sealed class CliOptionCollisionAnalyzer : DiagnosticAnalyzer
         if (!string.IsNullOrWhiteSpace(shortForm) && !string.Equals(name, shortForm, StringComparison.Ordinal))
         {
             yield return shortForm!;
+        }
+
+        var negatedName = attribute.NamedArguments
+            .FirstOrDefault(pair => pair.Key == "NegatedName")
+            .Value.Value as string;
+        if (!string.IsNullOrWhiteSpace(negatedName))
+        {
+            yield return negatedName!;
         }
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/CliPropertyAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/CliPropertyAttributeAnalyzer.cs
@@ -13,6 +13,7 @@ public sealed class CliPropertyAttributeAnalyzer : DiagnosticAnalyzer
     public const string InvalidFlagTypeDiagnosticId = "MPCLI001";
     public const string BooleanOptionDiagnosticId = "MPCLI002";
     public const string MultipleAttributesDiagnosticId = "MPCLI003";
+    public const string NegatedFlagTypeDiagnosticId = "MPCLI004";
 
     public static DiagnosticDescriptor InvalidFlagTypeRule { get; } = DiagnosticDescriptorFactory.Create(
         InvalidFlagTypeDiagnosticId, "CliFlagInvalidTypeTitle", "CliFlagInvalidTypeMessageFormat", "CliFlagInvalidTypeDescription");
@@ -23,8 +24,11 @@ public sealed class CliPropertyAttributeAnalyzer : DiagnosticAnalyzer
     public static DiagnosticDescriptor MultipleAttributesRule { get; } = DiagnosticDescriptorFactory.Create(
         MultipleAttributesDiagnosticId, "MultipleCliAttributesTitle", "MultipleCliAttributesMessageFormat", "MultipleCliAttributesDescription");
 
+    public static DiagnosticDescriptor NegatedFlagTypeRule { get; } = DiagnosticDescriptorFactory.Create(
+        NegatedFlagTypeDiagnosticId, "NegatedFlagInvalidTypeTitle", "NegatedFlagInvalidTypeMessageFormat", "NegatedFlagInvalidTypeDescription");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(InvalidFlagTypeRule, BooleanOptionRule, MultipleAttributesRule);
+        ImmutableArray.Create(InvalidFlagTypeRule, BooleanOptionRule, MultipleAttributesRule, NegatedFlagTypeRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -57,7 +61,18 @@ public sealed class CliPropertyAttributeAnalyzer : DiagnosticAnalyzer
 
         foreach (var attribute in cliAttributes)
         {
-            if (CliAttributeSymbols.Is(attribute, symbols.CliFlag) && !IsBooleanOrInteger(property.Type))
+            var isFlag = CliAttributeSymbols.Is(attribute, symbols.CliFlag);
+            if (isFlag
+                && HasNamedStringValue(attribute, "NegatedName")
+                && !IsNullableBoolean(property.Type))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    NegatedFlagTypeRule,
+                    CliAttributeSymbols.GetLocation(attribute, property),
+                    property.Name,
+                    property.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+            else if (isFlag && !IsBooleanOrInteger(property.Type))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     InvalidFlagTypeRule,
@@ -94,4 +109,7 @@ public sealed class CliPropertyAttributeAnalyzer : DiagnosticAnalyzer
 
     private static int? GetNamedEnumValue(AttributeData attribute, string name) =>
         attribute.NamedArguments.FirstOrDefault(pair => pair.Key == name).Value.Value as int?;
+
+    private static bool HasNamedStringValue(AttributeData attribute, string name) =>
+        attribute.NamedArguments.Any(pair => pair.Key == name && pair.Value.Value is string);
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/CliPropertyAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/CliPropertyAttributeAnalyzer.cs
@@ -13,7 +13,7 @@ public sealed class CliPropertyAttributeAnalyzer : DiagnosticAnalyzer
     public const string InvalidFlagTypeDiagnosticId = "MPCLI001";
     public const string BooleanOptionDiagnosticId = "MPCLI002";
     public const string MultipleAttributesDiagnosticId = "MPCLI003";
-    public const string NegatedFlagTypeDiagnosticId = "MPCLI004";
+    public const string NegatedFlagTypeDiagnosticId = "MPCLI005";
 
     public static DiagnosticDescriptor InvalidFlagTypeRule { get; } = DiagnosticDescriptorFactory.Create(
         InvalidFlagTypeDiagnosticId, "CliFlagInvalidTypeTitle", "CliFlagInvalidTypeMessageFormat", "CliFlagInvalidTypeDescription");

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.resx
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.resx
@@ -282,6 +282,9 @@
   <data name="MultipleCliAttributesTitle" xml:space="preserve"><value>Multiple CLI property attributes</value></data>
   <data name="MultipleCliAttributesMessageFormat" xml:space="preserve"><value>Property '{0}' has more than one CLI attribute</value></data>
   <data name="MultipleCliAttributesDescription" xml:space="preserve"><value>Apply exactly one of CliArgument, CliFlag, or CliOption to a property.</value></data>
+  <data name="NegatedFlagInvalidTypeTitle" xml:space="preserve"><value>Invalid negated CLI flag property type</value></data>
+  <data name="NegatedFlagInvalidTypeMessageFormat" xml:space="preserve"><value>CLI flag property '{0}' has type '{1}'; use bool? when NegatedName is set</value></data>
+  <data name="NegatedFlagInvalidTypeDescription" xml:space="preserve"><value>A negated flag requires nullable Boolean state to distinguish true, false, and unspecified values.</value></data>
   <data name="DuplicateCliSwitchTitle" xml:space="preserve"><value>Duplicate CLI switch</value></data>
   <data name="DuplicateCliSwitchMessageFormat" xml:space="preserve"><value>CLI switch '{0}' is declared by both '{1}' and '{2}'</value></data>
   <data name="DuplicateCliSwitchDescription" xml:space="preserve"><value>Long and short CLI switch names must be unique across an options type hierarchy.</value></data>

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -926,6 +926,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
 
         if (attributeName == CliFlagAttributeFullName)
         {
+            var negatedName = GetNamedString(attribute, "NegatedName");
             return new PropertyMetadata(
                 property.Name,
                 PropertyKind.Flag,
@@ -942,9 +943,10 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 isGlobalOption,
                 0,
                 property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                IsSupportedFlagType(property.Type),
+                IsSupportedFlagType(property.Type)
+                && (negatedName is null || IsNullableBooleanType(property.Type)),
                 false,
-                NegatedName: GetNamedString(attribute, "NegatedName"));
+                NegatedName: negatedName);
         }
 
         return new PropertyMetadata(
@@ -973,6 +975,12 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         propertyType = UnwrapNullable(propertyType);
         return propertyType.SpecialType is SpecialType.System_Boolean or SpecialType.System_Int32;
     }
+
+    private static bool IsNullableBooleanType(ITypeSymbol propertyType) =>
+        propertyType is INamedTypeSymbol namedType
+        && namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+        && namedType.TypeArguments.Length == 1
+        && namedType.TypeArguments[0].SpecialType == SpecialType.System_Boolean;
 
     private static bool IsSupportedOptionalValueType(ITypeSymbol propertyType)
     {

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -943,7 +943,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 0,
                 property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 IsSupportedFlagType(property.Type),
-                false);
+                false,
+                NegatedName: GetNamedString(attribute, "NegatedName"));
         }
 
         return new PropertyMetadata(
@@ -1522,6 +1523,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                    new global::ModularPipelines.Attributes.CliFlagAttribute({Literal(property.PrimaryValue!)})");
                     sb.AppendLine("                    {");
                     sb.AppendLine($"                        ShortForm = {NullableLiteral(property.ShortForm)},");
+                    sb.AppendLine($"                        NegatedName = {NullableLiteral(property.NegatedName)},");
                     sb.AppendLine($"                        PreferShortForm = {BooleanLiteral(property.BooleanValue)},");
                     sb.AppendLine($"                        Phase = global::ModularPipelines.Attributes.CommandLinePhase.{property.Phase},");
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, IsSupportedPropertyType = {BooleanLiteral(property.IsSupportedPropertyType)} }},");
@@ -2318,7 +2320,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         bool IsSupportedPropertyType,
         bool HasExplicitArgumentPosition,
         bool RepeatOptionTerminator = false,
-        string? CollectionSeparator = null);
+        string? CollectionSeparator = null,
+        string? NegatedName = null);
 
     private enum PropertyKind
     {

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -15,7 +15,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
 {
     private const int RuntimeRegistrationChunkSize = 32;
     private const int RuntimeMetadataSchemaVersion = 2;
-    private const int CommandMetadataSchemaVersion = 3;
+    private const int CommandMetadataSchemaVersion = 4;
     private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
     private const string CliValuePairFullName = "ModularPipelines.Models.CliValuePair";
 

--- a/src/ModularPipelines/Attributes/CliFlagAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliFlagAttribute.cs
@@ -29,6 +29,12 @@ public sealed class CliFlagAttribute(string name) : Attribute
     public string Name { get; } = name;
 
     /// <summary>
+    /// Gets or sets the flag name emitted when a nullable boolean property is explicitly false.
+    /// When unset, false continues to omit the flag.
+    /// </summary>
+    public string? NegatedName { get; set; }
+
+    /// <summary>
     /// Gets or sets the short form of the flag (e.g., "-d" for "--debug").
     /// When set and <see cref="PreferShortForm"/> is true, the short form will be used.
     /// </summary>

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -548,6 +548,7 @@ internal sealed class CommandLineBuilder(
             {
                 (Name: part.Attribute.Name, Part: part),
                 (Name: part.Attribute.ShortForm, Part: part),
+                (Name: part.Attribute.NegatedName, Part: part),
             })
             .Where(static item => item.Name is not null)
             .GroupBy(static item => item.Name!, StringComparer.Ordinal)

--- a/src/ModularPipelines/Generated/GeneratedCommandMetadata.cs
+++ b/src/ModularPipelines/Generated/GeneratedCommandMetadata.cs
@@ -11,7 +11,7 @@ namespace ModularPipelines.Generated;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class GeneratedCommandMetadata
 {
-    internal const int CurrentSchemaVersion = 3;
+    internal const int CurrentSchemaVersion = 4;
 
     private static readonly ConditionalWeakTable<Type, CommandMetadata> Models = [];
     private static readonly ConditionalWeakTable<Assembly, ProcessedAssembly> ProcessedAssemblies = [];

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -300,9 +300,18 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
 
     private static void AddFlag(List<string> args, FlagPart flagPart, object rawValue)
     {
-        if (rawValue is bool boolValue && boolValue)
+        if (rawValue is bool boolValue)
         {
-            args.Add(GetEffectiveName(flagPart.Attribute));
+            if (boolValue)
+            {
+                args.Add(GetEffectiveName(flagPart.Attribute));
+            }
+            else if (!string.IsNullOrEmpty(flagPart.Attribute.NegatedName))
+            {
+                args.Add(flagPart.Attribute.NegatedName);
+            }
+
+            return;
         }
 
         if (rawValue is int count && count > 0)

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -281,17 +281,39 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
         switch (part)
         {
-            case FlagPart flag
-                when flag.Attribute.NegatedName is not null
-                     && flag.IsSupportedPropertyType is false:
-                throw new InvalidOperationException(
-                    $"CLI flag property '{propertyName}' must use bool? when NegatedName is set.");
-            case FlagPart flag
-                when flag.IsSupportedPropertyType is false
-                     || (schemaVersion >= GeneratedCommandMetadata.CurrentSchemaVersion
-                         && flag.IsSupportedPropertyType is null):
-                throw new InvalidOperationException(
-                    $"CLI flag property '{propertyName}' must use bool, bool?, int, or int?.");
+            case FlagPart flag:
+                ValidateFlagProperty(propertyName, flag, schemaVersion);
+                break;
+            case OptionPart option:
+                ValidateOptionProperty(propertyName, option);
+                break;
+        }
+    }
+
+    private static void ValidateFlagProperty(
+        string propertyName,
+        FlagPart flag,
+        int schemaVersion)
+    {
+        if (flag.Attribute.NegatedName is not null && flag.IsSupportedPropertyType is false)
+        {
+            throw new InvalidOperationException(
+                $"CLI flag property '{propertyName}' must use bool? when NegatedName is set.");
+        }
+
+        if (flag.IsSupportedPropertyType is false
+            || (schemaVersion >= GeneratedCommandMetadata.CurrentSchemaVersion
+                && flag.IsSupportedPropertyType is null))
+        {
+            throw new InvalidOperationException(
+                $"CLI flag property '{propertyName}' must use bool, bool?, int, or int?.");
+        }
+    }
+
+    private static void ValidateOptionProperty(string propertyName, OptionPart option)
+    {
+        switch (option)
+        {
             case OptionPart { Attribute.GroupValues: true } groupedOption
                 when groupedOption.Attribute.Format != OptionFormat.SpaceSeparated:
                 throw new InvalidOperationException(
@@ -306,8 +328,8 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 when valuePairOption.Attribute.Format != OptionFormat.SpaceSeparated:
                 throw new InvalidOperationException(
                     $"CliValuePair CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
-            case OptionPart { Attribute.ValueArity: CliOptionValueArity.Optional } option
-                when option.IsSupportedPropertyType is not true:
+            case OptionPart { Attribute.ValueArity: CliOptionValueArity.Optional } optionalValueOption
+                when optionalValueOption.IsSupportedPropertyType is not true:
                 throw new InvalidOperationException(
                     $"Optional-value CLI option property '{propertyName}' must use "
                     + "CliOptionValue or IEnumerable<CliOptionValue>.");

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -67,7 +67,9 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 parts.Add(new FlagPart(property.Name, property.GetValue, flag)
                 {
                     IsGlobalOption = IsGlobalOption(property),
-                    IsSupportedPropertyType = IsSupportedFlagType(property.PropertyType),
+                    IsSupportedPropertyType = IsSupportedFlagType(property.PropertyType)
+                                              && (flag.NegatedName is null
+                                                  || IsNullableBooleanType(property.PropertyType)),
                 });
             }
             else if (commandAttribute is CliOptionAttribute option)
@@ -223,6 +225,9 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         return propertyType == typeof(bool) || propertyType == typeof(int);
     }
 
+    private static bool IsNullableBooleanType(Type propertyType) =>
+        Nullable.GetUnderlyingType(propertyType) == typeof(bool);
+
     private static bool IsSupportedOptionalValueType(Type propertyType)
     {
         propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
@@ -276,6 +281,11 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
         switch (part)
         {
+            case FlagPart flag
+                when flag.Attribute.NegatedName is not null
+                     && flag.IsSupportedPropertyType is false:
+                throw new InvalidOperationException(
+                    $"CLI flag property '{propertyName}' must use bool? when NegatedName is set.");
             case FlagPart flag
                 when flag.IsSupportedPropertyType is false
                      || (schemaVersion >= GeneratedCommandMetadata.CurrentSchemaVersion

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -319,7 +319,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                     throw new InvalidOperationException(
                         $"{optionsType.Name} defines CLI switch '{switchName}' more than once " +
                         $"on properties '{existingProperty}' and '{part.PropertyName}'. " +
-                        "Model aliases with ShortForm on a single property.");
+                        "Name, ShortForm, and NegatedName values must be unique.");
                 }
 
                 switches.Add(switchName, part.PropertyName);
@@ -331,10 +331,23 @@ internal sealed class CommandModelProvider : ICommandModelProvider
     {
         return part switch
         {
-            FlagPart flag => GetNames(flag.Attribute.Name, flag.Attribute.ShortForm),
+            FlagPart flag => GetFlagNames(flag.Attribute),
             OptionPart option => GetNames(option.Attribute.Name, option.Attribute.ShortForm),
             _ => [],
         };
+    }
+
+    private static IEnumerable<string> GetFlagNames(CliFlagAttribute attribute)
+    {
+        foreach (var name in GetNames(attribute.Name, attribute.ShortForm))
+        {
+            yield return name;
+        }
+
+        if (!string.IsNullOrWhiteSpace(attribute.NegatedName))
+        {
+            yield return attribute.NegatedName;
+        }
     }
 
     private static IEnumerable<string> GetNames(string name, string? shortForm)

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -36,10 +36,15 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 model = BuildModel(type);
                 schemaVersion = GeneratedCommandMetadata.CurrentSchemaVersion;
             }
-            else if (schemaVersion < GeneratedCommandMetadata.CurrentSchemaVersion
-                     && !RuntimeFeature.IsDynamicCodeSupported)
+            else if (schemaVersion < GeneratedCommandMetadata.CurrentSchemaVersion)
             {
-                throw new MissingCommandMetadataException(type);
+                if (!RuntimeFeature.IsDynamicCodeSupported)
+                {
+                    throw new MissingCommandMetadataException(type);
+                }
+
+                model = BuildModel(type);
+                schemaVersion = GeneratedCommandMetadata.CurrentSchemaVersion;
             }
 
             ValidateModel(type, model, schemaVersion);

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -2212,7 +2212,7 @@ abstract ModularPipelines.RunConditionAttribute.EvaluateAsync(ModularPipelines.I
 abstract ModularPipelines.RunConditionAttribute.Logic.get -> ModularPipelines.ConditionLogic
 abstract ModularPipelines.SyncModule.Execute(ModularPipelines.IModuleContext! context, System.Threading.CancellationToken cancellationToken) -> void
 abstract ModularPipelines.SyncModule<T>.Execute(ModularPipelines.IModuleContext! context, System.Threading.CancellationToken cancellationToken) -> T
-const ModularPipelines.Generated.RuntimeMetadataRegistry.CurrentCommandMetadataSchemaVersion = 3 -> int
+const ModularPipelines.Generated.RuntimeMetadataRegistry.CurrentCommandMetadataSchemaVersion = 4 -> int
 const ModularPipelines.Reporting.PipelineRunReport.CurrentSchemaVersion = 4 -> int
 const ModularPipelines.Tracing.PipelineTelemetry.CommandDurationTag = "modular_pipelines.command.duration_ms" -> string!
 const ModularPipelines.Tracing.PipelineTelemetry.CommandExitCodeTag = "process.exit.code" -> string!

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1180,6 +1180,8 @@
 *REMOVED*virtual ModularPipelines.Options.SecretMaskingOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 *REMOVED*virtual ModularPipelines.Requirements.PipelineRequirement.Must(ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Models.RequirementDecision!
 *REMOVED*virtual ModularPipelines.Requirements.PipelineRequirement.MustAsync(ModularPipelines.Context.IPipelineContext! context) -> System.Threading.Tasks.Task<ModularPipelines.Models.RequirementDecision!>!
+ModularPipelines.Attributes.CliFlagAttribute.NegatedName.get -> string?
+ModularPipelines.Attributes.CliFlagAttribute.NegatedName.set -> void
 ModularPipelines.Attributes.CliOptionAttribute.CollectionSeparator.get -> string?
 ModularPipelines.Attributes.CliOptionAttribute.CollectionSeparator.set -> void
 ModularPipelines.Attributes.ExecutionHintAttribute.ExecutionHint.get -> ModularPipelines.Enums.ExecutionHint

--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2RunInstancesOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2RunInstancesOptionsTests.cs
@@ -1,0 +1,28 @@
+using ModularPipelines.AmazonWebServices.Options;
+using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
+
+namespace ModularPipelines.UnitTests;
+
+public class AwsEc2RunInstancesOptionsTests
+{
+    [Test]
+    public async Task Public_Ip_Association_Emits_Both_Explicit_Forms()
+    {
+        var enabled = BuildArguments(new AwsEc2RunInstancesOptions
+        {
+            AssociatePublicIpAddress = true,
+        });
+        var disabled = BuildArguments(new AwsEc2RunInstancesOptions
+        {
+            AssociatePublicIpAddress = false,
+        });
+        var unspecified = BuildArguments(new AwsEc2RunInstancesOptions());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(enabled).IsEquivalentTo(["--associate-public-ip-address"]);
+            await Assert.That(disabled).IsEquivalentTo(["--no-associate-public-ip-address"]);
+            await Assert.That(unspecified).IsEmpty();
+        }
+    }
+}

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
@@ -33,7 +33,7 @@ public class GeneratedOptionsRegistrationAnalyzerTests
         {
             public static class RuntimeMetadataRegistry
             {
-                public const int CurrentCommandMetadataSchemaVersion = 3;
+                public const int CurrentCommandMetadataSchemaVersion = 4;
                 public static void RegisterCommandOptions(System.Type type, object model) { }
                 public static void RegisterCommandOptions(System.Type type, object model, int schemaVersion) { }
                 public static void RegisterSecrets(System.Type type, object accessors) { }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -575,8 +575,8 @@ public class IncompleteMetadataDiagnosticTests
             await Assert.That(generatedSource).Contains("GeneratedCommandMetadata.RegisterExternal(");
             await Assert.That(generatedSource).Contains("typeof(global::External.CrossLanguageOptions)");
             await Assert.That(generatedSource).Contains("public const int SchemaVersion = 2;");
-            await Assert.That(generatedSource).Contains("public const int CommandSchemaVersion = 3;");
-            await Assert.That(generatedSource).Contains("            3);");
+            await Assert.That(generatedSource).Contains("public const int CommandSchemaVersion = 4;");
+            await Assert.That(generatedSource).Contains("            4);");
             await Assert.That(generatedSource).Contains(
                 "DynamicallyAccessedMemberTypes.NonPublicProperties, typeof(global::External.CrossLanguageOptions)");
             await Assert.That(generatedSource).Contains("OptionPart");
@@ -747,7 +747,7 @@ public class IncompleteMetadataDiagnosticTests
                 internal static class RuntimeMetadataRegistration
                 {
                     public const int SchemaVersion = 2;
-                    public const int CommandSchemaVersion = 3;
+                    public const int CommandSchemaVersion = 4;
                 }
             }
 
@@ -804,7 +804,7 @@ public class IncompleteMetadataDiagnosticTests
         {
             await Assert.That(result.Diagnostics).IsEmpty();
             await Assert.That(generatedSource).Contains("public const int SchemaVersion = 2;");
-            await Assert.That(generatedSource).Contains("public const int CommandSchemaVersion = 3;");
+            await Assert.That(generatedSource).Contains("public const int CommandSchemaVersion = 4;");
             await Assert.That(generatedSource).Contains(
                 "DynamicallyAccessedMemberTypes.NonPublicProperties, typeof(global::InternalOptions)");
         }

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -876,6 +876,30 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task CommandModel_Rejects_Duplicate_Negated_Switches()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithDuplicateNegatedSwitch()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("--no-feature");
+    }
+
+    [Test]
+    public async Task CommandModel_Rejects_SelfColliding_Negated_Switches()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithSelfCollidingNegatedSwitch()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("--feature");
+    }
+
+    [Test]
+    public async Task CommandModel_Rejects_Negated_Switch_Matching_ShortForm()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithNegatedSwitchMatchingShortForm()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("-f");
+    }
+
+    [Test]
     public async Task CommandModel_Rejects_Unsupported_Flag_Type_When_Unset()
     {
         await Assert.That(() => BuildArguments(new TestCliOptionsWithInvalidFlagType()))
@@ -1288,6 +1312,27 @@ public class CliAttributeTests
 
         [CliOption("--duplicate")]
         public string? Second { get; set; }
+    }
+
+    internal record TestCliOptionsWithDuplicateNegatedSwitch : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--no-feature")]
+        public bool? Feature { get; set; }
+
+        [CliOption("--no-feature")]
+        public string? Other { get; set; }
+    }
+
+    internal record TestCliOptionsWithSelfCollidingNegatedSwitch : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--feature")]
+        public bool? Feature { get; set; }
+    }
+
+    internal record TestCliOptionsWithNegatedSwitchMatchingShortForm : CommandLineToolOptions
+    {
+        [CliFlag("--feature", ShortForm = "-f", NegatedName = "-f")]
+        public bool? Feature { get; set; }
     }
 
     internal record TestCliOptionsWithInvalidFlagType : CommandLineToolOptions

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -70,6 +70,29 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Parser_Uses_Negated_Flag_Name_For_Explicit_False()
+    {
+        var attribute = new CliFlagAttribute("--feature") { NegatedName = "--no-feature" };
+
+        await Assert.That(RenderFlag(attribute, false)).IsEquivalentTo(["--no-feature"]);
+    }
+
+    [Test]
+    public async Task Generated_Metadata_Preserves_Negated_Flag_Name()
+    {
+        var enabled = BuildArguments(new TestCliOptionsWithNegatedFlag { Feature = true });
+        var disabled = BuildArguments(new TestCliOptionsWithNegatedFlag { Feature = false });
+        var unspecified = BuildArguments(new TestCliOptionsWithNegatedFlag());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(enabled).IsEquivalentTo(["--feature"]);
+            await Assert.That(disabled).IsEquivalentTo(["--no-feature"]);
+            await Assert.That(unspecified).IsEmpty();
+        }
+    }
+
+    [Test]
     [Arguments(OptionFormat.SpaceSeparated, "--namespace|value")]
     [Arguments(OptionFormat.EqualsSeparated, "--namespace=value")]
     [Arguments(OptionFormat.ColonSeparated, "--namespace:value")]
@@ -1064,9 +1087,9 @@ public class CliAttributeTests
         await Assert.That(list).Contains("bitnami/nginx");
     }
 
-    private static IReadOnlyList<string> RenderFlag(CliFlagAttribute attribute) =>
+    private static IReadOnlyList<string> RenderFlag(CliFlagAttribute attribute, object? value = null) =>
         new CommandArgumentBuilder().BuildArguments(
-            [new FlagPart("Value", _ => true, attribute)],
+            [new FlagPart("Value", _ => value ?? true, attribute)],
             new object());
 
     private static IReadOnlyList<string> RenderOption(CliOptionAttribute attribute) =>
@@ -1088,6 +1111,12 @@ public class CliAttributeTests
 
         [CliOption("--values")]
         public double[]? Values { get; init; }
+    }
+
+    internal record TestCliOptionsWithNegatedFlag : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--no-feature")]
+        public bool? Feature { get; init; }
     }
 
     internal record TestCliOptionsWithFlag : CommandLineToolOptions

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -900,6 +900,17 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task CommandModel_Rejects_Negated_Switch_On_NonNullable_Or_Counted_Flag()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithNonNullableNegatedFlag()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("bool?");
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithCountedNegatedFlag()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("bool?");
+    }
+
+    [Test]
     public async Task CommandModel_Rejects_Unsupported_Flag_Type_When_Unset()
     {
         await Assert.That(() => BuildArguments(new TestCliOptionsWithInvalidFlagType()))
@@ -1333,6 +1344,18 @@ public class CliAttributeTests
     {
         [CliFlag("--feature", ShortForm = "-f", NegatedName = "-f")]
         public bool? Feature { get; set; }
+    }
+
+    internal record TestCliOptionsWithNonNullableNegatedFlag : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--no-feature")]
+        public bool Feature { get; set; }
+    }
+
+    internal record TestCliOptionsWithCountedNegatedFlag : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--no-feature")]
+        public int? Feature { get; set; }
     }
 
     internal record TestCliOptionsWithInvalidFlagType : CommandLineToolOptions

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -413,7 +413,7 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Schema2_Metadata_Defers_Ambiguous_Legacy_Optional_Validation_Until_Rendering()
+    public async Task Schema2_Metadata_Rebuilds_Ambiguous_Legacy_Optional_Validation()
     {
         var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>);
         GeneratedCommandMetadata.Register(
@@ -434,14 +434,7 @@ public class CliAttributeTests
             ],
             schemaVersion: 2);
 
-        var model = new CommandModelProvider().GetCommandModel(optionsType);
-
-        await Assert.That(() => new CommandArgumentBuilder().BuildArguments(
-                model,
-                new RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>
-                {
-                    Output = "json",
-                }))
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
             .Throws<InvalidOperationException>()
             .And.HasMessageContaining(nameof(CliOptionValue));
     }
@@ -1415,16 +1408,19 @@ public class CliAttributeTests
 
     private sealed record RegisteredLegacyOptionalOptions<T> : CommandLineToolOptions
     {
+        [CliOption("--output", ValueArity = CliOptionValueArity.Optional)]
         public string? Output { get; init; }
     }
 
     private sealed record RegisteredCurrentOptionalOptions<T> : CommandLineToolOptions
     {
+        [CliOption("--output", ValueArity = CliOptionValueArity.Optional)]
         public CliOptionValue? Output { get; init; }
     }
 
     private sealed record RegisteredFlagOptions<T> : CommandLineToolOptions
     {
+        [CliFlag("--force")]
         public bool Force { get; init; }
     }
 

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -460,6 +460,21 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Hoists_Manual_Negated_Flag_Before_Option_Terminator()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestNegatedManualFlagOptions
+        {
+            Arguments = ["--no-feature"],
+            ArgumentsContainToolOptions = true,
+            Filter = "-1",
+        });
+
+        await Assert.That(result.ToString()).IsEqualTo("tool --no-feature -- -1");
+    }
+
+    [Test]
     public async Task Build_Preserves_Manual_Arguments_After_Ordinary_Passthrough_Values()
     {
         var builder = await GetService<ICommandLineBuilder>();
@@ -1106,6 +1121,29 @@ public class CommandLineBuilderTests : TestBase
         var result = builder.Build(options);
 
         await Assert.That(result.ToString()).IsEqualTo("jq --arg name value -- tail");
+    }
+
+    [Test]
+    public async Task CommandModelProvider_Rebuilds_Stale_Negated_Flag_Metadata()
+    {
+        var optionsType = typeof(LegacyNegatedFlagOptions<LegacyNegatedFlagMarker>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new FlagPart(
+                    nameof(LegacyNegatedFlagOptions<LegacyNegatedFlagMarker>.Feature),
+                    static _ => null,
+                    new CliFlagAttribute("--feature"))
+                {
+                    IsSupportedPropertyType = true,
+                },
+            ],
+            GeneratedCommandMetadata.CurrentSchemaVersion - 1);
+
+        var model = new CommandModelProvider().GetCommandModel(optionsType);
+
+        await Assert.That(model.OfType<FlagPart>().Single().Attribute.NegatedName)
+            .IsEqualTo("--no-feature");
     }
 
     [Test]
@@ -1987,6 +2025,16 @@ public class CommandLineBuilderTests : TestBase
         public string? ConfigPath { get; set; }
     }
 
+    [CliTool("tool")]
+    private sealed record TestNegatedManualFlagOptions : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--no-feature")]
+        public bool? Feature { get; init; }
+
+        [CliArgument(0, PrependOptionTerminator = true)]
+        public string? Filter { get; init; }
+    }
+
     [CliTool("jq")]
     internal record TestTerminalOptions : CommandLineToolOptions
     {
@@ -2127,6 +2175,15 @@ public class CommandLineBuilderTests : TestBase
     }
 
     private sealed class LegacyMetadataMarker;
+
+    private sealed class LegacyNegatedFlagMarker;
+
+    [CliTool("tool")]
+    private sealed record LegacyNegatedFlagOptions<T> : CommandLineToolOptions
+    {
+        [CliFlag("--feature", NegatedName = "--no-feature")]
+        public bool? Feature { get; init; }
+    }
 
     [CliTool("jq")]
     private sealed record LegacyGeneratedMetadataOptions<T> : CommandLineToolOptions

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/External/ExternalToolDefinitionTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/External/ExternalToolDefinitionTests.cs
@@ -1079,6 +1079,37 @@ public class ExternalToolDefinitionTests
     }
 
     [Test]
+    public async Task External_Metadata_Rejects_MultiToken_Negated_Switch()
+    {
+        var workspace = CreateTemporaryDirectory();
+        var outputDirectory = Path.Combine(workspace, "integration");
+
+        try
+        {
+            var tool = await LoadValidToolAsync(workspace, outputDirectory);
+            var command = tool.Commands.Single();
+            var option = command.Options.Single() with
+            {
+                CSharpType = "bool?",
+                IsFlag = true,
+                NegatedSwitchName = "--no environment",
+            };
+            tool = tool with
+            {
+                Commands = [command with { Options = [option] }],
+            };
+
+            await Assert.That(async () =>
+                    await CreateOrchestrator().GenerateFromDefinitionAsync(tool, outputDirectory))
+                .Throws<InvalidDataException>();
+        }
+        finally
+        {
+            Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task External_Metadata_Rejects_Command_Switch_Colliding_With_Global_Alias()
     {
         var workspace = CreateTemporaryDirectory();
@@ -1101,6 +1132,40 @@ public class ExternalToolDefinitionTests
                         ShortForm = "--environment",
                         PropertyName = "GlobalEnvironment",
                         CSharpType = "string?",
+                    },
+                ],
+            };
+
+            await Assert.That(async () =>
+                    await CreateOrchestrator().GenerateFromDefinitionAsync(tool, outputDirectory))
+                .Throws<InvalidDataException>();
+        }
+        finally
+        {
+            Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task External_Metadata_Rejects_Negated_Switch_Colliding_With_Command_Switch()
+    {
+        var workspace = CreateTemporaryDirectory();
+        var outputDirectory = Path.Combine(workspace, "integration");
+
+        try
+        {
+            var tool = await LoadValidToolAsync(workspace, outputDirectory);
+            tool = tool with
+            {
+                GlobalOptions =
+                [
+                    new CliOptionDefinition
+                    {
+                        SwitchName = "--global-feature",
+                        NegatedSwitchName = "--environment",
+                        PropertyName = "GlobalFeature",
+                        CSharpType = "bool?",
+                        IsFlag = true,
                     },
                 ],
             };
@@ -1688,6 +1753,40 @@ public class ExternalToolDefinitionTests
             await Assert.That(async () =>
                     await CreateOrchestrator().GenerateFromDefinitionAsync(tool, outputDirectory))
                 .Throws<InvalidDataException>();
+        }
+        finally
+        {
+            Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task External_Metadata_Rejects_Negated_Switch_On_NonNullable_Or_Counted_Flag()
+    {
+        var workspace = CreateTemporaryDirectory();
+        var outputDirectory = Path.Combine(workspace, "integration");
+
+        try
+        {
+            foreach (var cSharpType in new[] { "bool", "int?" })
+            {
+                var tool = await LoadValidToolAsync(workspace, outputDirectory);
+                var command = tool.Commands.Single();
+                var option = command.Options.Single() with
+                {
+                    CSharpType = cSharpType,
+                    IsFlag = true,
+                    NegatedSwitchName = "--no-environment",
+                };
+                tool = tool with
+                {
+                    Commands = [command with { Options = [option] }],
+                };
+
+                await Assert.That(async () =>
+                        await CreateOrchestrator().GenerateFromDefinitionAsync(tool, outputDirectory))
+                    .Throws<InvalidDataException>();
+            }
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -180,7 +180,8 @@ public class GeneratorHardeningTests
         CommandLinePhase? phase = null,
         bool omitPhase = false,
         CliCompatibilityForwardingKind forwardingKind = CliCompatibilityForwardingKind.Direct,
-        CliOptionValueArity valueArity = CliOptionValueArity.Required) =>
+        CliOptionValueArity valueArity = CliOptionValueArity.Required,
+        string? negatedSwitchName = null) =>
         new(
             propertyName,
             cSharpType,
@@ -195,7 +196,8 @@ public class GeneratorHardeningTests
             ValueArity: valueArity,
             Phase: phase ?? (argumentPosition is not null && !omitPhase
                 ? CommandLinePhase.EarlyOperand
-                : null));
+                : null),
+            NegatedSwitchName: negatedSwitchName);
 
     private static CliOptionDefinition RequiredOption(string switchName, string propertyName) =>
         new()
@@ -2147,6 +2149,40 @@ public class GeneratorHardeningTests
 
         await Assert.That(exception.Message)
             .Contains("ToolCopyOptions.RemovedFlag changed type from bool? to string?");
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Rejects_Changed_Negated_Switch()
+    {
+        var command = Command("ToolCopyOptions", "ToolOptions", ["copy"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--feature",
+                    NegatedSwitchName = "--without-feature",
+                    PropertyName = "Feature",
+                    CSharpType = "bool?",
+                },
+            ],
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            GeneratedApiCompatibilityPreserver.Preserve(
+                command,
+                [
+                    BaselineProperty(
+                        "Feature",
+                        "bool?",
+                        switchName: "--feature",
+                        negatedSwitchName: "--no-feature"),
+                ]));
+
+        await Assert.That(exception.Message)
+            .Contains(
+                "ToolCopyOptions.Feature changed negated CLI switch from "
+                + "--no-feature to --without-feature");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2990,6 +2990,8 @@ public class GeneratorHardeningTests
                 + "[RegularExpression(\"^[0-6]$\")] "
                 + "[CliFlag(\"--force\", ShortForm = \"-f\", PreferShortForm = true, Phase = CommandLinePhase.Terminal)] "
                 + "public int? Force { get; set; } "
+                + "[CliFlag(\"--feature\", NegatedName = \"--no-feature\")] "
+                + "public bool? Feature { get; set; } "
                 + "[CliOptionValueRange(1, 3)] "
                 + "[CliOptionValueRegularExpression(\"^[1-3]$\")] "
                 + "[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, "
@@ -3013,6 +3015,7 @@ public class GeneratorHardeningTests
             var restored = preserved.Commands.Single(command =>
                 command.ClassName.Equals("ToolRemovedOptions", StringComparison.Ordinal));
             var force = restored.Options.Single(option => option.PropertyName == "Force");
+            var feature = restored.Options.Single(option => option.PropertyName == "Feature");
             var pull = restored.Options.Single(option => option.PropertyName == "Pull");
             var arguments = restored.Options.Single(option => option.PropertyName == "Arguments");
             var operand = restored.PositionalArguments.Single();
@@ -3034,6 +3037,7 @@ public class GeneratorHardeningTests
                 await Assert.That(force.ValidationConstraints!.MinValue).IsEqualTo(0);
                 await Assert.That(force.ValidationConstraints.MaxValue).IsEqualTo(6);
                 await Assert.That(force.ValidationConstraints.Pattern).IsEqualTo("^[0-6]$");
+                await Assert.That(feature.NegatedSwitchName).IsEqualTo("--no-feature");
                 await Assert.That(pull.IsFlag).IsFalse();
                 await Assert.That(pull.ShortForm).IsEqualTo("-p");
                 await Assert.That(pull.PreferShortForm).IsTrue();
@@ -3051,6 +3055,8 @@ public class GeneratorHardeningTests
                 await Assert.That(operand.PrependOptionTerminatorIfValueStartsWithDash).IsTrue();
                 await Assert.That(generatedOptions)
                     .Contains("[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]");
+                await Assert.That(generatedOptions)
+                    .Contains("[CliFlag(\"--feature\", NegatedName = \"--no-feature\")]");
                 await Assert.That(generatedOptions).Contains("[Range(0, 6)]");
                 await Assert.That(generatedOptions).Contains("[RegularExpression(\"^[0-6]$\")]");
                 await Assert.That(generatedOptions).Contains("[CliOptionValueRange(1, 3)]");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -333,6 +333,24 @@ public class GeneratorUtilsTests
     }
 
     [Test]
+    public async Task GenerateCliAttributeString_Returns_CliFlag_With_Negated_Name()
+    {
+        var option = new CliOptionDefinition
+        {
+            SwitchName = "--feature",
+            NegatedSwitchName = "--no-feature",
+            PropertyName = "Feature",
+            CSharpType = "bool?",
+            IsFlag = true,
+        };
+
+        var result = GeneratorUtils.GenerateCliAttributeString(option);
+
+        await Assert.That(result)
+            .IsEqualTo("CliFlag(\"--feature\", NegatedName = \"--no-feature\")");
+    }
+
+    [Test]
     public async Task GenerateCliAttributeString_Returns_CliOption_For_Value_Option()
     {
         var option = new CliOptionDefinition

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliGlobalOptionMergerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliGlobalOptionMergerTests.cs
@@ -123,6 +123,33 @@ public class CliGlobalOptionMergerTests
             .And.HasMessageContaining("-o");
     }
 
+    [Test]
+    public async Task Merge_Rejects_Conflicting_Negated_Switches_For_The_Same_Option()
+    {
+        var scraped = Option("--feature", "Feature") with
+        {
+            CSharpType = "bool?",
+            IsFlag = true,
+            NegatedSwitchName = "--no-feature",
+        };
+
+        await Assert.That(() => CliGlobalOptionMerger.Merge(
+                [scraped],
+                [scraped with { NegatedSwitchName = "--disable-feature" }]))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("--feature");
+    }
+
+    [Test]
+    public async Task Merge_Rejects_A_Negated_Alias_Shared_By_Different_Options()
+    {
+        await Assert.That(() => CliGlobalOptionMerger.Merge(
+                [Option("--feature", "Feature") with { NegatedSwitchName = "--no-feature" }],
+                [Option("--no-feature", "Other")]))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("--no-feature");
+    }
+
     private static CliOptionDefinition Option(string switchName, string propertyName) => new()
     {
         SwitchName = switchName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -236,6 +236,31 @@ public class AwsCliScraperTests
     }
 
     [Test]
+    public async Task Paired_Boolean_Switches_Become_One_Negatable_Option()
+    {
+        var scraper = new AwsCliScraper(
+            new AwsNegatedBooleanHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var option = commands.Single().Options.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("--associate-public-ip-address");
+            await Assert.That(option.NegatedSwitchName).IsEqualTo("--no-associate-public-ip-address");
+            await Assert.That(option.PropertyName).IsEqualTo("AssociatePublicIpAddress");
+            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+            await Assert.That(option.IsFlag).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Enum_Detection_Rejects_Free_Form_Character_Descriptions()
     {
         var definition = AwsCliScraper.TryDetectEnum(
@@ -531,6 +556,35 @@ public class AwsCliScraperTests
                            --quiet (boolean)
                     """,
                 _ when arguments.StartsWith("s3 ", StringComparison.Ordinal) => "OPTIONS\n       --quiet (boolean)\n",
+                _ => string.Empty,
+            };
+
+            return Task.FromResult(Result(output));
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class AwsNegatedBooleanHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            var output = arguments switch
+            {
+                "help" => "AVAILABLE SERVICES\n       o ec2",
+                "ec2 help" => "AVAILABLE COMMANDS\n       o run-instances",
+                "ec2 run-instances help" => """
+                    OPTIONS
+                           "--associate-public-ip-address" | "--no-associate-public-ip-address"
+                            (boolean) [EC2-VPC] If specified a public IP address will be assigned.
+                    """,
                 _ => string.Empty,
             };
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
@@ -243,6 +243,11 @@ public static class ExternalToolDefinitionLoader
             RequireSingleToken(option.ShortForm, $"{propertyName}[].shortForm");
         }
 
+        if (option.NegatedSwitchName is not null)
+        {
+            RequireSingleToken(option.NegatedSwitchName, $"{propertyName}[].negatedSwitchName");
+        }
+
         RequireIdentifier(option.PropertyName, $"{propertyName}[].propertyName");
         RequireTypeName(option.CSharpType, $"{propertyName}[].cSharpType");
         ValidateFlagType(option, propertyName);
@@ -297,6 +302,13 @@ public static class ExternalToolDefinitionLoader
         {
             throw new InvalidDataException(
                 $"{propertyName}[].cSharpType must be bool, bool?, int, or int? when isFlag is true.");
+        }
+
+        if (option.NegatedSwitchName is not null
+            && (!option.IsFlag || !IsNullableBooleanType(option.CSharpType)))
+        {
+            throw new InvalidDataException(
+                $"{propertyName}[].negatedSwitchName requires isFlag=true and cSharpType bool?.");
         }
     }
 
@@ -394,6 +406,14 @@ public static class ExternalToolDefinitionLoader
             or "System.Int32?";
     }
 
+    private static bool IsNullableBooleanType(string cSharpType)
+    {
+        var type = cSharpType
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Replace("global::", string.Empty, StringComparison.Ordinal);
+        return type is "bool?" or "System.Boolean?";
+    }
+
     private static void ValidateEquivalentEnumDefinitions(CliToolDefinition tool)
     {
         var definitions = tool.Commands
@@ -442,6 +462,15 @@ public static class ExternalToolDefinitionLoader
                 && !string.Equals(option.SwitchName, option.ShortForm, StringComparison.Ordinal))
             {
                 RegisterSwitch(option.ShortForm, option.PropertyName, propertiesBySwitch, command);
+            }
+
+            if (option.NegatedSwitchName is not null)
+            {
+                RegisterSwitch(
+                    option.NegatedSwitchName,
+                    option.PropertyName,
+                    propertiesBySwitch,
+                    command);
             }
         }
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -2602,6 +2602,18 @@ internal static class GeneratedApiCompatibilityPreserver
             return false;
         }
 
+        if (baseline.NegatedSwitchName is not null
+            && !string.Equals(
+                baseline.NegatedSwitchName,
+                current.NegatedSwitchName,
+                StringComparison.Ordinal))
+        {
+            violations.Add(
+                $"{command.ClassName}.{baseline.PropertyName} changed negated CLI switch from "
+                + $"{baseline.NegatedSwitchName} to {current.NegatedSwitchName ?? "<none>"}");
+            return false;
+        }
+
         return true;
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -622,6 +622,7 @@ internal static class GeneratedApiCompatibilityPreserver
             {
                 SwitchName = property.SwitchName!,
                 ShortForm = property.ShortForm,
+                NegatedSwitchName = property.NegatedSwitchName,
                 PreferShortForm = property.PreferShortForm,
                 PropertyName = property.PropertyName,
                 CSharpType = property.CSharpType,
@@ -3088,7 +3089,8 @@ internal static class GeneratedApiCompatibilityPreserver
             false,
             null,
             null,
-            option.IsRequired);
+            option.IsRequired,
+            NegatedSwitchName: option.NegatedSwitchName);
 
     private static bool HasSameCliIdentity(
         GeneratedApiProperty left,
@@ -3602,7 +3604,8 @@ internal static class GeneratedApiCompatibilityPreserver
             GetBooleanNamedArgument(cliArgument, "PrependOptionTerminatorIfValueStartsWithDash"),
             secretValue is not null,
             GetStringArguments(secretValue),
-            GetValidationConstraints(range, regularExpression));
+            GetValidationConstraints(range, regularExpression),
+            GetStringNamedArgument(cliFlag, "NegatedName"));
     }
 
     private static CliValidationConstraints? GetValidationConstraints(
@@ -3982,7 +3985,8 @@ internal sealed record GeneratedApiProperty(
     bool PrependOptionTerminatorIfValueStartsWithDash = false,
     bool IsSecret = false,
     string[]? SecretValueKeys = null,
-    CliValidationConstraints? ValidationConstraints = null);
+    CliValidationConstraints? ValidationConstraints = null,
+    string? NegatedSwitchName = null);
 
 internal sealed record GeneratedApiBaseline(
     string ClassName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -560,6 +560,11 @@ public static partial class GeneratorUtils
             parts.Add($"ShortForm = {FormatStringLiteral(option.ShortForm)}");
         }
 
+        if (!string.IsNullOrEmpty(option.NegatedSwitchName))
+        {
+            parts.Add($"NegatedName = {FormatStringLiteral(option.NegatedSwitchName)}");
+        }
+
         if (option.PreferShortForm)
         {
             parts.Add("PreferShortForm = true");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliGlobalOptionMerger.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliGlobalOptionMerger.cs
@@ -47,6 +47,11 @@ public static class CliGlobalOptionMerger
                 RegisterAlias(option.ShortForm, option.SwitchName, primarySwitchByAlias);
             }
 
+            if (option.NegatedSwitchName is not null)
+            {
+                RegisterAlias(option.NegatedSwitchName, option.SwitchName, primarySwitchByAlias);
+            }
+
             optionsBySwitch.Add(option.SwitchName, option);
             switchByProperty.Add(option.PropertyName, option.SwitchName);
         }
@@ -101,6 +106,7 @@ public static class CliGlobalOptionMerger
     {
         return left.SwitchName.Equals(right.SwitchName, StringComparison.OrdinalIgnoreCase)
                && StringEquals(left.ShortForm, right.ShortForm)
+               && StringEquals(left.NegatedSwitchName, right.NegatedSwitchName)
                && left.PreferShortForm == right.PreferShortForm
                && left.PropertyName.Equals(right.PropertyName, StringComparison.Ordinal)
                && left.CSharpType.Equals(right.CSharpType, StringComparison.Ordinal)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -21,6 +21,11 @@ public record CliOptionDefinition
     public required string SwitchName { get; init; }
 
     /// <summary>
+    /// Paired switch emitted when a nullable boolean flag is explicitly false.
+    /// </summary>
+    public string? NegatedSwitchName { get; init; }
+
+    /// <summary>
     /// Short form if available (e.g., "-o" for "--output").
     /// </summary>
     public string? ShortForm { get; init; }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/PublicAPI.Unshipped.txt
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ ModularPipelines.OptionsGenerator.Models.CliConditionallyAvailableCommand.Comman
 ModularPipelines.OptionsGenerator.Models.CliConditionallyAvailableCommand.Command.init -> void
 ModularPipelines.OptionsGenerator.Models.CliConditionallyAvailableCommand.Reason.get -> string!
 ModularPipelines.OptionsGenerator.Models.CliConditionallyAvailableCommand.Reason.init -> void
+ModularPipelines.OptionsGenerator.Models.CliOptionDefinition.NegatedSwitchName.get -> string?
+ModularPipelines.OptionsGenerator.Models.CliOptionDefinition.NegatedSwitchName.init -> void
 ModularPipelines.OptionsGenerator.Models.CliToolDefinition.GlobalOptionsBeforeSubcommands.get -> bool
 ModularPipelines.OptionsGenerator.Models.CliToolDefinition.GlobalOptionsBeforeSubcommands.init -> void
 override ModularPipelines.OptionsGenerator.Models.CliConditionallyAvailableCommand.Equals(object? obj) -> bool

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -348,10 +348,16 @@ public partial class AwsCliScraper : CliScraperBase
 
         foreach (Match match in optionMatches)
         {
-            var longForm = match.Groups["long"].Value;
+            var firstLongForm = match.Groups["long"].Value;
+            var alternateLongForm = match.Groups["alternate"].Value;
             var typeHint = match.Groups["type"].Value.Trim().Trim('(', ')');
+            var (longForm, negatedLongForm) = GetBooleanSwitchPair(
+                firstLongForm,
+                alternateLongForm);
 
-            if (string.IsNullOrEmpty(longForm) || seenOptions.Contains(longForm))
+            if (string.IsNullOrEmpty(longForm)
+                || seenOptions.Contains(longForm)
+                || (!string.IsNullOrEmpty(negatedLongForm) && seenOptions.Contains(negatedLongForm)))
             {
                 continue;
             }
@@ -363,6 +369,10 @@ public partial class AwsCliScraper : CliScraperBase
             }
 
             seenOptions.Add(longForm);
+            if (!string.IsNullOrEmpty(negatedLongForm))
+            {
+                seenOptions.Add(negatedLongForm);
+            }
 
             var propertyName = NormalizePropertyName(longForm);
             if (propertyName is null)
@@ -372,12 +382,15 @@ public partial class AwsCliScraper : CliScraperBase
 
             // Get description (lines following the option with more indentation)
             var optionEnd = match.Index + match.Length;
-            var descMatch = Regex.Match(optionsSection[optionEnd..], @"^\s{8,}(.+?)(?=\n\s{7}--|\n\n\s{7}--|\z)", RegexOptions.Singleline);
+            var descMatch = Regex.Match(
+                optionsSection[optionEnd..],
+                """^\s{8,}(.+?)(?=\n\s{7}"?--|\n\n\s{7}"?--|\z)""",
+                RegexOptions.Singleline);
             var description = descMatch.Success
                 ? Regex.Replace(descMatch.Groups[1].Value.Trim(), @"\s+", " ")
                 : null;
 
-            var isFlag = IsAwsBooleanType(typeHint)
+            var isFlag = (!string.IsNullOrEmpty(negatedLongForm) || IsAwsBooleanType(typeHint))
                          && !ValueOptionsWithoutTypeHints.Contains(longForm);
             var isArray = typeHint.Contains("list") || typeHint.Contains("...") || (description?.Contains("multiple values") ?? false);
             var isNumeric = IsNumericType(typeHint);
@@ -393,6 +406,7 @@ public partial class AwsCliScraper : CliScraperBase
             options.Add(new CliOptionDefinition
             {
                 SwitchName = longForm,
+                NegatedSwitchName = negatedLongForm,
                 PropertyName = propertyName,
                 CSharpType = csharpType,
                 Description = description,
@@ -411,6 +425,29 @@ public partial class AwsCliScraper : CliScraperBase
 
         return options;
     }
+
+    private static (string SwitchName, string? NegatedSwitchName) GetBooleanSwitchPair(
+        string switchName,
+        string alternateSwitchName)
+    {
+        if (string.IsNullOrEmpty(alternateSwitchName))
+        {
+            return (switchName, null);
+        }
+
+        if (IsNegatedFormOf(alternateSwitchName, switchName))
+        {
+            return (switchName, alternateSwitchName);
+        }
+
+        return IsNegatedFormOf(switchName, alternateSwitchName)
+            ? (alternateSwitchName, switchName)
+            : (switchName, null);
+    }
+
+    private static bool IsNegatedFormOf(string candidate, string positiveSwitch) =>
+        candidate.StartsWith("--no-", StringComparison.OrdinalIgnoreCase)
+        && candidate[5..].Equals(positiveSwitch[2..], StringComparison.OrdinalIgnoreCase);
 
     private static bool IsGlobalOption(string optionName)
     {
@@ -605,7 +642,7 @@ public partial class AwsCliScraper : CliScraperBase
     /// --option (type)
     /// --flag
     /// </summary>
-    [GeneratedRegex(@"^\s{7}(?<long>--[\w-]+)(?:\s+\((?<type>[^)]+)\))?", RegexOptions.Multiline)]
+    [GeneratedRegex("""^\s{7}"?(?<long>--[\w-]+)"?(?:\s+\|\s+"?(?<alternate>--[\w-]+)"?)?(?:\s+\((?<type>[^)]+)\))?""", RegexOptions.Multiline)]
     private static partial Regex AwsOptionPattern();
 
     [GeneratedRegex(


### PR DESCRIPTION
## Summary - detect authoritative AWS `--flag | --no-flag` help pairs as one nullable boolean option - preserve explicit `false` through generated metadata and render the paired negated switch - reject `NegatedName` collisions at runtime, compile time, and during global-option merging - require matching negated aliases when merging scraped and supplemental definitions - validate external negated aliases and preserve them when restoring compatibility baselines - restrict negated aliases to nullable Boolean flags in reflection and generated metadata - mechanically regenerate paired `ec2 run-instances` flags from AWS CLI 2.32.28, including public-IP association  ## Test plan - [x] `AwsCliScraperTests` (9/9) - [x] `GeneratorUtilsTests` (134/134) - [x] CliGlobalOptionMergerTests (10/10) - [x] ExternalToolDefinitionTests (58/58) - [x] compatibility restoration regressions (2/2) - [x] `CliAttributeTests` (93/93) - [x] analyzer suite (508/508) - [x] scoped production scraper/generator regeneration harness against installed AWS CLI (1/1) - [x] OptionsGenerator Release build (0 warnings, 0 errors) - [x] core Release build (four existing RS0026 warnings)
- [x] analyzer Release build (four existing RS0026 warnings) - [x] scoped formatting and `git diff --check` - [ ] core info-level format verification reports pre-existing diagnostics elsewhere in `CliAttributeTests`; changed code is formatter-applied - [ ] Amazon Web Services focused regression run: local 2 GB guard stopped the build at 2057 MB before test execution; CI should run it - [ ] full AWS regeneration: local 2 GB guard stopped discovery at 2467 MB before writes; scoped authoritative regeneration used instead - [ ] AWS solution formatting: local 2 GB guard stopped at 2070 MB  Closes #4352  <!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  * **New Features**   * Added support for paired CLI flags, such as `--feature` and `--no-feature`.   * Nullable Boolean options can emit a configured negated flag when explicitly set to false.   * AWS CLI option generation recognizes and preserves negated switch names.  * **Bug Fixes**   * Improved validation for incompatible types and duplicate or conflicting negated switches.  * **Tests**   * Added coverage for generated flags, AWS paired switches, validation conflicts, and omitted arguments when options are unspecified. <!-- end of auto-generated comment: release notes by coderabbit.ai --> 