### PR TITLE
[Automated] Update syft CLI Options

### DIFF
--- a/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
+++ b/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Syft.Services;
 
 namespace ModularPipelines.Syft.Extensions;
@@ -33,4 +32,5 @@ public static class SyftExtensions
         services.TryAddScoped<ISyftConfig, SyftConfig>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Syft/Options/SyftAttestOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftAttestOptions.Generated.cs
@@ -136,7 +136,4 @@ public record SyftAttestOptions(
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [Obsolete("Format is no longer supported by the installed CLI and has no effect.")]
-    public string? Format { get; set; }
-
 }

--- a/src/ModularPipelines.Syft/Options/SyftConvertOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftConvertOptions.Generated.cs
@@ -74,7 +74,4 @@ public record SyftConvertOptions : SyftOptions
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? SourceSbom { get; set; }
 
-    [Obsolete("Format is no longer supported by the installed CLI and has no effect.")]
-    public string? Format { get; set; }
-
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **syft** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- syft (syft 1.51.1): 8 commands, tree 312b56070505f8e9227e5762adaba7ae25213d326283923b5592ce0281c0c868

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator