### PR TITLE
Keep gcloud project selectors textual

### DIFF
--- a/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesEtdDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesEtdDeleteOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Google.Options;
 namespace ModularPipelines.Google.Options;
 
 /// <summary>
-/// delete an Event Threat     Detection custom module
+/// delete an Event Threat      Detection custom module
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
@@ -51,6 +51,6 @@ public record GcloudSccManageCustomModulesEtdDeleteOptions(
     /// At most one of these can be specified: Project associated with the custom module.
     /// </summary>
     [CliOption("--project", Format = OptionFormat.EqualsSeparated)]
-    public int? Project { get; set; }
+    public string? Project { get; set; }
 
 }

--- a/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesEtdDescribeEffectiveOptions.Generated.cs
+++ b/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesEtdDescribeEffectiveOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Google.Options;
 namespace ModularPipelines.Google.Options;
 
 /// <summary>
-/// get the effective     details of a Event Threat Detection effective custom module
+/// get the effective      details of a Event Threat Detection effective custom module
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
@@ -45,6 +45,6 @@ public record GcloudSccManageCustomModulesEtdDescribeEffectiveOptions(
     /// At most one of these can be specified: At most one of these can be specified: Project associated with the custom module.
     /// </summary>
     [CliOption("--project", Format = OptionFormat.EqualsSeparated)]
-    public int? Project { get; set; }
+    public string? Project { get; set; }
 
 }

--- a/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesEtdDescribeOptions.Generated.cs
+++ b/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesEtdDescribeOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Google.Options;
 namespace ModularPipelines.Google.Options;
 
 /// <summary>
-/// get the details of a Event     Threat Detection custom module
+/// get the details of a Event      Threat Detection custom module
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
@@ -45,6 +45,6 @@ public record GcloudSccManageCustomModulesEtdDescribeOptions(
     /// At most one of these can be specified: At most one of these can be specified: Project associated with the custom module.
     /// </summary>
     [CliOption("--project", Format = OptionFormat.EqualsSeparated)]
-    public int? Project { get; set; }
+    public string? Project { get; set; }
 
 }

--- a/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesShaDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesShaDeleteOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Google.Options;
 namespace ModularPipelines.Google.Options;
 
 /// <summary>
-/// delete a Security Health     Analytics custom module
+/// delete a Security Health      Analytics custom module
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
@@ -51,6 +51,6 @@ public record GcloudSccManageCustomModulesShaDeleteOptions(
     /// At most one of these can be specified: Project associated with the custom module.
     /// </summary>
     [CliOption("--project", Format = OptionFormat.EqualsSeparated)]
-    public int? Project { get; set; }
+    public string? Project { get; set; }
 
 }

--- a/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesShaDescribeEffectiveOptions.Generated.cs
+++ b/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesShaDescribeEffectiveOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Google.Options;
 namespace ModularPipelines.Google.Options;
 
 /// <summary>
-/// get effective the     details of a Security Health Analytics effective custom module
+/// get effective the      details of a Security Health Analytics effective custom module
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
@@ -45,6 +45,6 @@ public record GcloudSccManageCustomModulesShaDescribeEffectiveOptions(
     /// At most one of these can be specified: At most one of these can be specified: Project associated with the custom module.
     /// </summary>
     [CliOption("--project", Format = OptionFormat.EqualsSeparated)]
-    public int? Project { get; set; }
+    public string? Project { get; set; }
 
 }

--- a/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesShaDescribeOptions.Generated.cs
+++ b/src/ModularPipelines.Google/Options/GcloudSccManageCustomModulesShaDescribeOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Google.Options;
 namespace ModularPipelines.Google.Options;
 
 /// <summary>
-/// get the details of a     Security Health Analytics custom module
+/// get the details of a      Security Health Analytics custom module
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
@@ -45,6 +45,6 @@ public record GcloudSccManageCustomModulesShaDescribeOptions(
     /// At most one of these can be specified: At most one of these can be specified: Project associated with the custom module.
     /// </summary>
     [CliOption("--project", Format = OptionFormat.EqualsSeparated)]
-    public int? Project { get; set; }
+    public string? Project { get; set; }
 
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
@@ -1,0 +1,58 @@
+using ModularPipelines.Google.Options;
+using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
+
+namespace ModularPipelines.Google.UnitTests;
+
+public class GcloudProjectSelectorTests
+{
+    [Test]
+    public async Task CustomModuleSelectorsRenderProjectIdsAndResourceNames()
+    {
+        const string module = "custom-module";
+        const string project = "my-project";
+        const string parent = "projects/my-project";
+        var options = new object[]
+        {
+            new GcloudSccManageCustomModulesEtdDeleteOptions(module)
+            {
+                Project = project,
+                Parent = parent,
+            },
+            new GcloudSccManageCustomModulesEtdDescribeOptions(module)
+            {
+                Project = project,
+                Parent = parent,
+            },
+            new GcloudSccManageCustomModulesEtdDescribeEffectiveOptions(module)
+            {
+                Project = project,
+                Parent = parent,
+            },
+            new GcloudSccManageCustomModulesShaDeleteOptions(module)
+            {
+                Project = project,
+                Parent = parent,
+            },
+            new GcloudSccManageCustomModulesShaDescribeOptions(module)
+            {
+                Project = project,
+                Parent = parent,
+            },
+            new GcloudSccManageCustomModulesShaDescribeEffectiveOptions(module)
+            {
+                Project = project,
+                Parent = parent,
+            },
+        };
+
+        foreach (var option in options)
+        {
+            await Assert.That(BuildArguments(option)).IsEquivalentTo(
+            [
+                module,
+                $"--project={project}",
+                $"--parent={parent}",
+            ]);
+        }
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -261,6 +261,10 @@ public partial class NestedArgumentGroupParsingTests
             FLAGS
                  --trigger-service-account=TRIGGER_SERVICE_ACCOUNT
                     IAM service-account email address.
+                 --project=PROJECT_ID_OR_NUMBER
+                    Project associated with the custom module.
+                 --project-number=PROJECT_NUMBER
+                    Numeric project number.
                  --retry-count=RETRY_COUNT
                     Number of retries.
                  --disk-size=DISK_SIZE
@@ -279,6 +283,12 @@ public partial class NestedArgumentGroupParsingTests
             await Assert.That(command!.Options.Single(option =>
                 option.SwitchName == "--trigger-service-account").CSharpType)
                 .IsEqualTo("string?");
+            await Assert.That(command.Options.Single(option =>
+                option.SwitchName == "--project").CSharpType)
+                .IsEqualTo("string?");
+            await Assert.That(command.Options.Single(option =>
+                option.SwitchName == "--project-number").CSharpType)
+                .IsEqualTo("int?");
             await Assert.That(command.Options.Single(option =>
                 option.SwitchName == "--retry-count").CSharpType)
                 .IsEqualTo("int?");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -457,7 +457,8 @@ public partial class GcloudCliScraper : CliScraperBase
         => NumericHintPattern().IsMatch(hint);
 
     private static bool IsTextualIdentifierOption(string switchName)
-        => switchName.Equals("--billing-account", StringComparison.OrdinalIgnoreCase)
+        => switchName.Equals("--project", StringComparison.OrdinalIgnoreCase)
+            || switchName.Equals("--billing-account", StringComparison.OrdinalIgnoreCase)
             || (switchName.Contains("service-account", StringComparison.OrdinalIgnoreCase)
                 && !switchName.EndsWith("-project-number", StringComparison.OrdinalIgnoreCase));
 


### PR DESCRIPTION
## Summary
- classify gcloud's exact `--project` selector as textual while keeping numeric-only switches such as `--project-number` numeric
- regenerate the ETD and SHA custom-module delete, describe, and describe-effective option types from installed Google Cloud SDK 550.0.0 help
- cover all six generated option types rendering an alphanumeric project ID and `projects/<name>` parent resource

## Generator provenance
The temporary scoped harness invoked these live SDK 550.0.0 command paths through `GcloudCliScraper` and `OptionsClassGenerator`, then was removed:
- `scc manage custom-modules etd delete`
- `scc manage custom-modules etd describe`
- `scc manage custom-modules etd describe-effective`
- `scc manage custom-modules sha delete`
- `scc manage custom-modules sha describe`
- `scc manage custom-modules sha describe-effective`

Each authoritative help page declares `--project=PROJECT_ID_OR_NUMBER`; all six generated `Project` properties are now `string?`.

## Validation
- OptionsGenerator Release build: 0 warnings, 0 errors
- focused gcloud type-inference regression: 1/1 passed
- scoped authoritative regeneration: 1/1 passed
- scoped whitespace formatting: passed
- `git diff --check`: passed
- Google rendering test project reached 2.418 GB and was stopped by the mandated 2 GB agent guard; the limit was not raised or retried, so CI owns that expensive validation

Closes #4341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of the `--project` option so project IDs are treated as text rather than numeric values.
  * Ensured custom module commands include the configured project ID and parent resource in generated command arguments.

* **Tests**
  * Added coverage for project and project-number option parsing.
  * Added validation for project and resource name arguments across custom module commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->