### PR TITLE
[Automated] Update ansible CLI Options

### DIFF
--- a/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Ansible.Services;
 
 namespace ModularPipelines.Ansible.Extensions;
@@ -31,4 +30,5 @@ public static class AnsibleExtensions
         services.TryAddScoped<IAnsible, Services.Ansible>();
         return services;
     }
+
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **ansible** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- ansible (ansible [core 2.21.3]   config file = None   configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/): 1 commands, tree 0cb87f727f31e5f5a59cca8a10c8f9b55622be05305d4e7e92c334f5911e1034

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator