### PR TITLE
[Automated] Update packer CLI Options

### DIFF
--- a/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
+++ b/src/ModularPipelines.Packer/Extensions/PackerExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Packer.Services;
 
 namespace ModularPipelines.Packer.Extensions;
@@ -31,4 +30,5 @@ public static class PackerExtensions
         services.TryAddScoped<IPacker, Services.Packer>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Packer/Options/PackerBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerBuildOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerBuildOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Template
 ) : PackerOptions
 {
-    public PackerBuildOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Disable color output. (Default: color)
     /// </summary>
@@ -79,14 +74,14 @@ public record PackerBuildOptions(
     /// <summary>
     /// Variable for templates, can be used multiple times.
     /// </summary>
-    [CliFlag("--var")]
-    public bool? Var { get; set; }
+    [CliOption("--var", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? Var { get; set; }
 
     /// <summary>
     /// JSON or HCL2 file containing user variables, can be used multiple times.
     /// </summary>
     [CliOption("--var-file", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? VarFileValues { get; set; }
+    public IEnumerable<string>? VarFile { get; set; }
 
     /// <summary>
     /// Display warnings for user variable files containing undeclared variables.
@@ -111,12 +106,5 @@ public record PackerBuildOptions(
     /// </summary>
     [CliFlag("--skip-enforcement")]
     public bool? SkipEnforcement { get; set; }
-
-    [Obsolete("Use VarFileValues instead.")]
-    public string? VarFile
-    {
-        get => VarFileValues?.FirstOrDefault();
-        set => VarFileValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Packer/Options/PackerConsoleOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerConsoleOptions.Generated.cs
@@ -24,8 +24,8 @@ public record PackerConsoleOptions : PackerOptions
     /// <summary>
     /// Variable for templates, can be used multiple times.
     /// </summary>
-    [CliFlag("--var")]
-    public bool? Var { get; set; }
+    [CliOption("--var", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? Var { get; set; }
 
     /// <summary>
     /// JSON or HCL2 file containing user variables.

--- a/src/ModularPipelines.Packer/Options/PackerFixOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerFixOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerFixOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Template
 ) : PackerOptions
 {
-    public PackerFixOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true (default), validates the fixed template.
     /// </summary>

--- a/src/ModularPipelines.Packer/Options/PackerHcl2UpgradeOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerHcl2UpgradeOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerHcl2UpgradeOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Template
 ) : PackerOptions
 {
-    public PackerHcl2UpgradeOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Set output file name. By default this will be the TEMPLATE name with ".pkr.hcl" appended to it. To be a valid Packer HCL template, it must have the suffix ".pkr.hcl"
     /// </summary>

--- a/src/ModularPipelines.Packer/Options/PackerInitOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerInitOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerInitOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Template
 ) : PackerOptions
 {
-    public PackerInitOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// On top of installing missing plugins, update installed plugins to the latest available version, if there is a new higher one. Note that this still takes into consideration the version constraint of the config.
     /// </summary>

--- a/src/ModularPipelines.Packer/Options/PackerInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerInspectOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerInspectOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Template
 ) : PackerOptions
 {
-    public PackerInspectOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Machine-readable output
     /// </summary>

--- a/src/ModularPipelines.Packer/Options/PackerPluginsOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerPluginsOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerPluginsOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
 ) : PackerOptions
 {
-    public PackerPluginsOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// The args operand.
     /// </summary>

--- a/src/ModularPipelines.Packer/Options/PackerValidateOptions.Generated.cs
+++ b/src/ModularPipelines.Packer/Options/PackerValidateOptions.Generated.cs
@@ -23,11 +23,6 @@ public record PackerValidateOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Template
 ) : PackerOptions
 {
-    public PackerValidateOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Only check syntax. Do not verify config of the template.
     /// </summary>
@@ -55,14 +50,14 @@ public record PackerValidateOptions(
     /// <summary>
     /// Variable for templates, can be used multiple times.
     /// </summary>
-    [CliFlag("--var")]
-    public bool? Var { get; set; }
+    [CliOption("--var", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? Var { get; set; }
 
     /// <summary>
     /// JSON or HCL2 file containing user variables, can be used multiple times.
     /// </summary>
     [CliOption("--var-file", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? VarFileValues { get; set; }
+    public IEnumerable<string>? VarFile { get; set; }
 
     /// <summary>
     /// Disable warnings for user variable files containing undeclared variables.
@@ -87,12 +82,5 @@ public record PackerValidateOptions(
     /// </summary>
     [CliFlag("--use-sequential-evaluation")]
     public bool? UseSequentialEvaluation { get; set; }
-
-    [Obsolete("Use VarFileValues instead.")]
-    public string? VarFile
-    {
-        get => VarFileValues?.FirstOrDefault();
-        set => VarFileValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Packer/Services/IPacker.Generated.cs
+++ b/src/ModularPipelines.Packer/Services/IPacker.Generated.cs
@@ -27,7 +27,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> BuildAsync(PackerBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> BuildAsync(PackerBuildOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -47,7 +47,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> FixAsync(PackerFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> FixAsync(PackerFixOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -67,7 +67,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> Hcl2UpgradeAsync(PackerHcl2UpgradeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> Hcl2UpgradeAsync(PackerHcl2UpgradeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -77,7 +77,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> InitAsync(PackerInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InitAsync(PackerInitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -87,7 +87,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> InspectAsync(PackerInspectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InspectAsync(PackerInspectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -97,7 +97,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PluginsAsync(PackerPluginsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginsAsync(PackerPluginsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -107,7 +107,7 @@ public partial interface IPacker
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ValidateAsync(PackerValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ValidateAsync(PackerValidateOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Packer/Services/Packer.Generated.cs
+++ b/src/ModularPipelines.Packer/Services/Packer.Generated.cs
@@ -34,11 +34,11 @@ internal partial class Packer : IPacker
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> BuildAsync(
-        PackerBuildOptions? options = null,
+        PackerBuildOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerBuildOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -52,11 +52,11 @@ internal partial class Packer : IPacker
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> FixAsync(
-        PackerFixOptions? options = null,
+        PackerFixOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerFixOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -70,47 +70,47 @@ internal partial class Packer : IPacker
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> Hcl2UpgradeAsync(
-        PackerHcl2UpgradeOptions? options = null,
+        PackerHcl2UpgradeOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerHcl2UpgradeOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> InitAsync(
-        PackerInitOptions? options = null,
+        PackerInitOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerInitOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> InspectAsync(
-        PackerInspectOptions? options = null,
+        PackerInspectOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerInspectOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PluginsAsync(
-        PackerPluginsOptions? options = null,
+        PackerPluginsOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerPluginsOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ValidateAsync(
-        PackerValidateOptions? options = null,
+        PackerValidateOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PackerValidateOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **packer** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- packer (Packer v1.16.0): 10 commands, tree be2df7c68caac570b0c20475b96703fc7102b079dafc1108b0b0e8f5b676a78e

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator