### PR TITLE
Remove dead framework and migration branches

### DIFF
--- a/src/ModularPipelines.Testing/NoOpConsoleServices.cs
+++ b/src/ModularPipelines.Testing/NoOpConsoleServices.cs
@@ -40,7 +40,7 @@ internal sealed class NoOpConsoleServices :
     public Task FlushInProgressModuleOutputAsync(CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
-    public Task FlushModuleOutputAsync() => Task.CompletedTask;
+    public Task FlushUnattributedOutputAsync() => Task.CompletedTask;
 
     public void WriteResults(PipelineSummary summary)
     {

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -29,7 +29,7 @@ namespace ModularPipelines.Console;
 /// concurrently from multiple threads.
 /// </para>
 /// <para>
-/// <b>IProgressDisplay:</b> Implements IProgressDisplay to integrate with existing notification
+/// <b>IProgressDisplay:</b> Implements IProgressDisplay to integrate with the notification
 /// system. The ProgressPrinter forwards notifications here, which are delegated to the active session.
 /// </para>
 /// </remarks>
@@ -370,19 +370,15 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     }
 
     /// <inheritdoc />
-    public async Task FlushModuleOutputAsync()
+    public async Task FlushUnattributedOutputAsync()
     {
-        // Output is now flushed immediately when modules complete.
-        // This method remains for API compatibility but only flushes
-        // unattributed output (pipeline-level logs).
         if (_originalConsoleOut == null)
         {
-            return; // Not installed, nothing to flush
+            return;
         }
 
         var formatter = _formatterProvider.GetFormatter();
 
-        // Flush unattributed output (if any)
         if (_unattributedBuffer.HasOutput)
         {
             var unattributedLogger = _outputLogger
@@ -463,18 +459,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        // Flush any buffered module output before uninstalling
-        // This ensures logs are written even when pipeline isn't executed (e.g., in tests)
         if (_isInstalled)
         {
-            try
-            {
-                await FlushModuleOutputAsync().ConfigureAwait(false);
-            }
-            catch (InvalidOperationException)
-            {
-                // Ignore if not installed - FlushModuleOutputAsync requires installation
-            }
+            await FlushUnattributedOutputAsync().ConfigureAwait(false);
         }
 
         Uninstall();
@@ -484,17 +471,11 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     #region IProgressDisplay Implementation
 
     /// <summary>
-    /// Implements IProgressDisplay.RunAsync for integration with existing notification system.
-    /// This is called by ProgressPrinter when the old code path is used.
+    /// Runs the progress session started by <see cref="ModularPipelines.Engine.Executors.PipelineOutputCoordinator"/>,
+    /// which installs console interception before invoking the progress display.
     /// </summary>
     async Task IProgressDisplay.RunAsync(OrganizedModules organizedModules, CancellationToken cancellationToken)
     {
-        // Install if not already installed (for backward compatibility)
-        if (!_isInstalled)
-        {
-            Install();
-        }
-
         await using var session = await BeginProgressAsync(organizedModules, cancellationToken).ConfigureAwait(false);
 
         // Wait for cancellation - the session runs until disposed

--- a/src/ModularPipelines/Console/IConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/IConsoleCoordinator.cs
@@ -17,7 +17,7 @@ namespace ModularPipelines.Console;
 /// 2. BeginProgressAsync() - Starts progress display phase
 /// 3. [Pipeline executes] - All output buffered per-module
 /// 4. ProgressSession disposed - Ends progress phase
-/// 5. FlushModuleOutputAsync() - Writes buffered output in order
+/// 5. FlushUnattributedOutputAsync() - Writes remaining pipeline-level output
 /// 6. WriteResults() - Prints results table
 /// 7. WriteExceptions() - Prints deferred exceptions
 /// 8. Uninstall() - Restores original console
@@ -87,7 +87,7 @@ internal interface IConsoleCoordinator : IModuleOutputExcerptProvider, IAsyncDis
     /// Flushes any remaining unattributed output.
     /// Module output is flushed immediately when modules complete.
     /// </summary>
-    Task FlushModuleOutputAsync();
+    Task FlushUnattributedOutputAsync();
 
     /// <summary>
     /// Writes the pipeline results table.

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -241,7 +241,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
 
             // 5. Flush any unattributed output from coordinator.
             await CaptureExceptionAsync(
-                () => _consoleCoordinator.FlushModuleOutputAsync(),
+                () => _consoleCoordinator.FlushUnattributedOutputAsync(),
                 exceptions).ConfigureAwait(false);
 
             try

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -89,7 +89,6 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
         var fileName = $"Mod-{moduleName}-Sub-{encodedSubModuleName}.txt";
 
         await SaveModuleTimeAsync(subModuleEstimation.EstimatedDuration, fileName).ConfigureAwait(false);
-        DeleteLegacySubModuleFile(moduleName, subModuleEstimation.SubModuleName, fileName);
 
         lock (_subModuleIndexLock)
         {
@@ -207,20 +206,6 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
         {
             return name;
         }
-    }
-
-    private void DeleteLegacySubModuleFile(string moduleName, string subModuleName, string encodedFileName)
-    {
-        var legacyFileName = $"Mod-{moduleName}-Sub-{subModuleName}.txt";
-        if (legacyFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
-            || legacyFileName.Contains('/')
-            || legacyFileName.Contains('\\')
-            || string.Equals(legacyFileName, encodedFileName, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        TryDelete(new FileInfo(Path.Combine(_directory, legacyFileName)));
     }
 
     private static void TryDelete(FileInfo file)

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -89,6 +89,7 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
         var fileName = $"Mod-{moduleName}-Sub-{encodedSubModuleName}.txt";
 
         await SaveModuleTimeAsync(subModuleEstimation.EstimatedDuration, fileName).ConfigureAwait(false);
+        DeleteLegacySubModuleFile(moduleName, subModuleEstimation.SubModuleName, fileName);
 
         lock (_subModuleIndexLock)
         {
@@ -206,6 +207,20 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
         {
             return name;
         }
+    }
+
+    private void DeleteLegacySubModuleFile(string moduleName, string subModuleName, string encodedFileName)
+    {
+        var legacyFileName = $"Mod-{moduleName}-Sub-{subModuleName}.txt";
+        if (legacyFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || legacyFileName.Contains('/')
+            || legacyFileName.Contains('\\')
+            || string.Equals(legacyFileName, encodedFileName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        TryDelete(new FileInfo(Path.Combine(_directory, legacyFileName)));
     }
 
     private static void TryDelete(FileInfo file)

--- a/src/ModularPipelines/Http/ResilienceHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResilienceHttpHandler.cs
@@ -136,9 +136,7 @@ internal class ResilienceHttpHandler : DelegatingHandler
         var clone = new HttpRequestMessage(original.Method, original.RequestUri)
         {
             Version = original.Version,
-#if NET5_0_OR_GREATER
             VersionPolicy = original.VersionPolicy,
-#endif
         };
 
         // Create fresh content from buffered bytes for each retry attempt
@@ -157,19 +155,11 @@ internal class ResilienceHttpHandler : DelegatingHandler
             clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
-#if NET5_0_OR_GREATER
         // Clone options
         foreach (var option in original.Options)
         {
             clone.Options.TryAdd(option.Key, option.Value);
         }
-#else
-        // Clone properties for older frameworks
-        foreach (var property in original.Properties)
-        {
-            clone.Properties[property.Key] = property.Value;
-        }
-#endif
 
         return clone;
     }

--- a/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
@@ -115,6 +115,25 @@ public class FileSystemModuleEstimatedTimeProviderTests
     }
 
     [Test]
+    public async Task SaveSubModuleTime_ReplacesLegacyFileForSameName()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            WriteEstimation(directory, typeof(PrefixModule), "legacy", TimeSpan.FromSeconds(1));
+            var provider = CreateProvider(directory);
+
+            await provider.SaveSubModuleTimeAsync(
+                typeof(PrefixModule),
+                new SubModuleEstimation("legacy", TimeSpan.FromSeconds(2)));
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(Directory.GetFiles(directory)).HasSingleItem();
+            await Assert.That(estimations).HasSingleItem();
+            await Assert.That(estimations[0].EstimatedDuration).IsEqualTo(TimeSpan.FromSeconds(2));
+        });
+    }
+
+    [Test]
     public async Task GetSubModuleEstimatedTimes_RefreshesExpiredDirectoryIndex()
     {
         await RunWithTemporaryDirectoryAsync(async directory =>

--- a/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
@@ -115,25 +115,6 @@ public class FileSystemModuleEstimatedTimeProviderTests
     }
 
     [Test]
-    public async Task SaveSubModuleTime_ReplacesLegacyFileForSameName()
-    {
-        await RunWithTemporaryDirectoryAsync(async directory =>
-        {
-            WriteEstimation(directory, typeof(PrefixModule), "legacy", TimeSpan.FromSeconds(1));
-            var provider = CreateProvider(directory);
-
-            await provider.SaveSubModuleTimeAsync(
-                typeof(PrefixModule),
-                new SubModuleEstimation("legacy", TimeSpan.FromSeconds(2)));
-            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
-
-            await Assert.That(Directory.GetFiles(directory)).HasSingleItem();
-            await Assert.That(estimations).HasSingleItem();
-            await Assert.That(estimations[0].EstimatedDuration).IsEqualTo(TimeSpan.FromSeconds(2));
-        });
-    }
-
-    [Test]
     public async Task GetSubModuleEstimatedTimes_RefreshesExpiredDirectoryIndex()
     {
         await RunWithTemporaryDirectoryAsync(async directory =>

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -75,7 +75,7 @@ public class PipelineOutputCoordinatorTests
         consoleCoordinator.Setup(x => x.FlushPendingWritesAsync())
             .Callback(() => events.Add("retained"))
             .ReturnsAsync([retainedBuffer.Object]);
-        consoleCoordinator.Setup(x => x.FlushModuleOutputAsync())
+        consoleCoordinator.Setup(x => x.FlushUnattributedOutputAsync())
             .Callback(() => events.Add("unattributed"))
             .Returns(Task.CompletedTask);
 
@@ -126,7 +126,7 @@ public class PipelineOutputCoordinatorTests
             .Callback(() => events.Add("retained"))
             .ThrowsAsync(new InvalidOperationException("retained flush failed"));
         consoleCoordinator
-            .Setup(x => x.FlushModuleOutputAsync())
+            .Setup(x => x.FlushUnattributedOutputAsync())
             .Callback(() => events.Add("unattributed"))
             .Returns(Task.CompletedTask);
         var outputCoordinator = new Mock<IOutputCoordinator>();
@@ -169,7 +169,7 @@ public class PipelineOutputCoordinatorTests
             .Callback(() => events.Add("retained"))
             .ThrowsAsync(new InvalidOperationException("retained flush failed"));
         consoleCoordinator
-            .Setup(x => x.FlushModuleOutputAsync())
+            .Setup(x => x.FlushUnattributedOutputAsync())
             .Callback(() => events.Add("unattributed"))
             .ThrowsAsync(new IOException("unattributed flush failed"));
         var outputCoordinator = new Mock<IOutputCoordinator>();
@@ -227,7 +227,7 @@ public class PipelineOutputCoordinatorTests
                 .Setup(x => x.FlushPendingWritesAsync())
                 .ReturnsAsync([]);
             consoleCoordinator
-                .Setup(x => x.FlushModuleOutputAsync())
+                .Setup(x => x.FlushUnattributedOutputAsync())
                 .Returns(Task.CompletedTask);
             var outputCoordinator = new Mock<IOutputCoordinator>();
             outputCoordinator


### PR DESCRIPTION
Closes #4400

## Summary
- collapse HTTP request cloning to the net10 path
- stop probing and deleting legacy submodule estimate filenames
- rename the internal final flush to FlushUnattributedOutputAsync
- remove the unreachable progress-display auto-install fallback

## Validation
- focused HTTP, estimate-provider, console-coordinator, and pipeline-output tests: 23/23 passed
- ModularPipelines.Tests.slnf Release build: passed (181 existing warnings, 0 errors)
- touched-file whitespace verification: passed
- warning-format verification reports the pre-existing TUnit0015 warning in RunningScope_PeriodicallyFlushesInProgressOutput

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console output cleanup so remaining unattributed pipeline output is flushed reliably during shutdown.
  * Preserved submodule timing cache files instead of removing legacy entries after updates.
  * Improved HTTP request cloning consistency across supported platforms.

* **Refactor**
  * Renamed the console output flushing API to clarify that it handles unattributed output.
  * Updated progress display lifecycle behavior and related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->