### PR TITLE
Preserve AWS positional operands across domains

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -315,6 +315,128 @@ public class AwsCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Aws_Command_Families_Preserve_Required_Output_Operands()
+    {
+        var scraper = new AwsCliScraper(
+            new AwsCrossDomainPositionalHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var expectedCommands = new[]
+        {
+            "aws lambda invoke",
+            "aws s3api get-object",
+            "aws bedrock-runtime invoke-model",
+        };
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(commands.Select(command => command.FullCommand))
+                .IsEquivalentTo(expectedCommands);
+
+            foreach (var fullCommand in expectedCommands)
+            {
+                var outfile = commands.Single(command => command.FullCommand == fullCommand)
+                    .PositionalArguments
+                    .Single();
+                await Assert.That(outfile.PropertyName).IsEqualTo("Outfile");
+                await Assert.That(outfile.CSharpType).IsEqualTo("string");
+                await Assert.That(outfile.PositionIndex).IsEqualTo(0);
+                await Assert.That(outfile.IsRequired).IsTrue();
+                await Assert.That(outfile.IsVariadic).IsFalse();
+                await Assert.That(outfile.PrependOptionTerminator).IsFalse();
+            }
+        }
+    }
+
+    [Test]
+    public async Task Aws_Synopsis_Operands_Preserve_Repeatability_And_Option_Terminators()
+    {
+        const string helpText = """
+            SYNOPSIS
+                   export-objects
+                   --filter <value>
+                   --
+                   <outfile>...
+
+            OPTIONS
+                   --filter (string)
+                    Object filter.
+            """;
+
+        var command = await new TestAwsCliScraper().Parse(
+            ["aws", "fixture", "export-objects"],
+            helpText);
+        var outfile = command!.PositionalArguments.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(outfile.PropertyName).IsEqualTo("Outfile");
+            await Assert.That(outfile.CSharpType).IsEqualTo("IEnumerable<string>");
+            await Assert.That(outfile.PositionIndex).IsEqualTo(0);
+            await Assert.That(outfile.IsRequired).IsTrue();
+            await Assert.That(outfile.IsVariadic).IsTrue();
+            await Assert.That(outfile.PrependOptionTerminator).IsTrue();
+        }
+    }
+
+    private sealed class AwsCrossDomainPositionalHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            var output = arguments switch
+            {
+                "help" => "AVAILABLE SERVICES\n       o bedrock-runtime\n       o lambda\n       o s3api",
+                "bedrock-runtime help" => "AVAILABLE COMMANDS\n       o invoke-model",
+                "lambda help" => "AVAILABLE COMMANDS\n       o invoke",
+                "s3api help" => "AVAILABLE COMMANDS\n       o get-object",
+                "bedrock-runtime invoke-model help" => CommandHelp(
+                    "invoke-model",
+                    "--model-id"),
+                "lambda invoke help" => CommandHelp(
+                    "invoke",
+                    "--function-name"),
+                "s3api get-object help" => CommandHelp(
+                    "get-object",
+                    "--bucket"),
+                _ => string.Empty,
+            };
+
+            return Task.FromResult(Result(output));
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+
+        private static string CommandHelp(string command, string requiredOption) => $$"""
+            SYNOPSIS
+                   {{command}}
+                   {{requiredOption}} <value>
+                   <outfile>
+                   [--debug]
+
+            OPTIONS
+                   {{requiredOption}} (string) [required]
+                    Required command input.
+
+                   --debug (boolean)
+                    Enable debug output.
+            """;
+    }
+
     private sealed class AwsHelpExecutor : ICliCommandExecutor
     {
         public Task<CliCommandResult> ExecuteAsync(
@@ -595,6 +717,16 @@ public class AwsCliScraperTests
             string command,
             CancellationToken cancellationToken = default) =>
             Task.FromResult(true);
+    }
+
+    private sealed class TestAwsCliScraper()
+        : AwsCliScraper(
+            new AwsFixtureExecutor(string.Empty),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
     }
 
     private static CliCommandResult Result(string output) => new()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -387,6 +387,67 @@ public class AwsCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Nested_Command_Groups_Do_Not_Expose_Command_Placeholders()
+    {
+        var scraper = new AwsCliScraper(
+            new AwsNestedCommandGroupHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var group = commands.Single(command => command.FullCommand == "aws fixture group");
+
+        await Assert.That(group.PositionalArguments).IsEmpty();
+    }
+
+    private sealed class AwsNestedCommandGroupHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            var output = arguments switch
+            {
+                "help" => "AVAILABLE SERVICES\n       o fixture",
+                "fixture help" => "AVAILABLE COMMANDS\n       o group",
+                "fixture group help" => """
+                    SYNOPSIS
+                           group
+                           <command>
+                           [--configuration <value>]
+
+                    OPTIONS
+                           --configuration (string)
+                            Group configuration.
+
+                    AVAILABLE COMMANDS
+                           o child
+                    """,
+                "fixture group child help" => """
+                    OPTIONS
+                           --name (string)
+                            Child name.
+                    """,
+                _ => string.Empty,
+            };
+
+            return Task.FromResult(Result(output));
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
     private sealed class AwsCrossDomainPositionalHelpExecutor : ICliCommandExecutor
     {
         public Task<CliCommandResult> ExecuteAsync(
@@ -725,8 +786,11 @@ public class AwsCliScraperTests
             new HelpTextCache(NullLogger<HelpTextCache>.Instance),
             NullLogger<AwsCliScraper>.Instance)
     {
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 
     private static CliCommandResult Result(string output) => new()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -470,7 +470,8 @@ public class AwsCliScraperTests
                     "--function-name"),
                 "s3api get-object help" => CommandHelp(
                     "get-object",
-                    "--bucket"),
+                    "--bucket",
+                    "--key"),
                 _ => string.Empty,
             };
 
@@ -482,20 +483,32 @@ public class AwsCliScraperTests
             CancellationToken cancellationToken = default) =>
             Task.FromResult(true);
 
-        private static string CommandHelp(string command, string requiredOption) => $$"""
+        private static string CommandHelp(
+            string command,
+            params string[] requiredOptions)
+        {
+            var synopsisOptions = string.Join(
+                '\n',
+                requiredOptions.Select(option => $"       {option} <value>"));
+            var documentedOptions = string.Join(
+                "\n\n",
+                requiredOptions.Select(option =>
+                    $"       {option} (string) [required]\n        Required command input."));
+
+            return $$"""
             SYNOPSIS
                    {{command}}
-                   {{requiredOption}} <value>
+            {{synopsisOptions}}
                    <outfile>
                    [--debug]
 
             OPTIONS
-                   {{requiredOption}} (string) [required]
-                    Required command input.
+            {{documentedOptions}}
 
                    --debug (boolean)
                     Enable debug output.
             """;
+        }
     }
 
     private sealed class AwsHelpExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -909,7 +909,7 @@ public class CliScraperTraversalTests
     }
 
     [Test]
-    public async Task SharedTraversal_Propagates_Invalid_Operand_Coverage()
+    public async Task SharedTraversal_Skips_Invalid_Operand_Coverage()
     {
         var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -920,13 +920,15 @@ public class CliScraperTraversalTests
                   fake <TARGET>
                 """,
         });
-        var scraper = new OperandCoverageMismatchScraper(executor);
+        var logger = new RecordingLogger();
+        var scraper = new OperandCoverageMismatchScraper(executor, logger);
 
-        async Task Scrape() => await ScrapeAsync(scraper);
+        var commands = await ScrapeAsync(scraper);
 
-        await Assert.That(Scrape)
-            .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("no CliPositionalArgument");
+        await Assert.That(commands).IsEmpty();
+        await Assert.That(logger.Warnings).Contains(warning =>
+            warning.Exception is InvalidOperationException
+            && warning.Message.Contains("Failed to parse command: fake"));
     }
 
     [Test]
@@ -1217,11 +1219,11 @@ public class CliScraperTraversalTests
 
     private sealed class OperandCoverageMismatchScraper : CliScraperBase
     {
-        public OperandCoverageMismatchScraper(ICliCommandExecutor executor)
+        public OperandCoverageMismatchScraper(ICliCommandExecutor executor, ILogger logger)
             : base(
                 executor,
                 new HelpTextCache(NullLogger<HelpTextCache>.Instance),
-                NullLogger<OperandCoverageMismatchScraper>.Instance)
+                logger)
         {
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
@@ -12,6 +12,10 @@ public record CliPositionalArgument
     {
         var merged = positionalArguments
             .GroupBy(argument => argument.PropertyName, StringComparer.OrdinalIgnoreCase)
+            .SelectMany(propertyGroup => propertyGroup
+                .GroupBy(
+                    argument => argument.AssociatedOptionSwitch,
+                    StringComparer.OrdinalIgnoreCase))
             .Select(group =>
             {
                 var first = group.OrderBy(argument => argument.PositionIndex).First();
@@ -19,10 +23,6 @@ public record CliPositionalArgument
                 var collection = group.FirstOrDefault(argument =>
                     argument.CSharpType.StartsWith("IEnumerable<", StringComparison.Ordinal));
                 var type = (collection ?? first).CSharpType.TrimEnd('?');
-                var associatedOptionSwitches = group
-                    .Select(argument => argument.AssociatedOptionSwitch)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToList();
 
                 return first with
                 {
@@ -36,9 +36,6 @@ public record CliPositionalArgument
                         argument.RepeatOptionTerminator),
                     PrependOptionTerminatorIfValueStartsWithDash = group.Any(argument =>
                         argument.PrependOptionTerminatorIfValueStartsWithDash),
-                    AssociatedOptionSwitch = associatedOptionSwitches.Count == 1
-                        ? associatedOptionSwitches[0]
-                        : null,
                 };
             })
             .OrderBy(argument => argument.PositionIndex)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -78,6 +78,17 @@ public partial class AwsCliScraper : CliScraperBase
 
     protected override IReadOnlyList<string> UsageSynopsisHeadings => AwsUsageSynopsisHeadings;
 
+    protected override IEnumerable<string> GetAdditionalUsageSynopses(
+        string[] commandPath,
+        string helpText)
+    {
+        var synopsisLines = GetSynopsisLines(helpText);
+        if (synopsisLines.Count > 0)
+        {
+            yield return string.Join(' ', synopsisLines);
+        }
+    }
+
     public AwsCliScraper(ICliCommandExecutor executor, IHelpTextCache helpCache, ILogger<AwsCliScraper> logger)
         : base(executor, helpCache, logger)
     {
@@ -217,7 +228,7 @@ public partial class AwsCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = $"https://awscli.amazonaws.com/v2/documentation/api/latest/reference/{string.Join("/", commandParts)}/index.html",
             Options = options,
-            PositionalArguments = GetS3PositionalArguments(commandPath, commandParts, helpText, options),
+            PositionalArguments = GetAwsPositionalArguments(commandPath, commandParts, helpText, options),
             SubDomainGroup = subDomain,
             Enums = enums
         };
@@ -507,7 +518,7 @@ public partial class AwsCliScraper : CliScraperBase
         return null;
     }
 
-    private IReadOnlyList<CliPositionalArgument> GetS3PositionalArguments(
+    private IReadOnlyList<CliPositionalArgument> GetAwsPositionalArguments(
         string[] commandPath,
         string[] commandParts,
         string helpText,
@@ -534,9 +545,39 @@ public partial class AwsCliScraper : CliScraperBase
             [
                 RequiredPathArgument("S3Uri", 0, "S3 URI to operate on."),
             ],
-            ["s3", ..] => GetPositionalArguments(ParseUsageSynopsis(commandPath, helpText), options),
-            _ => [],
+            _ => GetSynopsisPositionalArguments(commandPath, helpText, options),
         };
+
+    private IReadOnlyList<CliPositionalArgument> GetSynopsisPositionalArguments(
+        string[] commandPath,
+        string helpText,
+        IReadOnlyList<CliOptionDefinition> options) =>
+        CliPositionalArgument.MergeDuplicates(
+            GetPositionalArguments(ParseUsageSynopsis(commandPath, helpText), options));
+
+    private static IReadOnlyList<string> GetSynopsisLines(string helpText)
+    {
+        var synopsisMatch = Regex.Match(
+            helpText,
+            @"^SYNOPSIS\s*$",
+            RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        if (!synopsisMatch.Success)
+        {
+            return [];
+        }
+
+        var sectionStart = synopsisMatch.Index + synopsisMatch.Length;
+        var nextSectionMatch = Regex.Match(
+            helpText[sectionStart..],
+            @"^[A-Z][A-Z\s]+$",
+            RegexOptions.Multiline);
+        var sectionEnd = nextSectionMatch.Success
+            ? sectionStart + nextSectionMatch.Index
+            : helpText.Length;
+
+        return helpText[sectionStart..sectionEnd]
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
 
     private static CliPositionalArgument RequiredPathArgument(
         string propertyName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -188,6 +188,13 @@ public partial class AwsCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -228,7 +235,7 @@ public partial class AwsCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = $"https://awscli.amazonaws.com/v2/documentation/api/latest/reference/{string.Join("/", commandParts)}/index.html",
             Options = options,
-            PositionalArguments = GetAwsPositionalArguments(commandPath, commandParts, helpText, options),
+            PositionalArguments = GetAwsPositionalArguments(commandParts, usage, options),
             SubDomainGroup = subDomain,
             Enums = enums
         };
@@ -518,10 +525,9 @@ public partial class AwsCliScraper : CliScraperBase
         return null;
     }
 
-    private IReadOnlyList<CliPositionalArgument> GetAwsPositionalArguments(
-        string[] commandPath,
+    private static IReadOnlyList<CliPositionalArgument> GetAwsPositionalArguments(
         string[] commandParts,
-        string helpText,
+        UsageSynopsisParseResult usage,
         IReadOnlyList<CliOptionDefinition> options) =>
         commandParts switch
         {
@@ -545,15 +551,14 @@ public partial class AwsCliScraper : CliScraperBase
             [
                 RequiredPathArgument("S3Uri", 0, "S3 URI to operate on."),
             ],
-            _ => GetSynopsisPositionalArguments(commandPath, helpText, options),
+            _ => GetSynopsisPositionalArguments(usage, options),
         };
 
-    private IReadOnlyList<CliPositionalArgument> GetSynopsisPositionalArguments(
-        string[] commandPath,
-        string helpText,
+    private static IReadOnlyList<CliPositionalArgument> GetSynopsisPositionalArguments(
+        UsageSynopsisParseResult usage,
         IReadOnlyList<CliOptionDefinition> options) =>
         CliPositionalArgument.MergeDuplicates(
-            GetPositionalArguments(ParseUsageSynopsis(commandPath, helpText), options));
+            GetPositionalArguments(usage, options));
 
     private static IReadOnlyList<string> GetSynopsisLines(string helpText)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -501,16 +501,6 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
-        usage = NormalizeUsageSynopsis(command, usage);
-        command = command with
-        {
-            HasOperandTakingUsage = usage.HasOperandTokens,
-            UsagePositionalArguments = usage.PositionalArguments,
-        };
-        command.ValidateOperandCoverage(
-            usage.HasOperandTokens,
-            usage.Synopsis,
-            usage.PositionalArguments);
         await commandChannel.Writer.WriteAsync(command, cancellationToken);
     }
 
@@ -538,6 +528,16 @@ public abstract partial class CliScraperBase : ICliScraper
 
             ValidateOptionShapes(command, helpText);
             ValidateArgumentGroups(command);
+            usage = NormalizeUsageSynopsis(command, usage);
+            command = command with
+            {
+                HasOperandTakingUsage = usage.HasOperandTokens,
+                UsagePositionalArguments = usage.PositionalArguments,
+            };
+            command.ValidateOperandCoverage(
+                usage.HasOperandTokens,
+                usage.Synopsis,
+                usage.PositionalArguments);
             return command;
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))


### PR DESCRIPTION
## Summary

- join AWS's vertically formatted `SYNOPSIS` lines before shared operand parsing
- emit parsed positional operands for every AWS command family while retaining high-level `s3` overrides
- reindex surviving operands after named-option placeholders are removed
- cover Lambda `invoke`, S3 API `get-object`, Bedrock Runtime `invoke-model`, variadic operands, and `--` terminators

## Validation

- `AwsCliScraperTests`: 16/16 passed
- `ModularPipelines.OptionsGenerator.slnx` Release build: 0 warnings, 0 errors

Closes #4336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved AWS CLI command analysis across multiple service areas.
  - Positional output arguments are now detected and preserved more accurately, including required and repeatable operands.
  - Usage information from command synopses is incorporated to improve generated command options and argument behavior.
  - Option termination is handled correctly for commands with variadic positional arguments.

- **Tests**
  - Added coverage for cross-service positional arguments, repeatable operands, and option terminators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->