### PR TITLE
Assert legacy Git context accessor removal

### DIFF
--- a/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitIntegrationMetadataTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
@@ -11,17 +10,9 @@ namespace ModularPipelines.Git.UnitTests;
 public class GitIntegrationMetadataTests
 {
     [Test]
-    public async Task LegacyContextAccessorIsHiddenAndObsolete()
+    public async Task LegacyContextAccessorIsRemoved()
     {
-        var accessor = typeof(GitExtensions).GetMethod("Git")!;
-
-        using (Assert.Multiple())
-        {
-            await Assert.That(accessor.GetCustomAttribute<EditorBrowsableAttribute>()!.State)
-                .IsEqualTo(EditorBrowsableState.Never);
-            await Assert.That(accessor.GetCustomAttribute<ObsoleteAttribute>()!.Message)
-                .IsEqualTo("Use context.Tools.Get<global::ModularPipelines.Git.IGit>().");
-        }
+        await Assert.That(typeof(GitExtensions).GetMethod("Git")).IsNull();
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- replace the stale assertion that `GitExtensions.Git()` is hidden/obsolete
- assert the legacy context accessor is absent, matching the v4 API decision from #4404
- unblock full-pipeline Git tests on current `main`

## Validation

- `ModularPipelines.Git.UnitTests`: 52 passed (Release, net10.0)

Part of #4331.