### PR TITLE
[Automated] Update grype CLI Options

### DIFF
--- a/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
+++ b/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Grype.Services;
 
 namespace ModularPipelines.Grype.Extensions;
@@ -32,4 +31,5 @@ public static class GrypeExtensions
         services.TryAddScoped<IGrypeDb, GrypeDb>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Grype/Options/GrypeDbOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbOptions.Generated.cs
@@ -50,7 +50,4 @@ public record GrypeDbOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
-    public string? Command { get; set; }
-
 }

--- a/src/ModularPipelines.Grype/Options/GrypeDbSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbSearchOptions.Generated.cs
@@ -116,7 +116,4 @@ public record GrypeDbSearchOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [Obsolete("Command is no longer supported by the installed CLI and has no effect.")]
-    public string? Command { get; set; }
-
 }

--- a/src/ModularPipelines.Grype/Options/GrypeExplainOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeExplainOptions.Generated.cs
@@ -56,7 +56,4 @@ public record GrypeExplainOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [Obsolete("VulnerabilityId is no longer supported by the installed CLI and has no effect.")]
-    public string? VulnerabilityId { get; set; }
-
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **grype** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- grype (grype 0.118.0): 12 commands, tree b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator