### PR TITLE
[Automated] Update terraform CLI Options

### DIFF
--- a/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Extensions/TerraformExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Terraform.Services;
 
 namespace ModularPipelines.Terraform.Extensions;
@@ -35,4 +34,5 @@ public static class TerraformExtensions
         services.TryAddScoped<ITerraformWorkspace, TerraformWorkspace>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformForceUnlockOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformForceUnlockOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformForceUnlockOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string LockId
 ) : TerraformOptions
 {
-    public TerraformForceUnlockOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Don't ask for input for unlock confirmation.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformImportOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformImportOptions.Generated.cs
@@ -23,11 +23,6 @@ public record TerraformImportOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Id
 ) : TerraformOptions
 {
-    public TerraformImportOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Path to a directory of Terraform configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformInitOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformInitOptions.Generated.cs
@@ -30,7 +30,7 @@ public record TerraformInitOptions : TerraformOptions
     /// Configuration to be merged with what is in the configuration file's 'backend' block. This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a 'key=value' format, and can be specified multiple times. The backend type must be in the configuration itself.
     /// </summary>
     [CliOption("-backend-config", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? BackendConfigValues { get; set; }
+    public IEnumerable<string>? BackendConfig { get; set; }
 
     /// <summary>
     /// Suppress prompts about copying state data when initializing a new state backend. This is equivalent to providing a "yes" to all confirmation prompts.
@@ -127,12 +127,5 @@ public record TerraformInitOptions : TerraformOptions
     /// </summary>
     [CliOption("-var-file", Format = OptionFormat.EqualsSeparated)]
     public string? VarFile { get; set; }
-
-    [Obsolete("Use BackendConfigValues instead.")]
-    public string? BackendConfig
-    {
-        get => BackendConfigValues?.FirstOrDefault();
-        set => BackendConfigValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformMetadataOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformMetadataOptions.Generated.cs
@@ -18,14 +18,12 @@ namespace ModularPipelines.Terraform.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("metadata")]
-public record TerraformMetadataOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Subcommand
-) : TerraformOptions
+public record TerraformMetadataOptions : TerraformOptions
 {
     /// <summary>
     /// The args operand.
     /// </summary>
-    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformProvidersMirrorOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformProvidersMirrorOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformProvidersMirrorOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string TargetDir
 ) : TerraformOptions
 {
-    public TerraformProvidersMirrorOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Choose which target platform to build a mirror for. By default Terraform will obtain plugin packages suitable for the platform where you run this command. Use this flag multiple times to include packages for multiple target systems.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformRefreshOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformRefreshOptions.Generated.cs
@@ -60,19 +60,12 @@ public record TerraformRefreshOptions : TerraformOptions
     /// Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.
     /// </summary>
     [CliOption("-target", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? TargetValues { get; set; }
+    public IEnumerable<string>? Target { get; set; }
 
     /// <summary>
     /// Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.
     /// </summary>
     [CliOption("-var-file", Format = OptionFormat.EqualsSeparated)]
     public string? VarFile { get; set; }
-
-    [Obsolete("Use TargetValues instead.")]
-    public string? Target
-    {
-        get => TargetValues?.FirstOrDefault();
-        set => TargetValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationFetchOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationFetchOptions.Generated.cs
@@ -24,45 +24,24 @@ public record TerraformStacksConfigurationFetchOptions : TerraformOptions
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The ID of the stack to fetch for. Has precedence over the -stack-name.
     /// </summary>
     [CliOption("-stack-id", Format = OptionFormat.EqualsSeparated)]
-    public string? StackIdValue { get; set; }
+    public string? StackId { get; set; }
 
     /// <summary>
     /// Output results in JSON format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackIdValue instead.")]
-    public bool? StackId
-    {
-        get => bool.TryParse(StackIdValue, out var value) ? value : null;
-        set => StackIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationListOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationListOptions.Generated.cs
@@ -24,45 +24,24 @@ public record TerraformStacksConfigurationListOptions : TerraformOptions
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The ID of the stack to list configurations for. Has precedence over the -stack-name.
     /// </summary>
     [CliOption("-stack-id", Format = OptionFormat.EqualsSeparated)]
-    public string? StackIdValue { get; set; }
+    public string? StackId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackIdValue instead.")]
-    public bool? StackId
-    {
-        get => bool.TryParse(StackIdValue, out var value) ? value : null;
-        set => StackIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationOptions.Generated.cs
@@ -18,13 +18,6 @@ namespace ModularPipelines.Terraform.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "configuration")]
-public record TerraformStacksConfigurationOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Subcommand
-) : TerraformOptions
+public record TerraformStacksConfigurationOptions : TerraformOptions
 {
-    public TerraformStacksConfigurationOptions()
-        : this(default(string)!)
-    {
-    }
-
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationShowOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationShowOptions.Generated.cs
@@ -24,45 +24,24 @@ public record TerraformStacksConfigurationShowOptions : TerraformOptions
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The ID of the configuration to show. Has precedence over the latest configuration of the stack provided in named args.
     /// </summary>
     [CliOption("-configuration-id", Format = OptionFormat.EqualsSeparated)]
-    public string? ConfigurationIdValue { get; set; }
+    public string? ConfigurationId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ConfigurationIdValue instead.")]
-    public bool? ConfigurationId
-    {
-        get => bool.TryParse(ConfigurationIdValue, out var value) ? value : null;
-        set => ConfigurationIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationUploadOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationUploadOptions.Generated.cs
@@ -24,19 +24,19 @@ public record TerraformStacksConfigurationUploadOptions : TerraformOptions
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The ID of the stack to upload to. Has precedence over the -stack-name.
     /// </summary>
     [CliOption("-stack-id", Format = OptionFormat.EqualsSeparated)]
-    public string? StackIdValue { get; set; }
+    public string? StackId { get; set; }
 
     /// <summary>
     /// If given, the upload will be speculative and will not trigger any deployments.
@@ -49,26 +49,5 @@ public record TerraformStacksConfigurationUploadOptions : TerraformOptions
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackIdValue instead.")]
-    public bool? StackId
-    {
-        get => bool.TryParse(StackIdValue, out var value) ? value : null;
-        set => StackIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationWatchOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksConfigurationWatchOptions.Generated.cs
@@ -24,39 +24,18 @@ public record TerraformStacksConfigurationWatchOptions : TerraformOptions
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The ID of the configuration to watch. Has precedence over the latest configuration of the stack provided in named args.
     /// </summary>
     [CliOption("-configuration-id", Format = OptionFormat.EqualsSeparated)]
-    public string? ConfigurationIdValue { get; set; }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ConfigurationIdValue instead.")]
-    public bool? ConfigurationId
-    {
-        get => bool.TryParse(ConfigurationIdValue, out var value) ? value : null;
-        set => ConfigurationIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? ConfigurationId { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksCreateOptions.Generated.cs
@@ -24,25 +24,25 @@ public record TerraformStacksCreateOptions : TerraformOptions
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided. (required)
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided. (required)
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided. (required)
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The directory within the configuration that contains the stack to be deployed. Defaults to the root of the configuration.
     /// </summary>
     [CliOption("-working-directory", Format = OptionFormat.EqualsSeparated)]
-    public string? WorkingDirectoryValue { get; set; }
+    public string? WorkingDirectory { get; set; }
 
     /// <summary>
     /// Generate boilerplate configuration
@@ -55,33 +55,5 @@ public record TerraformStacksCreateOptions : TerraformOptions
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use WorkingDirectoryValue instead.")]
-    public bool? WorkingDirectory
-    {
-        get => bool.TryParse(WorkingDirectoryValue, out var value) ? value : null;
-        set => WorkingDirectoryValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupApproveAllPlansOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupApproveAllPlansOptions.Generated.cs
@@ -24,65 +24,30 @@ public record TerraformStacksDeploymentGroupApproveAllPlansOptions : TerraformOp
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided.
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The name of the deployment group to approve plans for within the latest configuration of the stack specified in -stack-name. Requires the args -organization-name, -project-name, and -stack-name to be provided.
     /// </summary>
     [CliOption("-deployment-group-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupNameValue { get; set; }
+    public string? DeploymentGroupName { get; set; }
 
     /// <summary>
     /// The ID of the deployment group to approve plans for. Has precedence over -deployment-group-name.
     /// </summary>
     [CliOption("-deployment-group-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupIdValue { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupNameValue instead.")]
-    public bool? DeploymentGroupName
-    {
-        get => bool.TryParse(DeploymentGroupNameValue, out var value) ? value : null;
-        set => DeploymentGroupNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupIdValue instead.")]
-    public bool? DeploymentGroupId
-    {
-        get => bool.TryParse(DeploymentGroupIdValue, out var value) ? value : null;
-        set => DeploymentGroupIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? DeploymentGroupId { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupListOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupListOptions.Generated.cs
@@ -24,45 +24,24 @@ public record TerraformStacksDeploymentGroupListOptions : TerraformOptions
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The id of the configuration to list the deployment groups of. Has precedence over the latest configuration of the stack provided in named args.
     /// </summary>
     [CliOption("-configuration-id", Format = OptionFormat.EqualsSeparated)]
-    public string? ConfigurationIdValue { get; set; }
+    public string? ConfigurationId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ConfigurationIdValue instead.")]
-    public bool? ConfigurationId
-    {
-        get => bool.TryParse(ConfigurationIdValue, out var value) ? value : null;
-        set => ConfigurationIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupOptions.Generated.cs
@@ -18,13 +18,6 @@ namespace ModularPipelines.Terraform.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "deployment-group")]
-public record TerraformStacksDeploymentGroupOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Subcommand
-) : TerraformOptions
+public record TerraformStacksDeploymentGroupOptions : TerraformOptions
 {
-    public TerraformStacksDeploymentGroupOptions()
-        : this(default(string)!)
-    {
-    }
-
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupRerunOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupRerunOptions.Generated.cs
@@ -24,78 +24,36 @@ public record TerraformStacksDeploymentGroupRerunOptions : TerraformOptions
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided.
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The name of the deployment group to approve plans for within the latest configuration of the stack specified in -stack-name. Requires the args -organization-name, -project-name, and -stack-name to be provided.
     /// </summary>
     [CliOption("-deployment-group-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupNameValue { get; set; }
+    public string? DeploymentGroupName { get; set; }
 
     /// <summary>
     /// The ID of the deployment group to rerun. Has precedence over -deployment-group-name.
     /// </summary>
     [CliOption("-deployment-group-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupIdValue { get; set; }
+    public string? DeploymentGroupId { get; set; }
 
     /// <summary>
     /// A comma-separated list of deployment names to rerun within the deployment group (required).
     /// </summary>
     [CliOption("-deployment-names", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentNamesValue { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupNameValue instead.")]
-    public bool? DeploymentGroupName
-    {
-        get => bool.TryParse(DeploymentGroupNameValue, out var value) ? value : null;
-        set => DeploymentGroupNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupIdValue instead.")]
-    public bool? DeploymentGroupId
-    {
-        get => bool.TryParse(DeploymentGroupIdValue, out var value) ? value : null;
-        set => DeploymentGroupIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentNamesValue instead.")]
-    public bool? DeploymentNames
-    {
-        get => bool.TryParse(DeploymentNamesValue, out var value) ? value : null;
-        set => DeploymentNamesValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? DeploymentNames { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupShowOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupShowOptions.Generated.cs
@@ -24,71 +24,36 @@ public record TerraformStacksDeploymentGroupShowOptions : TerraformOptions
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided.
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The name of the deployment group to show within the latest configuration of the stack specified in -stack-name. Requires the args -organization-name, -project-name, and -stack-name to be provided.
     /// </summary>
     [CliOption("-deployment-group-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupNameValue { get; set; }
+    public string? DeploymentGroupName { get; set; }
 
     /// <summary>
     /// The ID of the deployment group to show. Has precedence over -deployment-group-name.
     /// </summary>
     [CliOption("-deployment-group-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupIdValue { get; set; }
+    public string? DeploymentGroupId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupNameValue instead.")]
-    public bool? DeploymentGroupName
-    {
-        get => bool.TryParse(DeploymentGroupNameValue, out var value) ? value : null;
-        set => DeploymentGroupNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupIdValue instead.")]
-    public bool? DeploymentGroupId
-    {
-        get => bool.TryParse(DeploymentGroupIdValue, out var value) ? value : null;
-        set => DeploymentGroupIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupWatchOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentGroupWatchOptions.Generated.cs
@@ -24,65 +24,30 @@ public record TerraformStacksDeploymentGroupWatchOptions : TerraformOptions
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided.
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The name of the deployment group to approve plans for within the latest configuration of the stack specified in -stack-name. Requires the args -organization-name, -project-name, and -stack-name to be provided.
     /// </summary>
     [CliOption("-deployment-group-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupNameValue { get; set; }
+    public string? DeploymentGroupName { get; set; }
 
     /// <summary>
     /// The ID of the deployment group to watch. Has precedence over -deployment-group-name.
     /// </summary>
     [CliOption("-deployment-group-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupIdValue { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupNameValue instead.")]
-    public bool? DeploymentGroupName
-    {
-        get => bool.TryParse(DeploymentGroupNameValue, out var value) ? value : null;
-        set => DeploymentGroupNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupIdValue instead.")]
-    public bool? DeploymentGroupId
-    {
-        get => bool.TryParse(DeploymentGroupIdValue, out var value) ? value : null;
-        set => DeploymentGroupIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? DeploymentGroupId { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunApproveAllPlansOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunApproveAllPlansOptions.Generated.cs
@@ -24,13 +24,6 @@ public record TerraformStacksDeploymentRunApproveAllPlansOptions : TerraformOpti
     /// The ID of the deployment run (required).
     /// </summary>
     [CliOption("-deployment-run-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentRunIdValue { get; set; }
-
-    [Obsolete("Use DeploymentRunIdValue instead.")]
-    public bool? DeploymentRunId
-    {
-        get => bool.TryParse(DeploymentRunIdValue, out var value) ? value : null;
-        set => DeploymentRunIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? DeploymentRunId { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunCancelOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunCancelOptions.Generated.cs
@@ -24,13 +24,6 @@ public record TerraformStacksDeploymentRunCancelOptions : TerraformOptions
     /// The ID of the deployment run to watch (required).
     /// </summary>
     [CliOption("-deployment-run-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentRunIdValue { get; set; }
-
-    [Obsolete("Use DeploymentRunIdValue instead.")]
-    public bool? DeploymentRunId
-    {
-        get => bool.TryParse(DeploymentRunIdValue, out var value) ? value : null;
-        set => DeploymentRunIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? DeploymentRunId { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunListOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunListOptions.Generated.cs
@@ -24,71 +24,36 @@ public record TerraformStacksDeploymentRunListOptions : TerraformOptions
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided.
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided.
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// The name of the stack to target. Overrides the ENV VAR 'TF_STACKS_STACK_NAME' if provided.
     /// </summary>
     [CliOption("-stack-name", Format = OptionFormat.EqualsSeparated)]
-    public string? StackNameValue { get; set; }
+    public string? StackName { get; set; }
 
     /// <summary>
     /// The name of the deployment group to list the deployment runs of within the latest configuration of the stack specified in -stack-name. Requires the args -organization-name, -project-name, and -stack-name to be provided.
     /// </summary>
     [CliOption("-deployment-group-name", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupNameValue { get; set; }
+    public string? DeploymentGroupName { get; set; }
 
     /// <summary>
     /// The id of the deployment group to list the deployment runs of. Has precedence over -deployment-group-name.
     /// </summary>
     [CliOption("-deployment-group-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentGroupIdValue { get; set; }
+    public string? DeploymentGroupId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use StackNameValue instead.")]
-    public bool? StackName
-    {
-        get => bool.TryParse(StackNameValue, out var value) ? value : null;
-        set => StackNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupNameValue instead.")]
-    public bool? DeploymentGroupName
-    {
-        get => bool.TryParse(DeploymentGroupNameValue, out var value) ? value : null;
-        set => DeploymentGroupNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use DeploymentGroupIdValue instead.")]
-    public bool? DeploymentGroupId
-    {
-        get => bool.TryParse(DeploymentGroupIdValue, out var value) ? value : null;
-        set => DeploymentGroupIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunOptions.Generated.cs
@@ -18,13 +18,6 @@ namespace ModularPipelines.Terraform.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks", "deployment-run")]
-public record TerraformStacksDeploymentRunOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Subcommand
-) : TerraformOptions
+public record TerraformStacksDeploymentRunOptions : TerraformOptions
 {
-    public TerraformStacksDeploymentRunOptions()
-        : this(default(string)!)
-    {
-    }
-
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunShowOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunShowOptions.Generated.cs
@@ -24,19 +24,12 @@ public record TerraformStacksDeploymentRunShowOptions : TerraformOptions
     /// The ID of the deployment run to show. (required)
     /// </summary>
     [CliOption("-deployment-run-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentRunIdValue { get; set; }
+    public string? DeploymentRunId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use DeploymentRunIdValue instead.")]
-    public bool? DeploymentRunId
-    {
-        get => bool.TryParse(DeploymentRunIdValue, out var value) ? value : null;
-        set => DeploymentRunIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunWatchOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentRunWatchOptions.Generated.cs
@@ -24,13 +24,6 @@ public record TerraformStacksDeploymentRunWatchOptions : TerraformOptions
     /// The ID of the deployment run to watch (required).
     /// </summary>
     [CliOption("-deployment-run-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentRunIdValue { get; set; }
-
-    [Obsolete("Use DeploymentRunIdValue instead.")]
-    public bool? DeploymentRunId
-    {
-        get => bool.TryParse(DeploymentRunIdValue, out var value) ? value : null;
-        set => DeploymentRunIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? DeploymentRunId { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepArtifactsOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepArtifactsOptions.Generated.cs
@@ -24,26 +24,12 @@ public record TerraformStacksDeploymentStepArtifactsOptions : TerraformOptions
     /// The ID of the deployment step. (required)
     /// </summary>
     [CliOption("-deployment-step-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentStepIdValue { get; set; }
+    public string? DeploymentStepId { get; set; }
 
     /// <summary>
     /// The artifact type to retrieve. (required)
     /// </summary>
     [CliOption("-artifact-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ArtifactNameValue { get; set; }
-
-    [Obsolete("Use DeploymentStepIdValue instead.")]
-    public bool? DeploymentStepId
-    {
-        get => bool.TryParse(DeploymentStepIdValue, out var value) ? value : null;
-        set => DeploymentStepIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ArtifactNameValue instead.")]
-    public bool? ArtifactName
-    {
-        get => bool.TryParse(ArtifactNameValue, out var value) ? value : null;
-        set => ArtifactNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
+    public string? ArtifactName { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepShowOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepShowOptions.Generated.cs
@@ -24,19 +24,12 @@ public record TerraformStacksDeploymentStepShowOptions : TerraformOptions
     /// The ID of the deployment step to show. (required)
     /// </summary>
     [CliOption("-deployment-step-id", Format = OptionFormat.EqualsSeparated)]
-    public string? DeploymentStepIdValue { get; set; }
+    public string? DeploymentStepId { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use DeploymentStepIdValue instead.")]
-    public bool? DeploymentStepId
-    {
-        get => bool.TryParse(DeploymentStepIdValue, out var value) ? value : null;
-        set => DeploymentStepIdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDiagnosticsOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDiagnosticsOptions.Generated.cs
@@ -24,19 +24,12 @@ public record TerraformStacksDiagnosticsOptions : TerraformOptions
     /// The ID of the stack configuration or deployment step to retrieve diagnostics for. Supported prefixes are "stc-" for configuration IDs and "sds-" for step IDs.
     /// </summary>
     [CliOption("-id", Format = OptionFormat.EqualsSeparated)]
-    public string? IdValue { get; set; }
+    public string? Id { get; set; }
 
     /// <summary>
     /// Output results in JSON format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use IdValue instead.")]
-    public bool? Id
-    {
-        get => bool.TryParse(IdValue, out var value) ? value : null;
-        set => IdValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksListOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksListOptions.Generated.cs
@@ -24,32 +24,18 @@ public record TerraformStacksListOptions : TerraformOptions
     /// The name of the organization to target. Overrides the ENV VAR 'TF_STACKS_ORGANIZATION_NAME' if provided. (required)
     /// </summary>
     [CliOption("-organization-name", Format = OptionFormat.EqualsSeparated)]
-    public string? OrganizationNameValue { get; set; }
+    public string? OrganizationName { get; set; }
 
     /// <summary>
     /// The name of the project to target. Overrides the ENV VAR 'TF_STACKS_PROJECT_NAME' if provided. (optional)
     /// </summary>
     [CliOption("-project-name", Format = OptionFormat.EqualsSeparated)]
-    public string? ProjectNameValue { get; set; }
+    public string? ProjectName { get; set; }
 
     /// <summary>
     /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }
-
-    [Obsolete("Use OrganizationNameValue instead.")]
-    public bool? OrganizationName
-    {
-        get => bool.TryParse(OrganizationNameValue, out var value) ? value : null;
-        set => OrganizationNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    [Obsolete("Use ProjectNameValue instead.")]
-    public bool? ProjectName
-    {
-        get => bool.TryParse(ProjectNameValue, out var value) ? value : null;
-        set => ProjectNameValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksOptions.Generated.cs
@@ -18,19 +18,12 @@ namespace ModularPipelines.Terraform.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stacks")]
-public record TerraformStacksOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Command
-) : TerraformOptions
+public record TerraformStacksOptions : TerraformOptions
 {
-    public TerraformStacksOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// The args operand.
     /// </summary>
-    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStateMvOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStateMvOptions.Generated.cs
@@ -23,11 +23,6 @@ public record TerraformStateMvOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Destination
 ) : TerraformOptions
 {
-    public TerraformStateMvOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// If set, prints out what would've been moved but doesn't actually move anything.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformStateOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStateOptions.Generated.cs
@@ -18,14 +18,12 @@ namespace ModularPipelines.Terraform.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("state")]
-public record TerraformStateOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Subcommand
-) : TerraformOptions
+public record TerraformStateOptions : TerraformOptions
 {
     /// <summary>
     /// The args operand.
     /// </summary>
-    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStatePushOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStatePushOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformStatePushOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Path
 ) : TerraformOptions
 {
-    public TerraformStatePushOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Write the state even if lineages don't match or the remote serial is higher.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformStateReplaceProviderOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStateReplaceProviderOptions.Generated.cs
@@ -23,11 +23,6 @@ public record TerraformStateReplaceProviderOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string ToProviderFqn
 ) : TerraformOptions
 {
-    public TerraformStateReplaceProviderOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Skip interactive approval.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformStateRmOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStateRmOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformStateRmOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Address
 ) : TerraformOptions
 {
-    public TerraformStateRmOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// If set, prints out what would've been removed but doesn't actually remove anything.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformStateShowOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStateShowOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformStateShowOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Address
 ) : TerraformOptions
 {
-    public TerraformStateShowOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformTaintOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformTaintOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformTaintOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Address
 ) : TerraformOptions
 {
-    public TerraformTaintOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If specified, the command will succeed (exit code 0) even if the resource is missing.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformUntaintOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformUntaintOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformUntaintOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Name
 ) : TerraformOptions
 {
-    public TerraformUntaintOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If specified, the command will succeed (exit code 0) even if the resource is missing.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformWorkspaceDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformWorkspaceDeleteOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformWorkspaceDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Name
 ) : TerraformOptions
 {
-    public TerraformWorkspaceDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Remove a workspace even if it is managing resources. Terraform can no longer track or manage the workspace's infrastructure.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformWorkspaceNewOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformWorkspaceNewOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformWorkspaceNewOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Name
 ) : TerraformOptions
 {
-    public TerraformWorkspaceNewOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Don't hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Options/TerraformWorkspaceSelectOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformWorkspaceSelectOptions.Generated.cs
@@ -22,11 +22,6 @@ public record TerraformWorkspaceSelectOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Name
 ) : TerraformOptions
 {
-    public TerraformWorkspaceSelectOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Create the Terraform workspace if it doesn't exist.
     /// </summary>

--- a/src/ModularPipelines.Terraform/Services/ITerraform.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/ITerraform.Generated.cs
@@ -91,7 +91,7 @@ public partial interface ITerraform
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ForceUnlockAsync(TerraformForceUnlockOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ForceUnlockAsync(TerraformForceUnlockOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -121,7 +121,7 @@ public partial interface ITerraform
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ImportAsync(TerraformImportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ImportAsync(TerraformImportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -161,7 +161,7 @@ public partial interface ITerraform
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> MetadataAsync(TerraformMetadataOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MetadataAsync(TerraformMetadataOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -231,7 +231,7 @@ public partial interface ITerraform
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TaintAsync(TerraformTaintOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TaintAsync(TerraformTaintOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -251,7 +251,7 @@ public partial interface ITerraform
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> UntaintAsync(TerraformUntaintOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UntaintAsync(TerraformUntaintOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Terraform/Services/ITerraformProviders.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/ITerraformProviders.Generated.cs
@@ -48,7 +48,7 @@ public interface ITerraformProviders
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> MirrorAsync(TerraformProvidersMirrorOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MirrorAsync(TerraformProvidersMirrorOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Terraform/Services/ITerraformState.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/ITerraformState.Generated.cs
@@ -28,7 +28,7 @@ public interface ITerraformState
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ExecuteAsync(TerraformStateOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecuteAsync(TerraformStateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface ITerraformState
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> MvAsync(TerraformStateMvOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> MvAsync(TerraformStateMvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -78,7 +78,7 @@ public interface ITerraformState
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PushAsync(TerraformStatePushOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PushAsync(TerraformStatePushOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -88,7 +88,7 @@ public interface ITerraformState
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ReplaceProviderAsync(TerraformStateReplaceProviderOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ReplaceProviderAsync(TerraformStateReplaceProviderOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -98,7 +98,7 @@ public interface ITerraformState
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> RmAsync(TerraformStateRmOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RmAsync(TerraformStateRmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -108,7 +108,7 @@ public interface ITerraformState
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ShowAsync(TerraformStateShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ShowAsync(TerraformStateShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Terraform/Services/ITerraformWorkspace.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/ITerraformWorkspace.Generated.cs
@@ -28,7 +28,7 @@ public interface ITerraformWorkspace
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(TerraformWorkspaceDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(TerraformWorkspaceDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -48,7 +48,7 @@ public interface ITerraformWorkspace
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> NewAsync(TerraformWorkspaceNewOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NewAsync(TerraformWorkspaceNewOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface ITerraformWorkspace
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SelectAsync(TerraformWorkspaceSelectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SelectAsync(TerraformWorkspaceSelectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Terraform/Services/Terraform.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/Terraform.Generated.cs
@@ -96,11 +96,11 @@ internal partial class Terraform : ITerraform
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ForceUnlockAsync(
-        TerraformForceUnlockOptions? options = null,
+        TerraformForceUnlockOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformForceUnlockOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -123,11 +123,11 @@ internal partial class Terraform : ITerraform
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ImportAsync(
-        TerraformImportOptions? options = null,
+        TerraformImportOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformImportOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -159,11 +159,11 @@ internal partial class Terraform : ITerraform
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> MetadataAsync(
-        TerraformMetadataOptions options,
+        TerraformMetadataOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformMetadataOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -222,11 +222,11 @@ internal partial class Terraform : ITerraform
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TaintAsync(
-        TerraformTaintOptions? options = null,
+        TerraformTaintOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformTaintOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -240,11 +240,11 @@ internal partial class Terraform : ITerraform
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> UntaintAsync(
-        TerraformUntaintOptions? options = null,
+        TerraformUntaintOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformUntaintOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.Terraform/Services/TerraformProviders.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformProviders.Generated.cs
@@ -70,11 +70,11 @@ public class TerraformProviders : ITerraformProviders
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> MirrorAsync(
-        TerraformProvidersMirrorOptions? options = null,
+        TerraformProvidersMirrorOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformProvidersMirrorOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksConfiguration.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksConfiguration.Generated.cs
@@ -40,11 +40,11 @@ public class TerraformStacksConfiguration
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ExecuteAsync(
-        TerraformStacksConfigurationOptions options,
+        TerraformStacksConfigurationOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStacksConfigurationOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentGroup.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentGroup.Generated.cs
@@ -40,11 +40,11 @@ public class TerraformStacksDeploymentGroup
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ExecuteAsync(
-        TerraformStacksDeploymentGroupOptions options,
+        TerraformStacksDeploymentGroupOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStacksDeploymentGroupOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentRun.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentRun.Generated.cs
@@ -40,11 +40,11 @@ public class TerraformStacksDeploymentRun
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ExecuteAsync(
-        TerraformStacksDeploymentRunOptions options,
+        TerraformStacksDeploymentRunOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStacksDeploymentRunOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentStep.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformStacksDeploymentStep.Generated.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System.CodeDom.Compiler;
+using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Models;
 using ModularPipelines.Options;

--- a/src/ModularPipelines.Terraform/Services/TerraformState.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformState.Generated.cs
@@ -40,11 +40,11 @@ public class TerraformState : ITerraformState
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ExecuteAsync(
-        TerraformStateOptions options,
+        TerraformStateOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStateOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class TerraformState : ITerraformState
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> MvAsync(
-        TerraformStateMvOptions? options = null,
+        TerraformStateMvOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStateMvOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -115,11 +115,11 @@ public class TerraformState : ITerraformState
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> PushAsync(
-        TerraformStatePushOptions? options = null,
+        TerraformStatePushOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStatePushOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -130,11 +130,11 @@ public class TerraformState : ITerraformState
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ReplaceProviderAsync(
-        TerraformStateReplaceProviderOptions? options = null,
+        TerraformStateReplaceProviderOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStateReplaceProviderOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -145,11 +145,11 @@ public class TerraformState : ITerraformState
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> RmAsync(
-        TerraformStateRmOptions? options = null,
+        TerraformStateRmOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStateRmOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -160,11 +160,11 @@ public class TerraformState : ITerraformState
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ShowAsync(
-        TerraformStateShowOptions? options = null,
+        TerraformStateShowOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformStateShowOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.Terraform/Services/TerraformWorkspace.Generated.cs
+++ b/src/ModularPipelines.Terraform/Services/TerraformWorkspace.Generated.cs
@@ -40,11 +40,11 @@ public class TerraformWorkspace : ITerraformWorkspace
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        TerraformWorkspaceDeleteOptions? options = null,
+        TerraformWorkspaceDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformWorkspaceDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -70,11 +70,11 @@ public class TerraformWorkspace : ITerraformWorkspace
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> NewAsync(
-        TerraformWorkspaceNewOptions? options = null,
+        TerraformWorkspaceNewOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformWorkspaceNewOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class TerraformWorkspace : ITerraformWorkspace
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SelectAsync(
-        TerraformWorkspaceSelectOptions? options = null,
+        TerraformWorkspaceSelectOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new TerraformWorkspaceSelectOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **terraform** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- terraform (Terraform v1.16.0 on linux_amd64): 68 commands, tree 68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator