### PR TITLE
Classify secret values without masking identifiers

### DIFF
--- a/docs/docs/mp-packages/cli/gh.md
+++ b/docs/docs/mp-packages/cli/gh.md
@@ -254,6 +254,7 @@ public class RunCommandModule : Module<CommandResult>
 | `gh ssh-key add` | `GhSshKeyAddOptions` |
 | `gh ssh-key delete` | `GhSshKeyDeleteOptions` |
 | `gh ssh-key list` | `GhSshKeyListOptions` |
+| `gh stack` | `GhStackOptions` |
 | `gh status` | `GhStatusOptions` |
 | `gh variable` | `GhVariableOptions` |
 | `gh variable delete` | `GhVariableDeleteOptions` |

--- a/src/ModularPipelines.GitHub/Enums/GhExtensionCreatePrecompiled.Generated.cs
+++ b/src/ModularPipelines.GitHub/Enums/GhExtensionCreatePrecompiled.Generated.cs
@@ -17,8 +17,8 @@ namespace ModularPipelines.GitHub.Enums;
 public enum GhExtensionCreatePrecompiled
 {
     [EnumValue("go")]
-    Go = 0,
+    Go,
 
     [EnumValue("other")]
-    Other = 1
+    Other
 }

--- a/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Extensions/GhExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.GitHub.Services;
 
 namespace ModularPipelines.GitHub.Extensions;
@@ -29,7 +28,7 @@ public static class GhExtensions
     public static IServiceCollection RegisterGhContext(this IServiceCollection services)
     {
         services.TryAddScoped<IGh, Services.Gh>();
-        services.TryAddScoped<IGhAgenttask, GhAgenttask>();
+        services.TryAddScoped<IGhAgentTask, GhAgentTask>();
         services.TryAddScoped<IGhAttestation, GhAttestation>();
         services.TryAddScoped<IGhAuth, GhAuth>();
         services.TryAddScoped<IGhCache, GhCache>();
@@ -38,7 +37,7 @@ public static class GhExtensions
         services.TryAddScoped<IGhDiscussion, GhDiscussion>();
         services.TryAddScoped<IGhExtension, GhExtension>();
         services.TryAddScoped<IGhGist, GhGist>();
-        services.TryAddScoped<IGhGpgkey, GhGpgkey>();
+        services.TryAddScoped<IGhGpgKey, GhGpgKey>();
         services.TryAddScoped<IGhIssue, GhIssue>();
         services.TryAddScoped<IGhLabel, GhLabel>();
         services.TryAddScoped<IGhOrg, GhOrg>();
@@ -52,9 +51,10 @@ public static class GhExtensions
         services.TryAddScoped<IGhSearch, GhSearch>();
         services.TryAddScoped<IGhSecret, GhSecret>();
         services.TryAddScoped<IGhSkill, GhSkill>();
-        services.TryAddScoped<IGhSshkey, GhSshkey>();
+        services.TryAddScoped<IGhSshKey, GhSshKey>();
         services.TryAddScoped<IGhVariable, GhVariable>();
         services.TryAddScoped<IGhWorkflow, GhWorkflow>();
         return services;
     }
+
 }

--- a/src/ModularPipelines.GitHub/Generated/Gh.CommandCoverage.json
+++ b/src/ModularPipelines.GitHub/Generated/Gh.CommandCoverage.json
@@ -2,8 +2,8 @@
   "formatVersion": 1,
   "toolName": "gh",
   "toolVersion": "gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0",
-  "commandCount": 221,
-  "commandTreeSha256": "3777cffcf304b41a18323a005d1f5bfd5dd24121249da59c9d985e6b8132d552",
+  "commandCount": 222,
+  "commandTreeSha256": "f3f924874c2a944f9c34cb5c08526accbbf78993506085ec687b956f6032f99d",
   "commands": [
     "gh agent-task",
     "gh agent-task create",
@@ -214,6 +214,7 @@
     "gh ssh-key add",
     "gh ssh-key delete",
     "gh ssh-key list",
+    "gh stack",
     "gh status",
     "gh variable",
     "gh variable delete",

--- a/src/ModularPipelines.GitHub/Options/GhApiOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhApiOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhApiOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Endpoint
 ) : GhOptions
 {
-    public GhApiOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Allow printing terminal escape sequences
     /// </summary>
@@ -43,13 +38,13 @@ public record GhApiOptions(
     /// Add a typed parameter in key=value format (use "@&lt;path&gt;" or "@-" to read value from file or stdin)
     /// </summary>
     [CliOption("--field", ShortForm = "-F", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? FieldValues { get; set; }
+    public IEnumerable<string>? Field { get; set; }
 
     /// <summary>
     /// Add a HTTP request header in key:value format
     /// </summary>
     [CliOption("--header", ShortForm = "-H", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? HeaderValues { get; set; }
+    public IEnumerable<string>? Header { get; set; }
 
     /// <summary>
     /// The GitHub hostname for the request (default "github.com")
@@ -97,7 +92,7 @@ public record GhApiOptions(
     /// Add a string parameter in key=value format
     /// </summary>
     [CliOption("--raw-field", ShortForm = "-f", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? RawFieldValues { get; set; }
+    public IEnumerable<string>? RawField { get; set; }
 
     /// <summary>
     /// Do not print the response body
@@ -128,26 +123,5 @@ public record GhApiOptions(
     /// </summary>
     [CliFlag("--help")]
     public bool? Help { get; set; }
-
-    [Obsolete("Use FieldValues instead.")]
-    public string? Field
-    {
-        get => FieldValues?.FirstOrDefault();
-        set => FieldValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use HeaderValues instead.")]
-    public string? Header
-    {
-        get => HeaderValues?.FirstOrDefault();
-        set => HeaderValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use RawFieldValues instead.")]
-    public string? RawField
-    {
-        get => RawFieldValues?.FirstOrDefault();
-        set => RawFieldValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.GitHub/Options/GhBrowseOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhBrowseOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.GitHub.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.GitHub.Options;
 
@@ -41,8 +42,8 @@ public record GhBrowseOptions : GhOptions
     /// <summary>
     /// Select another commit by passing in the commit SHA, default is the last commit
     /// </summary>
-    [CliOption("--commit", ShortForm = "-c", Format = OptionFormat.EqualsSeparated)]
-    public string? Commit { get; set; }
+    [CliOption("--commit", ShortForm = "-c", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? Commit { get; set; }
 
     /// <summary>
     /// Print destination URL instead of opening the browser

--- a/src/ModularPipelines.GitHub/Options/GhCodespaceCpOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhCodespaceCpOptions.Generated.cs
@@ -23,11 +23,6 @@ public record GhCodespaceCpOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string Dest
 ) : GhOptions
 {
-    public GhCodespaceCpOptions()
-        : this(default(IEnumerable<string>)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Name of the codespace
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhCodespacePortsForwardOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhCodespacePortsForwardOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhCodespacePortsForwardOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> RemotePortLocalPort
 ) : GhOptions
 {
-    public GhCodespacePortsForwardOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Listen on all network interfaces
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhCodespacePortsVisibilityOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhCodespacePortsVisibilityOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhCodespacePortsVisibilityOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> PortPublic
 ) : GhOptions
 {
-    public GhCodespacePortsVisibilityOptions()
-        : this(default(IEnumerable<string>)!)
-    {
-    }
-
     /// <summary>
     /// Name of the codespace
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhConfigSetOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhConfigSetOptions.Generated.cs
@@ -23,11 +23,6 @@ public record GhConfigSetOptions(
     [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Value
 ) : GhOptions
 {
-    public GhConfigSetOptions()
-        : this(default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Set per-host setting
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhExtensionInstallOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhExtensionInstallOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhExtensionInstallOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Repository
 ) : GhOptions
 {
-    public GhExtensionInstallOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Force upgrade extension, or ignore if latest already installed
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhExtensionRemoveOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhExtensionRemoveOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhExtensionRemoveOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Name
 ) : GhOptions
 {
-    public GhExtensionRemoveOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Show help for command
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhGistCloneOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhGistCloneOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhGistCloneOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Gist
 ) : GhOptions
 {
-    public GhGistCloneOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Show help for command
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhGistDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhGistDeleteOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhGistDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string IdOrUrl
 ) : GhOptions
 {
-    public GhGistDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Confirm deletion without prompting
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhGistEditOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhGistEditOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhGistEditOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string IdOrUrl
 ) : GhOptions
 {
-    public GhGistEditOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Add a new file to the gist
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhGistRenameOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhGistRenameOptions.Generated.cs
@@ -24,11 +24,6 @@ public record GhGistRenameOptions(
     [property: CliArgument(2, Phase = CommandLinePhase.EarlyOperand, Required = true)] string NewFilename
 ) : GhOptions
 {
-    public GhGistRenameOptions()
-        : this(default(string)!, default(string)!, default(string)!)
-    {
-    }
-
     /// <summary>
     /// Show help for command
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhGpgKeyDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhGpgKeyDeleteOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhGpgKeyDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string KeyId
 ) : GhOptions
 {
-    public GhGpgKeyDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Skip the confirmation prompt
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhLabelCloneOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhLabelCloneOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhLabelCloneOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string SourceRepository
 ) : GhOptions
 {
-    public GhLabelCloneOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Overwrite labels in the destination repository
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhLabelCreateOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhLabelCreateOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhLabelCreateOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Name
 ) : GhOptions
 {
-    public GhLabelCreateOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Color of the label
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhLabelDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhLabelDeleteOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhLabelDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Name
 ) : GhOptions
 {
-    public GhLabelDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Confirm deletion without prompting
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhLabelEditOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhLabelEditOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhLabelEditOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string NameArgument
 ) : GhOptions
 {
-    public GhLabelEditOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Color of the label
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhRunWatchOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhRunWatchOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhRunWatchOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string RunId
 ) : GhOptions
 {
-    public GhRunWatchOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Show only relevant/failed steps
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhSearchCodeOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSearchCodeOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhSearchCodeOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Query
 ) : GhOptions
 {
-    public GhSearchCodeOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Filter on file extension
     /// </summary>
@@ -79,7 +74,7 @@ public record GhSearchCodeOptions(
     /// Filter on repository, in OWNER/REPO format
     /// </summary>
     [CliOption("--repo", ShortForm = "-R", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? Repo { get; set; }
+    public string? Repo { get; set; }
 
     /// <summary>
     /// Filter on size range, in kilobytes

--- a/src/ModularPipelines.GitHub/Options/GhSearchCommitsOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSearchCommitsOptions.Generated.cs
@@ -120,7 +120,7 @@ public record GhSearchCommitsOptions : GhOptions
     /// Filter on repository, in OWNER/REPO format
     /// </summary>
     [CliOption("--repo", ShortForm = "-R", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? Repo { get; set; }
+    public string? Repo { get; set; }
 
     /// <summary>
     /// Sort fetched commits: {author-date|committer-date} (default "best-match")

--- a/src/ModularPipelines.GitHub/Options/GhSearchIssuesOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSearchIssuesOptions.Generated.cs
@@ -192,7 +192,7 @@ public record GhSearchIssuesOptions : GhOptions
     /// Filter on repository, in OWNER/REPO format
     /// </summary>
     [CliOption("--repo", ShortForm = "-R", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? Repo { get; set; }
+    public string? Repo { get; set; }
 
     /// <summary>
     /// Type of issue search to perform: {lexical|semantic|hybrid} (default "lexical")

--- a/src/ModularPipelines.GitHub/Options/GhSearchPrsOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSearchPrsOptions.Generated.cs
@@ -222,7 +222,7 @@ public record GhSearchPrsOptions : GhOptions
     /// Filter on repository, in OWNER/REPO format
     /// </summary>
     [CliOption("--repo", ShortForm = "-R", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? Repo { get; set; }
+    public string? Repo { get; set; }
 
     /// <summary>
     /// Filter based on review status: {none|required|approved|changes_requested}

--- a/src/ModularPipelines.GitHub/Options/GhSecretDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSecretDeleteOptions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.GitHub.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.GitHub.Options;
 
@@ -20,14 +19,9 @@ namespace ModularPipelines.GitHub.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("secret", "delete")]
 public record GhSecretDeleteOptions(
-    [property: SecretValue, CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string SecretName
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string SecretName
 ) : GhOptions
 {
-    public GhSecretDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Delete a secret for a specific application: {actions|agents|codespaces|dependabot}
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhSecretSetOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSecretSetOptions.Generated.cs
@@ -5,11 +5,11 @@
 
 #nullable enable
 
+using ModularPipelines.Secrets;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.GitHub.Options;
-using ModularPipelines.Secrets;
 
 namespace ModularPipelines.GitHub.Options;
 
@@ -20,14 +20,9 @@ namespace ModularPipelines.GitHub.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("secret", "set")]
 public record GhSecretSetOptions(
-    [property: SecretValue, CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string SecretName
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string SecretName
 ) : GhOptions
 {
-    public GhSecretSetOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Set the application for a secret: {actions|agents|codespaces|dependabot}
     /// </summary>
@@ -37,6 +32,7 @@ public record GhSecretSetOptions(
     /// <summary>
     /// The value for the secret (reads from standard input if not specified)
     /// </summary>
+    [SecretValue]
     [CliOption("--body", ShortForm = "-b", Format = OptionFormat.EqualsSeparated)]
     public string? Body { get; set; }
 

--- a/src/ModularPipelines.GitHub/Options/GhSkillInstallOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSkillInstallOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhSkillInstallOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Repository
 ) : GhOptions
 {
-    public GhSkillInstallOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Target agent (see supported values above)
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhSkillPreviewOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSkillPreviewOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhSkillPreviewOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Repository
 ) : GhOptions
 {
-    public GhSkillPreviewOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Include skills in hidden directories (e.g. .claude/skills/, .agents/skills/)
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhSkillSearchOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSkillSearchOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhSkillSearchOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Query
 ) : GhOptions
 {
-    public GhSkillSearchOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Filter JSON output using a jq expression
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhSshKeyDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhSshKeyDeleteOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhSshKeyDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Id
 ) : GhOptions
 {
-    public GhSshKeyDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Skip the confirmation prompt
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhStackOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhStackOptions.Generated.cs
@@ -13,25 +13,23 @@ using ModularPipelines.GitHub.Options;
 namespace ModularPipelines.GitHub.Options;
 
 /// <summary>
-/// Print the value of a given configuration key
+/// Stacked PRs let you break a large change into a chain of pull requests
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("config", "get")]
-public record GhConfigGetOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Key
-) : GhOptions
+[CliSubCommand("stack")]
+public record GhStackOptions : GhOptions
 {
     /// <summary>
-    /// Get per-host setting
+    /// help for stack
     /// </summary>
-    [CliOption("--host", ShortForm = "-h", Format = OptionFormat.EqualsSeparated)]
-    public string? Host { get; set; }
+    [CliFlag("--help", ShortForm = "-h")]
+    public bool? Help { get; set; }
 
     /// <summary>
-    /// Show help for command
+    /// version for stack
     /// </summary>
-    [CliFlag("--help")]
-    public bool? Help { get; set; }
+    [CliFlag("--version", ShortForm = "-v")]
+    public bool? Version { get; set; }
 
 }

--- a/src/ModularPipelines.GitHub/Options/GhVariableDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhVariableDeleteOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhVariableDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string VariableName
 ) : GhOptions
 {
-    public GhVariableDeleteOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Delete a variable for an environment
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhVariableGetOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhVariableGetOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhVariableGetOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string VariableName
 ) : GhOptions
 {
-    public GhVariableGetOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// Get a variable for an environment
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhVariableSetOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhVariableSetOptions.Generated.cs
@@ -22,11 +22,6 @@ public record GhVariableSetOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string VariableName
 ) : GhOptions
 {
-    public GhVariableSetOptions()
-        : this(default(string)!)
-    {
-    }
-
     /// <summary>
     /// The value for the variable (reads from standard input if not specified)
     /// </summary>

--- a/src/ModularPipelines.GitHub/Options/GhWorkflowRunOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhWorkflowRunOptions.Generated.cs
@@ -24,7 +24,7 @@ public record GhWorkflowRunOptions : GhOptions
     /// Add a string parameter in key=value format, respecting @ syntax (see "gh help api").
     /// </summary>
     [CliOption("--field", ShortForm = "-F", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? FieldValues { get; set; }
+    public IEnumerable<string>? Field { get; set; }
 
     /// <summary>
     /// Read workflow inputs as JSON via STDIN
@@ -36,7 +36,7 @@ public record GhWorkflowRunOptions : GhOptions
     /// Add a string parameter in key=value format
     /// </summary>
     [CliOption("--raw-field", ShortForm = "-f", Format = OptionFormat.EqualsSeparated)]
-    public IEnumerable<string>? RawFieldValues { get; set; }
+    public IEnumerable<string>? RawField { get; set; }
 
     /// <summary>
     /// Branch or tag name which contains the version of the workflow file you'd like to run
@@ -61,19 +61,5 @@ public record GhWorkflowRunOptions : GhOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? WorkflowIdOrWorkflowName { get; set; }
-
-    [Obsolete("Use FieldValues instead.")]
-    public string? Field
-    {
-        get => FieldValues?.FirstOrDefault();
-        set => FieldValues = value is null ? null : [value];
-    }
-
-    [Obsolete("Use RawFieldValues instead.")]
-    public string? RawField
-    {
-        get => RawFieldValues?.FirstOrDefault();
-        set => RawFieldValues = value is null ? null : [value];
-    }
 
 }

--- a/src/ModularPipelines.GitHub/Services/Gh.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/Gh.Generated.cs
@@ -26,7 +26,7 @@ internal partial class Gh : IGh
     /// Initializes a new instance of the <see cref="Gh"/> class.
     /// </summary>
     public Gh(
-        IGhAgenttask agenttask,
+        IGhAgentTask agentTask,
         IGhAttestation attestation,
         IGhAuth auth,
         IGhCache cache,
@@ -35,7 +35,7 @@ internal partial class Gh : IGh
         IGhDiscussion discussion,
         IGhExtension extension,
         IGhGist gist,
-        IGhGpgkey gpgkey,
+        IGhGpgKey gpgKey,
         IGhIssue issue,
         IGhLabel label,
         IGhOrg org,
@@ -49,13 +49,13 @@ internal partial class Gh : IGh
         IGhSearch search,
         IGhSecret secret,
         IGhSkill skill,
-        IGhSshkey sshkey,
+        IGhSshKey sshKey,
         IGhVariable variable,
         IGhWorkflow workflow,
         ICommandContext command
     )
     {
-        Agenttask = agenttask;
+        AgentTask = agentTask;
         Attestation = attestation;
         Auth = auth;
         Cache = cache;
@@ -64,7 +64,7 @@ internal partial class Gh : IGh
         Discussion = discussion;
         Extension = extension;
         Gist = gist;
-        Gpgkey = gpgkey;
+        GpgKey = gpgKey;
         Issue = issue;
         Label = label;
         Org = org;
@@ -78,7 +78,7 @@ internal partial class Gh : IGh
         Search = search;
         Secret = secret;
         Skill = skill;
-        Sshkey = sshkey;
+        SshKey = sshKey;
         Variable = variable;
         Workflow = workflow;
         _command = command;
@@ -87,7 +87,7 @@ internal partial class Gh : IGh
     #region Sub-domain Services
 
     /// <inheritdoc />
-    public IGhAgenttask Agenttask { get; }
+    public IGhAgentTask AgentTask { get; }
 
     /// <inheritdoc />
     public IGhAttestation Attestation { get; }
@@ -114,7 +114,7 @@ internal partial class Gh : IGh
     public IGhGist Gist { get; }
 
     /// <inheritdoc />
-    public IGhGpgkey Gpgkey { get; }
+    public IGhGpgKey GpgKey { get; }
 
     /// <inheritdoc />
     public IGhIssue Issue { get; }
@@ -156,7 +156,7 @@ internal partial class Gh : IGh
     public IGhSkill Skill { get; }
 
     /// <inheritdoc />
-    public IGhSshkey Sshkey { get; }
+    public IGhSshKey SshKey { get; }
 
     /// <inheritdoc />
     public IGhVariable Variable { get; }
@@ -170,11 +170,11 @@ internal partial class Gh : IGh
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ApiAsync(
-        GhApiOptions? options = null,
+        GhApiOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhApiOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -196,24 +196,6 @@ internal partial class Gh : IGh
     }
 
     /// <inheritdoc />
-    public virtual async Task<CommandResult> DiscussionAsync(
-        GhDiscussionOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhDiscussionOptions(), executionOptions, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public virtual async Task<CommandResult> IssueAsync(
-        GhIssueOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhIssueOptions(), executionOptions, cancellationToken);
-    }
-
-    /// <inheritdoc />
     public virtual async Task<CommandResult> LicensesAsync(
         GhLicensesOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
@@ -223,39 +205,12 @@ internal partial class Gh : IGh
     }
 
     /// <inheritdoc />
-    public virtual async Task<CommandResult> OrgAsync(
-        GhOrgOptions? options = null,
+    public virtual async Task<CommandResult> StackAsync(
+        GhStackOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhOrgOptions(), executionOptions, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public virtual async Task<CommandResult> PrAsync(
-        GhPrOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhPrOptions(), executionOptions, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public virtual async Task<CommandResult> ReleaseAsync(
-        GhReleaseOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhReleaseOptions(), executionOptions, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public virtual async Task<CommandResult> RepoAsync(
-        GhRepoOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhRepoOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GhStackOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.GitHub/Services/GhAgenttask.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhAgenttask.Generated.cs
@@ -18,14 +18,14 @@ namespace ModularPipelines.GitHub.Services;
 /// gh agenttask commands.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public class GhAgenttask : IGhAgenttask
+public class GhAgentTask : IGhAgentTask
 {
     private readonly ICommandContext _command;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="GhAgenttask"/> class.
+    /// Initializes a new instance of the <see cref="GhAgentTask"/> class.
     /// </summary>
-    public GhAgenttask(ICommandContext command)
+    public GhAgentTask(ICommandContext command)
     {
         _command = command;
     }

--- a/src/ModularPipelines.GitHub/Services/GhCodespace.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhCodespace.Generated.cs
@@ -80,11 +80,11 @@ public class GhCodespace : IGhCodespace
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CpAsync(
-        GhCodespaceCpOptions? options = null,
+        GhCodespaceCpOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhCodespaceCpOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhCodespacePorts.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhCodespacePorts.Generated.cs
@@ -55,11 +55,11 @@ public class GhCodespacePorts
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ForwardAsync(
-        GhCodespacePortsForwardOptions? options = null,
+        GhCodespacePortsForwardOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhCodespacePortsForwardOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -70,11 +70,11 @@ public class GhCodespacePorts
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> VisibilityAsync(
-        GhCodespacePortsVisibilityOptions? options = null,
+        GhCodespacePortsVisibilityOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhCodespacePortsVisibilityOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.GitHub/Services/GhConfig.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhConfig.Generated.cs
@@ -70,11 +70,11 @@ public class GhConfig : IGhConfig
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> GetAsync(
-        GhConfigGetOptions? options = null,
+        GhConfigGetOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhConfigGetOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public class GhConfig : IGhConfig
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SetAsync(
-        GhConfigSetOptions? options = null,
+        GhConfigSetOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhConfigSetOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.GitHub/Services/GhExtension.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhExtension.Generated.cs
@@ -85,11 +85,11 @@ public class GhExtension : IGhExtension
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> InstallAsync(
-        GhExtensionInstallOptions? options = null,
+        GhExtensionInstallOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhExtensionInstallOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -115,11 +115,11 @@ public class GhExtension : IGhExtension
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> RemoveAsync(
-        GhExtensionRemoveOptions? options = null,
+        GhExtensionRemoveOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhExtensionRemoveOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhGist.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhGist.Generated.cs
@@ -55,11 +55,11 @@ public class GhGist : IGhGist
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CloneAsync(
-        GhGistCloneOptions? options = null,
+        GhGistCloneOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhGistCloneOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class GhGist : IGhGist
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        GhGistDeleteOptions? options = null,
+        GhGistDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhGistDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public class GhGist : IGhGist
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> EditAsync(
-        GhGistEditOptions? options = null,
+        GhGistEditOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhGistEditOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -130,11 +130,11 @@ public class GhGist : IGhGist
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> RenameAsync(
-        GhGistRenameOptions? options = null,
+        GhGistRenameOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhGistRenameOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhGpgkey.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhGpgkey.Generated.cs
@@ -18,14 +18,14 @@ namespace ModularPipelines.GitHub.Services;
 /// gh gpgkey commands.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public class GhGpgkey : IGhGpgkey
+public class GhGpgKey : IGhGpgKey
 {
     private readonly ICommandContext _command;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="GhGpgkey"/> class.
+    /// Initializes a new instance of the <see cref="GhGpgKey"/> class.
     /// </summary>
-    public GhGpgkey(ICommandContext command)
+    public GhGpgKey(ICommandContext command)
     {
         _command = command;
     }
@@ -70,11 +70,11 @@ public class GhGpgkey : IGhGpgkey
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        GhGpgKeyDeleteOptions? options = null,
+        GhGpgKeyDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhGpgKeyDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhLabel.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhLabel.Generated.cs
@@ -55,11 +55,11 @@ public class GhLabel : IGhLabel
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CloneAsync(
-        GhLabelCloneOptions? options = null,
+        GhLabelCloneOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhLabelCloneOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -70,11 +70,11 @@ public class GhLabel : IGhLabel
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CreateAsync(
-        GhLabelCreateOptions? options = null,
+        GhLabelCreateOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhLabelCreateOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class GhLabel : IGhLabel
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        GhLabelDeleteOptions? options = null,
+        GhLabelDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhLabelDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public class GhLabel : IGhLabel
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> EditAsync(
-        GhLabelEditOptions? options = null,
+        GhLabelEditOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhLabelEditOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhRun.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhRun.Generated.cs
@@ -145,11 +145,11 @@ public class GhRun : IGhRun
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> WatchAsync(
-        GhRunWatchOptions? options = null,
+        GhRunWatchOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhRunWatchOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.GitHub/Services/GhSearch.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhSearch.Generated.cs
@@ -55,11 +55,11 @@ public class GhSearch : IGhSearch
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CodeAsync(
-        GhSearchCodeOptions? options = null,
+        GhSearchCodeOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSearchCodeOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhSecret.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhSecret.Generated.cs
@@ -55,11 +55,11 @@ public class GhSecret : IGhSecret
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        GhSecretDeleteOptions? options = null,
+        GhSecretDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSecretDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class GhSecret : IGhSecret
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SetAsync(
-        GhSecretSetOptions? options = null,
+        GhSecretSetOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSecretSetOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.GitHub/Services/GhSkill.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhSkill.Generated.cs
@@ -55,11 +55,11 @@ public class GhSkill : IGhSkill
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> InstallAsync(
-        GhSkillInstallOptions? options = null,
+        GhSkillInstallOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSkillInstallOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -85,11 +85,11 @@ public class GhSkill : IGhSkill
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> PreviewAsync(
-        GhSkillPreviewOptions? options = null,
+        GhSkillPreviewOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSkillPreviewOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -115,11 +115,11 @@ public class GhSkill : IGhSkill
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SearchAsync(
-        GhSkillSearchOptions? options = null,
+        GhSkillSearchOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSkillSearchOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhSshkey.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhSshkey.Generated.cs
@@ -18,14 +18,14 @@ namespace ModularPipelines.GitHub.Services;
 /// gh sshkey commands.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public class GhSshkey : IGhSshkey
+public class GhSshKey : IGhSshKey
 {
     private readonly ICommandContext _command;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="GhSshkey"/> class.
+    /// Initializes a new instance of the <see cref="GhSshKey"/> class.
     /// </summary>
-    public GhSshkey(ICommandContext command)
+    public GhSshKey(ICommandContext command)
     {
         _command = command;
     }
@@ -70,11 +70,11 @@ public class GhSshkey : IGhSshkey
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        GhSshKeyDeleteOptions? options = null,
+        GhSshKeyDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhSshKeyDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/GhVariable.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/GhVariable.Generated.cs
@@ -55,11 +55,11 @@ public class GhVariable : IGhVariable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DeleteAsync(
-        GhVariableDeleteOptions? options = null,
+        GhVariableDeleteOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhVariableDeleteOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -70,11 +70,11 @@ public class GhVariable : IGhVariable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> GetAsync(
-        GhVariableGetOptions? options = null,
+        GhVariableGetOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhVariableGetOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public class GhVariable : IGhVariable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> SetAsync(
-        GhVariableSetOptions? options = null,
+        GhVariableSetOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GhVariableSetOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.GitHub/Services/IGh.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGh.Generated.cs
@@ -23,7 +23,7 @@ public partial interface IGh
     /// <summary>
     /// Gets the agenttask sub-domain service.
     /// </summary>
-    IGhAgenttask Agenttask => throw new System.NotSupportedException();
+    IGhAgentTask AgentTask => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the attestation sub-domain service.
@@ -68,7 +68,7 @@ public partial interface IGh
     /// <summary>
     /// Gets the gpgkey sub-domain service.
     /// </summary>
-    IGhGpgkey Gpgkey => throw new System.NotSupportedException();
+    IGhGpgKey GpgKey => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the issue sub-domain service.
@@ -138,7 +138,7 @@ public partial interface IGh
     /// <summary>
     /// Gets the sshkey sub-domain service.
     /// </summary>
-    IGhSshkey Sshkey => throw new System.NotSupportedException();
+    IGhSshKey SshKey => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the variable sub-domain service.
@@ -161,7 +161,7 @@ public partial interface IGh
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ApiAsync(GhApiOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ApiAsync(GhApiOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -185,26 +185,6 @@ public partial interface IGh
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// Working with discussions in the GitHub CLI is in preview and subject to change without notice.
-    /// </summary>
-    /// <param name="options">The command options.</param>
-    /// <param name="executionOptions">The execution configuration options.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The command result.</returns>
-    public Task<CommandResult> DiscussionAsync(GhDiscussionOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => throw new System.NotSupportedException();
-
-    /// <summary>
-    /// Work with GitHub issues.
-    /// </summary>
-    /// <param name="options">The command options.</param>
-    /// <param name="executionOptions">The execution configuration options.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The command result.</returns>
-    public Task<CommandResult> IssueAsync(GhIssueOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => throw new System.NotSupportedException();
-
-    /// <summary>
     /// View license information for third-party libraries used in this build of the GitHub CLI.
     /// </summary>
     /// <param name="options">The command options.</param>
@@ -215,43 +195,13 @@ public partial interface IGh
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// Work with GitHub organizations.
+    /// Stacked PRs let you break a large change into a chain of pull requests
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OrgAsync(GhOrgOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => throw new System.NotSupportedException();
-
-    /// <summary>
-    /// Work with GitHub pull requests.
-    /// </summary>
-    /// <param name="options">The command options.</param>
-    /// <param name="executionOptions">The execution configuration options.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The command result.</returns>
-    public Task<CommandResult> PrAsync(GhPrOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => throw new System.NotSupportedException();
-
-    /// <summary>
-    /// Manage releases
-    /// </summary>
-    /// <param name="options">The command options.</param>
-    /// <param name="executionOptions">The execution configuration options.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The command result.</returns>
-    public Task<CommandResult> ReleaseAsync(GhReleaseOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => throw new System.NotSupportedException();
-
-    /// <summary>
-    /// Work with GitHub repositories.
-    /// </summary>
-    /// <param name="options">The command options.</param>
-    /// <param name="executionOptions">The execution configuration options.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The command result.</returns>
-    public Task<CommandResult> RepoAsync(GhRepoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StackAsync(GhStackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhAgenttask.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhAgenttask.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.GitHub.Services;
 /// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
 /// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public interface IGhAgenttask
+public interface IGhAgentTask
 {
     /// <summary>
     /// Working with agent tasks in the GitHub CLI is in preview and

--- a/src/ModularPipelines.GitHub/Services/IGhCodespace.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhCodespace.Generated.cs
@@ -53,7 +53,7 @@ public interface IGhCodespace
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CpAsync(GhCodespaceCpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CpAsync(GhCodespaceCpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhConfig.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhConfig.Generated.cs
@@ -48,7 +48,7 @@ public interface IGhConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> GetAsync(GhConfigGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> GetAsync(GhConfigGetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IGhConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SetAsync(GhConfigSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetAsync(GhConfigSetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.GitHub/Services/IGhExtension.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhExtension.Generated.cs
@@ -58,7 +58,7 @@ public interface IGhExtension
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> InstallAsync(GhExtensionInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InstallAsync(GhExtensionInstallOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -78,7 +78,7 @@ public interface IGhExtension
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> RemoveAsync(GhExtensionRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RemoveAsync(GhExtensionRemoveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhGist.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhGist.Generated.cs
@@ -38,7 +38,7 @@ public interface IGhGist
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CloneAsync(GhGistCloneOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CloneAsync(GhGistCloneOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface IGhGist
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(GhGistDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(GhGistDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IGhGist
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> EditAsync(GhGistEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> EditAsync(GhGistEditOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -88,7 +88,7 @@ public interface IGhGist
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> RenameAsync(GhGistRenameOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RenameAsync(GhGistRenameOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhGpgkey.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhGpgkey.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.GitHub.Services;
 /// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
 /// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public interface IGhGpgkey
+public interface IGhGpgKey
 {
     /// <summary>
     /// Manage GPG keys registered with your GitHub account.
@@ -48,7 +48,7 @@ public interface IGhGpgkey
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(GhGpgKeyDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(GhGpgKeyDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhLabel.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhLabel.Generated.cs
@@ -38,7 +38,7 @@ public interface IGhLabel
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CloneAsync(GhLabelCloneOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CloneAsync(GhLabelCloneOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -48,7 +48,7 @@ public interface IGhLabel
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CreateAsync(GhLabelCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CreateAsync(GhLabelCreateOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface IGhLabel
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(GhLabelDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(GhLabelDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IGhLabel
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> EditAsync(GhLabelEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> EditAsync(GhLabelEditOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhRun.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhRun.Generated.cs
@@ -98,7 +98,7 @@ public interface IGhRun
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> WatchAsync(GhRunWatchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WatchAsync(GhRunWatchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.GitHub/Services/IGhSearch.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhSearch.Generated.cs
@@ -38,7 +38,7 @@ public interface IGhSearch
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CodeAsync(GhSearchCodeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CodeAsync(GhSearchCodeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhSecret.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhSecret.Generated.cs
@@ -38,7 +38,7 @@ public interface IGhSecret
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(GhSecretDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(GhSecretDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface IGhSecret
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SetAsync(GhSecretSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetAsync(GhSecretSetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.GitHub/Services/IGhSkill.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhSkill.Generated.cs
@@ -38,7 +38,7 @@ public interface IGhSkill
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> InstallAsync(GhSkillInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InstallAsync(GhSkillInstallOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface IGhSkill
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PreviewAsync(GhSkillPreviewOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PreviewAsync(GhSkillPreviewOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -78,7 +78,7 @@ public interface IGhSkill
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SearchAsync(GhSkillSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SearchAsync(GhSkillSearchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhSshkey.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhSshkey.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.GitHub.Services;
 /// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
 /// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
-public interface IGhSshkey
+public interface IGhSshKey
 {
     /// <summary>
     /// Manage SSH keys registered with your GitHub account.
@@ -48,7 +48,7 @@ public interface IGhSshkey
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(GhSshKeyDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(GhSshKeyDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.GitHub/Services/IGhVariable.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGhVariable.Generated.cs
@@ -38,7 +38,7 @@ public interface IGhVariable
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> DeleteAsync(GhVariableDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DeleteAsync(GhVariableDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -48,7 +48,7 @@ public interface IGhVariable
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> GetAsync(GhVariableGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> GetAsync(GhVariableGetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IGhVariable
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SetAsync(GhVariableSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetAsync(GhVariableSetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -786,6 +786,45 @@ public class GeneratorUtilsTests
     }
 
     [Test]
+    [Arguments("SecretName")]
+    [Arguments("TokenName")]
+    [Arguments("KeyId")]
+    [Arguments("CredentialId")]
+    [Arguments("ApiKeyIdentifier")]
+    public async Task IsSecretOption_Returns_False_For_Secret_Identifiers(string propertyName)
+    {
+        var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false);
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    [Arguments("Body", "The value for the secret")]
+    [Arguments("Value", "Password value to store")]
+    [Arguments("Payload", "Contains secret material")]
+    public async Task IsSecretOption_Uses_Description_For_Generic_Secret_Values(
+        string propertyName,
+        string description)
+    {
+        var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false, description);
+
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    [Arguments("Repos", "List repositories that can access an organization secret")]
+    [Arguments("App", "Set the application for a secret")]
+    [Arguments("CertOidcIssuer", "Enforce that the issuer of the OIDC token matches the provided value")]
+    public async Task IsSecretOption_Does_Not_Mask_Non_Value_Secret_Context(
+        string propertyName,
+        string description)
+    {
+        var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false, description);
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
     public async Task IsSecretOption_Returns_False_When_Description_Identifies_A_Path()
     {
         var result = GeneratorUtils.IsSecretOption(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -299,6 +299,43 @@ public class ZeroOutputScraperTests
     }
 
     [Test]
+    public async Task Gh_Secret_Set_Masks_Body_But_Not_Name()
+    {
+        const string helpText = """
+            Set a secret value.
+
+            USAGE
+              gh secret set <secret-name> [flags]
+
+            FLAGS
+              -b, --body string   The value for the secret (reads from standard input if not specified)
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "secret", "set"], helpText);
+        var secretName = command!.PositionalArguments.Single();
+        var body = command.Options.Single(option => option.PropertyName == "Body");
+
+        await Assert.That(secretName.PropertyName).IsEqualTo("SecretName");
+        await Assert.That(secretName.IsSecret).IsFalse();
+        await Assert.That(body.IsSecret).IsTrue();
+    }
+
+    [Test]
+    public async Task Gh_Secret_Delete_Does_Not_Mask_Name()
+    {
+        const string helpText = """
+            Delete a secret.
+
+            USAGE
+              gh secret delete <secret-name> [flags]
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "secret", "delete"], helpText);
+
+        await Assert.That(command!.PositionalArguments.Single().IsSecret).IsFalse();
+    }
+
+    [Test]
     public async Task Yarn_Extracts_Classic_Bulleted_Command_List()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -892,11 +892,16 @@ public static partial class GeneratorUtils
 
     private static readonly string[] FilePathPropertySuffixes = ["File", "Path", "Keyring", "Dir"];
 
+    private static readonly string[] IdentifierPropertySuffixes = ["Name", "Id", "Identifier"];
+
+    private const string SecretDescriptionKeywordPattern =
+        @"secret|password|passphrase|token|credential|api[\s-]*key|private[\s-]*key|access[\s-]*key|secret[\s-]*key|one[\s-]*time[\s-]*password|otp";
+
+    private const string SecretMaterialTermPattern = @"value|content|body|material|payload";
+
     /// <summary>
     /// Determines if an option should be marked as a secret based on its property name and description.
-    /// Options containing secret-related keywords such as "Secret", "Password", "Passphrase",
-    /// "Token", "Credential", "Otp", or known compound key names are considered secrets and
-    /// should be obfuscated in logs.
+    /// Secret-bearing values are obfuscated, while identifiers and file paths remain visible.
     /// </summary>
     /// <param name="propertyName">The C# property name of the option.</param>
     /// <param name="isFlag">Whether this is a boolean flag (flags are not considered secrets).</param>
@@ -909,9 +914,10 @@ public static partial class GeneratorUtils
             return false;
         }
 
-        // A secrets provider identifies the encryption backend (for example "default"
-        // or "passphrase"); it is not itself secret material.
-        if (propertyName.EndsWith("SecretsProvider", StringComparison.OrdinalIgnoreCase))
+        if (isFlag
+            || propertyName.EndsWith("SecretsProvider", StringComparison.OrdinalIgnoreCase)
+            || IsSecretIdentifier(propertyName)
+            || IsFilePathOption(propertyName, description))
         {
             return false;
         }
@@ -920,15 +926,23 @@ public static partial class GeneratorUtils
                                    propertyName.Contains(keyword, StringComparison.OrdinalIgnoreCase))
                                || ContainsIdentifierSegment(propertyName, "Otp")
                                || propertyName.EndsWith("Creds", StringComparison.OrdinalIgnoreCase);
-        if (!hasSecretKeyword || IsFilePathOption(propertyName, description))
-        {
-            return false;
-        }
-
-        // A keyword-bearing flag is suspicious, but has no value to mask. The
-        // enhancer reports it so a bad scraped type cannot pass unnoticed.
-        return !isFlag;
+        return hasSecretKeyword || DescriptionIdentifiesSecretValue(description);
     }
+
+    private static bool IsSecretIdentifier(string propertyName) =>
+        IdentifierPropertySuffixes.Any(suffix =>
+            propertyName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+
+    private static bool DescriptionIdentifiesSecretValue(string? description) =>
+        !string.IsNullOrWhiteSpace(description)
+        && SecretMaterialDescriptionPattern().IsMatch(description);
+
+    [GeneratedRegex(
+        @"\b(?:" + SecretDescriptionKeywordPattern + @")\s+(?:" + SecretMaterialTermPattern + @")\b"
+        + @"|\b(?:" + SecretMaterialTermPattern + @")\s+(?:for|of)\s+(?:the\s+)?(?:"
+        + SecretDescriptionKeywordPattern + @")\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SecretMaterialDescriptionPattern();
 
     internal static bool IsFilePathOption(string propertyName, string? description)
     {


### PR DESCRIPTION
## Summary
- exclude identifier-shaped properties such as `SecretName`, `TokenName`, and `*Id` from secret masking
- classify generic values only when descriptions directly identify secret material
- regenerate GitHub CLI v2.98.0 so `secret set --body` is masked while secret names remain visible
- retain current generated command surface, including `gh stack`, and merged v4 generator drift

## Validation
- `ModularPipelines.OptionsGenerator.slnx` Release build
- `ModularPipelines.GitHub.slnx` Release build (19 pre-existing warnings, 0 errors)
- 146 `GeneratorUtilsTests` passed
- 19 `ZeroOutputScraperTests` passed
- changed-file whitespace verification passed
- `git diff --check` passed

Closes #4329