### PR TITLE
[Automated] Update podman CLI Options

### DIFF
--- a/src/ModularPipelines.Podman/Enums/PodmanComposeProgress.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanComposeProgress.Generated.cs
@@ -17,17 +17,17 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanComposeProgress
 {
     [EnumValue("auto")]
-    Auto = 0,
+    Auto,
 
     [EnumValue("tty")]
-    Tty = 1,
+    Tty,
 
     [EnumValue("plain")]
-    Plain = 2,
+    Plain,
 
     [EnumValue("json")]
-    Json = 3,
+    Json,
 
     [EnumValue("quiet")]
-    Quiet = 4
+    Quiet
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanContainerCreateSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanContainerCreateSystemd.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanContainerCreateSystemd
 {
     [EnumValue("true")]
-    True = 0,
+    True,
 
     [EnumValue("false")]
-    False = 1,
+    False,
 
     [EnumValue("always")]
-    Always = 2
+    Always
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanContainerRunSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanContainerRunSystemd.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanContainerRunSystemd
 {
     [EnumValue("true")]
-    True = 0,
+    True,
 
     [EnumValue("false")]
-    False = 1,
+    False,
 
     [EnumValue("always")]
-    Always = 2
+    Always
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanCreateSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanCreateSystemd.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanCreateSystemd
 {
     [EnumValue("true")]
-    True = 0,
+    True,
 
     [EnumValue("false")]
-    False = 1,
+    False,
 
     [EnumValue("always")]
-    Always = 2
+    Always
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanImagePushFormat.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanImagePushFormat.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanImagePushFormat
 {
     [EnumValue("oci")]
-    Oci = 0,
+    Oci,
 
     [EnumValue("v2s2")]
-    V2S2 = 1,
+    V2S2,
 
     [EnumValue("v2s1")]
-    V2S1 = 2
+    V2S1
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanPushFormat.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanPushFormat.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanPushFormat
 {
     [EnumValue("oci")]
-    Oci = 0,
+    Oci,
 
     [EnumValue("v2s2")]
-    V2S2 = 1,
+    V2S2,
 
     [EnumValue("v2s1")]
-    V2S1 = 2
+    V2S1
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanRunSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanRunSystemd.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Podman.Enums;
 public enum PodmanRunSystemd
 {
     [EnumValue("true")]
-    True = 0,
+    True,
 
     [EnumValue("false")]
-    False = 1,
+    False,
 
     [EnumValue("always")]
-    Always = 2
+    Always
 }

--- a/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
+++ b/src/ModularPipelines.Podman/Extensions/PodmanExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Podman.Services;
 
 namespace ModularPipelines.Podman.Extensions;
@@ -47,4 +46,5 @@ public static class PodmanExtensions
         services.TryAddScoped<IPodmanVolume, PodmanVolume>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
@@ -684,18 +684,4 @@ public record PodmanBuildOptions : PodmanOptions
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Context { get; set; }
 
-    [Obsolete("Use Outputs instead.")]
-    public string? Output
-    {
-        get => Outputs?.FirstOrDefault();
-        set => Outputs = value is null ? null : [value];
-    }
-
-    [Obsolete("Use TimestampValue instead.")]
-    public int? Timestamp
-    {
-        get => int.TryParse(TimestampValue, global::System.Globalization.NumberStyles.Integer, global::System.Globalization.CultureInfo.InvariantCulture, out var value) ? value : null;
-        set => TimestampValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanComposeCpOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanComposeCpOptions.Generated.cs
@@ -18,10 +18,7 @@ namespace ModularPipelines.Podman.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("compose", "cp")]
-public record PodmanComposeCpOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string ServiceSrcPath,
-    [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string DestPath
-) : PodmanOptions
+public record PodmanComposeCpOptions : PodmanOptions
 {
     /// <summary>
     /// Include containers created by the run command
@@ -52,5 +49,17 @@ public record PodmanComposeCpOptions(
     /// </summary>
     [CliOption("--index", Format = OptionFormat.EqualsSeparated)]
     public int? Index { get; set; }
+
+    /// <summary>
+    /// The SERVICE:SRC_PATH operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? ServiceSrcPath { get; set; }
+
+    /// <summary>
+    /// The DEST_PATH operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public string? DestPath { get; set; }
 
 }

--- a/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
@@ -630,11 +630,4 @@ public record PodmanFarmBuildOptions : PodmanOptions
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Context { get; set; }
 
-    [Obsolete("Use TimestampValue instead.")]
-    public int? Timestamp
-    {
-        get => int.TryParse(TimestampValue, global::System.Globalization.NumberStyles.Integer, global::System.Globalization.CultureInfo.InvariantCulture, out var value) ? value : null;
-        set => TimestampValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanGenerateKubeOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanGenerateKubeOptions.Generated.cs
@@ -52,7 +52,4 @@ public record PodmanGenerateKubeOptions(
     [CliOption("--type", ShortForm = "-t", Format = OptionFormat.EqualsSeparated)]
     public string? Type { get; set; }
 
-    [Obsolete("Podman no longer supports --no-trunc and this property has no effect.")]
-    public bool? NoTrunc { get; set; }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
@@ -684,18 +684,4 @@ public record PodmanImageBuildOptions : PodmanOptions
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Context { get; set; }
 
-    [Obsolete("Use Outputs instead.")]
-    public string? Output
-    {
-        get => Outputs?.FirstOrDefault();
-        set => Outputs = value is null ? null : [value];
-    }
-
-    [Obsolete("Use TimestampValue instead.")]
-    public int? Timestamp
-    {
-        get => int.TryParse(TimestampValue, global::System.Globalization.NumberStyles.Integer, global::System.Globalization.CultureInfo.InvariantCulture, out var value) ? value : null;
-        set => TimestampValue = value?.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
-    }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanKubeGenerateOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanKubeGenerateOptions.Generated.cs
@@ -52,7 +52,4 @@ public record PodmanKubeGenerateOptions(
     [CliOption("--type", ShortForm = "-t", Format = OptionFormat.EqualsSeparated)]
     public string? Type { get; set; }
 
-    [Obsolete("Podman no longer supports --no-trunc and this property has no effect.")]
-    public bool? NoTrunc { get; set; }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanKubePlayOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanKubePlayOptions.Generated.cs
@@ -180,7 +180,4 @@ public record PodmanKubePlayOptions(
     [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? AdditionalKubefiles { get; set; }
 
-    [Obsolete("Podman no longer supports --no-trunc and this property has no effect.")]
-    public bool? NoTrunc { get; set; }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineInitOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineInitOptions.Generated.cs
@@ -116,14 +116,4 @@ public record PodmanMachineInitOptions : PodmanOptions
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Name { get; set; }
 
-    [Obsolete("Use Image instead.")]
-    public string? ImagePath
-    {
-        get => Image;
-        set => Image = value;
-    }
-
-    [Obsolete("Podman no longer supports --volume-driver and this property has no effect.")]
-    public string? VolumeDriver { get; set; }
-
 }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineRmOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineRmOptions.Generated.cs
@@ -44,7 +44,4 @@ public record PodmanMachineRmOptions : PodmanOptions
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Machine { get; set; }
 
-    [Obsolete("Podman no longer supports --save-keys and this property has no effect.")]
-    public bool? SaveKeys { get; set; }
-
 }

--- a/src/ModularPipelines.Podman/Services/IPodmanCompose.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/IPodmanCompose.Generated.cs
@@ -83,7 +83,7 @@ public interface IPodmanCompose
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CpAsync(PodmanComposeCpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CpAsync(PodmanComposeCpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Services/PodmanCompose.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanCompose.Generated.cs
@@ -125,11 +125,11 @@ public class PodmanCompose : IPodmanCompose
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CpAsync(
-        PodmanComposeCpOptions options,
+        PodmanComposeCpOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new PodmanComposeCpOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **podman** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- podman (podman version 5.8.4): 255 commands, tree fa3930718b1ecf476ed61035c75543dfacf4d2df669953615aff3c98925335e8

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator