### PR TITLE
[Automated] Update docker CLI Options

### DIFF
--- a/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
@@ -66,12 +66,15 @@ public record DockerComposeExecOptions(
     public string? Workdir { get; set; }
 
     /// <summary>
+    /// Disable pseudo-TTY allocation (default: auto-detected) (default true)
+    /// </summary>
+    [CliOption("--no-TTY", ShortForm = "-T", Format = OptionFormat.EqualsSeparated)]
+    public bool? NoTty { get; set; }
+
+    /// <summary>
     /// The ARGS operand.
     /// </summary>
     [CliArgument(2, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Args { get; set; }
-
-    [Obsolete("NoTty is no longer supported by the installed CLI and has no effect.")]
-    public bool? NoTty { get; set; }
 
 }

--- a/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
+++ b/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
@@ -107,6 +107,20 @@ public class DockerBuilderCompatibilityTests
     }
 
     [Test]
+    public async Task ComposeExecNoTtyRendersCanonicalSwitch()
+    {
+        var options = new DockerComposeExecOptions("service", "command")
+        {
+            NoTty = true,
+        };
+        var model = new CommandModelProvider()
+            .GetCommandModel(typeof(DockerComposeExecOptions));
+        var arguments = new CommandArgumentBuilder().BuildArguments(model, options);
+
+        await Assert.That(arguments).Contains("--no-TTY=true");
+    }
+
+    [Test]
     public async Task CustomBuildxRegistrationDoesNotNeedToImplementBuilder()
     {
         var customBuildx = DispatchProxy.Create<IDockerBuildx, ThrowingProxy>();


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **docker** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- docker (Docker version 28.0.4, build b8034c0): 235 commands, tree 579289c22c807351975b3a09486be77beae5ff4ca69c15374eaa0413b47345a2

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator