### PR TITLE
Remove obsolete core aliases and legacy CLI phase

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -186,7 +186,8 @@ have also been deleted.
 
 `WithSkipWhen` now has boolean predicate overloads that accept a skip reason. Use
 `SkipDecision.When(bool, string?)` when constructing a decision directly.
-`SkipDecision.Of(bool, string?)` remains as an obsolete compatibility alias.
+`SkipDecision.Of(bool, string?)` has been removed; use `When` or a `WithSkipWhen`
+predicate overload.
 
 Asynchronous module predicates now consistently use `ValueTask`. The
 `ModuleConfiguration.IgnoreFailuresCondition` property and the asynchronous

--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -233,6 +233,9 @@ by a successful build remain owned by the resulting pipeline.
 `CommandLinePhase` is now the only ordering model for flags, options, and arguments.
 `ArgumentPlacement` has been removed. Migrate custom positional arguments as follows:
 
+`CommandLinePhase.EndOfOptions` has been removed. Use
+`CliArgumentAttribute.PrependOptionTerminator` instead.
+
 ```csharp
 // V3
 [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]

--- a/src/ModularPipelines/Attributes/CommandLinePhase.cs
+++ b/src/ModularPipelines/Attributes/CommandLinePhase.cs
@@ -18,12 +18,6 @@ public enum CommandLinePhase
     Normal = 1,
 
     /// <summary>
-    /// Compatibility phase for end-of-options flags emitted by older generated packages.
-    /// </summary>
-    [Obsolete("Use CliArgumentAttribute.PrependOptionTerminator instead.")]
-    EndOfOptions = 2,
-
-    /// <summary>
     /// A final option that must follow regular options and positional operands.
     /// </summary>
     Terminal = 4,
@@ -32,9 +26,4 @@ public enum CommandLinePhase
     /// Positional or pass-through values rendered after option parsing and before terminal options.
     /// </summary>
     Passthrough = 3,
-}
-
-internal static class CommandLinePhaseCompatibility
-{
-    internal const CommandLinePhase LegacyEndOfOptions = (CommandLinePhase) 2;
 }

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -267,19 +267,6 @@ internal sealed class CommandLineBuilder(
                     phase,
                     isGlobalOption)
                 .ToList();
-            if (phase == CommandLinePhaseCompatibility.LegacyEndOfOptions
-                && phaseAdditionalArguments.Count > 0)
-            {
-                if (emittedOptionTerminator)
-                {
-                    throw new InvalidOperationException(
-                        "An additional end-of-options marker cannot follow one that was already emitted.");
-                }
-
-                emittedOptionTerminatorIndex = result.Count;
-                emittedOptionTerminator = true;
-            }
-
             result.AddRange(phaseAdditionalArguments);
 
             var phaseModel = commandModel.Where(part => part.Phase == phase).ToList();
@@ -335,29 +322,13 @@ internal sealed class CommandLineBuilder(
                     nameof(CommandLineToolOptions.AdditionalArguments));
             }
 
-            if (argument.Phase == CommandLinePhaseCompatibility.LegacyEndOfOptions
-                && argument.Value != "--")
+            if (argument.Value == "--")
             {
                 throw new ArgumentException(
-                    "The legacy end-of-options phase only accepts the '--' marker.",
+                    "The '--' marker must be emitted by CliArgumentAttribute option-terminator settings "
+                    + "or declared manual arguments.",
                     nameof(CommandLineToolOptions.AdditionalArguments));
             }
-
-            if (argument.Value == "--"
-                && argument.Phase != CommandLinePhaseCompatibility.LegacyEndOfOptions)
-            {
-                throw new ArgumentException(
-                    "The '--' marker must use the legacy end-of-options phase.",
-                    nameof(CommandLineToolOptions.AdditionalArguments));
-            }
-        }
-
-        if (additionalArguments.Count(argument =>
-                argument.Phase == CommandLinePhaseCompatibility.LegacyEndOfOptions) > 1)
-        {
-            throw new ArgumentException(
-                "Additional arguments can contain at most one end-of-options marker.",
-                nameof(CommandLineToolOptions.AdditionalArguments));
         }
     }
 

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -98,7 +98,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
     {
         CommandLinePhase.EarlyOperand => 0,
         CommandLinePhase.Normal => 1,
-        CommandLinePhaseCompatibility.LegacyEndOfOptions => 2,
         CommandLinePhase.Passthrough => 3,
         CommandLinePhase.Terminal => 4,
         _ => throw new ArgumentOutOfRangeException(nameof(phase), phase, null),
@@ -134,14 +133,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         else
         {
             AddFlagsAndOptions(rendered, phaseOptions, renderedOptionValues);
-            if (phase == CommandLinePhaseCompatibility.LegacyEndOfOptions
-                && rendered.IndexOf("--") is var terminatorIndex
-                && terminatorIndex >= 0)
-            {
-                optionTerminatorIndex = terminatorIndex;
-                emittedOptionTerminator = true;
-            }
-
             AddArguments(
                 rendered,
                 phaseArguments,
@@ -225,17 +216,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             throw new InvalidOperationException(
                 "CLI flags or options cannot be rendered after an end-of-options marker "
                 + "emitted by an earlier property group.");
-        }
-
-        var legacyOptionTerminatorRendered = renderedOptionValues.Any(static pair =>
-            pair.Key.Phase == CommandLinePhaseCompatibility.LegacyEndOfOptions
-            && pair.Value.Contains("--", StringComparer.Ordinal));
-        if (legacyOptionTerminatorRendered
-            && renderedOptions.Any(static option =>
-                GetRenderOrder(option.Phase) > GetRenderOrder(CommandLinePhaseCompatibility.LegacyEndOfOptions)))
-        {
-            throw new InvalidOperationException(
-                "CLI flags or options cannot be rendered after a legacy end-of-options marker.");
         }
 
         foreach (var argument in arguments)

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -101,6 +101,7 @@
 *REMOVED*ModularPipelines.Attributes.RunIfAnyAttribute<T>.RunIfAnyAttribute() -> void
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute.ExpectedValue.get -> string?
+*REMOVED*ModularPipelines.Attributes.CommandLinePhase.EndOfOptions = 2 -> ModularPipelines.Attributes.CommandLinePhase
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute.RunIfEnvironmentVariableAttribute(string! variableName, string? expectedValue = null) -> void
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute.VariableName.get -> string!
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableUnsetAttribute
@@ -2669,7 +2670,7 @@ static ModularPipelines.Requirements.Require.WindowsAdmin(string? failureReason 
 static ModularPipelines.Secrets.SecretMaskingOptions.Default.get -> ModularPipelines.Secrets.SecretMaskingOptions!
 static ModularPipelines.Secrets.SecretMaskingOptions.operator !=(ModularPipelines.Secrets.SecretMaskingOptions? left, ModularPipelines.Secrets.SecretMaskingOptions? right) -> bool
 static ModularPipelines.Secrets.SecretMaskingOptions.operator ==(ModularPipelines.Secrets.SecretMaskingOptions? left, ModularPipelines.Secrets.SecretMaskingOptions? right) -> bool
-static ModularPipelines.SkipDecision.Of(bool shouldSkip, string? reason) -> ModularPipelines.SkipDecision!
+*REMOVED*static ModularPipelines.SkipDecision.Of(bool shouldSkip, string? reason) -> ModularPipelines.SkipDecision!
 static ModularPipelines.SkipDecision.Skip(string? reason) -> ModularPipelines.SkipDecision!
 static ModularPipelines.SkipDecision.When(bool shouldSkip, string? reason) -> ModularPipelines.SkipDecision!
 static ModularPipelines.SkipDecision.operator !=(ModularPipelines.SkipDecision? left, ModularPipelines.SkipDecision? right) -> bool

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+*REMOVED*ModularPipelines.Attributes.CommandLinePhase.EndOfOptions = 2 -> ModularPipelines.Attributes.CommandLinePhase
 *REMOVED*ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute
 *REMOVED*ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute.DependsOnAllModulesInheritingFromAttribute(System.Type! type) -> void
 *REMOVED*ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute.Type.get -> System.Type!
@@ -101,7 +102,6 @@
 *REMOVED*ModularPipelines.Attributes.RunIfAnyAttribute<T>.RunIfAnyAttribute() -> void
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute.ExpectedValue.get -> string?
-*REMOVED*ModularPipelines.Attributes.CommandLinePhase.EndOfOptions = 2 -> ModularPipelines.Attributes.CommandLinePhase
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute.RunIfEnvironmentVariableAttribute(string! variableName, string? expectedValue = null) -> void
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableAttribute.VariableName.get -> string!
 *REMOVED*ModularPipelines.Attributes.RunIfEnvironmentVariableUnsetAttribute

--- a/src/ModularPipelines/SkipDecision.cs
+++ b/src/ModularPipelines/SkipDecision.cs
@@ -56,13 +56,4 @@ public sealed record SkipDecision
     {
         Reason = shouldSkip ? reason : null,
     };
-
-    /// <summary>
-    /// Creates a skip decision from a boolean condition.
-    /// </summary>
-    /// <param name="shouldSkip"><see langword="true"/> to skip the module; otherwise, <see langword="false"/>.</param>
-    /// <param name="reason">The reason for skipping, used only when <paramref name="shouldSkip"/> is <see langword="true"/>.</param>
-    /// <returns>A decision matching <paramref name="shouldSkip"/>.</returns>
-    [Obsolete("Use When(bool, string?) instead.")]
-    public static SkipDecision Of(bool shouldSkip, string? reason) => When(shouldSkip, reason);
 }

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -1,6 +1,5 @@
 using System.CodeDom.Compiler;
 using System.Globalization;
-using System.Reflection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -137,14 +137,9 @@ public class CliAttributeTests
 
         await Assert.That(ordinals[CommandLinePhase.EarlyOperand]).IsEqualTo(0);
         await Assert.That(ordinals[CommandLinePhase.Normal]).IsEqualTo(1);
-        await Assert.That(ordinals[(CommandLinePhase) 2]).IsEqualTo(2);
         await Assert.That(ordinals[CommandLinePhase.Passthrough]).IsEqualTo(3);
         await Assert.That(ordinals[CommandLinePhase.Terminal]).IsEqualTo(4);
-        await Assert.That(Enum.GetName((CommandLinePhase) 2)).IsEqualTo("EndOfOptions");
-        await Assert.That(typeof(CommandLinePhase)
-                .GetField("EndOfOptions")!
-                .GetCustomAttribute<ObsoleteAttribute>())
-            .IsNotNull();
+        await Assert.That(ordinals.Values).DoesNotContain(2);
     }
 
     [Test]
@@ -839,26 +834,6 @@ public class CliAttributeTests
         await Assert.That(() => BuildArguments(options))
             .Throws<InvalidOperationException>()
             .And.HasMessageContaining("before a later flag or option");
-    }
-
-    [Test]
-    public async Task Parser_Rejects_Terminal_Option_After_Legacy_End_Marker()
-    {
-        PropertyCommandLinePart[] model =
-        [
-            new FlagPart(
-                "EndOfOptions",
-                static _ => true,
-                new CliFlagAttribute("--") { Phase = (CommandLinePhase) 2 }),
-            new OptionPart(
-                "RunTests",
-                static _ => "tests.jq",
-                new CliOptionAttribute("--run-tests") { Phase = CommandLinePhase.Terminal }),
-        ];
-
-        await Assert.That(() => new CommandArgumentBuilder().BuildArguments(model, new object()))
-            .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("legacy end-of-options marker");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -601,35 +601,6 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Renders_Legacy_EndOfOptions_Phase()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        var result = builder.Build(new TestLegacyEndOfOptionsOptions
-        {
-            EndOfOptions = true,
-            Filter = "-1",
-        });
-
-        await Assert.That(result.ToString()).IsEqualTo("jq -- -1");
-    }
-
-    [Test]
-    public async Task Build_Preserves_Declared_Manual_Marker_With_Legacy_Flag()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        var result = builder.Build(new TestLegacyEndOfOptionsOptions
-        {
-            Arguments = ["--", "tail"],
-            ArgumentsContainOptionTerminator = true,
-            ArgumentsContainToolOptions = true,
-        });
-
-        await Assert.That(result.ToString()).IsEqualTo("jq -- tail");
-    }
-
-    [Test]
     public async Task Build_Rejects_Manual_Terminal_Options_With_Manual_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
@@ -1535,7 +1506,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Rejects_Additional_Terminator_Outside_Legacy_Phase()
+    public async Task Build_Rejects_Additional_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
         CommandLinePhase[] phases =
@@ -1556,7 +1527,7 @@ public class CommandLineBuilderTests : TestBase
 
             await Assert.That(Build)
                 .Throws<ArgumentException>()
-                .And.HasMessageContaining("legacy end-of-options phase");
+                .And.HasMessageContaining("CliArgumentAttribute");
         }
     }
 
@@ -2208,16 +2179,6 @@ public class CommandLineBuilderTests : TestBase
         public bool? CompactOutput { get; set; }
 
         [CliArgument(0)]
-        public string? Filter { get; set; }
-    }
-
-    [CliTool("jq")]
-    private record TestLegacyEndOfOptionsOptions : CommandLineToolOptions
-    {
-        [CliFlag("--", Phase = (CommandLinePhase) 2)]
-        public bool? EndOfOptions { get; set; }
-
-        [CliArgument(0, PrependOptionTerminatorIfValueStartsWithDash = true)]
         public string? Filter { get; set; }
     }
 

--- a/test/ModularPipelines.UnitTests/Models/SkipDecisionTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/SkipDecisionTests.cs
@@ -78,20 +78,4 @@ public class SkipDecisionTests
             await Assert.That(skipDecision.Reason).IsEqualTo(shouldSkip ? "Blah!" : null);
         }
     }
-
-    [Test]
-    [Arguments(true)]
-    [Arguments(false)]
-    public async Task Of_ForwardsToWhen(bool shouldSkip)
-    {
-#pragma warning disable CS0618 // Verifies the compatibility alias.
-        var skipDecision = SkipDecision.Of(shouldSkip, "Blah!");
-#pragma warning restore CS0618
-
-        using (Assert.Multiple())
-        {
-            await Assert.That(skipDecision.ShouldSkip).IsEqualTo(shouldSkip);
-            await Assert.That(skipDecision.Reason).IsEqualTo(shouldSkip ? "Blah!" : null);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- remove the obsolete \SkipDecision.Of\ alias
- remove \CommandLinePhase.EndOfOptions\ and its compatibility rendering path
- retain current \CliArgumentAttribute\ option-terminator behavior and update API baselines/release notes

## Validation
- \CliAttributeTests\: 93 passed
- \CommandLineBuilderTests\: 96 passed
- \SkipDecisionTests\: 7 passed
- \ModularPipelines.Tests.slnf\ Release build: 0 errors

Closes #4398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the obsolete `SkipDecision.Of(bool, string?)` method. Use `SkipDecision.When` instead.
  * Removed the legacy `CommandLinePhase.EndOfOptions` option.
  * Additional arguments now reject literal `--` markers unless supplied through supported structured attributes or manual arguments.

* **Documentation**
  * Updated v4 release notes with migration guidance for these removed APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->