### PR TITLE
[Automated] Update pip CLI Options

### DIFF
--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Python.Services;
 
 namespace ModularPipelines.Python.Extensions;
@@ -31,4 +30,5 @@ public static class PipExtensions
         services.TryAddScoped<IPip, Services.Pip>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipDownloadOptions : PipOptions
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public IEnumerable<string>? ConstraintValues { get; set; }
+    public IEnumerable<string>? Constraint { get; set; }
 
     /// <summary>
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public IEnumerable<string>? RequirementValues { get; set; }
+    public IEnumerable<string>? Requirement { get; set; }
 
     /// <summary>
     /// Don't install package dependencies.
@@ -65,8 +65,8 @@ public record PipDownloadOptions : PipOptions
     /// <summary>
     /// Require a hash to check each requirement against, for repeatable installs. This option is implied when any package in a requirements file has a --hash option.
     /// </summary>
-    [CliOption("--require-hashes")]
-    public string? RequireHashes { get; set; }
+    [CliFlag("--require-hashes")]
+    public bool? RequireHashes { get; set; }
 
     /// <summary>
     /// Disable isolation when building a modern source distribution. Build dependencies specified by PEP 518 must be already installed if this option is used.
@@ -102,13 +102,13 @@ public record PipDownloadOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public IEnumerable<string>? PlatformValues { get; set; }
+    public IEnumerable<string>? Platform { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public IEnumerable<string>? AbiValues { get; set; }
+    public IEnumerable<string>? Abi { get; set; }
 
     /// <summary>
     /// Don't clean up build directories.
@@ -277,33 +277,5 @@ public record PipDownloadOptions : PipOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? RequirementSpecifier { get; set; }
-
-    [Obsolete("Use ConstraintValues instead.")]
-    public string? Constraint
-    {
-        get => ConstraintValues?.FirstOrDefault();
-        set => ConstraintValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use RequirementValues instead.")]
-    public string? Requirement
-    {
-        get => RequirementValues?.FirstOrDefault();
-        set => RequirementValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use PlatformValues instead.")]
-    public string? Platform
-    {
-        get => PlatformValues?.FirstOrDefault();
-        set => PlatformValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use AbiValues instead.")]
-    public string? Abi
-    {
-        get => AbiValues?.FirstOrDefault();
-        set => AbiValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipFreezeOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipFreezeOptions.Generated.cs
@@ -24,7 +24,7 @@ public record PipFreezeOptions : PipOptions
     /// Use the order in the given requirements file and its comments when generating output. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public IEnumerable<string>? RequirementValues { get; set; }
+    public IEnumerable<string>? Requirement { get; set; }
 
     /// <summary>
     /// If in a virtualenv that has global access, do not output globally-installed packages.
@@ -42,7 +42,7 @@ public record PipFreezeOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public IEnumerable<string>? PathValues { get; set; }
+    public IEnumerable<string>? Path { get; set; }
 
     /// <summary>
     /// Do not skip these packages in the output: pip
@@ -193,19 +193,5 @@ public record PipFreezeOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
-
-    [Obsolete("Use RequirementValues instead.")]
-    public string? Requirement
-    {
-        get => RequirementValues?.FirstOrDefault();
-        set => RequirementValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use PathValues instead.")]
-    public string? Path
-    {
-        get => PathValues?.FirstOrDefault();
-        set => PathValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipHashOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipHashOptions.Generated.cs
@@ -22,11 +22,6 @@ public record PipHashOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> File
 ) : PipOptions
 {
-    public PipHashOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Show help.
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipIndexOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public IEnumerable<string>? PlatformValues { get; set; }
+    public IEnumerable<string>? Platform { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public IEnumerable<string>? AbiValues { get; set; }
+    public IEnumerable<string>? Abi { get; set; }
 
     /// <summary>
     /// Ignore the Requires-Python information.
@@ -199,19 +199,5 @@ public record PipIndexOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
-
-    [Obsolete("Use PlatformValues instead.")]
-    public string? Platform
-    {
-        get => PlatformValues?.FirstOrDefault();
-        set => PlatformValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use AbiValues instead.")]
-    public string? Abi
-    {
-        get => AbiValues?.FirstOrDefault();
-        set => AbiValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInspectOptions.Generated.cs
@@ -36,7 +36,7 @@ public record PipInspectOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public IEnumerable<string>? PathValues { get; set; }
+    public IEnumerable<string>? Path { get; set; }
 
     /// <summary>
     /// Show help.
@@ -169,12 +169,5 @@ public record PipInspectOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
-
-    [Obsolete("Use PathValues instead.")]
-    public string? Path
-    {
-        get => PathValues?.FirstOrDefault();
-        set => PathValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipInstallOptions : PipOptions
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public IEnumerable<string>? RequirementValues { get; set; }
+    public IEnumerable<string>? Requirement { get; set; }
 
     /// <summary>
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public IEnumerable<string>? ConstraintValues { get; set; }
+    public IEnumerable<string>? Constraint { get; set; }
 
     /// <summary>
     /// Don't install package dependencies.
@@ -66,13 +66,13 @@ public record PipInstallOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public IEnumerable<string>? PlatformValues { get; set; }
+    public IEnumerable<string>? Platform { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public IEnumerable<string>? AbiValues { get; set; }
+    public IEnumerable<string>? Abi { get; set; }
 
     /// <summary>
     /// Install to the Python user install directory for your platform. Typically ~/.local/, or %APPDATA%\Python on Windows. (See the Python documentation for site.USER_BASE for full details.)
@@ -185,8 +185,8 @@ public record PipInstallOptions : PipOptions
     /// <summary>
     /// Require a hash to check each requirement against, for repeatable installs. This option is implied when any package in a requirements file has a --hash option.
     /// </summary>
-    [CliOption("--require-hashes")]
-    public string? RequireHashes { get; set; }
+    [CliFlag("--require-hashes")]
+    public bool? RequireHashes { get; set; }
 
     /// <summary>
     /// Generate a JSON file describing what pip did to install the provided requirements. Can be used in combination with --dry-run and --ignore- installed to 'resolve' the requirements. When - is used as file name it writes to stdout. When writing to stdout, please combine with the
@@ -361,33 +361,5 @@ public record PipInstallOptions : PipOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? RequirementSpecifier { get; set; }
-
-    [Obsolete("Use RequirementValues instead.")]
-    public string? Requirement
-    {
-        get => RequirementValues?.FirstOrDefault();
-        set => RequirementValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use ConstraintValues instead.")]
-    public string? Constraint
-    {
-        get => ConstraintValues?.FirstOrDefault();
-        set => ConstraintValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use PlatformValues instead.")]
-    public string? Platform
-    {
-        get => PlatformValues?.FirstOrDefault();
-        set => PlatformValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use AbiValues instead.")]
-    public string? Abi
-    {
-        get => AbiValues?.FirstOrDefault();
-        set => AbiValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
@@ -54,7 +54,7 @@ public record PipListOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public IEnumerable<string>? PathValues { get; set; }
+    public IEnumerable<string>? Path { get; set; }
 
     /// <summary>
     /// Include pre-release and development versions. By default, pip only finds stable versions.
@@ -247,12 +247,5 @@ public record PipListOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
-
-    [Obsolete("Use PathValues instead.")]
-    public string? Path
-    {
-        get => PathValues?.FirstOrDefault();
-        set => PathValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipSearchOptions.Generated.cs
@@ -22,11 +22,6 @@ public record PipSearchOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Query
 ) : PipOptions
 {
-    public PipSearchOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Base URL of Python Package Index (default https://pypi.org/pypi)
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipShowOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipShowOptions.Generated.cs
@@ -22,11 +22,6 @@ public record PipShowOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Package
 ) : PipOptions
 {
-    public PipShowOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Show the full list of installed files for each package.
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
@@ -24,7 +24,7 @@ public record PipUninstallOptions : PipOptions
     /// Uninstall all the packages listed in the given requirements file.  This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public IEnumerable<string>? RequirementValues { get; set; }
+    public IEnumerable<string>? Requirement { get; set; }
 
     /// <summary>
     /// Don't ask for confirmation of uninstall deletions.
@@ -175,12 +175,5 @@ public record PipUninstallOptions : PipOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Package { get; set; }
-
-    [Obsolete("Use RequirementValues instead.")]
-    public string? Requirement
-    {
-        get => RequirementValues?.FirstOrDefault();
-        set => RequirementValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
@@ -54,7 +54,7 @@ public record PipWheelOptions : PipOptions
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public IEnumerable<string>? ConstraintValues { get; set; }
+    public IEnumerable<string>? Constraint { get; set; }
 
     /// <summary>
     /// Install a project in editable mode (i.e. setuptools "develop mode") from a local project path or a VCS url.
@@ -66,7 +66,7 @@ public record PipWheelOptions : PipOptions
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public IEnumerable<string>? RequirementValues { get; set; }
+    public IEnumerable<string>? Requirement { get; set; }
 
     /// <summary>
     /// Directory to check out editable projects into. The default in a virtualenv is "&lt;venv path&gt;/src". The default for global installs is "&lt;current dir&gt;/src".
@@ -113,8 +113,8 @@ public record PipWheelOptions : PipOptions
     /// <summary>
     /// Require a hash to check each requirement against, for repeatable installs. This option is implied when any package in a requirements file has a --hash option.
     /// </summary>
-    [CliOption("--require-hashes")]
-    public string? RequireHashes { get; set; }
+    [CliFlag("--require-hashes")]
+    public bool? RequireHashes { get; set; }
 
     /// <summary>
     /// Don't clean up build directories.
@@ -283,19 +283,5 @@ public record PipWheelOptions : PipOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? RequirementSpecifier { get; set; }
-
-    [Obsolete("Use ConstraintValues instead.")]
-    public string? Constraint
-    {
-        get => ConstraintValues?.FirstOrDefault();
-        set => ConstraintValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use RequirementValues instead.")]
-    public string? Requirement
-    {
-        get => RequirementValues?.FirstOrDefault();
-        set => RequirementValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.Python/Services/IPip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/IPip.Generated.cs
@@ -77,7 +77,7 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> HashAsync(PipHashOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> HashAsync(PipHashOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -127,7 +127,7 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SearchAsync(PipSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SearchAsync(PipSearchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -137,7 +137,7 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ShowAsync(PipShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ShowAsync(PipShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Python/Services/Pip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/Pip.Generated.cs
@@ -79,11 +79,11 @@ internal partial class Pip : IPip
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> HashAsync(
-        PipHashOptions? options = null,
+        PipHashOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipHashOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -124,20 +124,20 @@ internal partial class Pip : IPip
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> SearchAsync(
-        PipSearchOptions? options = null,
+        PipSearchOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipSearchOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ShowAsync(
-        PipShowOptions? options = null,
+        PipShowOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipShowOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pip** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pip (pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)): 14 commands, tree a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator