### PR TITLE
Preserve Docker Compose no-TTY metadata

### DIFF
--- a/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
@@ -66,7 +66,7 @@ public record DockerComposeExecOptions(
     public string? Workdir { get; set; }
 
     /// <summary>
-    /// Disable pseudo-TTY allocation (default: auto-detected) (default true)
+    /// Disable pseudo-TTY allocation (default: auto-detected)
     /// </summary>
     [CliOption("--no-TTY", ShortForm = "-T", Format = OptionFormat.EqualsSeparated)]
     public bool? NoTty { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
@@ -66,12 +66,15 @@ public record DockerComposeExecOptions(
     public string? Workdir { get; set; }
 
     /// <summary>
+    /// Disable pseudo-TTY allocation (default: auto-detected) (default true)
+    /// </summary>
+    [CliOption("--no-TTY", ShortForm = "-T", Format = OptionFormat.EqualsSeparated)]
+    public bool? NoTty { get; set; }
+
+    /// <summary>
     /// The ARGS operand.
     /// </summary>
     [CliArgument(2, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Args { get; set; }
-
-    [Obsolete("NoTty is no longer supported by the installed CLI and has no effect.")]
-    public bool? NoTty { get; set; }
 
 }

--- a/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
+++ b/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
@@ -107,20 +107,6 @@ public class DockerBuilderCompatibilityTests
     }
 
     [Test]
-    public async Task ComposeExecNoTtyRendersCanonicalSwitch()
-    {
-        var options = new DockerComposeExecOptions("service", "command")
-        {
-            NoTty = true,
-        };
-        var model = new CommandModelProvider()
-            .GetCommandModel(typeof(DockerComposeExecOptions));
-        var arguments = new CommandArgumentBuilder().BuildArguments(model, options);
-
-        await Assert.That(arguments).Contains("--no-TTY=true");
-    }
-
-    [Test]
     public async Task CustomBuildxRegistrationDoesNotNeedToImplementBuilder()
     {
         var customBuildx = DispatchProxy.Create<IDockerBuildx, ThrowingProxy>();

--- a/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
+++ b/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
@@ -107,6 +107,20 @@ public class DockerBuilderCompatibilityTests
     }
 
     [Test]
+    public async Task ComposeExecNoTtyRendersCanonicalSwitch()
+    {
+        var options = new DockerComposeExecOptions("service", "command")
+        {
+            NoTty = true,
+        };
+        var model = new CommandModelProvider()
+            .GetCommandModel(typeof(DockerComposeExecOptions));
+        var arguments = new CommandArgumentBuilder().BuildArguments(model, options);
+
+        await Assert.That(arguments).Contains("--no-TTY=true");
+    }
+
+    [Test]
     public async Task CustomBuildxRegistrationDoesNotNeedToImplementBuilder()
     {
         var customBuildx = DispatchProxy.Create<IDockerBuildx, ThrowingProxy>();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
@@ -51,6 +51,30 @@ public class DockerCliCompatibilityTests
     }
 
     [Test]
+    public async Task ComposeExec_Preserves_NoTty_WhenInstalledHelpOmitsIt()
+    {
+        const string helpText = """
+            Execute a command in a running container
+
+            Usage: docker compose exec [OPTIONS] SERVICE COMMAND [ARGS...]
+            """;
+        var command = await new TestDockerCliScraper().Parse(
+            ["docker", "compose", "exec"],
+            helpText);
+
+        var option = command!.Options.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("--no-TTY");
+            await Assert.That(option.ShortForm).IsEqualTo("-T");
+            await Assert.That(option.PropertyName).IsEqualTo("NoTty");
+            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.ValueSeparator).IsEqualTo("=");
+        }
+    }
+
+    [Test]
     public async Task Switch_Normalization_Rejects_Distinct_Options_With_One_Canonical_Name()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
@@ -46,8 +46,19 @@ public class DockerCliCompatibilityTests
             helpText);
 
         var option = command!.Options.Single();
-        await Assert.That(option.SwitchName).IsEqualTo("--no-TTY");
-        await Assert.That(option.ShortForm).IsEqualTo("-T");
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("--no-TTY");
+            await Assert.That(option.ShortForm).IsEqualTo("-T");
+            if (subcommand == "exec")
+            {
+                await Assert.That(option.IsFlag).IsFalse();
+                await Assert.That(option.CSharpType).IsEqualTo("bool?");
+                await Assert.That(option.ValueSeparator).IsEqualTo("=");
+                await Assert.That(option.Description)
+                    .IsEqualTo("Disable pseudo-TTY allocation (default: auto-detected)");
+            }
+        }
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
@@ -29,18 +29,20 @@ public class DockerCliCompatibilityTests
     }
 
     [Test]
-    public async Task ComposeExec_Preserves_Canonical_NoTty_Switch_Casing()
+    [Arguments("exec")]
+    [Arguments("run")]
+    public async Task ComposeCommands_Preserve_Canonical_NoTty_Switch_Casing(string subcommand)
     {
-        const string helpText = """
+        var helpText = $$"""
             Execute a command in a running container
 
-            Usage: docker compose exec [OPTIONS] SERVICE COMMAND [ARGS...]
+            Usage: docker compose {{subcommand}} [OPTIONS] SERVICE COMMAND [ARGS...]
 
             Options:
               -T, --no-tty   Disable pseudo-TTY allocation
             """;
         var command = await new TestDockerCliScraper().Parse(
-            ["docker", "compose", "exec"],
+            ["docker", "compose", subcommand],
             helpText);
 
         var option = command!.Options.Single();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliCompatibilityTests.cs
@@ -69,6 +69,8 @@ public class DockerCliCompatibilityTests
             await Assert.That(option.ShortForm).IsEqualTo("-T");
             await Assert.That(option.PropertyName).IsEqualTo("NoTty");
             await Assert.That(option.CSharpType).IsEqualTo("bool?");
+            await Assert.That(option.Description)
+                .IsEqualTo("Disable pseudo-TTY allocation (default: auto-detected)");
             await Assert.That(option.IsFlag).IsFalse();
             await Assert.That(option.ValueSeparator).IsEqualTo("=");
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
@@ -57,12 +57,20 @@ public class DockerCliScraper : CobraCliScraper
         string[] commandParts,
         IReadOnlyList<CliOptionDefinition> options)
     {
-        if (commandParts is not ["compose", "exec"]
-            || options.Any(option => option.PropertyName == ComposeExecNoTtyOption.PropertyName))
+        if (commandParts is not ["compose", "exec"])
         {
             return options;
         }
 
-        return [.. options, ComposeExecNoTtyOption];
+        if (options.All(option => option.PropertyName != ComposeExecNoTtyOption.PropertyName))
+        {
+            return [.. options, ComposeExecNoTtyOption];
+        }
+
+        return options
+            .Select(option => option.PropertyName == ComposeExecNoTtyOption.PropertyName
+                ? ComposeExecNoTtyOption
+                : option)
+            .ToArray();
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
@@ -16,7 +16,7 @@ public class DockerCliScraper : CobraCliScraper
         ShortForm = "-T",
         PropertyName = "NoTty",
         CSharpType = "bool?",
-        Description = "Disable pseudo-TTY allocation (default: auto-detected) (default true)",
+        Description = "Disable pseudo-TTY allocation (default: auto-detected)",
         IsFlag = false,
         ValueSeparator = "=",
     };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
@@ -10,6 +10,17 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public class DockerCliScraper : CobraCliScraper
 {
+    private static readonly CliOptionDefinition ComposeExecNoTtyOption = new()
+    {
+        SwitchName = "--no-TTY",
+        ShortForm = "-T",
+        PropertyName = "NoTty",
+        CSharpType = "bool?",
+        Description = "Disable pseudo-TTY allocation (default: auto-detected) (default true)",
+        IsFlag = false,
+        ValueSeparator = "=",
+    };
+
     public override string ToolName => "docker";
     public override string NamespacePrefix => "Docker";
     public override string TargetNamespace => "ModularPipelines.Docker";
@@ -40,4 +51,18 @@ public class DockerCliScraper : CobraCliScraper
         && switchName.Equals("--no-tty", StringComparison.OrdinalIgnoreCase)
             ? "--no-TTY"
             : switchName;
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<CliOptionDefinition> ApplyOptionFixes(
+        string[] commandParts,
+        IReadOnlyList<CliOptionDefinition> options)
+    {
+        if (commandParts is not ["compose", "exec"]
+            || options.Any(option => option.PropertyName == ComposeExecNoTtyOption.PropertyName))
+        {
+            return options;
+        }
+
+        return [.. options, ComposeExecNoTtyOption];
+    }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DockerCliScraper.cs
@@ -36,7 +36,7 @@ public class DockerCliScraper : CobraCliScraper
     protected override string NormalizeOptionSwitchName(
         string[] commandParts,
         string switchName) =>
-        commandParts is ["compose", "exec"]
+        commandParts is ["compose", ..]
         && switchName.Equals("--no-tty", StringComparison.OrdinalIgnoreCase)
             ? "--no-TTY"
             : switchName;


### PR DESCRIPTION
## Summary
- normalize Compose `--no-tty` to the shipped canonical `--no-TTY` spelling for every `docker compose` command
- cover both `compose exec` and `compose run`, the latter previously aborted API compatibility validation
- add a generated-options rendering regression for `DockerComposeExecOptions.NoTty`

Fixes #4321

## Validation
- `DockerCliCompatibilityTests`: 6/6 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- local Docker 29.7.2 regeneration cleared API compatibility but stopped at the command-coverage gate because this installation adds 233+ plugin commands and removes the pinned baseline's `docker trust` tree; no generated files were written
- authoritative pinned Docker generation will run from this branch and provide the generated output as a stacked PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker Compose command option detection and normalization.
  * Preserved the canonical `--no-TTY` switch casing for Compose `exec` and `run` commands.
  * Ensured `docker compose exec` retains the no-TTY option even when it is absent from installed help text.
  * Corrected the displayed default information for the automatically detected no-TTY option.
  * Ensured the canonical no-TTY switch is rendered correctly in generated Compose commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->