### PR TITLE
[Automated] Update cargo CLI Options

### DIFF
--- a/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
+++ b/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Rust.Services;
 
 namespace ModularPipelines.Rust.Extensions;
@@ -31,4 +30,5 @@ public static class CargoExtensions
         services.TryAddScoped<ICargo, Services.Cargo>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
@@ -19,8 +19,12 @@ namespace ModularPipelines.Rust.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("add")]
-public record CargoAddOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Dep
-) : CargoOptions
+public record CargoAddOptions : CargoOptions
 {
+    /// <summary>
+    /// The DEP operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Dep { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Services/Cargo.Generated.cs
+++ b/src/ModularPipelines.Rust/Services/Cargo.Generated.cs
@@ -34,11 +34,11 @@ internal partial class Cargo : ICargo
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AddAsync(
-        CargoAddOptions options,
+        CargoAddOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new CargoAddOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.Rust/Services/ICargo.Generated.cs
+++ b/src/ModularPipelines.Rust/Services/ICargo.Generated.cs
@@ -27,7 +27,7 @@ public partial interface ICargo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AddAsync(CargoAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AddAsync(CargoAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **cargo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- cargo (cargo 1.98.0 (797e8a9bc 2026-08-05)): 16 commands, tree f8b1c0ec09c6f1a8fbc12f34c9e244131aa2869c068c7f752c8da91976b1ec19

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator