### PR TITLE
Enforce exact ordering in CLI argv tests

### DIFF
--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsAmplifyCreateAppOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsAmplifyCreateAppOptionsTests.cs
@@ -22,6 +22,6 @@ public class AwsAmplifyCreateAppOptionsTests
         [
             "--environment-variables",
             "FIRST=one,SECOND=two",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsAmplifyCreateAppOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsAmplifyCreateAppOptionsTests.cs
@@ -18,10 +18,10 @@ public class AwsAmplifyCreateAppOptionsTests
             ],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--environment-variables",
             "FIRST=one,SECOND=two",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2DescribeInstancesOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2DescribeInstancesOptionsTests.cs
@@ -18,6 +18,6 @@ public class AwsEc2DescribeInstancesOptionsTests
             "--instance-ids",
             "i-0123456789abcdef0",
             "i-0fedcba9876543210",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2DescribeInstancesOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2DescribeInstancesOptionsTests.cs
@@ -13,11 +13,11 @@ public class AwsEc2DescribeInstancesOptionsTests
             InstanceIds = ["i-0123456789abcdef0", "i-0fedcba9876543210"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--instance-ids",
             "i-0123456789abcdef0",
             "i-0fedcba9876543210",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2RunInstancesOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2RunInstancesOptionsTests.cs
@@ -20,8 +20,8 @@ public class AwsEc2RunInstancesOptionsTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(enabled).IsEquivalentTo(["--associate-public-ip-address"]);
-            await Assert.That(disabled).IsEquivalentTo(["--no-associate-public-ip-address"]);
+            await Assert.That(enabled).IsEquivalentTo(["--associate-public-ip-address"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+            await Assert.That(disabled).IsEquivalentTo(["--no-associate-public-ip-address"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
             await Assert.That(unspecified).IsEmpty();
         }
     }

--- a/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2RunInstancesOptionsTests.cs
+++ b/test/ModularPipelines.AmazonWebServices.UnitTests/AwsEc2RunInstancesOptionsTests.cs
@@ -20,8 +20,8 @@ public class AwsEc2RunInstancesOptionsTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(enabled).IsEquivalentTo(["--associate-public-ip-address"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
-            await Assert.That(disabled).IsEquivalentTo(["--no-associate-public-ip-address"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+            await AssertArguments(enabled, ["--associate-public-ip-address"]);
+            await AssertArguments(disabled, ["--no-associate-public-ip-address"]);
             await Assert.That(unspecified).IsEmpty();
         }
     }

--- a/test/ModularPipelines.Ansible.UnitTests/Attributes/AnsibleOptionsTests.cs
+++ b/test/ModularPipelines.Ansible.UnitTests/Attributes/AnsibleOptionsTests.cs
@@ -24,19 +24,19 @@ public class AnsibleOptionsTests : TestBase
             Verbose = 3,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "webservers",
+            "--flush-cache",
             "--background", "30",
             "--check",
             "--extra-vars", "environment=staging",
             "--extra-vars", "@vars.yml",
-            "--flush-cache",
             "--inventory", "hosts.ini",
             "--inventory", "dynamic.yml",
             "--module-name", "ping",
             "--verbose", "--verbose", "--verbose",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]

--- a/test/ModularPipelines.Ansible.UnitTests/Attributes/AnsibleOptionsTests.cs
+++ b/test/ModularPipelines.Ansible.UnitTests/Attributes/AnsibleOptionsTests.cs
@@ -36,7 +36,7 @@ public class AnsibleOptionsTests : TestBase
             "--inventory", "dynamic.yml",
             "--module-name", "ping",
             "--verbose", "--verbose", "--verbose",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.ArgoCd.UnitTests/Attributes/ArgoCdOptionsTests.cs
+++ b/test/ModularPipelines.ArgoCd.UnitTests/Attributes/ArgoCdOptionsTests.cs
@@ -28,7 +28,7 @@ public class ArgoCdOptionsTests
             "--output=json",
             "--timeout=30",
             "--auth-token=token-value",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -48,7 +48,7 @@ public class ArgoCdOptionsTests
             "--dry-run",
             "--output=yaml",
             "--upsert",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class ArgoCdOptionsTests
             "second",
             "--wait",
             "--yes",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -82,7 +82,7 @@ public class ArgoCdOptionsTests
             "apps.yaml",
             "more-apps.yaml",
             "--output=json",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -103,7 +103,7 @@ public class ArgoCdOptionsTests
             "create",
             "application"));
 
-        await Assert.That(arguments).IsEquivalentTo(["role:admin", "create", "application"]);
+        await Assert.That(arguments).IsEquivalentTo(["role:admin", "create", "application"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -123,7 +123,7 @@ public class ArgoCdOptionsTests
             "add-permission",
             "get",
             "--dry-run=false",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -148,7 +148,7 @@ public class ArgoCdOptionsTests
             ? ["first", "second", "--dry-run"]
             : ["first", "second", "--health"];
 
-        await Assert.That(arguments).IsEquivalentTo(expectedArguments);
+        await Assert.That(arguments).IsEquivalentTo(expectedArguments, TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -160,7 +160,7 @@ public class ArgoCdOptionsTests
             Yes = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second", "--yes"]);
+        await Assert.That(arguments).IsEquivalentTo(["first", "second", "--yes"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -173,7 +173,7 @@ public class ArgoCdOptionsTests
         [
             "https://first.example/repo.git",
             "https://second.example/repo.git",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -184,7 +184,7 @@ public class ArgoCdOptionsTests
             Name = "renamed-production",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["production", "--name=renamed-production"]);
+        await Assert.That(arguments).IsEquivalentTo(["production", "--name=renamed-production"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -201,7 +201,7 @@ public class ArgoCdOptionsTests
             "my-app",
             "--source-positions=1",
             "--source-positions=2",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -217,7 +217,7 @@ public class ArgoCdOptionsTests
             "my-app",
             "--sync-option=CreateNamespace=true",
             "--sync-option=PruneLast=true",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class ArgoCdOptionsTests
             PromptsEnabled = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--prompts-enabled=false"]);
+        await Assert.That(arguments).IsEquivalentTo(["--prompts-enabled=false"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -240,7 +240,7 @@ public class ArgoCdOptionsTests
             ? (object) new ArgoCdClusterGetOptions("production")
             : new ArgoCdClusterRmOptions("production");
 
-        await Assert.That(BuildArguments(options)).IsEquivalentTo(["production"]);
+        await Assert.That(BuildArguments(options)).IsEquivalentTo(["production"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -248,7 +248,7 @@ public class ArgoCdOptionsTests
     {
         var arguments = BuildArguments(new ArgoCdClusterRotateAuthOptions("production"));
 
-        await Assert.That(arguments).IsEquivalentTo(["production"]);
+        await Assert.That(arguments).IsEquivalentTo(["production"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -268,7 +268,7 @@ public class ArgoCdOptionsTests
             "production",
             "cluster.yaml",
             "--insecure-skip-tls-verify",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -288,7 +288,7 @@ public class ArgoCdOptionsTests
             "https://destination.example",
             "apps",
             "--server=https://argocd.example",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -303,7 +303,7 @@ public class ArgoCdOptionsTests
         [
             "repository.example",
             "--server-name=argocd.example",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -323,7 +323,7 @@ public class ArgoCdOptionsTests
             "production",
             "apps",
             "--name",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -334,7 +334,7 @@ public class ArgoCdOptionsTests
             Account = "alice",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["token-id", "--account=alice"]);
+        await Assert.That(arguments).IsEquivalentTo(["token-id", "--account=alice"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -352,7 +352,7 @@ public class ArgoCdOptionsTests
             "--account=alice",
             "--current-password=old-secret",
             "--new-password=new-secret",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
 
         var currentPassword = typeof(ArgoCdAccountUpdatePasswordOptions)
             .GetProperty(nameof(ArgoCdAccountUpdatePasswordOptions.CurrentPassword));
@@ -372,6 +372,6 @@ public class ArgoCdOptionsTests
             Delete = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["cd.argoproj.io", "--delete"]);
+        await Assert.That(arguments).IsEquivalentTo(["cd.argoproj.io", "--delete"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.ArgoCd.UnitTests/Attributes/ArgoCdOptionsTests.cs
+++ b/test/ModularPipelines.ArgoCd.UnitTests/Attributes/ArgoCdOptionsTests.cs
@@ -20,7 +20,7 @@ public class ArgoCdOptionsTests
             AuthToken = "token-value",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "guestbook",
             "--app-namespace=argocd",
@@ -28,7 +28,7 @@ public class ArgoCdOptionsTests
             "--output=json",
             "--timeout=30",
             "--auth-token=token-value",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -41,14 +41,14 @@ public class ArgoCdOptionsTests
             Upsert = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "apps.yaml",
             "more-apps.yaml",
             "--dry-run",
             "--output=yaml",
             "--upsert",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -60,13 +60,13 @@ public class ArgoCdOptionsTests
             Yes = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "first",
             "second",
             "--wait",
             "--yes",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -77,12 +77,12 @@ public class ArgoCdOptionsTests
             Output = ArgoCdApplicationSetGenerateOutput.Json,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "apps.yaml",
             "more-apps.yaml",
             "--output=json",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -103,7 +103,7 @@ public class ArgoCdOptionsTests
             "create",
             "application"));
 
-        await Assert.That(arguments).IsEquivalentTo(["role:admin", "create", "application"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["role:admin", "create", "application"]);
     }
 
     [Test]
@@ -117,13 +117,13 @@ public class ArgoCdOptionsTests
             DryRun = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "project-*",
             "add-permission",
             "get",
             "--dry-run=false",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -148,7 +148,7 @@ public class ArgoCdOptionsTests
             ? ["first", "second", "--dry-run"]
             : ["first", "second", "--health"];
 
-        await Assert.That(arguments).IsEquivalentTo(expectedArguments, TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, expectedArguments);
     }
 
     [Test]
@@ -160,7 +160,7 @@ public class ArgoCdOptionsTests
             Yes = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second", "--yes"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["first", "second", "--yes"]);
     }
 
     [Test]
@@ -169,11 +169,11 @@ public class ArgoCdOptionsTests
         var arguments = BuildArguments(new ArgoCdRepoRmOptions(
             ["https://first.example/repo.git", "https://second.example/repo.git"]));
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "https://first.example/repo.git",
             "https://second.example/repo.git",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -184,7 +184,7 @@ public class ArgoCdOptionsTests
             Name = "renamed-production",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["production", "--name=renamed-production"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["production", "--name=renamed-production"]);
     }
 
     [Test]
@@ -196,12 +196,12 @@ public class ArgoCdOptionsTests
             SourcePositions = ["1", "2"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "my-app",
             "--source-positions=1",
             "--source-positions=2",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -212,12 +212,12 @@ public class ArgoCdOptionsTests
             SyncOption = ["CreateNamespace=true", "PruneLast=true"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "my-app",
             "--sync-option=CreateNamespace=true",
             "--sync-option=PruneLast=true",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class ArgoCdOptionsTests
             PromptsEnabled = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--prompts-enabled=false"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--prompts-enabled=false"]);
     }
 
     [Test]
@@ -240,7 +240,7 @@ public class ArgoCdOptionsTests
             ? (object) new ArgoCdClusterGetOptions("production")
             : new ArgoCdClusterRmOptions("production");
 
-        await Assert.That(BuildArguments(options)).IsEquivalentTo(["production"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(BuildArguments(options), ["production"]);
     }
 
     [Test]
@@ -248,7 +248,7 @@ public class ArgoCdOptionsTests
     {
         var arguments = BuildArguments(new ArgoCdClusterRotateAuthOptions("production"));
 
-        await Assert.That(arguments).IsEquivalentTo(["production"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["production"]);
     }
 
     [Test]
@@ -263,12 +263,12 @@ public class ArgoCdOptionsTests
         });
 
         await Assert.That(listArguments).IsEmpty();
-        await Assert.That(generateArguments).IsEquivalentTo(
+        await AssertArguments(generateArguments,
         [
             "production",
             "cluster.yaml",
             "--insecure-skip-tls-verify",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -282,13 +282,13 @@ public class ArgoCdOptionsTests
             Server = "https://argocd.example",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "platform",
             "https://destination.example",
             "apps",
             "--server=https://argocd.example",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -299,11 +299,11 @@ public class ArgoCdOptionsTests
             ServerName = "argocd.example",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "repository.example",
             "--server-name=argocd.example",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -317,13 +317,13 @@ public class ArgoCdOptionsTests
             Name = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "platform",
             "production",
             "apps",
             "--name",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -334,7 +334,7 @@ public class ArgoCdOptionsTests
             Account = "alice",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["token-id", "--account=alice"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["token-id", "--account=alice"]);
     }
 
     [Test]
@@ -347,12 +347,12 @@ public class ArgoCdOptionsTests
             NewPassword = "new-secret",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--account=alice",
             "--current-password=old-secret",
             "--new-password=new-secret",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
 
         var currentPassword = typeof(ArgoCdAccountUpdatePasswordOptions)
             .GetProperty(nameof(ArgoCdAccountUpdatePasswordOptions.CurrentPassword));
@@ -372,6 +372,6 @@ public class ArgoCdOptionsTests
             Delete = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["cd.argoproj.io", "--delete"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["cd.argoproj.io", "--delete"]);
     }
 }

--- a/test/ModularPipelines.Chocolatey.UnitTests/ChocolateyOptionsTests.cs
+++ b/test/ModularPipelines.Chocolatey.UnitTests/ChocolateyOptionsTests.cs
@@ -14,7 +14,7 @@ public class ChocolateyOptionsTests : TestBase
             Pkg2PkgN = ["second", "third"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second", "third"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["first", "second", "third"]);
     }
 
     [Test]
@@ -25,7 +25,7 @@ public class ChocolateyOptionsTests : TestBase
             PropertyValuePropertyNValueN = ["Owner=team", "Port=443"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["sample", "Owner=team", "Port=443"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["sample", "Owner=team", "Port=443"]);
     }
 
     [Test]
@@ -37,6 +37,6 @@ public class ChocolateyOptionsTests : TestBase
             PropertyValue = "Version=1",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["sample.nuspec", "Version=1"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["sample.nuspec", "Version=1"]);
     }
 }

--- a/test/ModularPipelines.Chocolatey.UnitTests/ChocolateyOptionsTests.cs
+++ b/test/ModularPipelines.Chocolatey.UnitTests/ChocolateyOptionsTests.cs
@@ -14,7 +14,7 @@ public class ChocolateyOptionsTests : TestBase
             Pkg2PkgN = ["second", "third"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second", "third"]);
+        await Assert.That(arguments).IsEquivalentTo(["first", "second", "third"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -25,7 +25,7 @@ public class ChocolateyOptionsTests : TestBase
             PropertyValuePropertyNValueN = ["Owner=team", "Port=443"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["sample", "Owner=team", "Port=443"]);
+        await Assert.That(arguments).IsEquivalentTo(["sample", "Owner=team", "Port=443"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -37,6 +37,6 @@ public class ChocolateyOptionsTests : TestBase
             PropertyValue = "Version=1",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["sample.nuspec", "Version=1"]);
+        await Assert.That(arguments).IsEquivalentTo(["sample.nuspec", "Version=1"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Cosign.UnitTests/Attributes/CosignOptionsTests.cs
+++ b/test/ModularPipelines.Cosign.UnitTests/Attributes/CosignOptionsTests.cs
@@ -18,7 +18,7 @@ public class CosignOptionsTests
             Upload = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "registry.example/app:v1",
             "registry.example/app:v2",
@@ -26,7 +26,7 @@ public class CosignOptionsTests
             "--annotations=environment=production",
             "--slot=card-authentication",
             "--upload=true",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -38,12 +38,12 @@ public class CosignOptionsTests
             UseSigningConfig = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "registry.example/app:v1",
             "--upload=false",
             "--use-signing-config=false",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -55,12 +55,12 @@ public class CosignOptionsTests
             CheckClaims = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "registry.example/app:v1",
             "--check-claims=false",
             "--type=https://example.com/predicates/release/v1",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -73,12 +73,12 @@ public class CosignOptionsTests
             Username = "pipeline-user",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "registry.example",
             "--password=password-value",
             "--username=pipeline-user",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]

--- a/test/ModularPipelines.Cosign.UnitTests/Attributes/CosignOptionsTests.cs
+++ b/test/ModularPipelines.Cosign.UnitTests/Attributes/CosignOptionsTests.cs
@@ -26,7 +26,7 @@ public class CosignOptionsTests
             "--annotations=environment=production",
             "--slot=card-authentication",
             "--upload=true",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -43,7 +43,7 @@ public class CosignOptionsTests
             "registry.example/app:v1",
             "--upload=false",
             "--use-signing-config=false",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -60,7 +60,7 @@ public class CosignOptionsTests
             "registry.example/app:v1",
             "--check-claims=false",
             "--type=https://example.com/predicates/release/v1",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -78,7 +78,7 @@ public class CosignOptionsTests
             "registry.example",
             "--password=password-value",
             "--username=pipeline-user",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
+++ b/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
@@ -103,7 +103,7 @@ public class DockerBuilderCompatibilityTests
             .GetCommandModel(typeof(DockerBuilderHistoryLogsOptions));
         var arguments = new CommandArgumentBuilder().BuildArguments(model, options);
 
-        await Assert.That(arguments).IsEquivalentTo(["--progress=plain"]);
+        await Assert.That(arguments).IsEquivalentTo(["--progress=plain"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
+++ b/test/ModularPipelines.Docker.UnitTests/Helpers/DockerBuilderCompatibilityTests.cs
@@ -10,6 +10,7 @@ using ModularPipelines.Docker.Options;
 using ModularPipelines.Docker.Services;
 using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Options;
+using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
 
 namespace ModularPipelines.Docker.UnitTests.Helpers;
 
@@ -103,7 +104,7 @@ public class DockerBuilderCompatibilityTests
             .GetCommandModel(typeof(DockerBuilderHistoryLogsOptions));
         var arguments = new CommandArgumentBuilder().BuildArguments(model, options);
 
-        await Assert.That(arguments).IsEquivalentTo(["--progress=plain"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--progress=plain"]);
     }
 
     [Test]

--- a/test/ModularPipelines.DotNet.UnitTests/DotNetBuildOptionsCompatibilityTests.cs
+++ b/test/ModularPipelines.DotNet.UnitTests/DotNetBuildOptionsCompatibilityTests.cs
@@ -15,7 +15,7 @@ public class DotNetBuildOptionsCompatibilityTests
         var arguments = BuildArguments(options);
 
         await Assert.That(options.NoLogo).IsTrue();
-        await Assert.That(arguments).IsEquivalentTo(["--nologo"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--nologo"]);
     }
 
     [Test]

--- a/test/ModularPipelines.DotNet.UnitTests/DotNetBuildOptionsCompatibilityTests.cs
+++ b/test/ModularPipelines.DotNet.UnitTests/DotNetBuildOptionsCompatibilityTests.cs
@@ -15,7 +15,7 @@ public class DotNetBuildOptionsCompatibilityTests
         var arguments = BuildArguments(options);
 
         await Assert.That(options.NoLogo).IsTrue();
-        await Assert.That(arguments).IsEquivalentTo(["--nologo"]);
+        await Assert.That(arguments).IsEquivalentTo(["--nologo"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.DotNet.UnitTests/DotNetFormatOptionsTests.cs
+++ b/test/ModularPipelines.DotNet.UnitTests/DotNetFormatOptionsTests.cs
@@ -15,10 +15,10 @@ public class DotNetFormatOptionsTests
 
         var args = BuildArguments(options);
 
-        await Assert.That(args).IsEquivalentTo(new[]
+        await AssertArguments(args, new[]
         {
             "--exclude-diagnostics", "CS0246",
             "--exclude-diagnostics", "CS1503",
-        }, TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        });
     }
 }

--- a/test/ModularPipelines.DotNet.UnitTests/DotNetFormatOptionsTests.cs
+++ b/test/ModularPipelines.DotNet.UnitTests/DotNetFormatOptionsTests.cs
@@ -19,6 +19,6 @@ public class DotNetFormatOptionsTests
         {
             "--exclude-diagnostics", "CS0246",
             "--exclude-diagnostics", "CS1503",
-        });
+        }, TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Eksctl.UnitTests/Attributes/EksctlOptionsTests.cs
+++ b/test/ModularPipelines.Eksctl.UnitTests/Attributes/EksctlOptionsTests.cs
@@ -28,7 +28,7 @@ public class EksctlOptionsTests
             "--zones=eu-west-2b",
             "--nodes=3",
             "--managed=true",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -39,7 +39,7 @@ public class EksctlOptionsTests
             Managed = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--managed=false"]);
+        await Assert.That(arguments).IsEquivalentTo(["--managed=false"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class EksctlOptionsTests
             "--name=gitops",
             "--type=ARGOCD",
             "--cluster=production",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -69,7 +69,7 @@ public class EksctlOptionsTests
         });
 
         await Assert.That(arguments).IsEquivalentTo(
-            ["--well-known-policies=autoScaler,externalDNS"]);
+            ["--well-known-policies=autoScaler,externalDNS"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -92,7 +92,7 @@ public class EksctlOptionsTests
             "--approve",
             "--enable-types=api",
             "--enable-types=controllerManager",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -105,7 +105,7 @@ public class EksctlOptionsTests
         var property = typeof(EksctlUtilsEnableSecretsEncryptionOptions)
             .GetProperty(nameof(EksctlUtilsEnableSecretsEncryptionOptions.EncryptExistingSecrets));
 
-        await Assert.That(arguments).IsEquivalentTo(["--encrypt-existing-secrets=false"]);
+        await Assert.That(arguments).IsEquivalentTo(["--encrypt-existing-secrets=false"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
         await Assert.That(property!.IsDefined(typeof(SecretValueAttribute), inherit: true)).IsFalse();
     }
 }

--- a/test/ModularPipelines.Eksctl.UnitTests/Attributes/EksctlOptionsTests.cs
+++ b/test/ModularPipelines.Eksctl.UnitTests/Attributes/EksctlOptionsTests.cs
@@ -20,7 +20,7 @@ public class EksctlOptionsTests
             Managed = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--name=production",
             "--region=eu-west-2",
@@ -28,7 +28,7 @@ public class EksctlOptionsTests
             "--zones=eu-west-2b",
             "--nodes=3",
             "--managed=true",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -39,7 +39,7 @@ public class EksctlOptionsTests
             Managed = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--managed=false"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--managed=false"]);
     }
 
     [Test]
@@ -52,12 +52,12 @@ public class EksctlOptionsTests
             Cluster = "production",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--name=gitops",
             "--type=ARGOCD",
             "--cluster=production",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -68,8 +68,8 @@ public class EksctlOptionsTests
             WellKnownPolicies = "autoScaler,externalDNS",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
-            ["--well-known-policies=autoScaler,externalDNS"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments,
+            ["--well-known-policies=autoScaler,externalDNS"]);
     }
 
     [Test]
@@ -86,13 +86,13 @@ public class EksctlOptionsTests
             ],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--cluster=production",
             "--approve",
             "--enable-types=api",
             "--enable-types=controllerManager",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -105,7 +105,7 @@ public class EksctlOptionsTests
         var property = typeof(EksctlUtilsEnableSecretsEncryptionOptions)
             .GetProperty(nameof(EksctlUtilsEnableSecretsEncryptionOptions.EncryptExistingSecrets));
 
-        await Assert.That(arguments).IsEquivalentTo(["--encrypt-existing-secrets=false"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--encrypt-existing-secrets=false"]);
         await Assert.That(property!.IsDefined(typeof(SecretValueAttribute), inherit: true)).IsFalse();
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudCompositeValueTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudCompositeValueTests.cs
@@ -22,7 +22,7 @@ public class GcloudCompositeValueTests
         [
             "--add-allowed-client=network=network-a,cidr=10.0.0.0/24,mount-permissions=READ_ONLY",
             "--add-allowed-client=network=network-b,cidr=10.0.1.0/24,mount-permissions=READ_WRITE",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -33,7 +33,7 @@ public class GcloudCompositeValueTests
             UpdateLabels = GcloudUpdateLabels.ReadOnly,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--update-labels=READ_ONLY"]);
+        await Assert.That(arguments).IsEquivalentTo(["--update-labels=READ_ONLY"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -51,6 +51,6 @@ public class GcloudCompositeValueTests
             "--enabled-tool=handle=search,tool=projects/p/locations/l/tools/search",
             "--add-enabled-tool=handle=build,config=[{key=mode,value=fast}]",
             "--remove-enabled-tool=handle=legacy,tool=projects/p/locations/l/tools/legacy",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudCompositeValueTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudCompositeValueTests.cs
@@ -18,11 +18,11 @@ public class GcloudCompositeValueTests
             ],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--add-allowed-client=network=network-a,cidr=10.0.0.0/24,mount-permissions=READ_ONLY",
             "--add-allowed-client=network=network-b,cidr=10.0.1.0/24,mount-permissions=READ_WRITE",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -33,7 +33,7 @@ public class GcloudCompositeValueTests
             UpdateLabels = GcloudUpdateLabels.ReadOnly,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--update-labels=READ_ONLY"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--update-labels=READ_ONLY"]);
     }
 
     [Test]
@@ -46,11 +46,11 @@ public class GcloudCompositeValueTests
             RemoveEnabledTool = ["handle=legacy,tool=projects/p/locations/l/tools/legacy"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--enabled-tool=handle=search,tool=projects/p/locations/l/tools/search",
             "--add-enabled-tool=handle=build,config=[{key=mode,value=fast}]",
             "--remove-enabled-tool=handle=legacy,tool=projects/p/locations/l/tools/legacy",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
@@ -52,7 +52,7 @@ public class GcloudProjectSelectorTests
                 module,
                 $"--project={project}",
                 $"--parent={parent}",
-            ]);
+            ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
         }
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
@@ -50,8 +50,8 @@ public class GcloudProjectSelectorTests
             await AssertArguments(BuildArguments(option),
             [
                 module,
-                $"--project={project}",
                 $"--parent={parent}",
+                $"--project={project}",
             ]);
         }
     }

--- a/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudProjectSelectorTests.cs
@@ -47,12 +47,12 @@ public class GcloudProjectSelectorTests
 
         foreach (var option in options)
         {
-            await Assert.That(BuildArguments(option)).IsEquivalentTo(
+            await AssertArguments(BuildArguments(option),
             [
                 module,
                 $"--project={project}",
                 $"--parent={parent}",
-            ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+            ]);
         }
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudPubsubServiceAccountTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudPubsubServiceAccountTests.cs
@@ -26,6 +26,6 @@ public class GcloudPubsubServiceAccountTests
             "--confluent-cloud-ingestion-service-account=confluent-importer",
             "--kinesis-ingestion-service-account="
             + "kinesis-ingestion@project.iam.gserviceaccount.com",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudPubsubServiceAccountTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudPubsubServiceAccountTests.cs
@@ -18,7 +18,7 @@ public class GcloudPubsubServiceAccountTests
                 "kinesis-ingestion@project.iam.gserviceaccount.com",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--aws-msk-ingestion-service-account=msk-importer",
             "--azure-event-hubs-ingestion-service-account="
@@ -26,6 +26,6 @@ public class GcloudPubsubServiceAccountTests
             "--confluent-cloud-ingestion-service-account=confluent-importer",
             "--kinesis-ingestion-service-account="
             + "kinesis-ingestion@project.iam.gserviceaccount.com",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudServiceAccountTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudServiceAccountTests.cs
@@ -15,11 +15,11 @@ public class GcloudServiceAccountTests
                 "projects/project/serviceAccounts/build@project.iam.gserviceaccount.com",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--service-account=runtime@project.iam.gserviceaccount.com",
             "--build-service-account="
             + "projects/project/serviceAccounts/build@project.iam.gserviceaccount.com",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.Google.UnitTests/GcloudServiceAccountTests.cs
+++ b/test/ModularPipelines.Google.UnitTests/GcloudServiceAccountTests.cs
@@ -20,6 +20,6 @@ public class GcloudServiceAccountTests
             "--service-account=runtime@project.iam.gserviceaccount.com",
             "--build-service-account="
             + "projects/project/serviceAccounts/build@project.iam.gserviceaccount.com",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Hadolint.UnitTests/Attributes/HadolintOptionsTests.cs
+++ b/test/ModularPipelines.Hadolint.UnitTests/Attributes/HadolintOptionsTests.cs
@@ -19,7 +19,7 @@ public class HadolintOptionsTests
             FailureThreshold = HadolintFailureThreshold.Warning,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "Dockerfile",
             "build/Dockerfile",
@@ -29,7 +29,7 @@ public class HadolintOptionsTests
             "--error", "DL3020",
             "--ignore", "DL3008",
             "--failure-threshold", "warning",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -40,8 +40,8 @@ public class HadolintOptionsTests
             Format = HadolintFormat.GitlabCodeclimate,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
-            ["--format", "gitlab_codeclimate"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments,
+            ["--format", "gitlab_codeclimate"]);
     }
 
     [Test]
@@ -52,6 +52,6 @@ public class HadolintOptionsTests
             Format = HadolintFormat.Junit,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--format", "junit"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--format", "junit"]);
     }
 }

--- a/test/ModularPipelines.Hadolint.UnitTests/Attributes/HadolintOptionsTests.cs
+++ b/test/ModularPipelines.Hadolint.UnitTests/Attributes/HadolintOptionsTests.cs
@@ -29,7 +29,7 @@ public class HadolintOptionsTests
             "--error", "DL3020",
             "--ignore", "DL3008",
             "--failure-threshold", "warning",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -41,7 +41,7 @@ public class HadolintOptionsTests
         });
 
         await Assert.That(arguments).IsEquivalentTo(
-            ["--format", "gitlab_codeclimate"]);
+            ["--format", "gitlab_codeclimate"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -52,6 +52,6 @@ public class HadolintOptionsTests
             Format = HadolintFormat.Junit,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--format", "junit"]);
+        await Assert.That(arguments).IsEquivalentTo(["--format", "junit"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Helm.UnitTests/HelmRequiredArgumentsTests.cs
+++ b/test/ModularPipelines.Helm.UnitTests/HelmRequiredArgumentsTests.cs
@@ -30,6 +30,6 @@ public class HelmRequiredArgumentsTests
 
         var arguments = BuildArguments(options);
 
-        await Assert.That(arguments).IsEquivalentTo(["repository/chart", "--generate-name"]);
+        await Assert.That(arguments).IsEquivalentTo(["repository/chart", "--generate-name"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Helm.UnitTests/HelmRequiredArgumentsTests.cs
+++ b/test/ModularPipelines.Helm.UnitTests/HelmRequiredArgumentsTests.cs
@@ -30,6 +30,6 @@ public class HelmRequiredArgumentsTests
 
         var arguments = BuildArguments(options);
 
-        await Assert.That(arguments).IsEquivalentTo(["repository/chart", "--generate-name"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["repository/chart", "--generate-name"]);
     }
 }

--- a/test/ModularPipelines.Java.UnitTests/Attributes/JavaOptionsTests.cs
+++ b/test/ModularPipelines.Java.UnitTests/Attributes/JavaOptionsTests.cs
@@ -25,7 +25,7 @@ public class JavaOptionsTests
             "--define", "skipTests=true",
             "clean",
             "verify",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -48,6 +48,6 @@ public class JavaOptionsTests
             "--no-daemon",
             "clean",
             "build",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Java.UnitTests/Attributes/JavaOptionsTests.cs
+++ b/test/ModularPipelines.Java.UnitTests/Attributes/JavaOptionsTests.cs
@@ -18,14 +18,14 @@ public class JavaOptionsTests
             GoalsAndPhases = ["clean", "verify"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--batch-mode",
             "--color", "never",
             "--define", "skipTests=true",
             "clean",
             "verify",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -40,7 +40,7 @@ public class JavaOptionsTests
             Tasks = ["clean", "build"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--console", "plain",
             "--project-prop", "environment=ci",
@@ -48,6 +48,6 @@ public class JavaOptionsTests
             "--no-daemon",
             "clean",
             "build",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
+++ b/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
@@ -34,7 +34,7 @@ public class JqOptionsTests : TestBase
             "--arg", "environment", "ci",
             ".user",
             "input.json",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -54,7 +54,7 @@ public class JqOptionsTests : TestBase
             "--slurpfile", "documents", "documents.json",
             "--rawfile", "template", "template.txt",
             "input.json",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -73,7 +73,7 @@ public class JqOptionsTests : TestBase
         [
             "--arg", "empty", "",
             "--arg", "whitespace", "  ",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -294,6 +294,6 @@ public class JqOptionsTests : TestBase
     {
         var arguments = BuildArguments(new JqExecuteOptions { RunTests = CliOptionValue.Bare });
 
-        await Assert.That(arguments).IsEquivalentTo(["--run-tests"]);
+        await Assert.That(arguments).IsEquivalentTo(["--run-tests"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
+++ b/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
@@ -25,7 +25,7 @@ public class JqOptionsTests : TestBase
             InputFiles = ["input.json"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--null-input",
             "--raw-output",
@@ -34,7 +34,7 @@ public class JqOptionsTests : TestBase
             "--arg", "environment", "ci",
             ".user",
             "input.json",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -48,13 +48,13 @@ public class JqOptionsTests : TestBase
             InputFiles = ["input.json"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--from-file", "filter.jq",
             "--slurpfile", "documents", "documents.json",
             "--rawfile", "template", "template.txt",
             "input.json",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -69,11 +69,11 @@ public class JqOptionsTests : TestBase
             ],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--arg", "empty", "",
             "--arg", "whitespace", "  ",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -87,14 +87,13 @@ public class JqOptionsTests : TestBase
             Filter = ".",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "-L", "modules",
             "-b",
             ".",
             "--run-tests", "tests.jq",
-        ],
-        TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -106,9 +105,8 @@ public class JqOptionsTests : TestBase
             InputFiles = ["-input.json"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
-            [".", "--", "-input.json"],
-            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments,
+            [".", "--", "-input.json"]);
     }
 
     [Test]
@@ -284,9 +282,8 @@ public class JqOptionsTests : TestBase
             Filter = "-1",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
-            ["--", "-1"],
-            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments,
+            ["--", "-1"]);
     }
 
     [Test]
@@ -294,6 +291,6 @@ public class JqOptionsTests : TestBase
     {
         var arguments = BuildArguments(new JqExecuteOptions { RunTests = CliOptionValue.Bare });
 
-        await Assert.That(arguments).IsEquivalentTo(["--run-tests"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--run-tests"]);
     }
 }

--- a/test/ModularPipelines.NerdbankGitVersioning.UnitTests/Attributes/NbgvOptionsTests.cs
+++ b/test/ModularPipelines.NerdbankGitVersioning.UnitTests/Attributes/NbgvOptionsTests.cs
@@ -22,7 +22,7 @@ public class NbgvOptionsTests
             "--project", "src/App",
             "--metadata", "ci",
             "--public-release=false",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -41,7 +41,7 @@ public class NbgvOptionsTests
             "--skip-cloud-build-number",
             "--define", "Name=Value",
             "--define", "Channel=stable",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -61,6 +61,6 @@ public class NbgvOptionsTests
             "--nextVersion", "2.1",
             "--versionIncrement", "minor",
             "--what-if",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.NerdbankGitVersioning.UnitTests/Attributes/NbgvOptionsTests.cs
+++ b/test/ModularPipelines.NerdbankGitVersioning.UnitTests/Attributes/NbgvOptionsTests.cs
@@ -16,13 +16,13 @@ public class NbgvOptionsTests
             PublicRelease = false,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "HEAD~1",
             "--project", "src/App",
             "--metadata", "ci",
             "--public-release=false",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -35,13 +35,13 @@ public class NbgvOptionsTests
             Define = ["Name=Value", "Channel=stable"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--all-vars",
             "--skip-cloud-build-number",
             "--define", "Name=Value",
             "--define", "Channel=stable",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -55,12 +55,12 @@ public class NbgvOptionsTests
             WhatIf = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "v2.0",
             "--nextVersion", "2.1",
             "--versionIncrement", "minor",
             "--what-if",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 }

--- a/test/ModularPipelines.Snyk.UnitTests/Attributes/SnykOptionsTests.cs
+++ b/test/ModularPipelines.Snyk.UnitTests/Attributes/SnykOptionsTests.cs
@@ -204,8 +204,8 @@ public class SnykOptionsTests
         await AssertArguments(testArguments, ["--file=bom.json", "--json"]);
         await AssertArguments(containerArguments,
         [
-            "--format=spdx2.3+json",
             "registry.example.com/app:latest",
+            "--format=spdx2.3+json",
             "--org=security",
             "--exclude-app-vulns",
             "--exclude-node-modules",

--- a/test/ModularPipelines.Snyk.UnitTests/Attributes/SnykOptionsTests.cs
+++ b/test/ModularPipelines.Snyk.UnitTests/Attributes/SnykOptionsTests.cs
@@ -25,7 +25,7 @@ public class SnykOptionsTests
             "--auth-type=token",
             "--client-secret=client-secret",
             "--client-id=client-id",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class SnykOptionsTests
             "--nested-jars-depth=2",
             "--username=registry-user",
             "--password=registry-password",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class SnykOptionsTests
             Debug = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo([".snyk", "-d"]);
+        await Assert.That(arguments).IsEquivalentTo([".snyk", "-d"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -101,13 +101,13 @@ public class SnykOptionsTests
             "--tfc-token=terraform-token",
             "--tfc-endpoint=https://terraform.example.com",
             "--config-dir=.snyk-config",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
         await Assert.That(aibomArguments).IsEquivalentTo(
         [
             "--upload",
             "--repo=https://github.com/example/repository",
-        ]);
-        await Assert.That(codeArguments).IsEquivalentTo(["src"]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await Assert.That(codeArguments).IsEquivalentTo(["src"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
 
         var tfcToken = typeof(SnykIacDescribeOptions).GetProperty(nameof(SnykIacDescribeOptions.TfcToken));
         await Assert.That(tfcToken!.IsDefined(typeof(SecretValueAttribute), inherit: true)).IsTrue();
@@ -126,7 +126,7 @@ public class SnykOptionsTests
         [
             "github.com/example/repository",
             "--fail-on=patchable",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -137,7 +137,7 @@ public class SnykOptionsTests
             Target = "src/MyApp",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["src/MyApp"]);
+        await Assert.That(arguments).IsEquivalentTo(["src/MyApp"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -151,7 +151,7 @@ public class SnykOptionsTests
         await Assert.That(arguments).IsEquivalentTo(
         [
             "--filter=resource.type == 'aws_s3_bucket'",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -200,8 +200,8 @@ public class SnykOptionsTests
             "--prune-repeated-subdependencies",
             "--allow-incomplete-sbom",
             "--json-file-output=bom.json",
-        ]);
-        await Assert.That(testArguments).IsEquivalentTo(["--file=bom.json", "--json"]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await Assert.That(testArguments).IsEquivalentTo(["--file=bom.json", "--json"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
         await Assert.That(containerArguments).IsEquivalentTo(
         [
             "--format=spdx2.3+json",
@@ -212,7 +212,7 @@ public class SnykOptionsTests
             "--nested-jars-depth=2",
             "--username=registry-user",
             "--password=registry-password",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.Snyk.UnitTests/Attributes/SnykOptionsTests.cs
+++ b/test/ModularPipelines.Snyk.UnitTests/Attributes/SnykOptionsTests.cs
@@ -19,13 +19,13 @@ public class SnykOptionsTests
             ClientId = "client-id",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "token-value",
             "--auth-type=token",
             "--client-secret=client-secret",
             "--client-id=client-id",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -41,7 +41,7 @@ public class SnykOptionsTests
             Password = "registry-password",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "alpine:3.20",
             "--print-deps",
@@ -50,7 +50,7 @@ public class SnykOptionsTests
             "--nested-jars-depth=2",
             "--username=registry-user",
             "--password=registry-password",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class SnykOptionsTests
             Debug = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo([".snyk", "-d"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, [".snyk", "-d"]);
     }
 
     [Test]
@@ -96,18 +96,18 @@ public class SnykOptionsTests
             Path = "src",
         });
 
-        await Assert.That(describeArguments).IsEquivalentTo(
+        await AssertArguments(describeArguments,
         [
             "--tfc-token=terraform-token",
             "--tfc-endpoint=https://terraform.example.com",
             "--config-dir=.snyk-config",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
-        await Assert.That(aibomArguments).IsEquivalentTo(
+        ]);
+        await AssertArguments(aibomArguments,
         [
             "--upload",
             "--repo=https://github.com/example/repository",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
-        await Assert.That(codeArguments).IsEquivalentTo(["src"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
+        await AssertArguments(codeArguments, ["src"]);
 
         var tfcToken = typeof(SnykIacDescribeOptions).GetProperty(nameof(SnykIacDescribeOptions.TfcToken));
         await Assert.That(tfcToken!.IsDefined(typeof(SecretValueAttribute), inherit: true)).IsTrue();
@@ -122,11 +122,11 @@ public class SnykOptionsTests
             FailOn = SnykFailOn.Patchable,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "github.com/example/repository",
             "--fail-on=patchable",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -137,7 +137,7 @@ public class SnykOptionsTests
             Target = "src/MyApp",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["src/MyApp"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["src/MyApp"]);
     }
 
     [Test]
@@ -148,10 +148,10 @@ public class SnykOptionsTests
             Filter = "resource.type == 'aws_s3_bucket'",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--filter=resource.type == 'aws_s3_bucket'",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -190,7 +190,7 @@ public class SnykOptionsTests
             Password = "registry-password",
         });
 
-        await Assert.That(sbomArguments).IsEquivalentTo(
+        await AssertArguments(sbomArguments,
         [
             "--format=cyclonedx1.6+json",
             "--org=security",
@@ -200,9 +200,9 @@ public class SnykOptionsTests
             "--prune-repeated-subdependencies",
             "--allow-incomplete-sbom",
             "--json-file-output=bom.json",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
-        await Assert.That(testArguments).IsEquivalentTo(["--file=bom.json", "--json"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
-        await Assert.That(containerArguments).IsEquivalentTo(
+        ]);
+        await AssertArguments(testArguments, ["--file=bom.json", "--json"]);
+        await AssertArguments(containerArguments,
         [
             "--format=spdx2.3+json",
             "registry.example.com/app:latest",
@@ -212,7 +212,7 @@ public class SnykOptionsTests
             "--nested-jars-depth=2",
             "--username=registry-user",
             "--password=registry-password",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]

--- a/test/ModularPipelines.SonarScanner.UnitTests/Attributes/SonarScannerOptionsTests.cs
+++ b/test/ModularPipelines.SonarScanner.UnitTests/Attributes/SonarScannerOptionsTests.cs
@@ -28,7 +28,7 @@ public class SonarScannerOptionsTests
             Token = "token-value",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--define",
             "sonar.branch.name=main",
@@ -38,7 +38,7 @@ public class SonarScannerOptionsTests
             "-Dsonar.projectKey=example-project",
             "-Dsonar.sources=src",
             "-Dsonar.token=token-value",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]

--- a/test/ModularPipelines.SonarScanner.UnitTests/Attributes/SonarScannerOptionsTests.cs
+++ b/test/ModularPipelines.SonarScanner.UnitTests/Attributes/SonarScannerOptionsTests.cs
@@ -38,7 +38,7 @@ public class SonarScannerOptionsTests
             "-Dsonar.projectKey=example-project",
             "-Dsonar.sources=src",
             "-Dsonar.token=token-value",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.TestHelpers/OptionsRenderingTestHelper.cs
+++ b/test/ModularPipelines.TestHelpers/OptionsRenderingTestHelper.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Helpers.Internal;
+using TUnit.Assertions.Enums;
 
 namespace ModularPipelines.TestHelpers;
 
@@ -8,5 +9,13 @@ public static class OptionsRenderingTestHelper
     {
         var model = new CommandModelProvider().GetCommandModel(options.GetType());
         return new CommandArgumentBuilder().BuildArguments(model, options);
+    }
+
+    public static async Task AssertArguments(
+        IEnumerable<string> actualArguments,
+        IEnumerable<string> expectedArguments)
+    {
+        await Assert.That(actualArguments)
+            .IsEquivalentTo(expectedArguments, CollectionOrdering.Matching);
     }
 }

--- a/test/ModularPipelines.Trivy.UnitTests/Attributes/TrivyOptionsTests.cs
+++ b/test/ModularPipelines.Trivy.UnitTests/Attributes/TrivyOptionsTests.cs
@@ -28,7 +28,7 @@ public class TrivyOptionsTests
             "--severity=CRITICAL",
             "--timeout=2m",
             "--password=registry-secret",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -39,16 +39,16 @@ public class TrivyOptionsTests
             Input = "ruby-3.1.tar",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--input=ruby-3.1.tar"]);
+        await Assert.That(arguments).IsEquivalentTo(["--input=ruby-3.1.tar"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task Nested_Commands_Render_Required_Operands()
     {
         await Assert.That(BuildArguments(new TrivyPluginInstallOptions("aquasecurity/trivy-plugin")))
-            .IsEquivalentTo(["aquasecurity/trivy-plugin"]);
+            .IsEquivalentTo(["aquasecurity/trivy-plugin"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
         await Assert.That(BuildArguments(new TrivyRegistryLoginOptions("registry.example.com")))
-            .IsEquivalentTo(["registry.example.com"]);
+            .IsEquivalentTo(["registry.example.com"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -59,7 +59,7 @@ public class TrivyOptionsTests
             PluginNames = ["first", "second"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second"]);
+        await Assert.That(arguments).IsEquivalentTo(["first", "second"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -71,7 +71,7 @@ public class TrivyOptionsTests
             VulnDb = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--scan-cache", "--vuln-db"]);
+        await Assert.That(arguments).IsEquivalentTo(["--scan-cache", "--vuln-db"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class TrivyOptionsTests
             "--",
             "--exit-code",
             "1",
-        ]);
+        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
         await Assert.That(argumentList.IndexOf("--quiet")).IsLessThan(argumentList.IndexOf("--"));
     }
 
@@ -105,7 +105,7 @@ public class TrivyOptionsTests
             RepoNames = ["first", "second"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second"]);
+        await Assert.That(arguments).IsEquivalentTo(["first", "second"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.Trivy.UnitTests/Attributes/TrivyOptionsTests.cs
+++ b/test/ModularPipelines.Trivy.UnitTests/Attributes/TrivyOptionsTests.cs
@@ -20,7 +20,7 @@ public class TrivyOptionsTests
             Password = ["registry-secret"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "alpine:3.20",
             "--format=json",
@@ -28,7 +28,7 @@ public class TrivyOptionsTests
             "--severity=CRITICAL",
             "--timeout=2m",
             "--password=registry-secret",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
     }
 
     [Test]
@@ -39,16 +39,18 @@ public class TrivyOptionsTests
             Input = "ruby-3.1.tar",
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--input=ruby-3.1.tar"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--input=ruby-3.1.tar"]);
     }
 
     [Test]
     public async Task Nested_Commands_Render_Required_Operands()
     {
-        await Assert.That(BuildArguments(new TrivyPluginInstallOptions("aquasecurity/trivy-plugin")))
-            .IsEquivalentTo(["aquasecurity/trivy-plugin"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
-        await Assert.That(BuildArguments(new TrivyRegistryLoginOptions("registry.example.com")))
-            .IsEquivalentTo(["registry.example.com"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(
+            BuildArguments(new TrivyPluginInstallOptions("aquasecurity/trivy-plugin")),
+            ["aquasecurity/trivy-plugin"]);
+        await AssertArguments(
+            BuildArguments(new TrivyRegistryLoginOptions("registry.example.com")),
+            ["registry.example.com"]);
     }
 
     [Test]
@@ -59,7 +61,7 @@ public class TrivyOptionsTests
             PluginNames = ["first", "second"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["first", "second"]);
     }
 
     [Test]
@@ -71,7 +73,7 @@ public class TrivyOptionsTests
             VulnDb = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["--scan-cache", "--vuln-db"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["--scan-cache", "--vuln-db"]);
     }
 
     [Test]
@@ -84,7 +86,7 @@ public class TrivyOptionsTests
         });
         var argumentList = arguments.ToList();
 
-        await Assert.That(argumentList).IsEquivalentTo(
+        await AssertArguments(argumentList,
         [
             "kubectl",
             "--quiet",
@@ -93,7 +95,7 @@ public class TrivyOptionsTests
             "--",
             "--exit-code",
             "1",
-        ], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        ]);
         await Assert.That(argumentList.IndexOf("--quiet")).IsLessThan(argumentList.IndexOf("--"));
     }
 
@@ -105,7 +107,7 @@ public class TrivyOptionsTests
             RepoNames = ["first", "second"],
         });
 
-        await Assert.That(arguments).IsEquivalentTo(["first", "second"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await AssertArguments(arguments, ["first", "second"]);
     }
 
     [Test]

--- a/test/ModularPipelines.Trivy.UnitTests/Attributes/TrivyOptionsTests.cs
+++ b/test/ModularPipelines.Trivy.UnitTests/Attributes/TrivyOptionsTests.cs
@@ -22,12 +22,12 @@ public class TrivyOptionsTests
 
         await AssertArguments(arguments,
         [
-            "alpine:3.20",
+            "--password=registry-secret",
             "--format=json",
             "--severity=HIGH",
             "--severity=CRITICAL",
             "--timeout=2m",
-            "--password=registry-secret",
+            "alpine:3.20",
         ]);
     }
 

--- a/test/ModularPipelines.UnitTests/Attributes/OptionsRenderingTestHelperTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/OptionsRenderingTestHelperTests.cs
@@ -1,0 +1,17 @@
+using TUnit.Assertions.Exceptions;
+using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+public class OptionsRenderingTestHelperTests
+{
+    [Test]
+    public async Task Argument_Comparison_Rejects_Reordered_Tokens()
+    {
+        static Task CompareReorderedArguments() =>
+            AssertArguments(["--option", "value"], ["value", "--option"]);
+
+        await Assert.That(CompareReorderedArguments)
+            .Throws<AssertionException>();
+    }
+}

--- a/test/ModularPipelines.Yarn.UnitTests/YarnOptionsTests.cs
+++ b/test/ModularPipelines.Yarn.UnitTests/YarnOptionsTests.cs
@@ -14,7 +14,7 @@ public class YarnOptionsTests
             Quiet = true,
         });
 
-        await Assert.That(arguments).IsEquivalentTo(
+        await AssertArguments(arguments,
         [
             "--package", "typescript",
             "--quiet",


### PR DESCRIPTION
## Summary
- add a shared exact-order argv assertion helper
- make generated integration argv assertions order-sensitive
- add a regression proving reordered tokens fail

## Validation
- `OptionsRenderingTestHelperTests`: 1 passed
- `YarnOptionsTests`: 1 passed
- `HadolintOptionsTests`: 4 passed
- focused `dotnet format --verify-no-changes`: passed
- large Release integration builds exceeded the mandated 2 GB agent process-tree limit (exit 137); CI will run the full integration matrix

Closes #4335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Standardized command-rendering tests across supported integrations on shared ordered argument comparisons.
  - Added reusable argument validation and coverage confirming reordered arguments are rejected.
  - Updated Yarn option-rendering tests to use the shared ordered comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->