### PR TITLE
[Automated] Update vault CLI Options

### DIFF
--- a/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
+++ b/src/ModularPipelines.Vault/Extensions/VaultExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Vault.Services;
 
 namespace ModularPipelines.Vault.Extensions;
@@ -31,4 +30,5 @@ public static class VaultExtensions
         services.TryAddScoped<IVault, Services.Vault>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Vault/Options/VaultAuditOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultAuditOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("audit")]
-public record VaultAuditOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultAuditOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultAuthOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultAuthOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("auth")]
-public record VaultAuthOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultAuthOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultKvMetadataOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultKvMetadataOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("kv", "metadata")]
-public record VaultKvMetadataOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultKvMetadataOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultKvOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultKvOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("kv")]
-public record VaultKvOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultKvOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultLeaseOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultLeaseOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("lease")]
-public record VaultLeaseOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultLeaseOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultNamespaceOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultNamespaceOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("namespace")]
-public record VaultNamespaceOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultNamespaceOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultOperatorOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultOperatorOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("operator")]
-public record VaultOperatorOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultOperatorOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultOperatorRaftOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultOperatorRaftOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("operator", "raft")]
-public record VaultOperatorRaftOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultOperatorRaftOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultOperatorRaftSnapshotOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultOperatorRaftSnapshotOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("operator", "raft", "snapshot")]
-public record VaultOperatorRaftSnapshotOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultOperatorRaftSnapshotOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPkiOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPkiOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("pki")]
-public record VaultPkiOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultPkiOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPluginOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPluginOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("plugin")]
-public record VaultPluginOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultPluginOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPluginRuntimeOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPluginRuntimeOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("plugin", "runtime")]
-public record VaultPluginRuntimeOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultPluginRuntimeOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPolicyOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("policy")]
-public record VaultPolicyOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultPolicyOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPrintOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPrintOptions.Generated.cs
@@ -19,8 +19,6 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("print")]
-public record VaultPrintOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultPrintOptions : VaultOptions
 {
 }

--- a/src/ModularPipelines.Vault/Options/VaultSecretsOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultSecretsOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("secrets")]
-public record VaultSecretsOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultSecretsOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultSshOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultSshOptions.Generated.cs
@@ -27,6 +27,6 @@ public record VaultSshOptions(
     /// The ssh options operand.
     /// </summary>
     [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
-    public string? SshOptions { get; set; }
+    public IEnumerable<string>? SshOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Vault/Options/VaultTokenOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTokenOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("token")]
-public record VaultTokenOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultTokenOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultTransformImportVersionOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTransformImportVersionOptions.Generated.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Vault.Options;
 [CliSubCommand("transform", "import-version")]
 public record VaultTransformImportVersionOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Path,
-    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Key
+    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> Key
 ) : VaultOptions
 {
 }

--- a/src/ModularPipelines.Vault/Options/VaultTransformOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTransformOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("transform")]
-public record VaultTransformOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultTransformOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultTransitImportVersionOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTransitImportVersionOptions.Generated.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Vault.Options;
 [CliSubCommand("transit", "import-version")]
 public record VaultTransitImportVersionOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Path,
-    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Key
+    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> Key
 ) : VaultOptions
 {
 }

--- a/src/ModularPipelines.Vault/Options/VaultTransitOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTransitOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("transit")]
-public record VaultTransitOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
-) : VaultOptions
+public record VaultTransitOptions : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Services/IVault.Generated.cs
+++ b/src/ModularPipelines.Vault/Services/IVault.Generated.cs
@@ -77,7 +77,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AuditAsync(VaultAuditOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AuditAsync(VaultAuditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -127,7 +127,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AuthAsync(VaultAuthOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AuthAsync(VaultAuthOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -237,7 +237,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> KvMetadataAsync(VaultKvMetadataOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> KvMetadataAsync(VaultKvMetadataOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -267,7 +267,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> KvAsync(VaultKvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> KvAsync(VaultKvOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -327,7 +327,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> LeaseAsync(VaultLeaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> LeaseAsync(VaultLeaseOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -437,7 +437,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> NamespaceAsync(VaultNamespaceOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NamespaceAsync(VaultNamespaceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -527,7 +527,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OperatorAsync(VaultOperatorOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> OperatorAsync(VaultOperatorOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -587,7 +587,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OperatorRaftAsync(VaultOperatorRaftOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> OperatorRaftAsync(VaultOperatorRaftOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -617,7 +617,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OperatorRaftSnapshotAsync(VaultOperatorRaftSnapshotOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> OperatorRaftSnapshotAsync(VaultOperatorRaftSnapshotOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -767,7 +767,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PkiAsync(VaultPkiOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PkiAsync(VaultPkiOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     public Task<CommandResult> PkiReissueAsync(VaultPkiReissueOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
@@ -820,7 +820,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PluginAsync(VaultPluginOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginAsync(VaultPluginOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -890,7 +890,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PluginRuntimeAsync(VaultPluginRuntimeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginRuntimeAsync(VaultPluginRuntimeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -940,7 +940,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PolicyAsync(VaultPolicyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PolicyAsync(VaultPolicyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -970,7 +970,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PrintAsync(VaultPrintOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PrintAsync(VaultPrintOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1040,7 +1040,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SecretsAsync(VaultSecretsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SecretsAsync(VaultSecretsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1120,7 +1120,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TokenAsync(VaultTokenOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TokenAsync(VaultTokenOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1170,7 +1170,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TransformAsync(VaultTransformOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TransformAsync(VaultTransformOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1200,7 +1200,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TransitAsync(VaultTransitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TransitAsync(VaultTransitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Vault/Services/Vault.Generated.cs
+++ b/src/ModularPipelines.Vault/Services/Vault.Generated.cs
@@ -79,11 +79,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AuditAsync(
-        VaultAuditOptions options,
+        VaultAuditOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultAuditOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -124,11 +124,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AuthAsync(
-        VaultAuthOptions options,
+        VaultAuthOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultAuthOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -223,11 +223,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> KvMetadataAsync(
-        VaultKvMetadataOptions options,
+        VaultKvMetadataOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultKvMetadataOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -250,11 +250,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> KvAsync(
-        VaultKvOptions options,
+        VaultKvOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultKvOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -304,11 +304,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> LeaseAsync(
-        VaultLeaseOptions options,
+        VaultLeaseOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultLeaseOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -403,11 +403,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> NamespaceAsync(
-        VaultNamespaceOptions options,
+        VaultNamespaceOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultNamespaceOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -484,11 +484,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> OperatorAsync(
-        VaultOperatorOptions options,
+        VaultOperatorOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultOperatorOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -538,11 +538,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> OperatorRaftAsync(
-        VaultOperatorRaftOptions options,
+        VaultOperatorRaftOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultOperatorRaftOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -565,11 +565,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> OperatorRaftSnapshotAsync(
-        VaultOperatorRaftSnapshotOptions options,
+        VaultOperatorRaftSnapshotOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultOperatorRaftSnapshotOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -700,11 +700,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PkiAsync(
-        VaultPkiOptions options,
+        VaultPkiOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPkiOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -754,11 +754,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PluginAsync(
-        VaultPluginOptions options,
+        VaultPluginOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPluginOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -817,11 +817,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PluginRuntimeAsync(
-        VaultPluginRuntimeOptions options,
+        VaultPluginRuntimeOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPluginRuntimeOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -862,11 +862,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PolicyAsync(
-        VaultPolicyOptions options,
+        VaultPolicyOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPolicyOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -889,11 +889,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PrintAsync(
-        VaultPrintOptions options,
+        VaultPrintOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPrintOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -952,11 +952,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> SecretsAsync(
-        VaultSecretsOptions options,
+        VaultSecretsOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultSecretsOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -1024,11 +1024,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TokenAsync(
-        VaultTokenOptions options,
+        VaultTokenOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultTokenOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -1069,11 +1069,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TransformAsync(
-        VaultTransformOptions options,
+        VaultTransformOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultTransformOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -1096,11 +1096,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TransitAsync(
-        VaultTransitOptions options,
+        VaultTransitOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultTransitOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **vault** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- vault (Vault v2.0.4 (c9e9d1d4ddd4b55aae79a8949adffa9e96338720), built 2026-08-03T16:14:36Z): 122 commands, tree f36ed874ca357f0eaaca930ad12a318f29c127df35a38f4096aae134e56ae477

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator