### PR TITLE
Keep Terraform child docs off parent commands

### DIFF
--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationOptions.Generated.cs
@@ -12,9 +12,6 @@ using ModularPipelines.Terraform.Options;
 
 namespace ModularPipelines.Terraform.Options;
 
-/// <summary>
-/// list                List configurations associated with the given stack.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "configuration")]

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupOptions.Generated.cs
@@ -12,9 +12,6 @@ using ModularPipelines.Terraform.Options;
 
 namespace ModularPipelines.Terraform.Options;
 
-/// <summary>
-/// list                List all deployment groups in the given configuration.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "deployment-group")]

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunOptions.Generated.cs
@@ -12,9 +12,6 @@ using ModularPipelines.Terraform.Options;
 
 namespace ModularPipelines.Terraform.Options;
 
-/// <summary>
-/// list                List all deployment runs in the current configuration.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "deployment-run")]

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepOptions.Generated.cs
@@ -12,9 +12,6 @@ using ModularPipelines.Terraform.Options;
 
 namespace ModularPipelines.Terraform.Options;
 
-/// <summary>
-/// show                            Show details of a deployment step in the current configuration.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "deployment-step")]

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksConfiguration.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksConfiguration.Generated.cs
@@ -33,7 +33,7 @@ public class TerraformStacksConfiguration
     #region Commands
 
     /// <summary>
-    /// list                List configurations associated with the given stack.
+    /// Executes the parent command directly.
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentGroup.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentGroup.Generated.cs
@@ -33,7 +33,7 @@ public class TerraformStacksDeploymentGroup
     #region Commands
 
     /// <summary>
-    /// list                List all deployment groups in the given configuration.
+    /// Executes the parent command directly.
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentRun.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentRun.Generated.cs
@@ -33,7 +33,7 @@ public class TerraformStacksDeploymentRun
     #region Commands
 
     /// <summary>
-    /// list                List all deployment runs in the current configuration.
+    /// Executes the parent command directly.
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentStep.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentStep.Generated.cs
@@ -33,7 +33,7 @@ public class TerraformStacksDeploymentStep
     #region Commands
 
     /// <summary>
-    /// show                            Show details of a deployment step in the current configuration.
+    /// Executes the parent command directly.
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/TerraformCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/TerraformCliScraperTests.cs
@@ -61,6 +61,44 @@ public class TerraformCliScraperTests
         }
     }
 
+    [Test]
+    public async Task DeploymentStepParentDoesNotUseChildDescription()
+    {
+        const string helpText = """
+            Usage: terraform stacks deployment-step <subcommand> [options]
+
+            Subcommands:
+              artifacts  Download artifacts from a deployment step.
+              show       Show details of a deployment step in the current configuration.
+            """;
+
+        var definition = await _scraper.Parse(
+            ["terraform", "stacks", "deployment-step"],
+            helpText);
+
+        await Assert.That(definition!.Description).IsNull();
+    }
+
+    [Test]
+    public async Task DeploymentStepShowUsesItsOwnDescription()
+    {
+        const string helpText = """
+            Usage: terraform stacks deployment-step show [options]
+
+            Show the details of a single deployment step.
+
+            Options:
+              -deployment-step-id  The ID of the deployment step to show. (required)
+            """;
+
+        var definition = await _scraper.Parse(
+            ["terraform", "stacks", "deployment-step", "show"],
+            helpText);
+
+        await Assert.That(definition!.Description)
+            .IsEqualTo("Show the details of a single deployment step.");
+    }
+
     private static string CreateHelpText(string command, string switchName, string description) => $$"""
         Usage: terraform stacks deployment-step {{command}} [options]
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/TerraformCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/TerraformCliScraperTests.cs
@@ -99,6 +99,28 @@ public class TerraformCliScraperTests
             .IsEqualTo("Show the details of a single deployment step.");
     }
 
+    [Test]
+    public async Task DescriptionAfterAliasesIsPreserved()
+    {
+        const string helpText = """
+            Usage: terraform stacks deployment-step show [options]
+
+            Aliases: s
+
+            Show the details of a single deployment step.
+
+            Options:
+              -deployment-step-id  The ID of the deployment step to show. (required)
+            """;
+
+        var definition = await _scraper.Parse(
+            ["terraform", "stacks", "deployment-step", "show"],
+            helpText);
+
+        await Assert.That(definition!.Description)
+            .IsEqualTo("Show the details of a single deployment step.");
+    }
+
     private static string CreateHelpText(string command, string switchName, string description) => $$"""
         Usage: terraform stacks deployment-step {{command}} [options]
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -240,20 +240,17 @@ public partial class TerraformCliScraper : CliScraperBase
                 continue;
             }
 
-            if (foundUsage && !string.IsNullOrEmpty(trimmed) && !trimmed.StartsWith('-'))
+            if (!foundUsage || string.IsNullOrEmpty(trimmed))
             {
-                // Skip section headers
-                if (trimmed.EndsWith(':') && trimmed.Length < 50)
-                {
-                    continue;
-                }
-
-                // Found a description line
-                if (trimmed.Length > 10)
-                {
-                    return trimmed;
-                }
+                continue;
             }
+
+            if (trimmed.StartsWith('-') || (trimmed.EndsWith(':') && trimmed.Length < 50))
+            {
+                return null;
+            }
+
+            return trimmed.Length > 10 ? trimmed : null;
         }
 
         return null;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -245,12 +245,21 @@ public partial class TerraformCliScraper : CliScraperBase
                 continue;
             }
 
-            if (trimmed.StartsWith('-') || (trimmed.EndsWith(':') && trimmed.Length < 50))
+            if (trimmed.EndsWith(':') ||
+                trimmed.StartsWith("Aliases:", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (trimmed.StartsWith('-') || SubcommandLinePattern().IsMatch(line))
             {
                 return null;
             }
 
-            return trimmed.Length > 10 ? trimmed : null;
+            if (trimmed.Length > 10)
+            {
+                return trimmed;
+            }
         }
 
         return null;


### PR DESCRIPTION
## Summary
- stop Terraform description parsing at command-section boundaries
- add parent/child deployment-step regressions
- regenerate Terraform from the exact Linux 1.16.0 command baseline
- apply current generator output as source of truth, including stale compatibility cleanup

Closes #4333

## Validation
- OptionsGenerator tests: 1173/1173 passed
- Terraform solution Release build: 0 warnings, 0 errors
- Terraform tests: 1/1 passed
- repeated generation diff hash: identical
- command tree: 68 commands, baseline hash `68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7`
- touched source whitespace verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line help parsing to prevent parent commands from inheriting descriptions from child commands.
  - Ensured subcommands display their own accurate descriptions.
  - Improved handling of section headers, option lines, and incomplete descriptions in generated help output.

- **Tests**
  - Added coverage validating correct descriptions for deployment-step commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->