### PR TITLE
[Automated] Update yarn CLI Options

### DIFF
--- a/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Extensions/YarnExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Yarn.Services;
 
 namespace ModularPipelines.Yarn.Extensions;
@@ -31,4 +30,5 @@ public static class YarnExtensions
         services.TryAddScoped<IYarn, Services.Yarn>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Yarn/Options/YarnExecOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnExecOptions.Generated.cs
@@ -22,9 +22,4 @@ public record YarnExecOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> CommandName
 ) : YarnOptions
 {
-    public YarnExecOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
 }

--- a/src/ModularPipelines.Yarn/Options/YarnNpmPublishOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnNpmPublishOptions.Generated.cs
@@ -5,10 +5,10 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
-using ModularPipelines.Secrets;
 using ModularPipelines.Yarn.Options;
 
 namespace ModularPipelines.Yarn.Options;

--- a/src/ModularPipelines.Yarn/Options/YarnNpmStageApproveOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnNpmStageApproveOptions.Generated.cs
@@ -5,10 +5,10 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
-using ModularPipelines.Secrets;
 using ModularPipelines.Yarn.Options;
 
 namespace ModularPipelines.Yarn.Options;

--- a/src/ModularPipelines.Yarn/Options/YarnNpmStageRejectOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnNpmStageRejectOptions.Generated.cs
@@ -5,10 +5,10 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
-using ModularPipelines.Secrets;
 using ModularPipelines.Yarn.Options;
 
 namespace ModularPipelines.Yarn.Options;

--- a/src/ModularPipelines.Yarn/Options/YarnPatchCommitOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnPatchCommitOptions.Generated.cs
@@ -22,11 +22,6 @@ public record YarnPatchCommitOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string PatchFolder
 ) : YarnOptions
 {
-    public YarnPatchCommitOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Add the patch to your resolution entries
     /// </summary>

--- a/src/ModularPipelines.Yarn/Options/YarnPatchOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnPatchOptions.Generated.cs
@@ -22,11 +22,6 @@ public record YarnPatchOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Package
 ) : YarnOptions
 {
-    public YarnPatchOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Reapply local patches that already apply to this packages
     /// </summary>

--- a/src/ModularPipelines.Yarn/Options/YarnWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnWhyOptions.Generated.cs
@@ -22,11 +22,6 @@ public record YarnWhyOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Package
 ) : YarnOptions
 {
-    public YarnWhyOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// List, for each workspace, what are all the paths that lead to the dependency
     /// </summary>

--- a/src/ModularPipelines.Yarn/Services/IYarn.Generated.cs
+++ b/src/ModularPipelines.Yarn/Services/IYarn.Generated.cs
@@ -147,7 +147,7 @@ public partial interface IYarn
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ExecAsync(YarnExecOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecAsync(YarnExecOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -310,7 +310,7 @@ public partial interface IYarn
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PatchCommitAsync(YarnPatchCommitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PatchCommitAsync(YarnPatchCommitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -320,7 +320,7 @@ public partial interface IYarn
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PatchAsync(YarnPatchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PatchAsync(YarnPatchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -483,7 +483,7 @@ public partial interface IYarn
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> WhyAsync(YarnWhyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WhyAsync(YarnWhyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Yarn/Services/Yarn.Generated.cs
+++ b/src/ModularPipelines.Yarn/Services/Yarn.Generated.cs
@@ -142,11 +142,11 @@ internal partial class Yarn : IYarn
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ExecAsync(
-        YarnExecOptions? options = null,
+        YarnExecOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new YarnExecOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -295,20 +295,20 @@ internal partial class Yarn : IYarn
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PatchCommitAsync(
-        YarnPatchCommitOptions? options = null,
+        YarnPatchCommitOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new YarnPatchCommitOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PatchAsync(
-        YarnPatchOptions? options = null,
+        YarnPatchOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new YarnPatchOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -457,11 +457,11 @@ internal partial class Yarn : IYarn
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> WhyAsync(
-        YarnWhyOptions? options = null,
+        YarnWhyOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new YarnWhyOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **yarn** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- yarn (4.18.0): 52 commands, tree e257eecd91b494ea27b85879a1fe8297c96a2747f7308e7455a4d7479c2a0132

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator