### PR TITLE
Emit stable required pipeline context

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Test generated integration validation routing
         shell: pwsh
         run: ./scripts/Test-ResolveGeneratedIntegrationValidation.ps1
+      - name: Test required pipeline context routing
+        shell: pwsh
+        run: ./scripts/Test-RequiredPipelineContext.ps1
       - name: Verify public API baseline coverage
         shell: pwsh
         run: ./scripts/Assert-PublicApiBaselines.ps1
@@ -359,7 +362,7 @@ jobs:
           Write-Output 'Only pre-existing diagnostics outside changed C# files were found.'
 
   pipeline:
-    name: ${{ matrix.check_name }}
+    name: full pipeline (${{ matrix.os }})
     needs: fast-fail
     # Generated-options PRs use the one-tool validation job below. Main pushes and
     # every other PR retain the complete repository pipeline.
@@ -681,6 +684,27 @@ jobs:
             --framework net10.0 \
             --no-build \
             --no-restore
+
+  required-pipeline:
+    name: pipeline (ubuntu-latest)
+    needs: [fast-fail, pipeline, generated-integration]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - name: Validate required pipeline result
+        shell: pwsh
+        run: |
+          ./scripts/Assert-RequiredPipelineContext.ps1 `
+            -IsGeneratedIntegration '${{ needs.fast-fail.outputs.is_generated_integration }}' `
+            -FastFailResult '${{ needs.fast-fail.result }}' `
+            -FullPipelineResult '${{ needs.pipeline.result }}' `
+            -GeneratedIntegrationResult '${{ needs.generated-integration.result }}'
 
   trim-aot:
     name: trim and Native AOT

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -380,7 +380,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            check_name: pipeline (ubuntu-latest)
       fail-fast: false
     runs-on: ${{ matrix.os }}
     permissions:

--- a/scripts/Assert-RequiredPipelineContext.ps1
+++ b/scripts/Assert-RequiredPipelineContext.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('true', 'false')]
+    [string]$IsGeneratedIntegration,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('success', 'failure', 'cancelled', 'skipped')]
+    [string]$FastFailResult,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('success', 'failure', 'cancelled', 'skipped')]
+    [string]$FullPipelineResult,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('success', 'failure', 'cancelled', 'skipped')]
+    [string]$GeneratedIntegrationResult
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($FastFailResult -ne 'success') {
+    throw "Fast-fail result was '$FastFailResult'; required context cannot pass."
+}
+
+if ($IsGeneratedIntegration -eq 'true') {
+    if ($FullPipelineResult -ne 'skipped') {
+        throw "Generated validation expected the full pipeline to be skipped, received '$FullPipelineResult'."
+    }
+
+    if ($GeneratedIntegrationResult -ne 'success') {
+        throw "Generated integration result was '$GeneratedIntegrationResult'; required context cannot pass."
+    }
+
+    Write-Host 'Required pipeline context passed through generated integration validation.'
+    return
+}
+
+if ($FullPipelineResult -ne 'success') {
+    throw "Full pipeline result was '$FullPipelineResult'; required context cannot pass."
+}
+
+if ($GeneratedIntegrationResult -ne 'skipped') {
+    throw "Full validation expected generated integration to be skipped, received '$GeneratedIntegrationResult'."
+}
+
+Write-Host 'Required pipeline context passed through full validation.'

--- a/scripts/Assert-RequiredPipelineContext.ps1
+++ b/scripts/Assert-RequiredPipelineContext.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [ValidateSet('true', 'false')]
+    [AllowEmptyString()]
     [string]$IsGeneratedIntegration,
 
     [Parameter(Mandatory)]
@@ -21,6 +21,10 @@ $ErrorActionPreference = 'Stop'
 
 if ($FastFailResult -ne 'success') {
     throw "Fast-fail result was '$FastFailResult'; required context cannot pass."
+}
+
+if ($IsGeneratedIntegration -notin @('true', 'false')) {
+    throw "Generated integration routing value was '$IsGeneratedIntegration'; required context cannot pass."
 }
 
 if ($IsGeneratedIntegration -eq 'true') {

--- a/scripts/Test-RequiredPipelineContext.ps1
+++ b/scripts/Test-RequiredPipelineContext.ps1
@@ -1,0 +1,106 @@
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path $PSScriptRoot -Parent
+$assertScript = Join-Path $PSScriptRoot 'Assert-RequiredPipelineContext.ps1'
+
+function Assert-RoutePasses {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$IsGeneratedIntegration,
+        [Parameter(Mandatory)][string]$FastFailResult,
+        [Parameter(Mandatory)][string]$FullPipelineResult,
+        [Parameter(Mandatory)][string]$GeneratedIntegrationResult
+    )
+
+    & $assertScript `
+        -IsGeneratedIntegration $IsGeneratedIntegration `
+        -FastFailResult $FastFailResult `
+        -FullPipelineResult $FullPipelineResult `
+        -GeneratedIntegrationResult $GeneratedIntegrationResult
+}
+
+function Assert-RouteFails {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$IsGeneratedIntegration,
+        [Parameter(Mandatory)][string]$FastFailResult,
+        [Parameter(Mandatory)][string]$FullPipelineResult,
+        [Parameter(Mandatory)][string]$GeneratedIntegrationResult
+    )
+
+    try {
+        Assert-RoutePasses @PSBoundParameters
+    }
+    catch {
+        return
+    }
+
+    throw "Route '$Name' unexpectedly passed."
+}
+
+Assert-RoutePasses `
+    -Name 'normal pull request' `
+    -IsGeneratedIntegration false `
+    -FastFailResult success `
+    -FullPipelineResult success `
+    -GeneratedIntegrationResult skipped
+Assert-RoutePasses `
+    -Name 'generated integration pull request' `
+    -IsGeneratedIntegration true `
+    -FastFailResult success `
+    -FullPipelineResult skipped `
+    -GeneratedIntegrationResult success
+Assert-RouteFails `
+    -Name 'generated validation skipped' `
+    -IsGeneratedIntegration true `
+    -FastFailResult success `
+    -FullPipelineResult skipped `
+    -GeneratedIntegrationResult skipped
+Assert-RouteFails `
+    -Name 'generated validation failed' `
+    -IsGeneratedIntegration true `
+    -FastFailResult success `
+    -FullPipelineResult skipped `
+    -GeneratedIntegrationResult failure
+Assert-RouteFails `
+    -Name 'generated validation canceled' `
+    -IsGeneratedIntegration true `
+    -FastFailResult success `
+    -FullPipelineResult skipped `
+    -GeneratedIntegrationResult cancelled
+Assert-RouteFails `
+    -Name 'fast-fail failed' `
+    -IsGeneratedIntegration false `
+    -FastFailResult failure `
+    -FullPipelineResult failure `
+    -GeneratedIntegrationResult skipped
+
+$workflow = Get-Content -LiteralPath (Join-Path $repositoryRoot '.github/workflows/dotnet.yml') -Raw
+$requiredJob = [regex]::Match(
+    $workflow,
+    '(?ms)^  required-pipeline:.*?(?=^  [a-z0-9-]+:)').Value
+if ([string]::IsNullOrWhiteSpace($requiredJob)) {
+    throw 'Required pipeline aggregate job was not found.'
+}
+
+foreach ($requiredText in @(
+             'name: pipeline (ubuntu-latest)',
+             'needs: [fast-fail, pipeline, generated-integration]',
+             'if: always()',
+             './scripts/Assert-RequiredPipelineContext.ps1'
+         )) {
+    if (-not $requiredJob.Contains($requiredText, [StringComparison]::Ordinal)) {
+        throw "Required pipeline aggregate omitted '$requiredText'."
+    }
+}
+
+$fullPipelineJob = [regex]::Match(
+    $workflow,
+    '(?ms)^  pipeline:.*?(?=^  [a-z0-9-]+:)').Value
+if (-not $fullPipelineJob.Contains(
+        'name: full pipeline (${{ matrix.os }})',
+        [StringComparison]::Ordinal)) {
+    throw 'The full pipeline job must not emit the required aggregate context directly.'
+}
+
+Write-Host 'Required pipeline context tests passed.'

--- a/scripts/Test-RequiredPipelineContext.ps1
+++ b/scripts/Test-RequiredPipelineContext.ps1
@@ -6,7 +6,7 @@ $assertScript = Join-Path $PSScriptRoot 'Assert-RequiredPipelineContext.ps1'
 function Assert-RoutePasses {
     param(
         [Parameter(Mandatory)][string]$Name,
-        [Parameter(Mandatory)][string]$IsGeneratedIntegration,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$IsGeneratedIntegration,
         [Parameter(Mandatory)][string]$FastFailResult,
         [Parameter(Mandatory)][string]$FullPipelineResult,
         [Parameter(Mandatory)][string]$GeneratedIntegrationResult
@@ -22,7 +22,7 @@ function Assert-RoutePasses {
 function Assert-RouteFails {
     param(
         [Parameter(Mandatory)][string]$Name,
-        [Parameter(Mandatory)][string]$IsGeneratedIntegration,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$IsGeneratedIntegration,
         [Parameter(Mandatory)][string]$FastFailResult,
         [Parameter(Mandatory)][string]$FullPipelineResult,
         [Parameter(Mandatory)][string]$GeneratedIntegrationResult
@@ -74,11 +74,35 @@ Assert-RouteFails `
     -FastFailResult failure `
     -FullPipelineResult failure `
     -GeneratedIntegrationResult skipped
+Assert-RouteFails `
+    -Name 'full pipeline failed' `
+    -IsGeneratedIntegration false `
+    -FastFailResult success `
+    -FullPipelineResult failure `
+    -GeneratedIntegrationResult skipped
+Assert-RouteFails `
+    -Name 'full pipeline canceled' `
+    -IsGeneratedIntegration false `
+    -FastFailResult success `
+    -FullPipelineResult cancelled `
+    -GeneratedIntegrationResult skipped
+Assert-RouteFails `
+    -Name 'routing output missing after fast-fail success' `
+    -IsGeneratedIntegration '' `
+    -FastFailResult success `
+    -FullPipelineResult skipped `
+    -GeneratedIntegrationResult skipped
+Assert-RouteFails `
+    -Name 'routing output missing after fast-fail failure' `
+    -IsGeneratedIntegration '' `
+    -FastFailResult failure `
+    -FullPipelineResult skipped `
+    -GeneratedIntegrationResult skipped
 
 $workflow = Get-Content -LiteralPath (Join-Path $repositoryRoot '.github/workflows/dotnet.yml') -Raw
 $requiredJob = [regex]::Match(
     $workflow,
-    '(?ms)^  required-pipeline:.*?(?=^  [a-z0-9-]+:)').Value
+    '(?ms)^  required-pipeline:.*?(?=^  [a-z0-9-]+:|\z)').Value
 if ([string]::IsNullOrWhiteSpace($requiredJob)) {
     throw 'Required pipeline aggregate job was not found.'
 }


### PR DESCRIPTION
## Summary
- add a stable `pipeline (ubuntu-latest)` aggregate check for both full and generated-integration validation routes
- fail the required context when fast-fail or the selected validation route is skipped, failed, or cancelled
- add executable workflow-contract tests for normal, generated, skipped, failure, and cancellation paths

## Test plan
- [x] `pwsh scripts/Test-RequiredPipelineContext.ps1`
- [x] `pwsh scripts/Test-ResolveGeneratedIntegrationValidation.ps1`
- [x] `git diff --check`
- [ ] GitHub Actions workflow validation (`actionlint` is unavailable locally)

Closes #4457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Added validation for required pipeline context and job outcomes.
  * Improved handling of standard and generated-integration pipeline paths.
  * Added checks for skipped, failed, canceled, and fast-fail scenarios.
  * Updated pipeline job labels to clearly identify the operating system.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->