### PR TITLE
[Automated] Update pnpm CLI Options

### DIFF
--- a/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
+++ b/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Node.Services;
 
 namespace ModularPipelines.Node.Extensions;
@@ -31,4 +30,5 @@ public static class PnpmExtensions
         services.TryAddScoped<IPnpm, Services.Pnpm>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
@@ -23,8 +23,8 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
     /// </summary>
-    [CliOption("--aggregate-output")]
-    public string? AggregateOutput { get; set; }
+    [CliFlag("--aggregate-output")]
+    public bool? AggregateOutput { get; set; }
 
     /// <summary>
     /// A list of package names that are allowed to run postinstall scripts during installation
@@ -35,8 +35,8 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Save the dependency to configurational dependencies
     /// </summary>
-    [CliOption("--config")]
-    public string? Config { get; set; }
+    [CliFlag("--config")]
+    public bool? Config { get; set; }
 
     /// <summary>
     /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
@@ -59,8 +59,8 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Output usage information
     /// </summary>
-    [CliOption("--help", ShortForm = "-h")]
-    public string? Help { get; set; }
+    [CliFlag("--help", ShortForm = "-h")]
+    public bool? Help { get; set; }
 
     /// <summary>
     /// Don't run lifecycle scripts
@@ -101,8 +101,8 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Save package to the default catalog
     /// </summary>
-    [CliOption("--save-catalog")]
-    public string? SaveCatalog { get; set; }
+    [CliFlag("--save-catalog")]
+    public bool? SaveCatalog { get; set; }
 
     /// <summary>
     /// Save package to your `devDependencies`
@@ -125,8 +125,8 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Save package to your `dependencies`. The default behavior
     /// </summary>
-    [CliOption("--save-prod", ShortForm = "-p")]
-    public string? SaveProd { get; set; }
+    [CliFlag("--save-prod", ShortForm = "-p")]
+    public bool? SaveProd { get; set; }
 
     /// <summary>
     /// The directory in which all packages are saved on disk. Use a shared store only with trusted users and jobs
@@ -137,14 +137,14 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Stream output from child processes immediately, prefixed with the originating package directory. This allows output from different packages to be interleaved.
     /// </summary>
-    [CliOption("--stream")]
-    public string? Stream { get; set; }
+    [CliFlag("--stream")]
+    public bool? Stream { get; set; }
 
     /// <summary>
     /// Divert all output to stderr
     /// </summary>
-    [CliOption("--use-stderr")]
-    public string? UseStderr { get; set; }
+    [CliFlag("--use-stderr")]
+    public bool? UseStderr { get; set; }
 
     /// <summary>
     /// The directory with links to the store (default is node_modules/.pnpm). All direct and indirect dependencies of the project are linked into this directory
@@ -155,20 +155,20 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// Only adds the new dependency if it is found in the workspace
     /// </summary>
-    [CliOption("--workspace")]
-    public string? Workspace { get; set; }
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
 
     /// <summary>
     /// Run the command on the root workspace project
     /// </summary>
-    [CliOption("--workspace-root", ShortForm = "-w")]
-    public string? WorkspaceRoot { get; set; }
+    [CliFlag("--workspace-root", ShortForm = "-w")]
+    public bool? WorkspaceRoot { get; set; }
 
     /// <summary>
     /// Automatically answer yes to prompts and run non-interactively. Will abort if an undesirable situation occurs and user input is strictly necessary.
     /// </summary>
-    [CliOption("--yes", ShortForm = "-y")]
-    public string? Yes { get; set; }
+    [CliFlag("--yes", ShortForm = "-y")]
+    public bool? Yes { get; set; }
 
     /// <summary>
     /// Defines files to ignore when filtering for changed projects since the specified
@@ -179,8 +179,8 @@ public record PnpmAddOptions : PnpmOptions
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmAuditOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAuditOptions.Generated.cs
@@ -29,8 +29,8 @@ public record PnpmAuditOptions : PnpmOptions
     /// <summary>
     /// Only audit "devDependencies"
     /// </summary>
-    [CliOption("--dev", ShortForm = "-D")]
-    public string? Dev { get; set; }
+    [CliFlag("--dev", ShortForm = "-D")]
+    public bool? Dev { get; set; }
 
     /// <summary>
     /// Fix the audited vulnerabilities using the specified method: "override" or "update". "override" adds overrides to the package.json file in order to force non-vulnerable versions of the dependencies. "update" attempts to update the vulnerable packages in the lockfile to non-vulnerable versions. If no method is specified, "override" is used by default.
@@ -47,26 +47,26 @@ public record PnpmAuditOptions : PnpmOptions
     /// <summary>
     /// Use exit code 0 if the registry responds with an error. Useful when audit checks are used in CI. A build should not fail because the registry has issues.
     /// </summary>
-    [CliOption("--ignore-registry-errors")]
-    public string? IgnoreRegistryErrors { get; set; }
+    [CliFlag("--ignore-registry-errors")]
+    public bool? IgnoreRegistryErrors { get; set; }
 
     /// <summary>
     /// Ignore all vulnerabilities for which no fix exists
     /// </summary>
-    [CliOption("--ignore-unfixable")]
-    public string? IgnoreUnfixable { get; set; }
+    [CliFlag("--ignore-unfixable")]
+    public bool? IgnoreUnfixable { get; set; }
 
     /// <summary>
     /// Show vulnerabilities and select which ones to fix interactively
     /// </summary>
-    [CliOption("--interactive", ShortForm = "-i")]
-    public string? Interactive { get; set; }
+    [CliFlag("--interactive", ShortForm = "-i")]
+    public bool? Interactive { get; set; }
 
     /// <summary>
     /// Output audit report in JSON format
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// Don't audit "optionalDependencies"
@@ -77,7 +77,7 @@ public record PnpmAuditOptions : PnpmOptions
     /// <summary>
     /// Only audit "dependencies" and "optionalDependencies"
     /// </summary>
-    [CliOption("--prod", ShortForm = "-P")]
-    public string? Prod { get; set; }
+    [CliFlag("--prod", ShortForm = "-P")]
+    public bool? Prod { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmAuditSignaturesOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAuditSignaturesOptions.Generated.cs
@@ -29,8 +29,8 @@ public record PnpmAuditSignaturesOptions : PnpmOptions
     /// <summary>
     /// Only audit "devDependencies"
     /// </summary>
-    [CliOption("--dev", ShortForm = "-D")]
-    public string? Dev { get; set; }
+    [CliFlag("--dev", ShortForm = "-D")]
+    public bool? Dev { get; set; }
 
     /// <summary>
     /// Fix the audited vulnerabilities using the specified method: "override" or "update". "override" adds overrides to the package.json file in order to force non-vulnerable versions of the dependencies. "update" attempts to update the vulnerable packages in the lockfile to non-vulnerable versions. If no method is specified, "override" is used by default.
@@ -47,26 +47,26 @@ public record PnpmAuditSignaturesOptions : PnpmOptions
     /// <summary>
     /// Use exit code 0 if the registry responds with an error. Useful when audit checks are used in CI. A build should not fail because the registry has issues.
     /// </summary>
-    [CliOption("--ignore-registry-errors")]
-    public string? IgnoreRegistryErrors { get; set; }
+    [CliFlag("--ignore-registry-errors")]
+    public bool? IgnoreRegistryErrors { get; set; }
 
     /// <summary>
     /// Ignore all vulnerabilities for which no fix exists
     /// </summary>
-    [CliOption("--ignore-unfixable")]
-    public string? IgnoreUnfixable { get; set; }
+    [CliFlag("--ignore-unfixable")]
+    public bool? IgnoreUnfixable { get; set; }
 
     /// <summary>
     /// Show vulnerabilities and select which ones to fix interactively
     /// </summary>
-    [CliOption("--interactive", ShortForm = "-i")]
-    public string? Interactive { get; set; }
+    [CliFlag("--interactive", ShortForm = "-i")]
+    public bool? Interactive { get; set; }
 
     /// <summary>
     /// Output audit report in JSON format
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// Don't audit "optionalDependencies"
@@ -77,7 +77,7 @@ public record PnpmAuditSignaturesOptions : PnpmOptions
     /// <summary>
     /// Only audit "dependencies" and "optionalDependencies"
     /// </summary>
-    [CliOption("--prod", ShortForm = "-P")]
-    public string? Prod { get; set; }
+    [CliFlag("--prod", ShortForm = "-P")]
+    public bool? Prod { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmDlxOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmDlxOptions.Generated.cs
@@ -22,11 +22,6 @@ public record PnpmDlxOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Command
 ) : PnpmOptions
 {
-    public PnpmDlxOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// A list of package names that are allowed to run postinstall scripts during installation
     /// </summary>
@@ -42,8 +37,8 @@ public record PnpmDlxOptions(
     /// <summary>
     /// Runs the script inside of a shell. Uses /bin/sh on UNIX and \cmd.exe on Windows.
     /// </summary>
-    [CliOption("--shell-mode", ShortForm = "-c")]
-    public string? ShellMode { get; set; }
+    [CliFlag("--shell-mode", ShortForm = "-c")]
+    public bool? ShellMode { get; set; }
 
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
@@ -29,8 +29,8 @@ public record PnpmInitOptions : PnpmOptions
     /// <summary>
     /// Pin the pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing
     /// </summary>
-    [CliOption("--init-package-manager")]
-    public string? InitPackageManager { get; set; }
+    [CliFlag("--init-package-manager")]
+    public bool? InitPackageManager { get; set; }
 
     /// <summary>
     /// Set the module system for the package. Defaults to "module".

--- a/src/ModularPipelines.Node/Options/PnpmPublishOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmPublishOptions.Generated.cs
@@ -30,20 +30,20 @@ public record PnpmPublishOptions : PnpmOptions
     /// <summary>
     /// Send all packages to the registry in a single request instead of one request per package. Requires --recursive and a registry that implements the "/-/pnpm/v1/publish" endpoint (for example, pnpr)
     /// </summary>
-    [CliOption("--batch")]
-    public string? Batch { get; set; }
+    [CliFlag("--batch")]
+    public bool? Batch { get; set; }
 
     /// <summary>
     /// Does everything a publish would do except actually publishing to the registry
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Packages are proceeded to be published even if their current version is already in the registry. This is useful when a "prepublishOnly" script bumps the version of the package before it is published
     /// </summary>
-    [CliOption("--force")]
-    public string? Force { get; set; }
+    [CliFlag("--force")]
+    public bool? Force { get; set; }
 
     /// <summary>
     /// Ignores any publish related lifecycle scripts (prepublishOnly, postpublish, and the like)
@@ -54,8 +54,8 @@ public record PnpmPublishOptions : PnpmOptions
     /// <summary>
     /// Show information in JSON format
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// Don't check if current branch is your publish branch, clean, and up to date
@@ -85,14 +85,14 @@ public record PnpmPublishOptions : PnpmOptions
     /// <summary>
     /// Save the list of the newly published packages to "pnpm-publish-summary.json". Useful when some other tooling is used to report the list of published packages.
     /// </summary>
-    [CliOption("--report-summary")]
-    public string? ReportSummary { get; set; }
+    [CliFlag("--report-summary")]
+    public bool? ReportSummary { get; set; }
 
     /// <summary>
     /// Skip pnpm's manifest obfuscation: keep the original `packageManager` field and publish lifecycle scripts in the published manifest instead of stripping them. The pnpm-specific `pnpm` field is still omitted.
     /// </summary>
-    [CliOption("--skip-manifest-obfuscation")]
-    public string? SkipManifestObfuscation { get; set; }
+    [CliFlag("--skip-manifest-obfuscation")]
+    public bool? SkipManifestObfuscation { get; set; }
 
     /// <summary>
     /// Registers the published package with the given tag. By default, the "latest" tag is used.
@@ -109,8 +109,8 @@ public record PnpmPublishOptions : PnpmOptions
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
@@ -22,16 +22,11 @@ public record PnpmRunOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Command
 ) : PnpmOptions
 {
-    public PnpmRunOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
     /// </summary>
-    [CliOption("--aggregate-output")]
-    public string? AggregateOutput { get; set; }
+    [CliFlag("--aggregate-output")]
+    public bool? AggregateOutput { get; set; }
 
     /// <summary>
     /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
@@ -42,14 +37,14 @@ public record PnpmRunOptions(
     /// <summary>
     /// Output usage information
     /// </summary>
-    [CliOption("--help", ShortForm = "-h")]
-    public string? Help { get; set; }
+    [CliFlag("--help", ShortForm = "-h")]
+    public bool? Help { get; set; }
 
     /// <summary>
     /// Avoid exiting with a non-zero exit code when the script is undefined
     /// </summary>
-    [CliOption("--if-present")]
-    public string? IfPresent { get; set; }
+    [CliFlag("--if-present")]
+    public bool? IfPresent { get; set; }
 
     /// <summary>
     /// What level of logs to report. Any logs at or higher than the given level will be shown. Levels (lowest to highest): debug, info, warn, error. Or use "--silent" to turn off all logging.
@@ -66,8 +61,8 @@ public record PnpmRunOptions(
     /// <summary>
     /// Completely disregard concurrency and topological sorting, running a given script immediately in all matching packages with prefixed streaming output. This is the preferred flag for long-running processes such as watch run over many packages.
     /// </summary>
-    [CliOption("--parallel")]
-    public string? Parallel { get; set; }
+    [CliFlag("--parallel")]
+    public bool? Parallel { get; set; }
 
     /// <summary>
     /// Run the defined package script in every package found in subdirectories or every workspace package, when executed inside a workspace. For options that may be used with `-r`, see "pnpm help recursive"
@@ -78,14 +73,14 @@ public record PnpmRunOptions(
     /// <summary>
     /// Save the execution results of every package to "pnpm-exec-summary.json". Useful to inspect the execution time and status of each package.
     /// </summary>
-    [CliOption("--report-summary")]
-    public string? ReportSummary { get; set; }
+    [CliFlag("--report-summary")]
+    public bool? ReportSummary { get; set; }
 
     /// <summary>
     /// Hide project name prefix from output of running scripts. Useful when running in CI like GitHub Actions and the output from a script may create an annotation.
     /// </summary>
-    [CliOption("--reporter-hide-prefix")]
-    public string? ReporterHidePrefix { get; set; }
+    [CliFlag("--reporter-hide-prefix")]
+    public bool? ReporterHidePrefix { get; set; }
 
     /// <summary>
     /// Command executed from given package
@@ -96,32 +91,32 @@ public record PnpmRunOptions(
     /// <summary>
     /// Run the specified scripts one by one
     /// </summary>
-    [CliOption("--sequential", ShortForm = "-s")]
-    public string? Sequential { get; set; }
+    [CliFlag("--sequential", ShortForm = "-s")]
+    public bool? Sequential { get; set; }
 
     /// <summary>
     /// Stream output from child processes immediately, prefixed with the originating package directory. This allows output from different packages to be interleaved.
     /// </summary>
-    [CliOption("--stream")]
-    public string? Stream { get; set; }
+    [CliFlag("--stream")]
+    public bool? Stream { get; set; }
 
     /// <summary>
     /// Divert all output to stderr
     /// </summary>
-    [CliOption("--use-stderr")]
-    public string? UseStderr { get; set; }
+    [CliFlag("--use-stderr")]
+    public bool? UseStderr { get; set; }
 
     /// <summary>
     /// Run the command on the root workspace project
     /// </summary>
-    [CliOption("--workspace-root", ShortForm = "-w")]
-    public string? WorkspaceRoot { get; set; }
+    [CliFlag("--workspace-root", ShortForm = "-w")]
+    public bool? WorkspaceRoot { get; set; }
 
     /// <summary>
     /// Automatically answer yes to prompts and run non-interactively. Will abort if an undesirable situation occurs and user input is strictly necessary.
     /// </summary>
-    [CliOption("--yes", ShortForm = "-y")]
-    public string? Yes { get; set; }
+    [CliFlag("--yes", ShortForm = "-y")]
+    public bool? Yes { get; set; }
 
     /// <summary>
     /// Defines files to ignore when filtering for changed projects since the specified
@@ -132,8 +127,8 @@ public record PnpmRunOptions(
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStageApproveOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageApproveOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Node.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.Node.Options;
 
@@ -32,14 +32,14 @@ public record PnpmStageApproveOptions(
     /// <summary>
     /// Does everything stage publish would do except uploading to the registry.
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Show information in JSON format for list, view, publish, and download.
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// One-time password for approve and reject.
@@ -75,8 +75,8 @@ public record PnpmStageApproveOptions(
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStageDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageDownloadOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Node.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.Node.Options;
 
@@ -32,14 +32,14 @@ public record PnpmStageDownloadOptions(
     /// <summary>
     /// Does everything stage publish would do except uploading to the registry.
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Show information in JSON format for list, view, publish, and download.
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// One-time password for approve and reject.
@@ -75,8 +75,8 @@ public record PnpmStageDownloadOptions(
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStageListOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageListOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Node.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.Node.Options;
 
@@ -30,14 +30,14 @@ public record PnpmStageListOptions : PnpmOptions
     /// <summary>
     /// Does everything stage publish would do except uploading to the registry.
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Show information in JSON format for list, view, publish, and download.
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// One-time password for approve and reject.
@@ -73,8 +73,8 @@ public record PnpmStageListOptions : PnpmOptions
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
@@ -30,14 +30,14 @@ public record PnpmStageOptions : PnpmOptions
     /// <summary>
     /// Does everything stage publish would do except uploading to the registry.
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Show information in JSON format for list, view, publish, and download.
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// One-time password for approve and reject.
@@ -73,8 +73,8 @@ public record PnpmStageOptions : PnpmOptions
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStagePublishOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStagePublishOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Node.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.Node.Options;
 
@@ -73,8 +73,8 @@ public record PnpmStagePublishOptions : PnpmOptions
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStageRejectOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageRejectOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Node.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.Node.Options;
 
@@ -32,14 +32,14 @@ public record PnpmStageRejectOptions(
     /// <summary>
     /// Does everything stage publish would do except uploading to the registry.
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Show information in JSON format for list, view, publish, and download.
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// One-time password for approve and reject.
@@ -75,8 +75,8 @@ public record PnpmStageRejectOptions(
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmStageViewOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageViewOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Node.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.Node.Options;
 
@@ -32,14 +32,14 @@ public record PnpmStageViewOptions(
     /// <summary>
     /// Does everything stage publish would do except uploading to the registry.
     /// </summary>
-    [CliOption("--dry-run")]
-    public string? DryRun { get; set; }
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
     /// Show information in JSON format for list, view, publish, and download.
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// One-time password for approve and reject.
@@ -75,8 +75,8 @@ public record PnpmStageViewOptions(
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Options/PnpmUnlinkOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmUnlinkOptions.Generated.cs
@@ -23,8 +23,8 @@ public record PnpmUnlinkOptions : PnpmOptions
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
     /// </summary>
-    [CliOption("--aggregate-output")]
-    public string? AggregateOutput { get; set; }
+    [CliFlag("--aggregate-output")]
+    public bool? AggregateOutput { get; set; }
 
     /// <summary>
     /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
@@ -35,8 +35,8 @@ public record PnpmUnlinkOptions : PnpmOptions
     /// <summary>
     /// Output usage information
     /// </summary>
-    [CliOption("--help", ShortForm = "-h")]
-    public string? Help { get; set; }
+    [CliFlag("--help", ShortForm = "-h")]
+    public bool? Help { get; set; }
 
     /// <summary>
     /// What level of logs to report. Any logs at or higher than the given level will be shown. Levels (lowest to highest): debug, info, warn, error. Or use "--silent" to turn off all logging.
@@ -53,26 +53,26 @@ public record PnpmUnlinkOptions : PnpmOptions
     /// <summary>
     /// Stream output from child processes immediately, prefixed with the originating package directory. This allows output from different packages to be interleaved.
     /// </summary>
-    [CliOption("--stream")]
-    public string? Stream { get; set; }
+    [CliFlag("--stream")]
+    public bool? Stream { get; set; }
 
     /// <summary>
     /// Divert all output to stderr
     /// </summary>
-    [CliOption("--use-stderr")]
-    public string? UseStderr { get; set; }
+    [CliFlag("--use-stderr")]
+    public bool? UseStderr { get; set; }
 
     /// <summary>
     /// Run the command on the root workspace project
     /// </summary>
-    [CliOption("--workspace-root", ShortForm = "-w")]
-    public string? WorkspaceRoot { get; set; }
+    [CliFlag("--workspace-root", ShortForm = "-w")]
+    public bool? WorkspaceRoot { get; set; }
 
     /// <summary>
     /// Automatically answer yes to prompts and run non-interactively. Will abort if an undesirable situation occurs and user input is strictly necessary.
     /// </summary>
-    [CliOption("--yes", ShortForm = "-y")]
-    public string? Yes { get; set; }
+    [CliFlag("--yes", ShortForm = "-y")]
+    public bool? Yes { get; set; }
 
     /// <summary>
     /// The &lt;pkg&gt; operand.

--- a/src/ModularPipelines.Node/Options/PnpmWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmWhyOptions.Generated.cs
@@ -22,16 +22,11 @@ public record PnpmWhyOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Pkg
 ) : PnpmOptions
 {
-    public PnpmWhyOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
     /// </summary>
-    [CliOption("--aggregate-output")]
-    public string? AggregateOutput { get; set; }
+    [CliFlag("--aggregate-output")]
+    public bool? AggregateOutput { get; set; }
 
     /// <summary>
     /// Max display depth of the reverse dependency tree
@@ -42,8 +37,8 @@ public record PnpmWhyOptions(
     /// <summary>
     /// Display only the dependency graph for packages in `devDependencies`
     /// </summary>
-    [CliOption("--dev", ShortForm = "-D")]
-    public string? Dev { get; set; }
+    [CliFlag("--dev", ShortForm = "-D")]
+    public bool? Dev { get; set; }
 
     /// <summary>
     /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
@@ -54,8 +49,8 @@ public record PnpmWhyOptions(
     /// <summary>
     /// Exclude peer dependencies
     /// </summary>
-    [CliOption("--exclude-peers")]
-    public string? ExcludePeers { get; set; }
+    [CliFlag("--exclude-peers")]
+    public bool? ExcludePeers { get; set; }
 
     /// <summary>
     /// List packages in the global install prefix instead of in the current project
@@ -72,14 +67,14 @@ public record PnpmWhyOptions(
     /// <summary>
     /// Output usage information
     /// </summary>
-    [CliOption("--help", ShortForm = "-h")]
-    public string? Help { get; set; }
+    [CliFlag("--help", ShortForm = "-h")]
+    public bool? Help { get; set; }
 
     /// <summary>
     /// Show information in JSON format
     /// </summary>
-    [CliOption("--json")]
-    public string? Json { get; set; }
+    [CliFlag("--json")]
+    public bool? Json { get; set; }
 
     /// <summary>
     /// What level of logs to report. Any logs at or higher than the given level will be shown. Levels (lowest to highest): debug, info, warn, error. Or use "--silent" to turn off all logging.
@@ -90,8 +85,8 @@ public record PnpmWhyOptions(
     /// <summary>
     /// Show extended information
     /// </summary>
-    [CliOption("--long")]
-    public string? Long { get; set; }
+    [CliFlag("--long")]
+    public bool? Long { get; set; }
 
     /// <summary>
     /// Don't display packages from `optionalDependencies`
@@ -102,14 +97,14 @@ public record PnpmWhyOptions(
     /// <summary>
     /// Show parseable output instead of tree view
     /// </summary>
-    [CliOption("--parseable")]
-    public string? Parseable { get; set; }
+    [CliFlag("--parseable")]
+    public bool? Parseable { get; set; }
 
     /// <summary>
     /// Display only the dependency graph for packages in `dependencies` and `optionalDependencies`
     /// </summary>
-    [CliOption("--prod", ShortForm = "-P")]
-    public string? Prod { get; set; }
+    [CliFlag("--prod", ShortForm = "-P")]
+    public bool? Prod { get; set; }
 
     /// <summary>
     /// Perform command on every package in subdirectories or on every workspace package, when executed inside a workspace. For options that may be used with `-r`, see "pnpm help recursive"
@@ -120,26 +115,26 @@ public record PnpmWhyOptions(
     /// <summary>
     /// Stream output from child processes immediately, prefixed with the originating package directory. This allows output from different packages to be interleaved.
     /// </summary>
-    [CliOption("--stream")]
-    public string? Stream { get; set; }
+    [CliFlag("--stream")]
+    public bool? Stream { get; set; }
 
     /// <summary>
     /// Divert all output to stderr
     /// </summary>
-    [CliOption("--use-stderr")]
-    public string? UseStderr { get; set; }
+    [CliFlag("--use-stderr")]
+    public bool? UseStderr { get; set; }
 
     /// <summary>
     /// Run the command on the root workspace project
     /// </summary>
-    [CliOption("--workspace-root", ShortForm = "-w")]
-    public string? WorkspaceRoot { get; set; }
+    [CliFlag("--workspace-root", ShortForm = "-w")]
+    public bool? WorkspaceRoot { get; set; }
 
     /// <summary>
     /// Automatically answer yes to prompts and run non-interactively. Will abort if an undesirable situation occurs and user input is strictly necessary.
     /// </summary>
-    [CliOption("--yes", ShortForm = "-y")]
-    public string? Yes { get; set; }
+    [CliFlag("--yes", ShortForm = "-y")]
+    public bool? Yes { get; set; }
 
     /// <summary>
     /// Defines files to ignore when filtering for changed projects since the specified
@@ -150,8 +145,8 @@ public record PnpmWhyOptions(
     /// <summary>
     /// If no projects are matched by the command, exit with exit code 1 (fail)
     /// </summary>
-    [CliOption("--fail-if-no-match")]
-    public string? FailIfNoMatch { get; set; }
+    [CliFlag("--fail-if-no-match")]
+    public bool? FailIfNoMatch { get; set; }
 
     /// <summary>
     /// Restricts the scope to package names matching the given pattern. E.g.: foo, "@bar/*"

--- a/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
@@ -67,7 +67,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DlxAsync(PnpmDlxOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DlxAsync(PnpmDlxOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -97,7 +97,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> RunAsync(PnpmRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RunAsync(PnpmRunOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -187,7 +187,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> WhyAsync(PnpmWhyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WhyAsync(PnpmWhyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion

--- a/src/ModularPipelines.Node/Services/Pnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/Pnpm.Generated.cs
@@ -70,11 +70,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> DlxAsync(
-        PnpmDlxOptions? options = null,
+        PnpmDlxOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmDlxOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -97,11 +97,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> RunAsync(
-        PnpmRunOptions? options = null,
+        PnpmRunOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmRunOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -178,11 +178,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> WhyAsync(
-        PnpmWhyOptions? options = null,
+        PnpmWhyOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmWhyOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pnpm** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pnpm (11.24.0): 17 commands, tree 18696e1b021b815b55d2466263ab6d8af87d0d9de99a4f2adf93ef61a3961e51

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator