### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Go.Services;
 
 namespace ModularPipelines.Go.Extensions;
@@ -31,4 +30,5 @@ public static class GoExtensions
         services.TryAddScoped<IGo, Services.Go>();
         return services;
     }
+
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- go (go version go1.27.0 linux/amd64): 23 commands, tree 93c8759ef56e6f27c819ff7e849e2156e7837444f7311267b71d63d48ea78f5d

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator