### PR TITLE
[Automated] Update skopeo CLI Options

### DIFF
--- a/src/ModularPipelines.Skopeo/Enums/SkopeoCopyFormat.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Enums/SkopeoCopyFormat.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Skopeo.Enums;
 public enum SkopeoCopyFormat
 {
     [EnumValue("oci")]
-    Oci = 0,
+    Oci,
 
     [EnumValue("v2s1")]
-    V2S1 = 1,
+    V2S1,
 
     [EnumValue("v2s2")]
-    V2S2 = 2
+    V2S2
 }

--- a/src/ModularPipelines.Skopeo/Enums/SkopeoSyncFormat.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Enums/SkopeoSyncFormat.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Skopeo.Enums;
 public enum SkopeoSyncFormat
 {
     [EnumValue("oci")]
-    Oci = 0,
+    Oci,
 
     [EnumValue("v2s1")]
-    V2S1 = 1,
+    V2S1,
 
     [EnumValue("v2s2")]
-    V2S2 = 2
+    V2S2
 }

--- a/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Extensions/SkopeoExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Skopeo.Services;
 
 namespace ModularPipelines.Skopeo.Extensions;
@@ -31,4 +30,5 @@ public static class SkopeoExtensions
         services.TryAddScoped<ISkopeo, Services.Skopeo>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoGenerateSigstoreKeyOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoGenerateSigstoreKeyOptions.Generated.cs
@@ -18,9 +18,7 @@ namespace ModularPipelines.Skopeo.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("generate-sigstore-key")]
-public record SkopeoGenerateSigstoreKeyOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Prefix
-) : SkopeoOptions
+public record SkopeoGenerateSigstoreKeyOptions : SkopeoOptions
 {
     /// <summary>
     /// help for generate-sigstore-key

--- a/src/ModularPipelines.Skopeo/Options/SkopeoSyncOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoSyncOptions.Generated.cs
@@ -21,9 +21,8 @@ namespace ModularPipelines.Skopeo.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("sync")]
 public record SkopeoSyncOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Transport,
-    [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Source,
-    [property: CliArgument(2, Phase = CommandLinePhase.Passthrough, Required = true)] string Destination
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Source,
+    [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Destination
 ) : SkopeoOptions
 {
     /// <summary>

--- a/src/ModularPipelines.Skopeo/Services/ISkopeo.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Services/ISkopeo.Generated.cs
@@ -47,7 +47,7 @@ public partial interface ISkopeo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> GenerateSigstoreKeyAsync(SkopeoGenerateSigstoreKeyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> GenerateSigstoreKeyAsync(SkopeoGenerateSigstoreKeyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Skopeo/Services/Skopeo.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Services/Skopeo.Generated.cs
@@ -52,11 +52,11 @@ internal partial class Skopeo : ISkopeo
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> GenerateSigstoreKeyAsync(
-        SkopeoGenerateSigstoreKeyOptions options,
+        SkopeoGenerateSigstoreKeyOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new SkopeoGenerateSigstoreKeyOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **skopeo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- skopeo (skopeo version 1.13.3): 11 commands, tree 71df545926b8f3395c60d1ed9e037569395c16b401bff0417eacdfb16d3d7908

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator