### PR TITLE
Document the shipped distributed coordinator API

### DIFF
--- a/docs/docs/distributed/architecture.md
+++ b/docs/docs/distributed/architecture.md
@@ -18,7 +18,8 @@ This page describes the internal architecture of distributed mode for contributo
    of `0` selects the master even when `DistributedOptions.InstanceIndex` is non-zero;
    any other valid integer selects a worker. When the variable is absent or invalid,
    `InstanceIndex == 0` selects the master. The master replaces the default
-   `IModuleExecutor` with `DistributedModuleExecutor`.
+   `IModuleExecutor` with `DistributedModuleExecutor`. The environment variable affects
+   role selection only; it does not change `DistributedOptions.InstanceIndex`.
 4. A registered `IDistributedCoordinatorFactory` is wrapped in a deferred coordinator,
    so its `CreateAsync` method runs when the coordinator is first used. A directly
    registered `IDistributedCoordinator` is used as-is.
@@ -31,7 +32,9 @@ This page describes the internal architecture of distributed mode for contributo
    `DistributedOptions.InstanceIndex`. A valid non-zero environment value selects a
    worker, while `0` selects the master even when `InstanceIndex` is non-zero. Without
    a valid override, every non-zero `InstanceIndex` is a worker. Workers replace the
-   default `IModuleExecutor` with `WorkerModuleExecutor`.
+   default `IModuleExecutor` with `WorkerModuleExecutor`. Registration and run-report
+   metrics still use `DistributedOptions.InstanceIndex`, so every worker must configure
+   a distinct non-zero index even when the environment variable selects its role.
 2. The worker registers all available module types for serialization.
 3. The worker builds its capability set from configured capabilities and, by default,
    the auto-detected operating-system capability.

--- a/docs/docs/distributed/architecture.md
+++ b/docs/docs/distributed/architecture.md
@@ -11,19 +11,26 @@ This page describes the internal architecture of distributed mode for contributo
 
 ### Master Startup
 
-1. The `DistributedPipelinePlugin` detects role based on `InstanceIndex` and registers master services.
-2. The default `IModuleExecutor` is replaced with `DistributedModuleExecutor`.
-3. All module types are registered in the `ModuleTypeRegistry` for serialization.
-4. The coordinator is initialized (via `IDistributedCoordinatorFactory.CreateAsync()` or directly).
-5. The `WorkerHealthMonitor` background service starts monitoring worker heartbeats.
+1. `AddDistributedMode` enables distributed services and configures `DistributedOptions`.
+2. While the pipeline is built, `PipelineBuilder` activates distributed mode when
+   `Enabled` is `true` and `TotalInstances` is greater than one.
+3. `RoleDetector` treats `InstanceIndex == 0` as the master and replaces the default
+   `IModuleExecutor` with `DistributedModuleExecutor`.
+4. A registered `IDistributedCoordinatorFactory` is wrapped in a deferred coordinator,
+   so its `CreateAsync` method runs when the coordinator is first used. A directly
+   registered `IDistributedCoordinator` is used as-is.
+5. Before scheduling work, the master registers module types for serialization and waits
+   up to `DistributedOptions.CapabilityTimeout` for the configured workers to register.
 
 ### Worker Startup
 
-1. The plugin detects the worker role and registers worker services.
-2. The default `IModuleExecutor` is replaced with `WorkerModuleExecutor`.
-3. The worker builds its capability set (configured capabilities + auto-detected OS).
-4. The worker registers with the coordinator via `RegisterWorkerAsync`.
-5. Two background services start: `WorkerHeartbeatService` (periodic heartbeats) and `WorkerCancellationMonitor` (polls for cancellation).
+1. `RoleDetector` treats every non-zero `InstanceIndex` as a worker and replaces the
+   default `IModuleExecutor` with `WorkerModuleExecutor`.
+2. The worker registers all available module types for serialization.
+3. The worker builds its capability set from configured capabilities and, by default,
+   the auto-detected operating-system capability.
+4. The worker registers once with the coordinator via `RegisterWorkerAsync`.
+5. The worker enters its dequeue/execute/publish loop.
 
 ### Module Execution (Master Side)
 
@@ -64,14 +71,11 @@ The master runs a concurrent worker loop that competes with external workers for
 Register with coordinator
         │
         ▼
-   ┌──► Dequeue assignment ◄─────┐
-   │         │                   │
-   │    ┌────┴────┐              │
-   │    │ Match?  │              │
-   │    ▼ Yes     ▼ No          │
-   │  Execute   Re-enqueue      │
-   │    │         │              │
-   │    ▼         └──────────────┘
+   ┌──► Dequeue compatible assignment
+   │         │
+   │      Execute
+   │         │
+   │         ▼
    │  Serialize result
    │    │
    │    ▼
@@ -80,40 +84,40 @@ Register with coordinator
    └────┘ (loop)
 ```
 
-Workers loop until the queue is empty and no more work is expected, or until cancellation is requested.
+Workers loop until `DequeueModuleAsync` returns `null`. Coordinators return `null` after
+the master calls `SignalCompletionAsync`, or when that worker's local cancellation token
+is canceled.
 
 ## Coordinator Interface
 
-The `IDistributedCoordinator` interface defines nine methods across four concerns:
+The shipped `IDistributedCoordinator` interface defines seven methods across four concerns:
 
 ### Work Queue
 
 | Method | Direction | Description |
 |--------|-----------|-------------|
 | `EnqueueModuleAsync` | Master → Queue | Pushes a module assignment onto the work queue. |
-| `DequeueModuleAsync` | Queue → Worker | Pops an assignment from the queue, checking capability match. Re-enqueues if the worker can't handle it. |
+| `DequeueModuleAsync` | Queue → Worker | Waits for and claims an assignment compatible with the worker's capabilities, or returns `null` after completion. |
 
 ### Results
 
 | Method | Direction | Description |
 |--------|-----------|-------------|
 | `PublishResultAsync` | Worker → Coordinator | Stores the serialized result and notifies waiters. |
-| `WaitForResultAsync` | Master ← Coordinator | Blocks until a specific module's result is available. Uses Pub/Sub to avoid polling. |
+| `WaitForResultAsync` | Master ← Coordinator | Blocks until a specific module's result is available. |
 
 ### Worker Management
 
 | Method | Direction | Description |
 |--------|-----------|-------------|
-| `RegisterWorkerAsync` | Worker → Coordinator | Registers a worker with its capabilities and status. |
-| `SendHeartbeatAsync` | Worker → Coordinator | Updates the heartbeat timestamp. Transitions status from Connected to Active. |
-| `GetRegisteredWorkersAsync` | Master ← Coordinator | Returns all registered workers (for health monitoring). |
+| `RegisterWorkerAsync` | Worker → Coordinator | Registers a worker with its index, capabilities, registration time, and run identifier. |
+| `GetRegisteredWorkersAsync` | Master ← Coordinator | Returns registered workers so the master can wait for the expected worker count. |
 
-### Cancellation
+### Completion
 
 | Method | Direction | Description |
 |--------|-----------|-------------|
-| `BroadcastCancellationAsync` | Any → All | Stores a cancellation signal and notifies all instances. |
-| `IsCancellationRequestedAsync` | Any ← Coordinator | Checks whether cancellation has been requested. |
+| `SignalCompletionAsync` | Master → All | Tells waiting workers that the run has finished and no more assignments will arrive. |
 
 ## Redis Implementation Details
 
@@ -121,15 +125,13 @@ The `RedisDistributedCoordinator` maps each method to Redis operations:
 
 | Method | Redis Operations |
 |--------|-----------------|
-| `EnqueueModuleAsync` | `LPUSH` to work queue list + `EXPIRE` |
-| `DequeueModuleAsync` | `RPOP` from work queue (FIFO via LPUSH/RPOP), poll loop with configurable delay |
-| `PublishResultAsync` | `HSET` on results hash + `PUBLISH` on result channel |
+| `EnqueueModuleAsync` | `LPUSH` to the work queue + `EXPIRE` + `PUBLISH` on the work-available channel |
+| `DequeueModuleAsync` | Subscribe to work/completion channels; atomically scan `LRANGE` and claim a capability-compatible item with `LREM` |
+| `PublishResultAsync` | `HSET` on results hash + `EXPIRE` + `PUBLISH` on the module result channel |
 | `WaitForResultAsync` | `HGET` results hash (check first), then `SUBSCRIBE` result channel, then `HGET` again (close race window), await message |
 | `RegisterWorkerAsync` | `HSET` on workers hash + `EXPIRE` |
-| `SendHeartbeatAsync` | `HSET` on heartbeats hash + update worker status in workers hash |
 | `GetRegisteredWorkersAsync` | `HGETALL` on workers hash |
-| `BroadcastCancellationAsync` | `SET` cancellation key with TTL + `PUBLISH` cancellation channel |
-| `IsCancellationRequestedAsync` | `GET` cancellation key |
+| `SignalCompletionAsync` | `SET` completion key with TTL + `PUBLISH` completion channel |
 
 ### WaitForResultAsync Race Condition Handling
 
@@ -153,17 +155,46 @@ The `ReadOnlySetJsonConverter` handles `IReadOnlySet<string>` fields (used in `M
 To implement a different transport (HTTP, shared filesystem, message queue, etc.), implement `IDistributedCoordinator` and optionally `IDistributedCoordinatorFactory`:
 
 ```csharp
-public class MyCustomCoordinator : IDistributedCoordinator
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Distributed;
+using ModularPipelines.Distributed.Extensions;
+
+public sealed class MyCustomCoordinator : IDistributedCoordinator
 {
-    public Task EnqueueModuleAsync(ModuleAssignment assignment, CancellationToken ct) { ... }
-    public Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> capabilities, CancellationToken ct) { ... }
-    public Task PublishResultAsync(SerializedModuleResult result, CancellationToken ct) { ... }
-    public Task<SerializedModuleResult> WaitForResultAsync(string moduleTypeName, CancellationToken ct) { ... }
-    public Task RegisterWorkerAsync(WorkerRegistration registration, CancellationToken ct) { ... }
-    public Task SendHeartbeatAsync(int workerIndex, CancellationToken ct) { ... }
-    public Task<IReadOnlyList<WorkerRegistration>> GetRegisteredWorkersAsync(CancellationToken ct) { ... }
-    public Task BroadcastCancellationAsync(string reason, CancellationToken ct) { ... }
-    public Task<CancellationSignal?> IsCancellationRequestedAsync(CancellationToken ct) { ... }
+    public Task EnqueueModuleAsync(
+        ModuleAssignment assignment,
+        CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
+
+    public Task<ModuleAssignment?> DequeueModuleAsync(
+        IReadOnlySet<string> workerCapabilities,
+        CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
+
+    public Task PublishResultAsync(
+        SerializedModuleResult result,
+        CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
+
+    public Task<SerializedModuleResult> WaitForResultAsync(
+        string moduleTypeName,
+        CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
+
+    public Task RegisterWorkerAsync(
+        WorkerRegistration registration,
+        CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
+
+    public Task<IReadOnlyList<WorkerRegistration>> GetRegisteredWorkersAsync(
+        CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
+
+    public Task SignalCompletionAsync(CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
 }
 ```
 
@@ -176,24 +207,36 @@ builder.AddDistributedCoordinator<MyCustomCoordinator>();
 Or via a factory for async initialization:
 
 ```csharp
-public class MyCoordinatorFactory : IDistributedCoordinatorFactory
+public sealed class MyCoordinatorFactory : IDistributedCoordinatorFactory
 {
-    public async Task<IDistributedCoordinator> CreateAsync(CancellationToken ct)
-    {
-        // Connect to your backend...
-        return new MyCustomCoordinator(connection);
-    }
+    public Task<IDistributedCoordinator> CreateAsync(
+        CancellationToken cancellationToken) =>
+        Task.FromResult<IDistributedCoordinator>(new MyCustomCoordinator());
 }
 
 builder.AddDistributedCoordinatorFactory<MyCoordinatorFactory>();
 ```
 
-## Health Monitoring
+## Current Liveness Limitations
 
-The master runs a `WorkerHealthMonitor` background service that periodically checks worker heartbeats via `GetRegisteredWorkersAsync`. If a worker hasn't sent a heartbeat within `HeartbeatTimeoutSeconds`, the master considers it unresponsive.
+Worker registration is a one-time record. The shipped coordinator contract has no heartbeat,
+unregister, or worker-health member. The master uses `GetRegisteredWorkersAsync` only while
+waiting for the expected worker count; after `CapabilityTimeout` it proceeds with the workers
+that registered.
 
-Workers send heartbeats via the `WorkerHeartbeatService` at the interval configured in `HeartbeatIntervalSeconds`. The first heartbeat transitions a worker's status from `Connected` to `Active`.
+If a worker disappears after claiming an assignment, the master can wait until
+`ModuleResultTimeout` (45 minutes by default) for that assignment's result. SignalR can react
+to connection state internally, but that behavior is not part of the shared coordinator
+contract. First-class liveness is tracked by
+[#4373](https://github.com/thomhurst/ModularPipelines/issues/4373).
 
-## Cancellation
+## Cancellation and Completion
 
-Either the master or a worker can broadcast a cancellation signal. The `WorkerCancellationMonitor` background service polls `IsCancellationRequestedAsync` every 2 seconds on each worker. When a signal is detected, it triggers the pipeline's `CancellationToken`, causing all in-progress modules to receive cancellation.
+Cancellation tokens stop work only in the process where cancellation is requested. The
+shipped coordinator contract does not broadcast cancellation between the master and workers.
+
+`SignalCompletionAsync` is different from cancellation. The master calls it in a `finally`
+block after distributed execution ends. Coordinators use that signal to wake workers blocked
+in `DequeueModuleAsync` and let their execution loops exit normally. First-class distributed
+cancellation is also tracked by
+[#4373](https://github.com/thomhurst/ModularPipelines/issues/4373).

--- a/docs/docs/distributed/architecture.md
+++ b/docs/docs/distributed/architecture.md
@@ -14,7 +14,10 @@ This page describes the internal architecture of distributed mode for contributo
 1. `AddDistributedMode` enables distributed services and configures `DistributedOptions`.
 2. While the pipeline is built, `PipelineBuilder` activates distributed mode when
    `Enabled` is `true` and `TotalInstances` is greater than one.
-3. `RoleDetector` treats `InstanceIndex == 0` as the master and replaces the default
+3. `RoleDetector` checks `MODULAR_PIPELINES_INSTANCE` first. A valid environment value
+   of `0` selects the master even when `DistributedOptions.InstanceIndex` is non-zero;
+   any other valid integer selects a worker. When the variable is absent or invalid,
+   `InstanceIndex == 0` selects the master. The master replaces the default
    `IModuleExecutor` with `DistributedModuleExecutor`.
 4. A registered `IDistributedCoordinatorFactory` is wrapped in a deferred coordinator,
    so its `CreateAsync` method runs when the coordinator is first used. A directly
@@ -24,12 +27,17 @@ This page describes the internal architecture of distributed mode for contributo
 
 ### Worker Startup
 
-1. `RoleDetector` treats every non-zero `InstanceIndex` as a worker and replaces the
+1. `RoleDetector` checks `MODULAR_PIPELINES_INSTANCE` before
+   `DistributedOptions.InstanceIndex`. A valid non-zero environment value selects a
+   worker, while `0` selects the master even when `InstanceIndex` is non-zero. Without
+   a valid override, every non-zero `InstanceIndex` is a worker. Workers replace the
    default `IModuleExecutor` with `WorkerModuleExecutor`.
 2. The worker registers all available module types for serialization.
 3. The worker builds its capability set from configured capabilities and, by default,
    the auto-detected operating-system capability.
-4. The worker registers once with the coordinator via `RegisterWorkerAsync`.
+4. The worker registers its capabilities with the coordinator via
+   `RegisterWorkerAsync`. During run-report finalization it calls the method again to
+   upsert its final command metrics.
 5. The worker enters its dequeue/execute/publish loop.
 
 ### Module Execution (Master Side)
@@ -110,8 +118,8 @@ The shipped `IDistributedCoordinator` interface defines seven methods across fou
 
 | Method | Direction | Description |
 |--------|-----------|-------------|
-| `RegisterWorkerAsync` | Worker → Coordinator | Registers a worker with its index, capabilities, registration time, and run identifier. |
-| `GetRegisteredWorkersAsync` | Master ← Coordinator | Returns registered workers so the master can wait for the expected worker count. |
+| `RegisterWorkerAsync` | Worker → Coordinator | Upserts a worker's index, capabilities, registration time, and run identifier; workers call it again after execution with final command metrics. |
+| `GetRegisteredWorkersAsync` | Master ← Coordinator | Returns registered workers during the startup wait and again after execution while the master aggregates final worker metrics. |
 
 ### Completion
 
@@ -219,10 +227,15 @@ builder.AddDistributedCoordinatorFactory<MyCoordinatorFactory>();
 
 ## Current Liveness Limitations
 
-Worker registration is a one-time record. The shipped coordinator contract has no heartbeat,
-unregister, or worker-health member. The master uses `GetRegisteredWorkersAsync` only while
-waiting for the expected worker count; after `CapabilityTimeout` it proceeds with the workers
-that registered.
+Worker registration is not a heartbeat. Workers upsert an initial capability record and later
+upsert final command metrics during run-report finalization. The master reads registrations
+while waiting for the expected worker count and polls them again after execution to aggregate
+those final metrics. A custom coordinator must therefore retain registration state for the
+whole run and support repeated upserts and post-execution reads.
+
+The shipped coordinator contract still has no heartbeat, unregister, or worker-health member.
+After `CapabilityTimeout`, the master proceeds with the workers that registered; the later
+metrics polling reports completion data but does not provide continuous liveness detection.
 
 If a worker disappears after claiming an assignment, the master can wait until
 `ModuleResultTimeout` (45 minutes by default) for that assignment's result. SignalR can react

--- a/docs/docs/distributed/architecture.md
+++ b/docs/docs/distributed/architecture.md
@@ -99,6 +99,11 @@ Workers loop until `DequeueModuleAsync` returns `null`. Coordinators return `nul
 the master calls `SignalCompletionAsync`, or when that worker's local cancellation token
 is canceled.
 
+Capability-mismatch handling is transport-specific. The in-memory and Redis coordinators
+scan their lists and leave incompatible assignments in place. The queue-backed SignalR
+master coordinator dequeues each candidate, re-enqueues an incompatible assignment, and
+continues scanning for work that the current worker can execute.
+
 ## Coordinator Interface
 
 The shipped `IDistributedCoordinator` interface defines seven methods across four concerns:
@@ -137,12 +142,12 @@ The `RedisDistributedCoordinator` maps each method to Redis operations:
 | Method | Redis Operations |
 |--------|-----------------|
 | `EnqueueModuleAsync` | `LPUSH` to the work queue + `EXPIRE` + `PUBLISH` on the work-available channel |
-| `DequeueModuleAsync` | Subscribe to work/completion channels; atomically scan `LRANGE` and claim a capability-compatible item with `LREM` |
+| `DequeueModuleAsync` | `GET` completion flag (check first), `SUBSCRIBE` to work/completion channels, atomically scan `LRANGE` and claim a capability-compatible item with `LREM`, then `GET` completion again (close race window) |
 | `PublishResultAsync` | `HSET` on results hash + `EXPIRE` + `PUBLISH` on the module result channel |
 | `WaitForResultAsync` | `HGET` results hash (check first), then `SUBSCRIBE` result channel, then `HGET` again (close race window), await message |
 | `RegisterWorkerAsync` | `HSET` on workers hash + `EXPIRE` |
 | `GetRegisteredWorkersAsync` | `HGETALL` on workers hash |
-| `SignalCompletionAsync` | `SET` completion key with TTL + `PUBLISH` completion channel |
+| `SignalCompletionAsync` | `SET` completion key, separate `EXPIRE`, then `PUBLISH` completion channel |
 
 ### WaitForResultAsync Race Condition Handling
 

--- a/docs/docs/distributed/architecture.md
+++ b/docs/docs/distributed/architecture.md
@@ -248,8 +248,10 @@ contract. First-class liveness is tracked by
 Cancellation tokens stop work only in the process where cancellation is requested. The
 shipped coordinator contract does not broadcast cancellation between the master and workers.
 
-`SignalCompletionAsync` is different from cancellation. The master calls it in a `finally`
-block after distributed execution ends. Coordinators use that signal to wake workers blocked
-in `DequeueModuleAsync` and let their execution loops exit normally. First-class distributed
-cancellation is also tracked by
+`SignalCompletionAsync` is different from cancellation. When the master receives at least
+one runnable module, it calls this method in a `finally` block after distributed execution
+ends. Coordinators use that signal to wake workers blocked in `DequeueModuleAsync` and let
+their execution loops exit normally. If the runnable set is empty, the master currently
+returns before sending the signal, so external workers remain blocked until their local
+cancellation tokens are canceled. First-class distributed cancellation is also tracked by
 [#4373](https://github.com/thomhurst/ModularPipelines/issues/4373).


### PR DESCRIPTION
## Summary

- replace the unshipped plugin, heartbeat, and distributed-cancellation design with the actual `PipelineBuilder` activation flow
- document the shipped seven-method coordinator contract and Redis operations
- provide a compile-valid custom coordinator skeleton and state current liveness/cancellation limitations

## Validation

- `npm run build --prefix docs` (331 documents; static build succeeded)
- `git diff --check`

Closes #4387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the distributed architecture guide to reflect the simplified coordinator workflow.
  * Revised master and worker startup instructions, execution flow, and Redis operation mappings.
  * Updated custom coordinator and factory examples to match the current seven-method contract.
  * Clarified liveness, cancellation, and completion behavior, with links to related tracking information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->