### PR TITLE
Narrow Azure deny-settings value detection

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -637,23 +637,27 @@ public class AzCliScraperTests
     }
 
     [Test]
-    public async Task Stack_Child_Scope_Is_A_Presence_Only_Flag()
+    public async Task Stack_Deny_Settings_Mode_Is_A_Value_And_Child_Scope_Is_A_Flag()
     {
         const string helpText = """
             Command
                 az stack group create : Create a stack.
 
             Optional Arguments
-                --cs --deny-settings-apply-to-child-scopes : DenySettings will be applied to child scopes.
+                --deny-settings-mode --dm                  : DenySettings mode.
+                --cs --deny-settings-apply-to-child-scopes : DenySettings apply to child scopes.
             """;
 
         var command = await new TestAzCliScraper().Parse(["az", "stack", "group", "create"], helpText);
-        var option = command!.Options.Single();
+        var denySettingsMode = command!.Options.Single(option => option.SwitchName == "--deny-settings-mode");
+        var childScope = command.Options.Single(option => option.SwitchName == "--cs");
 
         using (Assert.Multiple())
         {
-            await Assert.That(option.IsFlag).IsTrue();
-            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+            await Assert.That(denySettingsMode.IsFlag).IsFalse();
+            await Assert.That(denySettingsMode.CSharpType).IsEqualTo("string?");
+            await Assert.That(childScope.IsFlag).IsTrue();
+            await Assert.That(childScope.CSharpType).IsEqualTo("bool?");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -373,13 +373,6 @@ public partial class AzCliScraper : CliScraperBase
             return true;
         }
 
-        if (switchName.Equals("cs", StringComparison.OrdinalIgnoreCase)
-            && description.Contains("DenySettings will be applied to child scopes", StringComparison.OrdinalIgnoreCase)
-            && string.IsNullOrEmpty(valueHint))
-        {
-            return true;
-        }
-
         if (explicitBooleanValue || HelpDeclaresOptionValue(switchName, description))
         {
             return false;
@@ -392,6 +385,7 @@ public partial class AzCliScraper : CliScraperBase
 
     private static bool HelpDeclaresOptionValue(string switchName, string description) =>
         AzValueDescriptionPattern().IsMatch(description)
+        || AzDenySettingsModeDescriptionPattern().IsMatch(description)
         || AzEmbeddedValueDescriptionPattern().IsMatch(description)
         || description.Contains("may be supplied", StringComparison.OrdinalIgnoreCase)
         || HelpDeclaresSpaceSeparatedList(description)
@@ -605,8 +599,11 @@ public partial class AzCliScraper : CliScraperBase
     [GeneratedRegex(@"^\s+--(?<long>[\w-]+)(?:\s+(?<alias>-{1,2}[\w-]+))*(?:\s+(?<value>[A-Z_]+))?(?:\s+\[(?<required>Required)\])?\s*:\s*(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex AzOptionPattern();
 
-    [GeneratedRegex(@"^(?:(?:a|an|the)\s+)?(?:path|uri|url|name|id|identifier|description|query|string|value|access token|marketplace version|template|resource|parameters?|managed identity|subnet|virtual network|default identity|install script|registry adapter|storage mount|key vault|source|related resource|related change|batch|issue|scope|list\s+of|defines?|validation level|denysettings|accepts?)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(?:(?:a|an|the)\s+)?(?:path|uri|url|name|id|identifier|description|query|string|value|access token|marketplace version|template|resource|parameters?|managed identity|subnet|virtual network|default identity|install script|registry adapter|storage mount|key vault|source|related resource|related change|batch|issue|scope|list\s+of|defines?|validation level|accepts?)\b", RegexOptions.IgnoreCase)]
     private static partial Regex AzValueDescriptionPattern();
+
+    [GeneratedRegex(@"^(?:(?:a|an|the)\s+)?denysettings\s+mode\b", RegexOptions.IgnoreCase)]
+    private static partial Regex AzDenySettingsModeDescriptionPattern();
 
     [GeneratedRegex(@"\b(?:resource ID|secret URI|URI or path|key-value pairs|accepted values?|allowed values?)\b", RegexOptions.IgnoreCase)]
     private static partial Regex AzEmbeddedValueDescriptionPattern();


### PR DESCRIPTION
## Summary
- narrow Azure value detection from any `DenySettings` sentence to the actual `DenySettings mode` value shape
- remove the `cs` switch/description-specific flag workaround
- cover `--deny-settings-mode` and bare `--cs` together, including changed help wording

## Validation
- `AzCliScraperTests`: 24 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- touched-file whitespace format: passed
- scoped Azure CLI 2.84.0 regeneration reached command 328, then hit the mandated 2 GB process-tree limit (exit 137) before output; no partial generated writes occurred
- committed stack and stack-whatif outputs already expose `DenySettingsMode` as `CliOption` and `Cs` as `CliFlag`; CI generation will confirm the full snapshot

Closes #4334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure CLI option parsing for deny-settings options.
  * `--deny-settings-mode` is now correctly recognized as a string value option.
  * `--cs` / `--deny-settings-apply-to-child-scopes` remains correctly recognized as a presence-only flag.
  * Updated validation coverage to ensure both option types are handled accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->