### PR TITLE
[Automated] Update mvn CLI Options

### DIFF
--- a/src/ModularPipelines.Java/Enums/MavenColor.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/MavenColor.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Java.Enums;
 public enum MavenColor
 {
     [EnumValue("auto")]
-    Auto = 0,
+    Auto,
 
     [EnumValue("always")]
-    Always = 1,
+    Always,
 
     [EnumValue("never")]
-    Never = 2
+    Never
 }

--- a/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Java.Services;
 
 namespace ModularPipelines.Java.Extensions;
@@ -31,4 +30,5 @@ public static class MavenExtensions
         services.TryAddScoped<IMaven, Services.Maven>();
         return services;
     }
+
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **mvn** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- mvn (Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5) Maven home: /home/runner/work/_temp/cli-tools/apache-maven-3.9.16 Java version: 17.0.20.1, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64 Default locale: en, platform encoding: UTF-8 OS name: "linux", version: "6.17.0-1022-azure", arch: "amd64", family: "unix"): 1 commands, tree 77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator