### PR TITLE
Model terminated pass-through before operands

### DIFF
--- a/src/ModularPipelines.GitHub/Options/GhCodespaceCpOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhCodespaceCpOptions.Generated.cs
@@ -19,8 +19,8 @@ namespace ModularPipelines.GitHub.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("codespace", "cp")]
 public record GhCodespaceCpOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Sources,
-    [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Dest
+    [property: CliArgument(0, Phase = CommandLinePhase.LateOperand, Required = true)] IEnumerable<string> Sources,
+    [property: CliArgument(1, Phase = CommandLinePhase.LateOperand, Required = true)] string Dest
 ) : GhOptions
 {
     /// <summary>
@@ -64,5 +64,11 @@ public record GhCodespaceCpOptions(
     /// </summary>
     [CliFlag("--help")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// The &lt;scp flags&gt; operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true)]
+    public IEnumerable<string>? ScpFlags { get; set; }
 
 }

--- a/src/ModularPipelines.GitHub/Options/GhCodespaceSshOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhCodespaceSshOptions.Generated.cs
@@ -89,7 +89,7 @@ public record GhCodespaceSshOptions : GhOptions
     /// <summary>
     /// The &lt;command&gt; operand.
     /// </summary>
-    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    [CliArgument(0, Phase = CommandLinePhase.LateOperand)]
     public string? Command { get; set; }
 
 }

--- a/src/ModularPipelines.GitHub/Options/GhSecretDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSecretDeleteOptions.Generated.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;

--- a/src/ModularPipelines/Attributes/CommandLinePhase.cs
+++ b/src/ModularPipelines/Attributes/CommandLinePhase.cs
@@ -26,4 +26,22 @@ public enum CommandLinePhase
     /// Positional or pass-through values rendered after option parsing and before terminal options.
     /// </summary>
     Passthrough = 3,
+
+    /// <summary>
+    /// A positional operand rendered after pass-through values and before terminal options.
+    /// </summary>
+    LateOperand = 5,
+}
+
+internal static class CommandLinePhaseOrder
+{
+    internal static int GetRenderOrder(CommandLinePhase phase) => phase switch
+    {
+        CommandLinePhase.EarlyOperand => 0,
+        CommandLinePhase.Normal => 1,
+        CommandLinePhase.Passthrough => 3,
+        CommandLinePhase.LateOperand => 4,
+        CommandLinePhase.Terminal => 5,
+        _ => throw new ArgumentOutOfRangeException(nameof(phase), phase, null),
+    };
 }

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -166,6 +166,7 @@ internal sealed class CommandLineBuilder(
             extractedManualOptions,
             globalOptionTerminatorIndex,
             commandOptionTerminatorIndex,
+            commandLateOperandIndex,
             hasRenderedCommandOptions);
         InsertManualArgumentsBeforeLateOperands(
             propertyArgs,
@@ -415,6 +416,7 @@ internal sealed class CommandLineBuilder(
         ExtractedManualOptions extractedManualOptions,
         int? globalOptionTerminatorIndex,
         int? commandOptionTerminatorIndex,
+        int? commandLateOperandIndex,
         bool hasRenderedCommandOptions)
     {
         globalArgs.InsertRange(
@@ -428,7 +430,9 @@ internal sealed class CommandLineBuilder(
         }
         else
         {
-            propertyArgs.AddRange(extractedManualOptions.Command);
+            propertyArgs.InsertRange(
+                commandLateOperandIndex ?? propertyArgs.Count,
+                extractedManualOptions.Command);
         }
     }
 

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -94,7 +94,8 @@ internal sealed class CommandLineBuilder(
             manualRequiredOperands: null,
             requiredOperandMatch.MaterializedValues,
             ref emittedOptionTerminator,
-            out var globalOptionTerminatorIndex);
+            out var globalOptionTerminatorIndex,
+            out _);
         var terminatorEmittedBeforeProperties = emittedOptionTerminator;
         var propertyArgs = BuildNonTerminalArguments(
             commandSpecificModel,
@@ -104,7 +105,8 @@ internal sealed class CommandLineBuilder(
             requiredOperandMatch.ManualValues,
             requiredOperandMatch.MaterializedValues,
             ref emittedOptionTerminator,
-            out var commandOptionTerminatorIndex);
+            out var commandOptionTerminatorIndex,
+            out var commandLateOperandIndex);
         ValidateManualOptionsAfterGlobalTerminator(
             options,
             manualArgs,
@@ -157,6 +159,7 @@ internal sealed class CommandLineBuilder(
             propertyArgs,
             commandSpecificModel,
             options);
+        var propertyArgumentCountBeforeManualOptions = propertyArgs.Count;
         InsertManualOptions(
             globalArgs,
             propertyArgs,
@@ -164,6 +167,12 @@ internal sealed class CommandLineBuilder(
             globalOptionTerminatorIndex,
             commandOptionTerminatorIndex,
             hasRenderedCommandOptions);
+        InsertManualArgumentsBeforeLateOperands(
+            propertyArgs,
+            manualArgs,
+            manualOptionTerminatorRemains,
+            commandLateOperandIndex,
+            propertyArgs.Count - propertyArgumentCountBeforeManualOptions);
 
         emittedOptionTerminator = pendingTerminatorState;
         var terminalOptionArgs = _commandArgumentBuilder.BuildArguments(
@@ -254,10 +263,12 @@ internal sealed class CommandLineBuilder(
         IReadOnlyDictionary<ArgumentPart, string>? manualRequiredOperands,
         IReadOnlyDictionary<ArgumentPart, IReadOnlyList<string>> materializedRequiredOperands,
         ref bool emittedOptionTerminator,
-        out int? emittedOptionTerminatorIndex)
+        out int? emittedOptionTerminatorIndex,
+        out int? lateOperandIndex)
     {
         var result = new List<string>();
         emittedOptionTerminatorIndex = null;
+        lateOperandIndex = null;
 
         foreach (var phase in Enum.GetValues<CommandLinePhase>()
                      .Where(static phase => phase != CommandLinePhase.Terminal))
@@ -267,9 +278,14 @@ internal sealed class CommandLineBuilder(
                     phase,
                     isGlobalOption)
                 .ToList();
-            result.AddRange(phaseAdditionalArguments);
-
             var phaseModel = commandModel.Where(part => part.Phase == phase).ToList();
+            if (phase == CommandLinePhase.LateOperand
+                && (phaseAdditionalArguments.Count > 0 || phaseModel.Count > 0))
+            {
+                lateOperandIndex = result.Count;
+            }
+
+            result.AddRange(phaseAdditionalArguments);
             var phaseArguments = _commandArgumentBuilder.BuildArguments(
                 phaseModel,
                 options,
@@ -287,6 +303,24 @@ internal sealed class CommandLineBuilder(
         }
 
         return result;
+    }
+
+    private static void InsertManualArgumentsBeforeLateOperands(
+        List<string> propertyArgs,
+        List<string> manualArgs,
+        bool manualOptionTerminatorRemains,
+        int? lateOperandIndex,
+        int insertedManualOptionCount)
+    {
+        if (!manualOptionTerminatorRemains
+            || lateOperandIndex is not { } insertionIndex
+            || manualArgs.Count == 0)
+        {
+            return;
+        }
+
+        propertyArgs.InsertRange(insertionIndex + insertedManualOptionCount, manualArgs);
+        manualArgs.Clear();
     }
 
     private static IEnumerable<string> GetAdditionalArguments(
@@ -478,13 +512,15 @@ internal sealed class CommandLineBuilder(
         }
 
         var matchedOperandCount = Math.Min(missingRequiredOperands.Count, operandIndices.Count);
+        var matchedRequiredOperands = missingRequiredOperands.Take(matchedOperandCount).ToList();
+        var matchedOperandIndices = SelectRequiredOperandIndices(matchedRequiredOperands, operandIndices);
         var result = new Dictionary<ArgumentPart, string>(matchedOperandCount);
         var indicesToRemove = new HashSet<int>();
         var consumedOptionTerminator = false;
         for (var index = 0; index < matchedOperandCount; index++)
         {
-            var operandIndex = operandIndices[index];
-            var requiredOperand = missingRequiredOperands[index];
+            var operandIndex = matchedOperandIndices[index];
+            var requiredOperand = matchedRequiredOperands[index];
             result.Add(requiredOperand, manualArgs[operandIndex]);
             indicesToRemove.Add(operandIndex);
             if (requiredOperand.Attribute.PrependOptionTerminator
@@ -502,6 +538,21 @@ internal sealed class CommandLineBuilder(
         }
 
         return new RequiredOperandMatch(result, materializedValues, consumedOptionTerminator);
+    }
+
+    private static IReadOnlyList<int> SelectRequiredOperandIndices(
+        IReadOnlyList<ArgumentPart> requiredOperands,
+        IReadOnlyList<int> candidateIndices)
+    {
+        var lateOperandOrder = CommandLinePhaseOrder.GetRenderOrder(CommandLinePhase.LateOperand);
+        var trailingOperandCount = requiredOperands.Count(part =>
+            CommandLinePhaseOrder.GetRenderOrder(part.Phase) >= lateOperandOrder);
+        var leadingOperandCount = requiredOperands.Count - trailingOperandCount;
+        return
+        [
+            .. candidateIndices.Take(leadingOperandCount),
+            .. candidateIndices.TakeLast(trailingOperandCount),
+        ];
     }
 
     private static ExtractedManualOptions ExtractRecognizedManualOptionsByScope(

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -439,7 +439,7 @@ internal sealed class CommandLineBuilder(
             .OfType<ArgumentPart>()
             .Where(part => !part.IsGlobalOption
                            && part.Attribute.Required)
-            .OrderBy(static part => part.Phase)
+            .OrderBy(static part => CommandLinePhaseOrder.GetRenderOrder(part.Phase))
             .ThenBy(static part => part.Attribute.Position)
             .ToList();
         var materializedValues = requiredOperands.ToDictionary(
@@ -538,7 +538,10 @@ internal sealed class CommandLineBuilder(
         var commandOptions = new List<string>();
         var remainingArguments = new List<string>();
         var hasTerminalOptions = false;
-        for (var index = 0; index < manualArgs.Count;)
+        var optionParsingCount = GetOptionParsingCount(
+            manualArgs,
+            options.ArgumentsContainOptionTerminator);
+        for (var index = 0; index < optionParsingCount;)
         {
             var match = TryMatchManualOption(
                 manualArgs,
@@ -575,6 +578,12 @@ internal sealed class CommandLineBuilder(
             index += match.Value.ArgumentCount;
         }
 
+        AppendOptionTerminatedArguments(
+            manualArgs,
+            optionParsingCount,
+            remainingArguments,
+            positionalArgumentIndices);
+
         if (globalOptions.Count == 0
             && commandOptions.Count == 0
             && !hasTerminalOptions)
@@ -588,6 +597,32 @@ internal sealed class CommandLineBuilder(
             globalOptions,
             commandOptions,
             hasTerminalOptions);
+    }
+
+    private static int GetOptionParsingCount(
+        List<string> manualArgs,
+        bool argumentsContainOptionTerminator)
+    {
+        if (!argumentsContainOptionTerminator)
+        {
+            return manualArgs.Count;
+        }
+
+        var optionTerminatorIndex = manualArgs.IndexOf("--");
+        return optionTerminatorIndex < 0 ? manualArgs.Count : optionTerminatorIndex;
+    }
+
+    private static void AppendOptionTerminatedArguments(
+        List<string> manualArgs,
+        int optionParsingCount,
+        List<string> remainingArguments,
+        ICollection<int>? positionalArgumentIndices)
+    {
+        remainingArguments.AddRange(manualArgs.Skip(optionParsingCount));
+        for (var index = optionParsingCount + 1; index < manualArgs.Count; index++)
+        {
+            positionalArgumentIndices?.Add(index);
+        }
     }
 
     private static ManualOptionMatch? TryMatchManualOption(

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -551,6 +551,11 @@ internal sealed class CommandLineBuilder(
                 flagsByName,
                 optionsByName,
                 options);
+            if (match is not null && index + match.Value.ArgumentCount > optionParsingCount)
+            {
+                match = null;
+            }
+
             if (match is null)
             {
                 remainingArguments.Add(manualArgs[index]);
@@ -625,10 +630,31 @@ internal sealed class CommandLineBuilder(
                 flagsByName,
                 optionsByName,
                 options);
-            index += match?.ArgumentCount ?? 1;
+            if (match is null)
+            {
+                index++;
+                continue;
+            }
+
+            if (GetConsumedTerminatorBoundary(manualArgs, index, match.Value) is { } boundary)
+            {
+                return boundary;
+            }
+
+            index += match.Value.ArgumentCount;
         }
 
         return manualArgs.Count;
+    }
+
+    private static int? GetConsumedTerminatorBoundary(
+        List<string> manualArgs,
+        int matchStart,
+        ManualOptionMatch match)
+    {
+        var boundary = manualArgs.IndexOf("--", matchStart, match.ArgumentCount);
+        var hasArgumentsAfterMatch = matchStart + match.ArgumentCount < manualArgs.Count;
+        return boundary >= 0 && hasArgumentsAfterMatch ? boundary : null;
     }
 
     private static void AppendOptionTerminatedArguments(

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -540,7 +540,9 @@ internal sealed class CommandLineBuilder(
         var hasTerminalOptions = false;
         var optionParsingCount = GetOptionParsingCount(
             manualArgs,
-            options.ArgumentsContainOptionTerminator);
+            flagsByName,
+            optionsByName,
+            options);
         for (var index = 0; index < optionParsingCount;)
         {
             var match = TryMatchManualOption(
@@ -601,15 +603,32 @@ internal sealed class CommandLineBuilder(
 
     private static int GetOptionParsingCount(
         List<string> manualArgs,
-        bool argumentsContainOptionTerminator)
+        IReadOnlyDictionary<string, FlagPart> flagsByName,
+        IReadOnlyDictionary<string, OptionPart> optionsByName,
+        CommandLineToolOptions options)
     {
-        if (!argumentsContainOptionTerminator)
+        if (!options.ArgumentsContainOptionTerminator)
         {
             return manualArgs.Count;
         }
 
-        var optionTerminatorIndex = manualArgs.IndexOf("--");
-        return optionTerminatorIndex < 0 ? manualArgs.Count : optionTerminatorIndex;
+        for (var index = 0; index < manualArgs.Count;)
+        {
+            if (manualArgs[index] == "--")
+            {
+                return index;
+            }
+
+            var match = TryMatchManualOption(
+                manualArgs,
+                index,
+                flagsByName,
+                optionsByName,
+                options);
+            index += match?.ArgumentCount ?? 1;
+        }
+
+        return manualArgs.Count;
     }
 
     private static void AppendOptionTerminatedArguments(

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -537,12 +537,51 @@ internal sealed class CommandLineBuilder(
         var globalOptions = new List<string>();
         var commandOptions = new List<string>();
         var remainingArguments = new List<string>();
-        var hasTerminalOptions = false;
         var optionParsingCount = GetOptionParsingCount(
             manualArgs,
             flagsByName,
             optionsByName,
             options);
+        var hasTerminalOptions = ClassifyManualOptions(
+            manualArgs,
+            optionParsingCount,
+            flagsByName,
+            optionsByName,
+            options,
+            preserveTerminalOptions,
+            globalOptions,
+            commandOptions,
+            remainingArguments,
+            positionalArgumentIndices);
+
+        if (globalOptions.Count == 0
+            && commandOptions.Count == 0
+            && !hasTerminalOptions)
+        {
+            return ExtractedManualOptions.Empty;
+        }
+
+        manualArgs.Clear();
+        manualArgs.AddRange(remainingArguments);
+        return new ExtractedManualOptions(
+            globalOptions,
+            commandOptions,
+            hasTerminalOptions);
+    }
+
+    private static bool ClassifyManualOptions(
+        List<string> manualArgs,
+        int optionParsingCount,
+        IReadOnlyDictionary<string, FlagPart> flagsByName,
+        IReadOnlyDictionary<string, OptionPart> optionsByName,
+        CommandLineToolOptions options,
+        bool preserveTerminalOptions,
+        List<string> globalOptions,
+        List<string> commandOptions,
+        List<string> remainingArguments,
+        ICollection<int>? positionalArgumentIndices)
+    {
+        var hasTerminalOptions = false;
         for (var index = 0; index < optionParsingCount;)
         {
             var match = TryMatchManualOption(
@@ -591,19 +630,7 @@ internal sealed class CommandLineBuilder(
             remainingArguments,
             positionalArgumentIndices);
 
-        if (globalOptions.Count == 0
-            && commandOptions.Count == 0
-            && !hasTerminalOptions)
-        {
-            return ExtractedManualOptions.Empty;
-        }
-
-        manualArgs.Clear();
-        manualArgs.AddRange(remainingArguments);
-        return new ExtractedManualOptions(
-            globalOptions,
-            commandOptions,
-            hasTerminalOptions);
+        return hasTerminalOptions;
     }
 
     private static int GetOptionParsingCount(

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -80,7 +80,8 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
 
         var rendered = new List<string>();
         emittedOptionTerminatorIndex = null;
-        foreach (var phase in renderedPhases.OrderBy(pair => GetRenderOrder(pair.Key)))
+        foreach (var phase in renderedPhases.OrderBy(pair =>
+                     CommandLinePhaseOrder.GetRenderOrder(pair.Key)))
         {
             if (emittedOptionTerminatorIndex is null
                 && phase.Value.OptionTerminatorIndex is { } phaseIndex)
@@ -93,15 +94,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
 
         return rendered;
     }
-
-    private static int GetRenderOrder(CommandLinePhase phase) => phase switch
-    {
-        CommandLinePhase.EarlyOperand => 0,
-        CommandLinePhase.Normal => 1,
-        CommandLinePhase.Passthrough => 3,
-        CommandLinePhase.Terminal => 4,
-        _ => throw new ArgumentOutOfRangeException(nameof(phase), phase, null),
-    };
 
     private static RenderedPhase RenderPhase(
         CommandLinePhase phase,
@@ -264,8 +256,8 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         PropertyCommandLinePart option,
         ArgumentPart argument)
     {
-        var optionOrder = GetRenderOrder(option.Phase);
-        var argumentOrder = GetRenderOrder(argument.Phase);
+        var optionOrder = CommandLinePhaseOrder.GetRenderOrder(option.Phase);
+        var argumentOrder = CommandLinePhaseOrder.GetRenderOrder(argument.Phase);
         return optionOrder > argumentOrder
                || (optionOrder == argumentOrder
                    && argument.Phase == CommandLinePhase.Terminal);

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 *REMOVED*ModularPipelines.Attributes.CommandLinePhase.EndOfOptions = 2 -> ModularPipelines.Attributes.CommandLinePhase
+ModularPipelines.Attributes.CommandLinePhase.LateOperand = 5 -> ModularPipelines.Attributes.CommandLinePhase
 *REMOVED*ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute
 *REMOVED*ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute.DependsOnAllModulesInheritingFromAttribute(System.Type! type) -> void
 *REMOVED*ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute.Type.get -> System.Type!

--- a/test/ModularPipelines.GitHub.UnitTests/GhCodespaceCpOptionsTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/GhCodespaceCpOptionsTests.cs
@@ -1,0 +1,35 @@
+using ModularPipelines.Context;
+using ModularPipelines.GitHub.Options;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.GitHub.UnitTests;
+
+public class GhCodespaceCpOptionsTests : TestBase
+{
+    [Test]
+    public async Task Renders_Scp_Flags_Between_Terminator_And_Operands()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var commandLine = builder.Build(new GhCodespaceCpOptions(["source"], "destination")
+        {
+            Recursive = true,
+            ScpFlags = ["-F", "config"],
+        });
+
+        await Assert.That(commandLine.ToString())
+            .IsEqualTo("gh codespace cp --recursive -- -F config source destination");
+    }
+
+    [Test]
+    public async Task Omits_Terminator_Without_Scp_Flags()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var commandLine = builder.Build(
+            new GhCodespaceCpOptions(["source"], "destination"));
+
+        await Assert.That(commandLine.ToString())
+            .IsEqualTo("gh codespace cp source destination");
+    }
+}

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -138,6 +138,7 @@ public class CliAttributeTests
         await Assert.That(ordinals[CommandLinePhase.Normal]).IsEqualTo(1);
         await Assert.That(ordinals[CommandLinePhase.Passthrough]).IsEqualTo(3);
         await Assert.That(ordinals[CommandLinePhase.Terminal]).IsEqualTo(4);
+        await Assert.That(ordinals[CommandLinePhase.LateOperand]).IsEqualTo(5);
         await Assert.That(ordinals.Values).DoesNotContain(2);
     }
 

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -489,6 +489,31 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Places_Terminated_Passthrough_Before_Late_Operands()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminatedPassthroughOptions("source", "destination")
+        {
+            Force = true,
+            ScpFlags = ["-F", "config"],
+        });
+
+        await Assert.That(result.ToString())
+            .IsEqualTo("tool copy --force -- -F config source destination");
+    }
+
+    [Test]
+    public async Task Build_Omits_Terminator_When_Terminated_Passthrough_Is_Absent()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminatedPassthroughOptions("source", "destination"));
+
+        await Assert.That(result.ToString()).IsEqualTo("tool copy source destination");
+    }
+
+    [Test]
     public async Task Build_Allows_Manual_Arguments_To_Supply_New_Required_Operand()
     {
         var builder = await GetService<ICommandLineBuilder>();
@@ -601,20 +626,19 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Rejects_Manual_Terminal_Options_With_Manual_Terminator()
+    public async Task Build_Preserves_Terminal_Like_Tokens_After_Manual_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        CommandLine Build() => builder.Build(new TestTerminalOptions
+        var result = builder.Build(new TestTerminalOptions
         {
             Arguments = ["--", "value", "--run-tests", "tests.jq"],
             ArgumentsContainOptionTerminator = true,
             ArgumentsContainToolOptions = true,
         });
 
-        await Assert.That(Build)
-            .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("end-of-options marker");
+        await Assert.That(result.ToString())
+            .IsEqualTo("jq -- value --run-tests tests.jq");
     }
 
     [Test]
@@ -946,7 +970,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Prefers_Exact_Manual_Option_Over_NoSeparator_Prefix()
+    public async Task Build_Preserves_Exact_Option_Like_Tokens_After_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
@@ -958,7 +982,7 @@ public class CommandLineBuilderTests : TestBase
         });
 
         await Assert.That(result.ToString())
-            .IsEqualTo("jq -Debug value -- tail");
+            .IsEqualTo("jq -- tail -Debug value");
     }
 
     [Test]
@@ -978,7 +1002,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Hoists_All_Grouped_Manual_Option_Values()
+    public async Task Build_Preserves_Grouped_Option_Like_Tokens_After_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
@@ -990,7 +1014,7 @@ public class CommandLineBuilderTests : TestBase
         });
 
         await Assert.That(result.ToString())
-            .IsEqualTo("jq --arguments one two -- tail");
+            .IsEqualTo("jq -- tail --arguments one two");
     }
 
     [Test]
@@ -1010,7 +1034,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Hoists_Trailing_Values_With_Attached_Grouped_Option()
+    public async Task Build_Preserves_Attached_Grouped_Tokens_After_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
@@ -1022,7 +1046,7 @@ public class CommandLineBuilderTests : TestBase
         });
 
         await Assert.That(result.ToString())
-            .IsEqualTo("jq --arguments=one two -- tail");
+            .IsEqualTo("jq -- tail --arguments=one two");
     }
 
     [Test]
@@ -1144,7 +1168,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Hoists_Manual_Option_Before_Manual_Terminator()
+    public async Task Build_Preserves_Manual_Tokens_After_Manual_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
@@ -1157,7 +1181,7 @@ public class CommandLineBuilderTests : TestBase
         });
 
         await Assert.That(result.ToString())
-            .IsEqualTo("jq . --compact-output -- input.json");
+            .IsEqualTo("jq . -- input.json --compact-output");
     }
 
     [Test]
@@ -1194,7 +1218,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Matches_Exact_MultiCharacter_Short_Option_Before_Cluster()
+    public async Task Build_Preserves_MultiCharacter_Option_Like_Tokens_After_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
@@ -1206,7 +1230,7 @@ public class CommandLineBuilderTests : TestBase
         });
 
         await Assert.That(result.ToString())
-            .IsEqualTo("dotnet -ss https://symbols -- tail");
+            .IsEqualTo("dotnet -- tail -ss https://symbols");
     }
 
     [Test]
@@ -2063,6 +2087,20 @@ public class CommandLineBuilderTests : TestBase
 
         [CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true)]
         public IReadOnlyList<string>? Parameters { get; init; }
+    }
+
+    [CliTool("tool")]
+    [CliSubCommand("copy")]
+    private sealed record TestTerminatedPassthroughOptions(
+        [property: CliArgument(0, Phase = CommandLinePhase.LateOperand, Required = true)] string Source,
+        [property: CliArgument(1, Phase = CommandLinePhase.LateOperand, Required = true)] string Destination)
+        : CommandLineToolOptions
+    {
+        [CliFlag("--force")]
+        public bool Force { get; init; }
+
+        [CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true)]
+        public IReadOnlyList<string>? ScpFlags { get; init; }
     }
 
     [CliTool("tool")]

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -876,6 +876,21 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Does_Not_Match_Manual_Option_Across_Declared_Terminator()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminalOptions
+        {
+            Arguments = ["--arg", "name", "--", "tail"],
+            ArgumentsContainOptionTerminator = true,
+            ArgumentsContainToolOptions = true,
+        });
+
+        await Assert.That(result.ToString()).IsEqualTo("jq --arg name -- tail");
+    }
+
+    [Test]
     public async Task Build_Hoists_Manual_Option_Operands_Before_Property_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -514,6 +514,22 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Reserves_Trailing_Manual_Values_For_Late_Operands()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminatedPassthroughOptions(default!, default!)
+        {
+            Arguments = ["--", "--force", "source", "destination"],
+            ArgumentsContainOptionTerminator = true,
+            ArgumentsContainToolOptions = true,
+        });
+
+        await Assert.That(result.ToString())
+            .IsEqualTo("tool copy -- --force source destination");
+    }
+
+    [Test]
     public async Task Build_Allows_Manual_Arguments_To_Supply_New_Required_Operand()
     {
         var builder = await GetService<ICommandLineBuilder>();

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -504,6 +504,22 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Places_Manual_Options_Before_Terminated_Passthrough()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminatedPassthroughOptions("source", "destination")
+        {
+            Arguments = ["--force", "--", "-F", "config"],
+            ArgumentsContainOptionTerminator = true,
+            ArgumentsContainToolOptions = true,
+        });
+
+        await Assert.That(result.ToString())
+            .IsEqualTo("tool copy --force -- -F config source destination");
+    }
+
+    [Test]
     public async Task Build_Omits_Terminator_When_Terminated_Passthrough_Is_Absent()
     {
         var builder = await GetService<ICommandLineBuilder>();

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -859,6 +859,23 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Does_Not_Treat_Manual_Option_Operand_As_Declared_Terminator()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        CommandLine Build() => builder.Build(new TestTerminalOptions
+        {
+            Arguments = ["--arg", "name", "--"],
+            ArgumentsContainOptionTerminator = true,
+            ArgumentsContainToolOptions = true,
+        });
+
+        await Assert.That(Build)
+            .Throws<ArgumentException>()
+            .And.HasMessageContaining("unconsumed '--'");
+    }
+
+    [Test]
     public async Task Build_Hoists_Manual_Option_Operands_Before_Property_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -606,6 +606,26 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Places_Operands_After_Terminated_Passthrough_In_Late_Phase()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: gh codespace cp [-e] [-r] [-- [<scp flags>...]] <sources>... <dest>",
+            ["gh", "codespace", "cp"]);
+
+        var arguments = result.PositionalArguments;
+
+        await Assert.That(arguments.Select(argument => argument.PropertyName))
+            .IsEquivalentTo(["ScpFlags", "Sources", "Dest"]);
+        await Assert.That(arguments[0].CSharpType).IsEqualTo("IEnumerable<string>?");
+        await Assert.That(arguments[0].Phase).IsEqualTo(CommandLinePhase.Passthrough);
+        await Assert.That(arguments[0].PrependOptionTerminator).IsTrue();
+        await Assert.That(arguments[0].AssociatedOptionSwitch).IsNull();
+        await Assert.That(arguments.Skip(1).All(argument =>
+                argument.Phase == CommandLinePhase.LateOperand))
+            .IsTrue();
+    }
+
+    [Test]
     public async Task Parses_Inline_Usage_Continuation_Lines()
     {
         const string helpText = """
@@ -851,6 +871,43 @@ public class UsageSynopsisParserTests
 
         await Assert.That(generated).Contains(
             "PrependOptionTerminator = true");
+    }
+
+    [Test]
+    public async Task Generator_Emits_Terminated_Passthrough_Before_Late_Operands()
+    {
+        var usage = UsageSynopsisParser.Parse(
+            "Usage: gh codespace cp [-- [<scp flags>...]] <sources>... <dest>",
+            ["gh", "codespace", "cp"]);
+        var command = new CliCommandDefinition
+        {
+            FullCommand = "gh codespace cp",
+            CommandParts = ["codespace", "cp"],
+            ClassName = "GhCodespaceCpOptions",
+            ParentClassName = "GhOptions",
+            ToolNamespacePrefix = "Gh",
+            Options = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
+        };
+        var tool = new CliToolDefinition
+        {
+            ToolName = "gh",
+            NamespacePrefix = "Gh",
+            TargetNamespace = "ModularPipelines.GitHub",
+            OutputDirectory = "src/ModularPipelines.GitHub",
+            Commands = [command],
+        };
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(tool)).Single().Content;
+
+        await Assert.That(generated).Contains(
+            "CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true)");
+        await Assert.That(generated).Contains(
+            "CliArgument(0, Phase = CommandLinePhase.LateOperand, Required = true)");
+        await Assert.That(generated).Contains(
+            "CliArgument(1, Phase = CommandLinePhase.LateOperand, Required = true)");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -675,6 +675,30 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Standalone_Option_Terminator_Clears_Prior_Option_Association()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run [--verbose] -- <args>",
+            ["tool", "run"]);
+
+        var argument = result.PositionalArguments.Single();
+        await Assert.That(argument.PrependOptionTerminator).IsTrue();
+        await Assert.That(argument.AssociatedOptionSwitch).IsNull();
+    }
+
+    [Test]
+    public async Task Nested_Operand_Group_Preserves_Option_Terminator()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run [-- [<command> [<arg>...]]]",
+            ["tool", "run"]);
+
+        await Assert.That(result.PositionalArguments).Count().IsEqualTo(2);
+        await Assert.That(result.PositionalArguments[0].PrependOptionTerminator).IsTrue();
+        await Assert.That(result.PositionalArguments[1].PrependOptionTerminator).IsFalse();
+    }
+
+    [Test]
     public async Task Relaxes_Operands_Absent_From_Alternate_Invocation_Forms()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -690,12 +690,12 @@ public class UsageSynopsisParserTests
     public async Task Nested_Operand_Group_Preserves_Option_Terminator()
     {
         var result = UsageSynopsisParser.Parse(
-            "Usage: tool run [-- [<command> [<arg>...]]]",
+            "Usage: tool run [-- [<left>] [<right>]]",
             ["tool", "run"]);
 
         await Assert.That(result.PositionalArguments).Count().IsEqualTo(2);
         await Assert.That(result.PositionalArguments[0].PrependOptionTerminator).IsTrue();
-        await Assert.That(result.PositionalArguments[1].PrependOptionTerminator).IsFalse();
+        await Assert.That(result.PositionalArguments[1].PrependOptionTerminator).IsTrue();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
+using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -259,6 +261,45 @@ public class ZeroOutputScraperTests
             await Assert.That(arguments["SshFlags"].IsRequired).IsFalse();
             await Assert.That(arguments["Command"].CSharpType).IsEqualTo("string?");
         }
+    }
+
+    [Test]
+    public async Task Gh_Codespace_Cp_Models_Terminated_Scp_Flags_Before_Operands()
+    {
+        const string helpText = """
+            Copy files to and from a codespace.
+
+            USAGE
+              gh codespace cp [-e] [-r] [-- [<scp flags>...]] <sources>... <dest>
+
+            FLAGS
+              -e, --expand      Expand remote file names
+              -r, --recursive   Recursively copy directories
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "codespace", "cp"], helpText);
+        var arguments = command!.PositionalArguments.ToDictionary(argument => argument.PropertyName);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(arguments.Keys).IsEquivalentTo(["ScpFlags", "Sources", "Dest"]);
+            await Assert.That(arguments["ScpFlags"].PrependOptionTerminator).IsTrue();
+            await Assert.That(arguments["ScpFlags"].Phase).IsEqualTo(CommandLinePhase.Passthrough);
+            await Assert.That(arguments["Sources"].Phase).IsEqualTo(CommandLinePhase.LateOperand);
+            await Assert.That(arguments["Dest"].Phase).IsEqualTo(CommandLinePhase.LateOperand);
+        }
+
+        var tool = new CliToolDefinition
+        {
+            ToolName = "gh",
+            NamespacePrefix = "Gh",
+            TargetNamespace = "ModularPipelines.GitHub",
+            OutputDirectory = "src/ModularPipelines.GitHub",
+            Commands = [command],
+        };
+        var generated = (await new OptionsClassGenerator().GenerateAsync(
+            InheritedPropertyCollisionResolver.Resolve(tool))).Single().Content;
+        await Assert.That(generated).Contains("IEnumerable<string>? ScpFlags");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -199,6 +199,7 @@ public static class UsageSynopsisParser
             if (IsStandaloneOptionTerminator(token))
             {
                 prependOptionTerminatorToNextOperand = true;
+                associatedOptionSwitch = null;
                 continue;
             }
 
@@ -231,6 +232,9 @@ public static class UsageSynopsisParser
                     operandPhase,
                     out var nestedArguments))
             {
+                nestedArguments = PreserveOptionTerminatorOnNestedGroup(
+                    nestedArguments,
+                    groupedBehindOptionTerminator || prependOptionTerminatorToNextOperand);
                 arguments.AddRange(nestedArguments);
                 prependOptionTerminatorToNextOperand = false;
                 AdvancePastOptionTerminatedOperand(groupedBehindOptionTerminator, ref phase);
@@ -263,6 +267,22 @@ public static class UsageSynopsisParser
         }
 
         return new ParsedOperands(arguments, unparsedTokens);
+    }
+
+    private static IReadOnlyList<CliPositionalArgument> PreserveOptionTerminatorOnNestedGroup(
+        IReadOnlyList<CliPositionalArgument> arguments,
+        bool prependOptionTerminator)
+    {
+        if (!prependOptionTerminator || arguments.Count == 0)
+        {
+            return arguments;
+        }
+
+        return
+        [
+            arguments[0] with { PrependOptionTerminator = true },
+            .. arguments.Skip(1),
+        ];
     }
 
     private static void ClearAssociatedOptionSwitch(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -205,6 +205,10 @@ public static class UsageSynopsisParser
             var groupedBehindOptionTerminator =
                 TryUnwrapOptionTerminatedOperand(token, out var unwrappedOperand);
             var operandToken = groupedBehindOptionTerminator ? unwrappedOperand : token;
+            ClearAssociatedOptionSwitch(
+                groupedBehindOptionTerminator,
+                ref associatedOptionSwitch);
+
             if (TryGetOptionSwitch(operandToken, out var optionSwitch))
             {
                 associatedOptionSwitch = optionSwitch;
@@ -229,6 +233,8 @@ public static class UsageSynopsisParser
             {
                 arguments.AddRange(nestedArguments);
                 prependOptionTerminatorToNextOperand = false;
+                AdvancePastOptionTerminatedOperand(groupedBehindOptionTerminator, ref phase);
+
                 continue;
             }
 
@@ -253,9 +259,30 @@ public static class UsageSynopsisParser
             arguments.Add(argument);
             prependOptionTerminatorToNextOperand = false;
             associatedOptionSwitch = null;
+            AdvancePastOptionTerminatedOperand(groupedBehindOptionTerminator, ref phase);
         }
 
         return new ParsedOperands(arguments, unparsedTokens);
+    }
+
+    private static void ClearAssociatedOptionSwitch(
+        bool groupedBehindOptionTerminator,
+        ref string? associatedOptionSwitch)
+    {
+        if (groupedBehindOptionTerminator)
+        {
+            associatedOptionSwitch = null;
+        }
+    }
+
+    private static void AdvancePastOptionTerminatedOperand(
+        bool groupedBehindOptionTerminator,
+        ref CommandLinePhase phase)
+    {
+        if (groupedBehindOptionTerminator)
+        {
+            phase = CommandLinePhase.LateOperand;
+        }
     }
 
     private static CommandLinePhase TransitionPhase(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -278,11 +278,9 @@ public static class UsageSynopsisParser
             return arguments;
         }
 
-        return
-        [
-            arguments[0] with { PrependOptionTerminator = true },
-            .. arguments.Skip(1),
-        ];
+        return arguments
+            .Select(static argument => argument with { PrependOptionTerminator = true })
+            .ToArray();
     }
 
     private static void ClearAssociatedOptionSwitch(


### PR DESCRIPTION
Closes #4330.

## Summary
- add `CommandLinePhase.LateOperand` for operands rendered after terminated pass-through values
- stop option extraction after a declared manual `--`, preserving subsequent tokens verbatim
- parse grouped terminated pass-through segments and regenerate the GitHub CLI integration from `gh 2.98.0`
- add parser, scraper, generator, runtime, and generated `GhCodespaceCpOptions` regressions

## Validation
- OptionsGenerator tests: 1,174 passed
- core `CommandLineBuilderTests` + `CliAttributeTests`: 191 passed
- `GhCodespaceCpOptionsTests`: 2 passed
- `src/ModularPipelines.GitHub/ModularPipelines.GitHub.slnx` Release build passed
- `git diff --check` passed

## Local generation limit
A complete GitHub regeneration succeeded once and produced the committed generated refresh. A later full rerun after the final parser correction hit the repository guard's 2 GB process-tree limit (exit 137), so it was not retried with a raised limit. The affected `GhCodespaceCpOptions.Generated.cs` was regenerated through the same scraper and `OptionsClassGenerator` with a focused temporary harness; the full generator suite and GitHub build validate the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for command-line arguments that appear after a `--` terminator.
  * Preserved passthrough flags and trailing operands in their intended order.
  * Added support for late positional operands, including sources and destinations in copy commands.

* **Bug Fixes**
  * Prevented option-like arguments after `--` from being incorrectly reordered or interpreted as regular options.
  * Improved handling of `--` when used as an option value versus a command terminator.

* **Tests**
  * Expanded coverage for passthrough flags, terminated arguments, operand ordering, and command-line rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->