### PR TITLE
[Automated] Update hadolint CLI Options

### DIFF
--- a/src/ModularPipelines.Hadolint/Enums/HadolintFailureThreshold.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Enums/HadolintFailureThreshold.Generated.cs
@@ -17,20 +17,20 @@ namespace ModularPipelines.Hadolint.Enums;
 public enum HadolintFailureThreshold
 {
     [EnumValue("error")]
-    Error = 0,
+    Error,
 
     [EnumValue("warning")]
-    Warning = 1,
+    Warning,
 
     [EnumValue("info")]
-    Info = 2,
+    Info,
 
     [EnumValue("style")]
-    Style = 3,
+    Style,
 
     [EnumValue("ignore")]
-    Ignore = 4,
+    Ignore,
 
     [EnumValue("none")]
-    None = 5
+    None
 }

--- a/src/ModularPipelines.Hadolint/Enums/HadolintFormat.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Enums/HadolintFormat.Generated.cs
@@ -17,32 +17,32 @@ namespace ModularPipelines.Hadolint.Enums;
 public enum HadolintFormat
 {
     [EnumValue("tty")]
-    Tty = 0,
+    Tty,
 
     [EnumValue("json")]
-    Json = 1,
+    Json,
 
     [EnumValue("checkstyle")]
-    Checkstyle = 2,
+    Checkstyle,
 
     [EnumValue("codeclimate")]
-    Codeclimate = 3,
+    Codeclimate,
 
     [EnumValue("gitlab_codeclimate")]
-    GitlabCodeclimate = 4,
+    GitlabCodeclimate,
 
     [EnumValue("gnu")]
-    Gnu = 5,
+    Gnu,
 
     [EnumValue("codacy")]
-    Codacy = 6,
+    Codacy,
 
     [EnumValue("sonarqube")]
-    Sonarqube = 7,
+    Sonarqube,
 
     [EnumValue("sarif")]
-    Sarif = 8,
+    Sarif,
 
     [EnumValue("junit")]
-    Junit = 9
+    Junit
 }

--- a/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Hadolint.Services;
 
 namespace ModularPipelines.Hadolint.Extensions;
@@ -31,4 +30,5 @@ public static class HadolintExtensions
         services.TryAddScoped<IHadolint, Services.Hadolint>();
         return services;
     }
+
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **hadolint** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- hadolint (Haskell Dockerfile Linter 2.15.1): 1 commands, tree aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator