### PR TITLE
Scope synopsis headings per CLI scraper

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -32,7 +32,7 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
-    public async Task Parses_Indented_Synopsis_Sections()
+    public async Task Parses_Indented_Opted_In_Synopsis_Sections()
     {
         const string helpText = """
             SYNOPSIS
@@ -41,7 +41,8 @@ public class UsageSynopsisParserTests
 
         var result = UsageSynopsisParser.Parse(
             helpText,
-            ["aws", "s3", "future-command"]);
+            ["aws", "s3", "future-command"],
+            acceptedHeadings: ["usage", "synopsis"]);
 
         using (Assert.Multiple())
         {
@@ -49,6 +50,23 @@ public class UsageSynopsisParserTests
                 .IsEquivalentTo(["Source", "Destination"]);
             await Assert.That(result.PositionalArguments[0].IsRequired).IsTrue();
             await Assert.That(result.PositionalArguments[1].IsRequired).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Default_Scraper_Ignores_Synopsis_Sections()
+    {
+        const string helpText = """
+            SYNOPSIS
+                tool <TARGET>
+            """;
+
+        var result = new CountingUsageScraper().ParseUsage(["tool"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.HasExtractedSynopses).IsFalse();
+            await Assert.That(result.PositionalArguments).IsEmpty();
         }
     }
 
@@ -1094,6 +1112,9 @@ public class UsageSynopsisParserTests
         }
 
         public int UsageParseCount { get; private set; }
+
+        public UsageSynopsisParseResult ParseUsage(string[] commandPath, string helpText) =>
+            ParseUsageSynopsis(commandPath, helpText);
 
         public override string ToolName => "tool";
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -58,6 +58,8 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public partial class AwsCliScraper : CliScraperBase
 {
+    private static readonly string[] AwsUsageSynopsisHeadings = ["usage", "synopsis"];
+
     private static readonly HashSet<string> ValueOptionsWithoutTypeHints = new(StringComparer.OrdinalIgnoreCase)
     {
         "--cli-input-json",
@@ -73,6 +75,8 @@ public partial class AwsCliScraper : CliScraperBase
         "numbers",
         "punctuation",
     };
+
+    protected override IReadOnlyList<string> UsageSynopsisHeadings => AwsUsageSynopsisHeadings;
 
     public AwsCliScraper(ICliCommandExecutor executor, IHelpTextCache helpCache, ILogger<AwsCliScraper> logger)
         : base(executor, helpCache, logger)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -15,6 +15,8 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public abstract partial class CliScraperBase : ICliScraper
 {
+    private static readonly string[] DefaultUsageSynopsisHeadings = ["usage"];
+
     private readonly ConcurrentDictionary<string, CliCommandGroupAlias> _commandGroupAliases =
         new(StringComparer.OrdinalIgnoreCase);
 
@@ -77,6 +79,11 @@ public abstract partial class CliScraperBase : ICliScraper
     /// Defaults to Environment.ProcessorCount.
     /// </summary>
     protected virtual int MaxParallelism => Environment.ProcessorCount;
+
+    /// <summary>
+    /// Section headings that can introduce positional-operand syntax.
+    /// </summary>
+    protected virtual IReadOnlyList<string> UsageSynopsisHeadings => DefaultUsageSynopsisHeadings;
 
     /// <summary>
     /// The base options class name (e.g., "HelmOptions", "GcloudOptions").
@@ -788,7 +795,8 @@ public abstract partial class CliScraperBase : ICliScraper
         UsageSynopsisParser.Parse(
             helpText,
             commandPath,
-            GetAdditionalUsageSynopses(commandPath, helpText));
+            GetAdditionalUsageSynopses(commandPath, helpText),
+            UsageSynopsisHeadings);
 
     /// <summary>
     /// Lets a tool associate ambiguous usage operands with named options using its help metadata.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -9,7 +9,7 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public static class UsageSynopsisParser
 {
-    private static readonly string[] UsageHeadings = ["usage", "synopsis"];
+    private static readonly string[] DefaultUsageHeadings = ["usage"];
 
     private static readonly HashSet<string> ControlTokens = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -54,7 +54,8 @@ public static class UsageSynopsisParser
     public static UsageSynopsisParseResult Parse(
         string helpText,
         IReadOnlyList<string> commandPath,
-        IEnumerable<string>? additionalSynopses = null)
+        IEnumerable<string>? additionalSynopses = null,
+        IReadOnlyList<string>? acceptedHeadings = null)
     {
         ArgumentNullException.ThrowIfNull(helpText);
         ArgumentNullException.ThrowIfNull(commandPath);
@@ -64,7 +65,7 @@ public static class UsageSynopsisParser
             .Distinct(StringComparer.Ordinal)
             .ToList();
         var suppliedSynopsisSet = suppliedSynopses.ToHashSet(StringComparer.Ordinal);
-        var synopses = ExtractSynopses(helpText)
+        var synopses = ExtractSynopses(helpText, acceptedHeadings ?? DefaultUsageHeadings)
             .Concat(suppliedSynopses)
             .Where(synopsis => !string.IsNullOrWhiteSpace(synopsis))
             .Distinct(StringComparer.Ordinal)
@@ -329,7 +330,9 @@ public static class UsageSynopsisParser
             .ToList();
     }
 
-    private static IReadOnlyList<string> ExtractSynopses(string helpText)
+    private static IReadOnlyList<string> ExtractSynopses(
+        string helpText,
+        IReadOnlyList<string> acceptedHeadings)
     {
         var lines = helpText
             .Replace("\r\n", "\n", StringComparison.Ordinal)
@@ -340,7 +343,7 @@ public static class UsageSynopsisParser
         for (var index = 0; index < lines.Length; index++)
         {
             var trimmed = lines[index].Trim();
-            if (!TryReadSynopsisHeading(trimmed, out var inlineSynopsis))
+            if (!TryReadSynopsisHeading(trimmed, acceptedHeadings, out var inlineSynopsis))
             {
                 continue;
             }
@@ -422,11 +425,14 @@ public static class UsageSynopsisParser
     internal static bool IsSynopsisContinuation(string line) =>
         IsSynopsisContinuationCore(line.Trim());
 
-    private static bool TryReadSynopsisHeading(string line, out string synopsis)
+    private static bool TryReadSynopsisHeading(
+        string line,
+        IReadOnlyList<string> acceptedHeadings,
+        out string synopsis)
     {
         synopsis = "";
         var normalizedLine = line.Trim(' ', '\t', '━', '─');
-        var heading = UsageHeadings.FirstOrDefault(candidate =>
+        var heading = acceptedHeadings.FirstOrDefault(candidate =>
             normalizedLine.Equals(candidate, StringComparison.OrdinalIgnoreCase)
             || normalizedLine.StartsWith(candidate, StringComparison.OrdinalIgnoreCase));
         if (heading is null)


### PR DESCRIPTION
Closes #4345

## Summary

- make accepted usage/synopsis section headings configurable per CLI scraper
- keep `Usage` as the shared default
- opt only AWS into bare `SYNOPSIS` parsing
- cover AWS s3 operand discovery and default-scraper isolation

## Validation

- `Parses_Indented_Opted_In_Synopsis_Sections`: passed
- `Default_Scraper_Ignores_Synopsis_Sections`: passed
- `High_Level_S3_Commands_Expose_Their_Path_Operands`: passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- scoped whitespace formatting and `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable recognition of command-line usage and synopsis sections.
  - AWS CLI help output now supports both “Usage” and “Synopsis” sections when extracting command information.

- **Bug Fixes**
  - Prevented synopsis content from being interpreted by default when a scraper does not explicitly support synopsis sections.
  - Improved extraction of positional arguments from supported synopsis formats.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->