### PR TITLE
Allow Kubectl operands replaced by selectors

### DIFF
--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAnnotateDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAnnotateDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAnnotateDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAnnotateOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAnnotateOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAnnotateOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyCascade.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyCascade.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplyCascade
 {
     [EnumValue("background")]
-    Background = 0,
+    Background,
 
     [EnumValue("orphan")]
-    Orphan = 1,
+    Orphan,
 
     [EnumValue("foreground")]
-    Foreground = 2
+    Foreground
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplyDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyEditLastAppliedOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyEditLastAppliedOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplyEditLastAppliedOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplyOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplySetLastAppliedDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplySetLastAppliedDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplySetLastAppliedDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplySetLastAppliedOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplySetLastAppliedOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplySetLastAppliedOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyViewLastAppliedOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesApplyViewLastAppliedOutput.Generated.cs
@@ -17,8 +17,8 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesApplyViewLastAppliedOutput
 {
     [EnumValue("yaml")]
-    Yaml = 0,
+    Yaml,
 
     [EnumValue("json")]
-    Json = 1
+    Json
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAuthReconcileDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAuthReconcileDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAuthReconcileDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAuthReconcileOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAuthReconcileOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAuthReconcileOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAuthWhoamiOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAuthWhoamiOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAuthWhoamiOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAutoscaleDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAutoscaleDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAutoscaleDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesAutoscaleOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesAutoscaleOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesAutoscaleOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesCertificateApproveOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesCertificateApproveOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesCertificateApproveOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesCertificateDenyOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesCertificateDenyOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesCertificateDenyOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesClusterInfoDumpOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesClusterInfoDumpOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesClusterInfoDumpOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesConfigViewOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesConfigViewOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesConfigViewOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesCordonDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesCordonDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesCordonDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesDrainDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesDrainDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesDrainDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesEventsOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesEventsOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesEventsOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesKubercSetPolicy.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesKubercSetPolicy.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesKubercSetPolicy
 {
     [EnumValue("AllowAll")]
-    Allowall = 0,
+    AllowAll,
 
     [EnumValue("DenyAll")]
-    Denyall = 1,
+    DenyAll,
 
     [EnumValue("Allowlist")]
-    Allowlist = 2
+    Allowlist
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesKubercViewOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesKubercViewOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesKubercViewOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesLabelDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesLabelDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesLabelDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesLabelOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesLabelOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesLabelOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesPatchDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesPatchDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesPatchDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesPatchOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesPatchOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesPatchOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesReplaceCascade.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesReplaceCascade.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesReplaceCascade
 {
     [EnumValue("background")]
-    Background = 0,
+    Background,
 
     [EnumValue("orphan")]
-    Orphan = 1,
+    Orphan,
 
     [EnumValue("foreground")]
-    Foreground = 2
+    Foreground
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesReplaceDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesReplaceDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesReplaceDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesReplaceOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesReplaceOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesReplaceOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutHistoryOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutHistoryOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesRolloutHistoryOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutPauseOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutPauseOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesRolloutPauseOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutRestartOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutRestartOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesRolloutRestartOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutResumeOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutResumeOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesRolloutResumeOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutUndoDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutUndoDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesRolloutUndoDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutUndoOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesRolloutUndoOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesRolloutUndoOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesScaleDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesScaleDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesScaleDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesScaleOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesScaleOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesScaleOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesTaintDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesTaintDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesTaintDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesTaintOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesTaintOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesTaintOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesUncordonDryRun.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesUncordonDryRun.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesUncordonDryRun
 {
     [EnumValue("none")]
-    None = 0,
+    None,
 
     [EnumValue("server")]
-    Server = 1,
+    Server,
 
     [EnumValue("client")]
-    Client = 2
+    Client
 }

--- a/src/ModularPipelines.Kubernetes/Enums/KubernetesWaitOutput.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Enums/KubernetesWaitOutput.Generated.cs
@@ -17,35 +17,35 @@ namespace ModularPipelines.Kubernetes.Enums;
 public enum KubernetesWaitOutput
 {
     [EnumValue("json")]
-    Json = 0,
+    Json,
 
     [EnumValue("yaml")]
-    Yaml = 1,
+    Yaml,
 
     [EnumValue("kyaml")]
-    Kyaml = 2,
+    Kyaml,
 
     [EnumValue("name")]
-    Name = 3,
+    Name,
 
     [EnumValue("go-template")]
-    GoTemplate = 4,
+    GoTemplate,
 
     [EnumValue("go-template-file")]
-    GoTemplateFile = 5,
+    GoTemplateFile,
 
     [EnumValue("template")]
-    Template = 6,
+    Template,
 
     [EnumValue("templatefile")]
-    Templatefile = 7,
+    Templatefile,
 
     [EnumValue("jsonpath")]
-    Jsonpath = 8,
+    Jsonpath,
 
     [EnumValue("jsonpath-as-json")]
-    JsonpathAsJson = 9,
+    JsonpathAsJson,
 
     [EnumValue("jsonpath-file")]
-    JsonpathFile = 10
+    JsonpathFile
 }

--- a/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KubernetesExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Kubernetes.Services;
 
 namespace ModularPipelines.Kubernetes.Extensions;
@@ -32,11 +31,12 @@ public static class KubernetesExtensions
         services.TryAddScoped<IKubernetesApply, KubernetesApply>();
         services.TryAddScoped<IKubernetesAuth, KubernetesAuth>();
         services.TryAddScoped<IKubernetesCertificate, KubernetesCertificate>();
-        services.TryAddScoped<IKubernetesClusterinfo, KubernetesClusterinfo>();
+        services.TryAddScoped<IKubernetesClusterInfo, KubernetesClusterInfo>();
         services.TryAddScoped<IKubernetesConfig, KubernetesConfig>();
         services.TryAddScoped<IKubernetesKuberc, KubernetesKuberc>();
         services.TryAddScoped<IKubernetesRollout, KubernetesRollout>();
         services.TryAddScoped<IKubernetesTop, KubernetesTop>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesAnnotateOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesAnnotateOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesAnnotateOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough)] IEnumerable<string> Annotations
 ) : KubernetesOptions
 {
-    public KubernetesAnnotateOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Select all resources in the namespace of the specified resource types
     /// </summary>
@@ -50,7 +45,7 @@ public record KubernetesAnnotateOptions(
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesAnnotateDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesApplyOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesApplyOptions.Generated.cs
@@ -37,13 +37,13 @@ public record KubernetesApplyOptions : KubernetesOptions
     /// Must be "background", "orphan", or "foreground". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to background.
     /// </summary>
     [CliOption("--cascade", Format = OptionFormat.EqualsSeparated)]
-    public string? Cascade { get; set; }
+    public KubernetesApplyCascade? Cascade { get; set; }
 
     /// <summary>
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesApplyDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.
@@ -156,8 +156,8 @@ public record KubernetesApplyOptions : KubernetesOptions
     /// <summary>
     /// Must be one of: strict (or true), warn, ignore (or false). "true" or "strict" will use a schema to validate the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation is enabled on the api-server, but will fall back to less reliable client-side validation if not. "warn" will warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled on the API server, and behave as "ignore" otherwise. "false" or "ignore" will not perform any schema validation, silently dropping any unknown or duplicate fields.
     /// </summary>
-    [CliOption("--validate")]
-    public string? Validate { get; set; }
+    [CliFlag("--validate")]
+    public bool? Validate { get; set; }
 
     /// <summary>
     /// If true, wait for resources to be gone before returning. This waits for finalizers.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesApplyOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesApplyOptions.Generated.cs
@@ -156,8 +156,8 @@ public record KubernetesApplyOptions : KubernetesOptions
     /// <summary>
     /// Must be one of: strict (or true), warn, ignore (or false). "true" or "strict" will use a schema to validate the input and fail the request if invalid. It will perform server side validation if ServerSideFieldValidation is enabled on the api-server, but will fall back to less reliable client-side validation if not. "warn" will warn about unknown or duplicate fields without blocking the request if server-side field validation is enabled on the API server, and behave as "ignore" otherwise. "false" or "ignore" will not perform any schema validation, silently dropping any unknown or duplicate fields.
     /// </summary>
-    [CliFlag("--validate")]
-    public bool? Validate { get; set; }
+    [CliOption("--validate", Format = OptionFormat.EqualsSeparated)]
+    public string? Validate { get; set; }
 
     /// <summary>
     /// If true, wait for resources to be gone before returning. This waits for finalizers.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesApplySetLastAppliedOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesApplySetLastAppliedOptions.Generated.cs
@@ -37,7 +37,7 @@ public record KubernetesApplySetLastAppliedOptions : KubernetesOptions
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesApplySetLastAppliedDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Filename, directory, or URL to files that contains the last-applied-configuration annotations

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesAttachOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesAttachOptions.Generated.cs
@@ -22,11 +22,6 @@ public record KubernetesAttachOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Pod
 ) : KubernetesOptions
 {
-    public KubernetesAttachOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesAuthCanIOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesAuthCanIOptions.Generated.cs
@@ -22,11 +22,6 @@ public record KubernetesAuthCanIOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Verb
 ) : KubernetesOptions
 {
-    public KubernetesAuthCanIOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true, check the specified action in all namespaces.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesAuthReconcileOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesAuthReconcileOptions.Generated.cs
@@ -31,7 +31,7 @@ public record KubernetesAuthReconcileOptions : KubernetesOptions
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesAuthReconcileDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Filename, directory, or URL to files identifying the resource to reconcile.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesAutoscaleOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesAutoscaleOptions.Generated.cs
@@ -37,7 +37,7 @@ public record KubernetesAutoscaleOptions : KubernetesOptions
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesAutoscaleDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesConfigSetClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesConfigSetClusterOptions.Generated.cs
@@ -22,11 +22,6 @@ public record KubernetesConfigSetClusterOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Name
 ) : KubernetesOptions
 {
-    public KubernetesConfigSetClusterOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Path to certificate-authority file for the cluster entry in kubeconfig
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesConfigSetCredentialsOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesConfigSetCredentialsOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesConfigSetCredentialsOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Name
 ) : KubernetesOptions
 {
-    public KubernetesConfigSetCredentialsOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Auth provider for the user entry in kubeconfig
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesConfigSetOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesConfigSetOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesConfigSetOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string PropertyValue
 ) : KubernetesOptions
 {
-    public KubernetesConfigSetOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// When writing a []byte PROPERTY_VALUE, write the given string directly without base64 decoding.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesCordonOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesCordonOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Kubernetes.Options;
+using ModularPipelines.Kubernetes.Enums;
 
 namespace ModularPipelines.Kubernetes.Options;
 
@@ -22,16 +23,11 @@ public record KubernetesCordonOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Node
 ) : KubernetesOptions
 {
-    public KubernetesCordonOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesCordonDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Selector (label query) to filter on, supports '=', '==', '!=', 'in', 'notin'.(e.g. -l key1=value1,key2=value2,key3 in (value3)). Matching objects must satisfy all of the specified label constraints.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesCpOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesCpOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesCpOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string FileSpecDest
 ) : KubernetesOptions
 {
-    public KubernetesCpOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesDebugOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesDebugOptions.Generated.cs
@@ -19,15 +19,10 @@ namespace ModularPipelines.Kubernetes.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("debug")]
 public record KubernetesDebugOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Pod,
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Pod,
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true)] string CommandArgs
 ) : KubernetesOptions
 {
-    public KubernetesDebugOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// If specified, everything after -- will be passed to the new container as Args instead of Command.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesDrainOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesDrainOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Kubernetes.Options;
+using ModularPipelines.Kubernetes.Enums;
 
 namespace ModularPipelines.Kubernetes.Options;
 
@@ -22,11 +23,6 @@ public record KubernetesDrainOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Node
 ) : KubernetesOptions
 {
-    public KubernetesDrainOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Return large lists in chunks rather than all at once. Pass 0 to disable.
     /// </summary>
@@ -49,7 +45,7 @@ public record KubernetesDrainOptions(
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesDrainDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Continue even if there are pods that do not declare a controller.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesEventsOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesEventsOptions.Generated.cs
@@ -81,7 +81,4 @@ public record KubernetesEventsOptions : KubernetesOptions
     [CliFlag("--watch", ShortForm = "-w")]
     public bool? Watch { get; set; }
 
-    [Obsolete("O is no longer supported by the installed CLI and has no effect.")]
-    public string? O { get; set; }
-
 }

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesExecOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesExecOptions.Generated.cs
@@ -19,15 +19,10 @@ namespace ModularPipelines.Kubernetes.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("exec")]
 public record KubernetesExecOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Pod,
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Pod,
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, Required = true)] string Command
 ) : KubernetesOptions
 {
-    public KubernetesExecOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesLabelOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesLabelOptions.Generated.cs
@@ -20,15 +20,10 @@ namespace ModularPipelines.Kubernetes.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("label")]
 public record KubernetesLabelOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Key_1Val_1,
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough)] IEnumerable<string> Key_1Val_1,
     [property: CliArgument(1, Phase = CommandLinePhase.Passthrough)] string KeyNValN
 ) : KubernetesOptions
 {
-    public KubernetesLabelOptions()
-        : this(default(IEnumerable<string>)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Select all resources, in the namespace of the specified resource types
     /// </summary>
@@ -51,7 +46,7 @@ public record KubernetesLabelOptions(
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesLabelDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesLogsOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesLogsOptions.Generated.cs
@@ -22,11 +22,6 @@ public record KubernetesLogsOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough)] string Pod
 ) : KubernetesOptions
 {
-    public KubernetesLogsOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Get all containers' logs in the pod(s).
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesPatchOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesPatchOptions.Generated.cs
@@ -31,7 +31,7 @@ public record KubernetesPatchOptions : KubernetesOptions
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesPatchDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesPortForwardOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesPortForwardOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesPortForwardOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> LocalPortRemotePort
 ) : KubernetesOptions
 {
-    public KubernetesPortForwardOptions()
-        : this(default(string)!, default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesReplaceOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesReplaceOptions.Generated.cs
@@ -31,13 +31,13 @@ public record KubernetesReplaceOptions : KubernetesOptions
     /// Must be "background", "orphan", or "foreground". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to background.
     /// </summary>
     [CliOption("--cascade", Format = OptionFormat.EqualsSeparated)]
-    public string? Cascade { get; set; }
+    public KubernetesReplaceCascade? Cascade { get; set; }
 
     /// <summary>
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesReplaceDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutHistoryOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutHistoryOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesRolloutHistoryOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string TypeName
 ) : KubernetesOptions
 {
-    public KubernetesRolloutHistoryOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutPauseOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutPauseOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesRolloutPauseOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Resource
 ) : KubernetesOptions
 {
-    public KubernetesRolloutPauseOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutRestartOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutRestartOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesRolloutRestartOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Resource
 ) : KubernetesOptions
 {
-    public KubernetesRolloutRestartOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutResumeOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutResumeOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesRolloutResumeOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Resource
 ) : KubernetesOptions
 {
-    public KubernetesRolloutResumeOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutStatusOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutStatusOptions.Generated.cs
@@ -22,11 +22,6 @@ public record KubernetesRolloutStatusOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string TypeName
 ) : KubernetesOptions
 {
-    public KubernetesRolloutStatusOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Filename, directory, or URL to files identifying the resource to get from a server.
     /// </summary>

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutUndoOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesRolloutUndoOptions.Generated.cs
@@ -23,11 +23,6 @@ public record KubernetesRolloutUndoOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string TypeName
 ) : KubernetesOptions
 {
-    public KubernetesRolloutUndoOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     /// </summary>
@@ -38,7 +33,7 @@ public record KubernetesRolloutUndoOptions(
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesRolloutUndoDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Filename, directory, or URL to files identifying the resource to get from a server.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesScaleOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesScaleOptions.Generated.cs
@@ -43,7 +43,7 @@ public record KubernetesScaleOptions : KubernetesOptions
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesScaleDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Filename, directory, or URL to files identifying the resource to set a new size

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesTaintOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesTaintOptions.Generated.cs
@@ -25,11 +25,6 @@ public record KubernetesTaintOptions(
     [property: CliArgument(2, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> Taints
 ) : KubernetesOptions
 {
-    public KubernetesTaintOptions()
-        : this(default(string)!, default(string)!, default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Select all nodes in the cluster
     /// </summary>
@@ -46,7 +41,7 @@ public record KubernetesTaintOptions(
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesTaintDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Name of the manager used to track field ownership.

--- a/src/ModularPipelines.Kubernetes/Options/KubernetesUncordonOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesUncordonOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Kubernetes.Options;
+using ModularPipelines.Kubernetes.Enums;
 
 namespace ModularPipelines.Kubernetes.Options;
 
@@ -22,16 +23,11 @@ public record KubernetesUncordonOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand)] string Node
 ) : KubernetesOptions
 {
-    public KubernetesUncordonOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.
     /// </summary>
     [CliOption("--dry-run", Format = OptionFormat.EqualsSeparated)]
-    public string? DryRun { get; set; }
+    public KubernetesUncordonDryRun? DryRun { get; set; }
 
     /// <summary>
     /// Selector (label query) to filter on, supports '=', '==', '!=', 'in', 'notin'.(e.g. -l key1=value1,key2=value2,key3 in (value3)). Matching objects must satisfy all of the specified label constraints.

--- a/src/ModularPipelines.Kubernetes/Services/IKubernetes.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKubernetes.Generated.cs
@@ -38,7 +38,7 @@ public partial interface IKubernetes
     /// <summary>
     /// Gets the clusterinfo sub-domain service.
     /// </summary>
-    IKubernetesClusterinfo Clusterinfo => throw new System.NotSupportedException();
+    IKubernetesClusterInfo ClusterInfo => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the config sub-domain service.
@@ -71,7 +71,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AnnotateAsync(KubernetesAnnotateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AnnotateAsync(KubernetesAnnotateOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -81,7 +81,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AttachAsync(KubernetesAttachOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AttachAsync(KubernetesAttachOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -101,7 +101,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CordonAsync(KubernetesCordonOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CordonAsync(KubernetesCordonOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -111,7 +111,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CpAsync(KubernetesCpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CpAsync(KubernetesCpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -121,7 +121,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DebugAsync(KubernetesDebugOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DebugAsync(KubernetesDebugOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -151,7 +151,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DrainAsync(KubernetesDrainOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DrainAsync(KubernetesDrainOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -171,7 +171,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ExecAsync(KubernetesExecOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecAsync(KubernetesExecOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -181,7 +181,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> LabelAsync(KubernetesLabelOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> LabelAsync(KubernetesLabelOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -191,7 +191,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> LogsAsync(KubernetesLogsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> LogsAsync(KubernetesLogsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -211,7 +211,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PortForwardAsync(KubernetesPortForwardOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PortForwardAsync(KubernetesPortForwardOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -251,7 +251,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TaintAsync(KubernetesTaintOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TaintAsync(KubernetesTaintOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -261,7 +261,7 @@ public partial interface IKubernetes
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> UncordonAsync(KubernetesUncordonOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UncordonAsync(KubernetesUncordonOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Kubernetes/Services/IKubernetesAuth.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKubernetesAuth.Generated.cs
@@ -38,7 +38,7 @@ public interface IKubernetesAuth
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CanIAsync(KubernetesAuthCanIOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CanIAsync(KubernetesAuthCanIOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Kubernetes/Services/IKubernetesClusterinfo.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKubernetesClusterinfo.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Kubernetes.Services;
 /// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
 /// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public interface IKubernetesClusterinfo
+public interface IKubernetesClusterInfo
 {
     /// <summary>
     /// Display addresses of the control plane and services with label kubernetes.io/cluster-service=true. To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

--- a/src/ModularPipelines.Kubernetes/Services/IKubernetesConfig.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKubernetesConfig.Generated.cs
@@ -88,7 +88,7 @@ public interface IKubernetesConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SetClusterAsync(KubernetesConfigSetClusterOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetClusterAsync(KubernetesConfigSetClusterOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -108,7 +108,7 @@ public interface IKubernetesConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SetCredentialsAsync(KubernetesConfigSetCredentialsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetCredentialsAsync(KubernetesConfigSetCredentialsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -118,7 +118,7 @@ public interface IKubernetesConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SetAsync(KubernetesConfigSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetAsync(KubernetesConfigSetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Kubernetes/Services/IKubernetesRollout.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKubernetesRollout.Generated.cs
@@ -38,7 +38,7 @@ public interface IKubernetesRollout
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> HistoryAsync(KubernetesRolloutHistoryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> HistoryAsync(KubernetesRolloutHistoryOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -48,7 +48,7 @@ public interface IKubernetesRollout
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PauseAsync(KubernetesRolloutPauseOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PauseAsync(KubernetesRolloutPauseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface IKubernetesRollout
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> RestartAsync(KubernetesRolloutRestartOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RestartAsync(KubernetesRolloutRestartOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IKubernetesRollout
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ResumeAsync(KubernetesRolloutResumeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ResumeAsync(KubernetesRolloutResumeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -78,7 +78,7 @@ public interface IKubernetesRollout
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> StatusAsync(KubernetesRolloutStatusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StatusAsync(KubernetesRolloutStatusOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -88,7 +88,7 @@ public interface IKubernetesRollout
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> UndoAsync(KubernetesRolloutUndoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UndoAsync(KubernetesRolloutUndoOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kubernetes/Services/Kubernetes.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/Kubernetes.Generated.cs
@@ -29,7 +29,7 @@ internal partial class Kubernetes : IKubernetes
         IKubernetesApply apply,
         IKubernetesAuth auth,
         IKubernetesCertificate certificate,
-        IKubernetesClusterinfo clusterinfo,
+        IKubernetesClusterInfo clusterInfo,
         IKubernetesConfig config,
         IKubernetesKuberc kuberc,
         IKubernetesRollout rollout,
@@ -40,7 +40,7 @@ internal partial class Kubernetes : IKubernetes
         Apply = apply;
         Auth = auth;
         Certificate = certificate;
-        Clusterinfo = clusterinfo;
+        ClusterInfo = clusterInfo;
         Config = config;
         Kuberc = kuberc;
         Rollout = rollout;
@@ -60,7 +60,7 @@ internal partial class Kubernetes : IKubernetes
     public IKubernetesCertificate Certificate { get; }
 
     /// <inheritdoc />
-    public IKubernetesClusterinfo Clusterinfo { get; }
+    public IKubernetesClusterInfo ClusterInfo { get; }
 
     /// <inheritdoc />
     public IKubernetesConfig Config { get; }
@@ -80,20 +80,20 @@ internal partial class Kubernetes : IKubernetes
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AnnotateAsync(
-        KubernetesAnnotateOptions? options = null,
+        KubernetesAnnotateOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesAnnotateOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AttachAsync(
-        KubernetesAttachOptions? options = null,
+        KubernetesAttachOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesAttachOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -107,29 +107,29 @@ internal partial class Kubernetes : IKubernetes
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> CordonAsync(
-        KubernetesCordonOptions? options = null,
+        KubernetesCordonOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesCordonOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> CpAsync(
-        KubernetesCpOptions? options = null,
+        KubernetesCpOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesCpOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> DebugAsync(
-        KubernetesDebugOptions? options = null,
+        KubernetesDebugOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesDebugOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -152,11 +152,11 @@ internal partial class Kubernetes : IKubernetes
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> DrainAsync(
-        KubernetesDrainOptions? options = null,
+        KubernetesDrainOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesDrainOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -170,29 +170,29 @@ internal partial class Kubernetes : IKubernetes
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ExecAsync(
-        KubernetesExecOptions? options = null,
+        KubernetesExecOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesExecOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> LabelAsync(
-        KubernetesLabelOptions? options = null,
+        KubernetesLabelOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesLabelOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> LogsAsync(
-        KubernetesLogsOptions? options = null,
+        KubernetesLogsOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesLogsOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -206,11 +206,11 @@ internal partial class Kubernetes : IKubernetes
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PortForwardAsync(
-        KubernetesPortForwardOptions? options = null,
+        KubernetesPortForwardOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesPortForwardOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -242,20 +242,20 @@ internal partial class Kubernetes : IKubernetes
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TaintAsync(
-        KubernetesTaintOptions? options = null,
+        KubernetesTaintOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesTaintOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> UncordonAsync(
-        KubernetesUncordonOptions? options = null,
+        KubernetesUncordonOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesUncordonOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.Kubernetes/Services/KubernetesAuth.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/KubernetesAuth.Generated.cs
@@ -55,11 +55,11 @@ public class KubernetesAuth : IKubernetesAuth
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CanIAsync(
-        KubernetesAuthCanIOptions? options = null,
+        KubernetesAuthCanIOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesAuthCanIOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Kubernetes/Services/KubernetesClusterinfo.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/KubernetesClusterinfo.Generated.cs
@@ -18,14 +18,14 @@ namespace ModularPipelines.Kubernetes.Services;
 /// kubectl clusterinfo commands.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public class KubernetesClusterinfo : IKubernetesClusterinfo
+public class KubernetesClusterInfo : IKubernetesClusterInfo
 {
     private readonly ICommandContext _command;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="KubernetesClusterinfo"/> class.
+    /// Initializes a new instance of the <see cref="KubernetesClusterInfo"/> class.
     /// </summary>
-    public KubernetesClusterinfo(ICommandContext command)
+    public KubernetesClusterInfo(ICommandContext command)
     {
         _command = command;
     }

--- a/src/ModularPipelines.Kubernetes/Services/KubernetesConfig.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/KubernetesConfig.Generated.cs
@@ -130,11 +130,11 @@ public class KubernetesConfig : IKubernetesConfig
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SetClusterAsync(
-        KubernetesConfigSetClusterOptions? options = null,
+        KubernetesConfigSetClusterOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesConfigSetClusterOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -160,11 +160,11 @@ public class KubernetesConfig : IKubernetesConfig
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SetCredentialsAsync(
-        KubernetesConfigSetCredentialsOptions? options = null,
+        KubernetesConfigSetCredentialsOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesConfigSetCredentialsOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -175,11 +175,11 @@ public class KubernetesConfig : IKubernetesConfig
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SetAsync(
-        KubernetesConfigSetOptions? options = null,
+        KubernetesConfigSetOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesConfigSetOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Kubernetes/Services/KubernetesRollout.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/KubernetesRollout.Generated.cs
@@ -55,11 +55,11 @@ public class KubernetesRollout : IKubernetesRollout
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> HistoryAsync(
-        KubernetesRolloutHistoryOptions? options = null,
+        KubernetesRolloutHistoryOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesRolloutHistoryOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -70,11 +70,11 @@ public class KubernetesRollout : IKubernetesRollout
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> PauseAsync(
-        KubernetesRolloutPauseOptions? options = null,
+        KubernetesRolloutPauseOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesRolloutPauseOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class KubernetesRollout : IKubernetesRollout
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> RestartAsync(
-        KubernetesRolloutRestartOptions? options = null,
+        KubernetesRolloutRestartOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesRolloutRestartOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public class KubernetesRollout : IKubernetesRollout
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ResumeAsync(
-        KubernetesRolloutResumeOptions? options = null,
+        KubernetesRolloutResumeOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesRolloutResumeOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -115,11 +115,11 @@ public class KubernetesRollout : IKubernetesRollout
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> StatusAsync(
-        KubernetesRolloutStatusOptions? options = null,
+        KubernetesRolloutStatusOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesRolloutStatusOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -130,11 +130,11 @@ public class KubernetesRollout : IKubernetesRollout
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> UndoAsync(
-        KubernetesRolloutUndoOptions? options = null,
+        KubernetesRolloutUndoOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesRolloutUndoOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
+++ b/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
@@ -12,7 +12,7 @@ public class KubernetesCommandRenderingTests : TestBase
     [Test]
     public async Task Auth_CanI_List_Does_Not_Require_A_Verb()
     {
-        var result = await GetResult(new KubernetesAuthCanIOptions { List = true });
+        var result = await GetResult(new KubernetesAuthCanIOptions(null!) { List = true });
 
         await Assert.That(result.CommandInput).IsEqualTo("kubectl auth can-i --list");
     }
@@ -20,9 +20,8 @@ public class KubernetesCommandRenderingTests : TestBase
     [Test]
     public async Task Debug_Does_Not_Require_A_Command()
     {
-        var result = await GetResult(new KubernetesDebugOptions
+        var result = await GetResult(new KubernetesDebugOptions("example-pod", null!)
         {
-            Pod = "example-pod",
             Image = "busybox",
         });
 
@@ -43,12 +42,36 @@ public class KubernetesCommandRenderingTests : TestBase
     }
 
     [Test]
+    public async Task Debug_Filename_Does_Not_Require_A_Pod()
+    {
+        var result = await GetResult(new KubernetesDebugOptions(null!, null!)
+        {
+            Filename = ["pod.yaml"],
+            Image = "busybox",
+        });
+
+        await Assert.That(result.CommandInput)
+            .IsEqualTo("kubectl debug --filename=pod.yaml --image=busybox");
+    }
+
+    [Test]
+    public async Task Exec_Filename_Does_Not_Require_A_Pod()
+    {
+        var result = await GetResult(new KubernetesExecOptions(null!, "env")
+        {
+            Filename = ["pod.yaml"],
+        });
+
+        await Assert.That(result.CommandInput)
+            .IsEqualTo("kubectl exec --filename=pod.yaml -- env");
+    }
+
+    [Test]
     public async Task Label_File_With_One_Label_Does_Not_Require_Another_Label()
     {
-        var result = await GetResult(new KubernetesLabelOptions
+        var result = await GetResult(new KubernetesLabelOptions(["environment=test"], null!)
         {
             Filename = ["deployment.yaml"],
-            Key_1Val_1 = ["environment=test"],
         });
 
         await Assert.That(result.CommandInput)
@@ -56,13 +79,27 @@ public class KubernetesCommandRenderingTests : TestBase
     }
 
     [Test]
+    public async Task Label_List_Does_Not_Require_Labels()
+    {
+        var result = await GetResult(new KubernetesLabelOptions(null!, null!)
+        {
+            Filename = ["deployment.yaml"],
+            List = true,
+        });
+
+        await Assert.That(result.CommandInput)
+            .IsEqualTo("kubectl label --filename=deployment.yaml --list");
+    }
+
+    [Test]
     public async Task Taint_All_Nodes_Does_Not_Require_A_Name()
     {
-        var result = await GetResult(new KubernetesTaintOptions
+        var result = await GetResult(new KubernetesTaintOptions(
+            "nodes",
+            null!,
+            ["example=value:NoSchedule"])
         {
-            Node = "nodes",
             All = true,
-            Taints = ["example=value:NoSchedule"],
         });
 
         await Assert.That(result.CommandInput)

--- a/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
+++ b/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
@@ -10,6 +10,18 @@ namespace ModularPipelines.Kubernetes.UnitTests;
 public class KubernetesCommandRenderingTests : TestBase
 {
     [Test]
+    public async Task Apply_Validate_Renders_Selected_Mode()
+    {
+        var result = await GetResult(new KubernetesApplyOptions
+        {
+            Validate = "warn",
+        });
+
+        await Assert.That(result.CommandInput)
+            .IsEqualTo("kubectl apply --validate=warn");
+    }
+
+    [Test]
     public async Task Auth_CanI_List_Does_Not_Require_A_Verb()
     {
         var result = await GetResult(new KubernetesAuthCanIOptions(null!) { List = true });

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
@@ -205,7 +205,31 @@ public class KubectlCliScraperTests
     }
 
     [Test]
-    public async Task Label_Uses_One_Required_Variadic_Labels_Operand()
+    [Arguments("debug", "(POD | TYPE[[.VERSION].GROUP]/NAME)")]
+    [Arguments("exec", "POD -- COMMAND [args...]")]
+    public async Task Target_Commands_Allow_Filename_Without_Pod(
+        string commandName,
+        string usageOperand)
+    {
+        var helpText = $"""
+            Usage:
+              kubectl {commandName} {usageOperand} [options]
+
+            Options:
+              -f, --filename stringArray   File identifying the target resource.
+            """;
+
+        var command = await new TestKubectlCliScraper().Parse(
+            ["kubectl", commandName],
+            helpText);
+
+        var pod = command!.PositionalArguments.Single(argument => argument.PropertyName == "Pod");
+        await Assert.That(pod.IsRequired).IsTrue();
+        await Assert.That(pod.IsValidationRequired).IsFalse();
+    }
+
+    [Test]
+    public async Task Label_Allows_List_Without_Labels()
     {
         const string helpText = """
             Usage:
@@ -224,12 +248,13 @@ public class KubectlCliScraperTests
         using (Assert.Multiple())
         {
             await Assert.That(labels.IsRequired).IsTrue();
+            await Assert.That(labels.IsValidationRequired).IsFalse();
             await Assert.That(labels.IsVariadic).IsTrue();
             await Assert.That(labels.CSharpType).IsEqualTo("IEnumerable<string>");
             await Assert.That(trailingLabel.IsValidationRequired).IsFalse();
             await Assert.That(command.PositionalArguments.Count(argument =>
                 argument.IsValidationRequired ?? argument.IsRequired))
-                .IsEqualTo(1);
+                .IsEqualTo(0);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
@@ -142,6 +142,34 @@ public class OptionTypeEnhancerTests
     }
 
     [Test]
+    public async Task Kubectl_Apply_Validate_Override_Preserves_Value()
+    {
+        var detector = new ManualOverrideDetector(
+            NullLogger<ManualOverrideDetector>.Instance,
+            Path.Combine(AppContext.BaseDirectory, "TypeOverrides"));
+        var pipeline = new OptionTypeDetectorPipeline(
+            [detector],
+            NullLogger<OptionTypeDetectorPipeline>.Instance);
+        var enhancer = new OptionTypeEnhancer(pipeline, NullLogger<OptionTypeEnhancer>.Instance);
+        var tool = CreateTool(new CliOptionDefinition
+        {
+            SwitchName = "--validate",
+            PropertyName = "Validate",
+            CSharpType = "bool?",
+            IsFlag = true,
+        }, toolName: "kubectl", commandName: "apply");
+
+        var enhanced = await enhancer.EnhanceManualOverridesAsync(tool);
+        var option = enhanced.Commands.Single().Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.CSharpType).IsEqualTo("string?");
+            await Assert.That(option.IsFlag).IsFalse();
+        }
+    }
+
+    [Test]
     [Arguments("--identity-token", "IdentityToken", "Token or path to a file containing the token.")]
     [Arguments("--oidc-client-secret-file", "OidcClientSecretFile", "Path to the OIDC client secret file.")]
     public async Task Cosign_Override_Preserves_Path_Capable_Secrets(
@@ -246,7 +274,8 @@ public class OptionTypeEnhancerTests
 
     private static CliToolDefinition CreateTool(
         CliOptionDefinition option,
-        string toolName = "docker")
+        string toolName = "docker",
+        string commandName = "build")
     {
         return new CliToolDefinition
         {
@@ -258,8 +287,8 @@ public class OptionTypeEnhancerTests
             [
                 new CliCommandDefinition
                 {
-                    FullCommand = "docker build",
-                    CommandParts = ["build"],
+                    FullCommand = $"{toolName} {commandName}",
+                    CommandParts = [commandName],
                     ClassName = "DockerBuildOptions",
                     ParentClassName = "DockerOptions",
                     ToolNamespacePrefix = "Docker",

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
@@ -69,8 +69,11 @@ public class KubectlCliScraper : CobraCliScraper
                 "Annotations"),
             ["auth", "can-i"] => AllowOmittedValue(positionalArguments, "Verb"),
             ["cordon" or "drain" or "uncordon"] => AllowOmittedValue(positionalArguments, "Node"),
-            ["debug"] => NormalizeDebugArguments(positionalArguments),
+            ["debug"] => AllowOmittedValue(
+                NormalizeDebugArguments(positionalArguments),
+                "Pod"),
             ["events"] => RemoveArgument(positionalArguments, "O"),
+            ["exec"] => AllowOmittedValue(positionalArguments, "Pod"),
             ["label"] => NormalizeLabelArguments(positionalArguments),
             ["logs"] => AllowOmittedValue(positionalArguments, "Pod"),
             ["port-forward"] => CollapseNumberedRepeat(
@@ -124,6 +127,7 @@ public class KubectlCliScraper : CobraCliScraper
                     CSharpType = "IEnumerable<string>",
                     IsRequired = true,
                     IsVariadic = true,
+                    IsValidationRequired = false,
                 },
                 "KeyNValN" => argument with
                 {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/kubectl.json
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/kubectl.json
@@ -49,8 +49,8 @@
         "reason": "Use server-side apply"
       },
       "--validate": {
-        "type": "bool",
-        "reason": "Validate input before sending"
+        "type": "string",
+        "reason": "Accepts 'strict', 'warn', 'ignore', 'true', or 'false'"
       },
       "--wait": {
         "type": "bool",


### PR DESCRIPTION
## Summary
- disable render-time validation for Kubectl label assignments and debug/exec pod operands when documented flags replace them
- add scraper and command-rendering regressions for `--list` and `--filename`
- regenerate Kubectl v1.37.0 output, including pending v4 generator drift already present on main

## Validation
- `ModularPipelines.OptionsGenerator.slnx` Release build
- `ModularPipelines.Kubernetes.slnx` Release build
- 23 `KubectlCliScraperTests` passed
- 8 `KubernetesCommandRenderingTests` passed
- changed-file whitespace verification passed
- `git diff --check` passed

Broad OptionsGenerator format verification remains red on unrelated pre-existing `IHelpTextCache.cs` whitespace and Azure scraper IDE0011 findings.

Closes #4325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes `debug` and `exec` commands now support targeting by filename without requiring a pod name.
  * Kubernetes label listing no longer requires label values or positional arguments.
* **Tests**
  * Added coverage for filename-based targeting and label commands with omitted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->