### PR TITLE
Prevent blanket mass command shrinkage

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -23,7 +23,7 @@ on:
         default: true
         type: boolean
       approve-command-coverage-shrinkage:
-        description: 'Explicitly approve command-set changes or shrinkage for this run'
+        description: 'Approve same-version additions and at most five undocumented removals for this run'
         required: false
         default: false
         type: boolean
@@ -596,6 +596,15 @@ jobs:
             echo "$coverage_delimiter"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Upload scrape failure diagnostics
+        if: always() && steps.should-run.outputs.run == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: options-generator-diagnostics-${{ matrix.tool }}-${{ runner.os }}
+          path: artifacts/options-generator-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Check for changes
         if: steps.should-run.outputs.run == 'true'
         id: changes
@@ -866,6 +875,15 @@ jobs:
               Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
           $coverageDelimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Upload scrape failure diagnostics
+        if: always() && steps.should-run.outputs.run == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: options-generator-diagnostics-${{ matrix.tool }}-${{ runner.os }}
+          path: artifacts/options-generator-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Check for changes
         if: steps.should-run.outputs.run == 'true'

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -23,7 +23,7 @@ on:
         default: true
         type: boolean
       approve-command-coverage-shrinkage:
-        description: 'Approve same-version additions and at most five undocumented removals for this run'
+        description: 'Approve same-version changes and at most five undocumented removals; larger removals need reasoned exclusions, and minimum/sentinel checks remain enforced'
         required: false
         default: false
         type: boolean

--- a/tools/ModularPipelines.OptionsGenerator/README.md
+++ b/tools/ModularPipelines.OptionsGenerator/README.md
@@ -176,8 +176,9 @@ When command coverage changes:
 3. If a same-version addition or at most five upstream removals are expected, run once with
    `--approve-command-coverage-shrinkage` and review the generated API, baseline-version
    comparison, and coverage diff.
-4. For larger removals, add a documented exclusion with a reviewed reason for every removed
-   command. Blanket approval deliberately has no mass-removal escape hatch.
+4. For larger removals, add a documented exclusion with a reviewed reason for each removal
+   beyond the five-command allowance. Blanket approval alone deliberately has no mass-removal
+   escape hatch.
 
 Approval permits same-version additions, up to five undocumented removals, and groups losing
 all children. Minimum counts, sentinel requirements, and the removal blast-radius ceiling

--- a/tools/ModularPipelines.OptionsGenerator/README.md
+++ b/tools/ModularPipelines.OptionsGenerator/README.md
@@ -83,7 +83,7 @@ Use a comma-separated list for `--tools`, or `all`. Useful options are:
 | `--use-cli-first <true\|false>` | Prefer installed CLI help over HTML documentation. Defaults to `true`. |
 | `--enhance-types <true\|false>` | Run type detection after HTML scraping. Defaults to `true`. |
 | `--change-manifest <path>` | Record every repository-relative generated or deleted path for safe automation. |
-| `--approve-command-coverage-shrinkage` | Acknowledge reviewed command-set changes for this run, including same-version additions or removals. It does not bypass minimum counts or sentinel commands. |
+| `--approve-command-coverage-shrinkage` | Acknowledge reviewed same-version additions and up to five undocumented command removals for this run. Larger removals require per-command exclusions with reasons. It never bypasses minimum counts or sentinel commands. |
 | `--input <path>` | Generate an external integration from JSON. This cannot be combined with `--tools`. |
 
 For reproducible CI scraping, set `MODULARPIPELINES_CLI_EXECUTABLE` to the verified absolute
@@ -158,6 +158,7 @@ Generation fails when:
 - a configured sentinel command disappeared;
 - the command set changed while the resolved tool version stayed the same, without explicit approval;
 - a previously generated command disappeared without explicit approval;
+- blanket approval would remove more than five commands without documented exclusions;
 - a known command group lost all children without explicit approval; or
 - an exclusion lacks a full command and non-empty reason.
 
@@ -172,13 +173,18 @@ When command coverage changes:
    plugin, authentication prompt, preview flag, or wrong executable must not be approved as
    upstream shrinkage.
 2. Fix the scraper when the commands still exist, then regenerate.
-3. If the change is expected, run once with
-   `--approve-command-coverage-shrinkage` and review the generated API and coverage diff.
-4. Add a documented exclusion instead when a command intentionally remains unsupported.
+3. If a same-version addition or at most five upstream removals are expected, run once with
+   `--approve-command-coverage-shrinkage` and review the generated API, baseline-version
+   comparison, and coverage diff.
+4. For larger removals, add a documented exclusion with a reviewed reason for every removed
+   command. Blanket approval deliberately has no mass-removal escape hatch.
 
-Approval permits same-version command-set changes, removed commands, and groups losing all
-children. Minimum counts and sentinel requirements always remain enforced. Additions after
-an intentional tool-version change need no approval.
+Approval permits same-version additions, up to five undocumented removals, and groups losing
+all children. Minimum counts, sentinel requirements, and the removal blast-radius ceiling
+always remain enforced. Additions after an intentional tool-version change need no approval.
+On a CLI coverage failure, raw root and relevant parent help output is written under
+`artifacts/options-generator-diagnostics/`; generation CI uploads that directory so reviewers
+can distinguish an upstream removal from a partial scrape.
 
 ## Validate a change
 
@@ -240,4 +246,5 @@ Regenerate outputs instead of changing version attributes in place.
 
 Breaking generated API changes remain visible for human review. The workflow's manual
 `approve-command-coverage-shrinkage` input is an explicit acknowledgement for a single run,
-not a permanent weakening of the coverage policy.
+not a permanent weakening of the coverage policy. It cannot approve more than five
+undocumented removals; coverage failures upload raw help provenance for diagnosis.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -143,6 +143,31 @@ public class CodeGeneratorOrchestratorTests
             Task.FromCanceled<CliToolDefinition>(new CancellationToken(canceled: true));
     }
 
+    private sealed class SuccessfulHtmlScraper : ICliDocumentationScraper
+    {
+        public string ToolName => "fake";
+
+        public string NamespacePrefix => "Fake";
+
+        public string TargetNamespace => "ModularPipelines.Fake";
+
+        public string OutputDirectory => ToolOutputDirectory;
+
+        public Task<CliToolDefinition> ScrapeAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new CliToolDefinition
+            {
+                ToolName = ToolName,
+                NamespacePrefix = NamespacePrefix,
+                TargetNamespace = TargetNamespace,
+                OutputDirectory = OutputDirectory,
+                Commands = [FakeCommand()],
+                ExecutablePrerequisite = new CliExecutablePrerequisite
+                {
+                    CommandName = "fake",
+                },
+            });
+    }
+
     private sealed class DiagnosticExecutor : ICliCommandExecutor
     {
         public Task<CliCommandResult> ExecuteAsync(
@@ -237,6 +262,38 @@ public class CodeGeneratorOrchestratorTests
             await Assert.That(File.Exists(diagnosticsPath)).IsTrue();
             var diagnostics = await File.ReadAllTextAsync(diagnosticsPath);
             await Assert.That(diagnostics).Contains("RAW ROOT HELP: fake run only");
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task SuccessfulHtmlFallback_ExcludesProvisionalCliCoverage()
+    {
+        var outputRoot = Path.Combine(
+            Path.GetTempPath(),
+            "mp-orchestrator-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputRoot);
+
+        try
+        {
+            var cliScraper = new DiagnosticCliScraper(
+                new DiagnosticExecutor(),
+                produceCommand: false);
+            var orchestrator = new CodeGeneratorOrchestrator(
+                [cliScraper],
+                [new SuccessfulHtmlScraper()],
+                [new FakeGenerator()],
+                NullLogger<CodeGeneratorOrchestrator>.Instance);
+
+            var result = await orchestrator.GenerateAsync("fake", outputRoot);
+
+            await Assert.That(result.Errors).IsEmpty();
+            await Assert.That(result.CommandCoverage).HasSingleItem();
+            await Assert.That(result.CommandCoverage[0].Manifest.CommandCount).IsEqualTo(1);
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Base;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -90,7 +91,9 @@ public class CodeGeneratorOrchestratorTests
             => Task.FromResult(OnGenerate(tool));
     }
 
-    private sealed class DiagnosticCliScraper(ICliCommandExecutor executor)
+    private sealed class DiagnosticCliScraper(
+        ICliCommandExecutor executor,
+        bool produceCommand = true)
         : CliScraperBase(
             executor,
             new HelpTextCache(NullLogger<HelpTextCache>.Instance),
@@ -123,7 +126,21 @@ public class CodeGeneratorOrchestratorTests
             string[] commandPath,
             string helpText,
             CancellationToken cancellationToken) =>
-            Task.FromResult<CliCommandDefinition?>(FakeCommand());
+            Task.FromResult<CliCommandDefinition?>(produceCommand ? FakeCommand() : null);
+    }
+
+    private sealed class CancelingHtmlScraper : ICliDocumentationScraper
+    {
+        public string ToolName => "fake";
+
+        public string NamespacePrefix => "Fake";
+
+        public string TargetNamespace => "ModularPipelines.Fake";
+
+        public string OutputDirectory => ToolOutputDirectory;
+
+        public Task<CliToolDefinition> ScrapeAsync(CancellationToken cancellationToken = default) =>
+            Task.FromCanceled<CliToolDefinition>(new CancellationToken(canceled: true));
     }
 
     private sealed class DiagnosticExecutor : ICliCommandExecutor
@@ -194,6 +211,50 @@ public class CodeGeneratorOrchestratorTests
         {
             Directory.Delete(outputRoot, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task EmptyCliScrape_WritesRawHelpDiagnostics()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputRoot);
+        var diagnosticsPath = Path.Combine(
+            outputRoot,
+            "artifacts",
+            "options-generator-diagnostics",
+            "fake",
+            "command-coverage-failure.json");
+
+        try
+        {
+            var scraper = new DiagnosticCliScraper(new DiagnosticExecutor(), produceCommand: false);
+
+            var result = await Orchestrator(scraper, new FakeGenerator())
+                .GenerateAsync("fake", outputRoot);
+
+            await Assert.That(result.HasErrors).IsTrue();
+            await Assert.That(result.Errors[0].Message).Contains("Raw help diagnostics");
+            await Assert.That(File.Exists(diagnosticsPath)).IsTrue();
+            var diagnostics = await File.ReadAllTextAsync(diagnosticsPath);
+            await Assert.That(diagnostics).Contains("RAW ROOT HELP: fake run only");
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task HtmlScraperCancellation_Propagates()
+    {
+        var orchestrator = new CodeGeneratorOrchestrator(
+            cliScrapers: [],
+            htmlScrapers: [new CancelingHtmlScraper()],
+            generators: [new FakeGenerator()],
+            NullLogger<CodeGeneratorOrchestrator>.Instance);
+
+        await Assert.That(async () => await orchestrator.GenerateAsync("fake", Path.GetTempPath()))
+            .Throws<OperationCanceledException>();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -865,6 +865,8 @@ public class CodeGeneratorOrchestratorTests
             await Assert.That(approved.GetSummary())
                 .Contains("WARNING: COMMAND COVERAGE SHRINKAGE DETECTED")
                 .And.Contains("Removed (approved): fake deploy");
+            await Assert.That(approved.GetSummary()).Contains(
+                "Baseline comparison: 2 commands at fake 1.0 -> 1 commands at fake 1.0");
 
             var manifest = await File.ReadAllTextAsync(Path.Combine(
                 outputRoot,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Tests.Generators;
 
@@ -89,6 +90,64 @@ public class CodeGeneratorOrchestratorTests
             => Task.FromResult(OnGenerate(tool));
     }
 
+    private sealed class DiagnosticCliScraper(ICliCommandExecutor executor)
+        : CliScraperBase(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<DiagnosticCliScraper>.Instance)
+    {
+        public override string ToolName => "fake";
+
+        public override string NamespacePrefix => "Fake";
+
+        public override string TargetNamespace => "ModularPipelines.Fake";
+
+        public override string OutputDirectory => ToolOutputDirectory;
+
+        public override CliToolDefinition CreateToolDefinition() =>
+            base.CreateToolDefinition() with
+            {
+                CommandCoverage = new CliCommandCoveragePolicy
+                {
+                    MinimumCommandCount = 2,
+                },
+                ExecutablePrerequisite = new CliExecutablePrerequisite
+                {
+                    CommandName = "fake",
+                },
+            };
+
+        protected override IEnumerable<string> ExtractSubcommands(string helpText) => [];
+
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string helpText,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<CliCommandDefinition?>(FakeCommand());
+    }
+
+    private sealed class DiagnosticExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = arguments == "--version"
+                    ? "fake 1.0"
+                    : "RAW ROOT HELP: fake run only\nUsage: fake [flags]\nOptions:\n  --value string",
+                StandardError = string.Empty,
+                ExitCode = 0,
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
     private static CliCommandDefinition FakeCommand() => new()
     {
         FullCommand = "fake run",
@@ -99,12 +158,43 @@ public class CodeGeneratorOrchestratorTests
         Options = [],
     };
 
-    private static CodeGeneratorOrchestrator Orchestrator(FakeCliScraper scraper, params ICodeGenerator[] generators) =>
+    private static CodeGeneratorOrchestrator Orchestrator(ICliScraper scraper, params ICodeGenerator[] generators) =>
         new(
             [scraper],
             htmlScrapers: [],
             generators,
             NullLogger<CodeGeneratorOrchestrator>.Instance);
+
+    [Test]
+    public async Task FirstGenerationCoverageFailure_WritesRawHelpDiagnostics()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputRoot);
+        var diagnosticsPath = Path.Combine(
+            outputRoot,
+            "artifacts",
+            "options-generator-diagnostics",
+            "fake",
+            "command-coverage-failure.json");
+
+        try
+        {
+            var scraper = new DiagnosticCliScraper(new DiagnosticExecutor());
+
+            var result = await Orchestrator(scraper, new FakeGenerator())
+                .GenerateAsync("fake", outputRoot);
+
+            await Assert.That(result.HasErrors).IsTrue();
+            await Assert.That(result.Errors[0].Message).Contains("Raw help diagnostics");
+            await Assert.That(File.Exists(diagnosticsPath)).IsTrue();
+            var diagnostics = await File.ReadAllTextAsync(diagnosticsPath);
+            await Assert.That(diagnostics).Contains("RAW ROOT HELP: fake run only");
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
 
     [Test]
     public async Task Cli_Metadata_Is_Preserved_For_Generators()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -197,6 +197,28 @@ public class CodeGeneratorOrchestratorTests
     }
 
     [Test]
+    public async Task CliCoverageDiagnosticCancellation_Propagates()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputRoot);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        try
+        {
+            var scraper = new DiagnosticCliScraper(new DiagnosticExecutor());
+
+            await Assert.That(async () => await Orchestrator(scraper, new FakeGenerator())
+                    .GenerateAsync("fake", outputRoot, cancellationToken: cancellationTokenSource.Token))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task Cli_Metadata_Is_Preserved_For_Generators()
     {
         var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -192,7 +193,7 @@ public class CommandCoverageGuardTests
         {
             var baseline = CommandCoverageGuard.Evaluate(
                 Tool(
-                    Command("aws apigateway get-model"),
+                    Command("aws apigateway models get-model"),
                     Command("aws ec2 describe-instances"),
                     Command("aws ec2 modify-vpc-attribute"),
                     Command("aws efs create-file-system"),
@@ -220,6 +221,10 @@ public class CommandCoverageGuardTests
                 "help",
                 Result("RAW ROOT HELP: ec2 only"));
             provenance.Record(
+                ["aws", "apigateway"],
+                "apigateway help",
+                Result("RAW APIGATEWAY HELP: models omitted"));
+            provenance.Record(
                 ["aws", "ec2"],
                 "ec2 help",
                 Result("RAW EC2 HELP: describe-instances only"));
@@ -232,10 +237,17 @@ public class CommandCoverageGuardTests
                 current,
                 CancellationToken.None);
             var json = await File.ReadAllTextAsync(path!);
+            using var diagnostics = JsonDocument.Parse(json);
+            var missingHelpPaths = diagnostics.RootElement
+                .GetProperty("missingHelpPaths")
+                .EnumerateArray()
+                .Select(static element => element.GetString())
+                .ToArray();
 
             await Assert.That(json).Contains("RAW ROOT HELP: ec2 only");
+            await Assert.That(json).Contains("RAW APIGATEWAY HELP: models omitted");
             await Assert.That(json).Contains("RAW EC2 HELP: describe-instances only");
-            await Assert.That(json).Contains("aws apigateway");
+            await Assert.That(missingHelpPaths).Contains("aws apigateway models");
             await Assert.That(json).Contains("aws-cli/2.36.29");
             await Assert.That(json).Contains("aws-cli/2.36.35");
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -287,6 +287,7 @@ public class CommandCoverageGuardTests
                 ["fake", "group", "leaf"],
                 "group leaf --help",
                 Result("RAW LEAF HELP"));
+            provenance.DiscardLeafHelp(["fake", "group", "leaf"]);
 
             var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
                 outputDirectory,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -246,6 +246,45 @@ public class CommandCoverageGuardTests
     }
 
     [Test]
+    public async Task CoverageFailureDiagnostics_AreWrittenWithoutRemovedCommands()
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            var current = CommandCoverageGuard.Evaluate(
+                Tool(Command("fake run")) with
+                {
+                    CommandCoverage = new CliCommandCoveragePolicy
+                    {
+                        MinimumCommandCount = 2,
+                    },
+                },
+                outputDirectory,
+                approveShrinkage: false);
+            var provenance = new CliScrapeProvenance();
+            provenance.Record(
+                ["fake"],
+                "--help",
+                Result("RAW ROOT HELP: run only"));
+
+            var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                current,
+                CancellationToken.None);
+            var json = await File.ReadAllTextAsync(path!);
+
+            await Assert.That(path).IsNotNull();
+            await Assert.That(json).Contains("RAW ROOT HELP: run only");
+            await Assert.That(json).Contains("\"removedCommands\": []");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task DocumentedExclusions_AllowMassRemovalWithoutBlanketApproval()
     {
         var outputDirectory = CreateOutputDirectory();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -1,5 +1,7 @@
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Tests.Generators;
 
@@ -129,6 +131,154 @@ public class CommandCoverageGuardTests
             await Assert.That(current.Violations).IsEmpty();
             await Assert.That(current.AddedCommands).IsEquivalentTo(["fake init"]);
             await Assert.That(current.RemovedCommands).IsEquivalentTo(["fake list-engines"]);
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task BlanketApproval_RejectsTruncatedAwsServiceScrape()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        var baselineCommands = new[]
+        {
+            "aws apigateway get-model",
+            "aws ec2 describe-instances",
+            "aws ec2 modify-vpc-attribute",
+            "aws efs create-file-system",
+            "aws iam create-role",
+            "aws lambda create-function",
+            "aws s3api create-bucket",
+            "aws sts get-caller-identity",
+        };
+
+        try
+        {
+            var baseline = CommandCoverageGuard.Evaluate(
+                Tool(baselineCommands.Select(Command).ToArray()) with { ToolVersion = "aws-cli/2.36.29" },
+                outputDirectory,
+                approveShrinkage: false);
+            await CommandCoverageGuard.WriteManifestAsync(baseline, CancellationToken.None);
+
+            var current = CommandCoverageGuard.Evaluate(
+                Tool(Command("aws sts get-caller-identity")) with { ToolVersion = "aws-cli/2.36.35" },
+                outputDirectory,
+                approveShrinkage: true);
+
+            await Assert.That(current.Violations).Contains(
+                violation => violation.Contains("Blanket approval cannot authorize 7 command removals", StringComparison.Ordinal)
+                             && violation.Contains("aws-cli/2.36.29", StringComparison.Ordinal)
+                             && violation.Contains("aws-cli/2.36.35", StringComparison.Ordinal)
+                             && violation.Contains("aws apigateway get-model", StringComparison.Ordinal)
+                             && violation.Contains("explicit command coverage exclusions", StringComparison.Ordinal));
+            await Assert.That(current.PreviousCommandCount).IsEqualTo(8);
+            await Assert.That(current.PreviousToolVersion).IsEqualTo("aws-cli/2.36.29");
+            await Assert.That(current.ShrinkageApproved).IsFalse();
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task CoverageFailureDiagnostics_PreserveRelevantRawHelpAndMissingParents()
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            var baseline = CommandCoverageGuard.Evaluate(
+                Tool(
+                    Command("aws apigateway get-model"),
+                    Command("aws ec2 describe-instances"),
+                    Command("aws ec2 modify-vpc-attribute"),
+                    Command("aws efs create-file-system"),
+                    Command("aws iam create-role"),
+                    Command("aws lambda create-function"),
+                    Command("aws s3api create-bucket")) with
+                {
+                    ToolName = "aws",
+                    ToolVersion = "aws-cli/2.36.29",
+                },
+                outputDirectory,
+                approveShrinkage: false);
+            await CommandCoverageGuard.WriteManifestAsync(baseline, CancellationToken.None);
+            var current = CommandCoverageGuard.Evaluate(
+                Tool(Command("aws ec2 describe-instances")) with
+                {
+                    ToolName = "aws",
+                    ToolVersion = "aws-cli/2.36.35",
+                },
+                outputDirectory,
+                approveShrinkage: true);
+            var provenance = new CliScrapeProvenance();
+            provenance.Record(
+                ["aws"],
+                "help",
+                Result("RAW ROOT HELP: ec2 only"));
+            provenance.Record(
+                ["aws", "ec2"],
+                "ec2 help",
+                Result("RAW EC2 HELP: describe-instances only"));
+            provenance.PreserveGroupHelp(
+                ["aws", "ec2"],
+                "RAW EC2 HELP: describe-instances only");
+
+            var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                current,
+                CancellationToken.None);
+            var json = await File.ReadAllTextAsync(path!);
+
+            await Assert.That(json).Contains("RAW ROOT HELP: ec2 only");
+            await Assert.That(json).Contains("RAW EC2 HELP: describe-instances only");
+            await Assert.That(json).Contains("aws apigateway");
+            await Assert.That(json).Contains("aws-cli/2.36.29");
+            await Assert.That(json).Contains("aws-cli/2.36.35");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task DocumentedExclusions_AllowMassRemovalWithoutBlanketApproval()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        var removedCommands = Enumerable.Range(1, 6)
+            .Select(index => $"fake removed-{index}")
+            .ToArray();
+
+        try
+        {
+            var baseline = CommandCoverageGuard.Evaluate(
+                Tool([Command("fake keep"), .. removedCommands.Select(Command)]),
+                outputDirectory,
+                approveShrinkage: false);
+            await CommandCoverageGuard.WriteManifestAsync(baseline, CancellationToken.None);
+            var current = CommandCoverageGuard.Evaluate(
+                Tool(Command("fake keep")) with
+                {
+                    CommandCoverage = new CliCommandCoveragePolicy
+                    {
+                        Exclusions = removedCommands
+                            .Select(command => new CliCommandCoverageExclusion
+                            {
+                                Command = command,
+                                Reason = "Removed upstream and reviewed in issue #4465.",
+                            })
+                            .ToArray(),
+                    },
+                },
+                outputDirectory,
+                approveShrinkage: false);
+
+            await Assert.That(current.Violations).IsEmpty();
+            await Assert.That(current.RemovedCommands).Count().IsEqualTo(6);
         }
         finally
         {
@@ -389,5 +539,12 @@ public class CommandCoverageGuardTests
         ParentClassName = "FakeOptions",
         ToolNamespacePrefix = "Fake",
         Options = [],
+    };
+
+    private static CliCommandResult Result(string standardOutput) => new()
+    {
+        StandardOutput = standardOutput,
+        StandardError = string.Empty,
+        ExitCode = 0,
     };
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -175,7 +175,7 @@ public class CommandCoverageGuardTests
                              && violation.Contains("explicit command coverage exclusions", StringComparison.Ordinal));
             await Assert.That(current.PreviousCommandCount).IsEqualTo(8);
             await Assert.That(current.PreviousToolVersion).IsEqualTo("aws-cli/2.36.29");
-            await Assert.That(current.ShrinkageApproved).IsFalse();
+            await Assert.That(current.ChangesApproved).IsFalse();
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -224,6 +224,9 @@ public class CommandCoverageGuardTests
                 ["aws", "apigateway"],
                 "apigateway help",
                 Result("RAW APIGATEWAY HELP: models omitted"));
+            provenance.PreserveGroupHelp(
+                ["aws", "apigateway"],
+                "RAW APIGATEWAY HELP: models omitted");
             provenance.Record(
                 ["aws", "ec2"],
                 "ec2 help",
@@ -250,6 +253,53 @@ public class CommandCoverageGuardTests
             await Assert.That(missingHelpPaths).Contains("aws apigateway models");
             await Assert.That(json).Contains("aws-cli/2.36.29");
             await Assert.That(json).Contains("aws-cli/2.36.35");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task CoverageFailureDiagnostics_DiscardUnpreservedLeafRawHelp()
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            var baseline = CommandCoverageGuard.Evaluate(
+                Tool(Command("fake group leaf nested")),
+                outputDirectory,
+                approveShrinkage: false);
+            await CommandCoverageGuard.WriteManifestAsync(baseline, CancellationToken.None);
+            var current = CommandCoverageGuard.Evaluate(
+                Tool(Command("fake keep")),
+                outputDirectory,
+                approveShrinkage: false);
+            var provenance = new CliScrapeProvenance();
+            provenance.Record(["fake"], "--help", Result("RAW ROOT HELP"));
+            provenance.Record(
+                ["fake", "group"],
+                "group --help",
+                Result("RAW GROUP HELP"));
+            provenance.PreserveGroupHelp(["fake", "group"], "RAW GROUP HELP");
+            provenance.Record(
+                ["fake", "group", "leaf"],
+                "group leaf --help",
+                Result("RAW LEAF HELP"));
+
+            var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                current,
+                CancellationToken.None);
+            var json = await File.ReadAllTextAsync(path!);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(json).Contains("RAW ROOT HELP");
+                await Assert.That(json).Contains("RAW GROUP HELP");
+                await Assert.That(json).DoesNotContain("RAW LEAF HELP");
+            }
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -285,6 +285,40 @@ public class CommandCoverageGuardTests
     }
 
     [Test]
+    public async Task PreservedGroupHelp_ReplacesEarlierRawInvocationOutput()
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            var current = CommandCoverageGuard.Evaluate(
+                Tool(Command("fake run")),
+                outputDirectory,
+                approveShrinkage: false);
+            var provenance = new CliScrapeProvenance();
+            provenance.Record(
+                ["fake"],
+                "--help",
+                Result("RAW ROOT HELP"));
+            provenance.PreserveGroupHelp(
+                ["fake"],
+                "RAW ROOT HELP\n\nCommands:\n  run  Discovered by supplemental inventory.");
+
+            var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                current,
+                CancellationToken.None);
+            var json = await File.ReadAllTextAsync(path!);
+
+            await Assert.That(json).Contains("Discovered by supplemental inventory");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task DocumentedExclusions_AllowMassRemovalWithoutBlanketApproval()
     {
         var outputDirectory = CreateOutputDirectory();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CommandCoverageGuardTests.cs
@@ -224,16 +224,12 @@ public class CommandCoverageGuardTests
                 ["aws", "apigateway"],
                 "apigateway help",
                 Result("RAW APIGATEWAY HELP: models omitted"));
-            provenance.PreserveGroupHelp(
-                ["aws", "apigateway"],
-                "RAW APIGATEWAY HELP: models omitted");
+            provenance.PreserveGroupHelp(["aws", "apigateway"]);
             provenance.Record(
                 ["aws", "ec2"],
                 "ec2 help",
                 Result("RAW EC2 HELP: describe-instances only"));
-            provenance.PreserveGroupHelp(
-                ["aws", "ec2"],
-                "RAW EC2 HELP: describe-instances only");
+            provenance.PreserveGroupHelp(["aws", "ec2"]);
 
             var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
                 outputDirectory,
@@ -282,7 +278,7 @@ public class CommandCoverageGuardTests
                 ["fake", "group"],
                 "group --help",
                 Result("RAW GROUP HELP"));
-            provenance.PreserveGroupHelp(["fake", "group"], "RAW GROUP HELP");
+            provenance.PreserveGroupHelp(["fake", "group"]);
             provenance.Record(
                 ["fake", "group", "leaf"],
                 "group leaf --help",
@@ -348,24 +344,32 @@ public class CommandCoverageGuardTests
     }
 
     [Test]
-    public async Task PreservedGroupHelp_ReplacesEarlierRawInvocationOutput()
+    public async Task PreservedGroupHelp_KeepsOriginalCombinedInvocationOutput()
     {
         var outputDirectory = CreateOutputDirectory();
 
         try
         {
+            var baseline = CommandCoverageGuard.Evaluate(
+                Tool(Command("fake group child")),
+                outputDirectory,
+                approveShrinkage: false);
+            await CommandCoverageGuard.WriteManifestAsync(baseline, CancellationToken.None);
             var current = CommandCoverageGuard.Evaluate(
                 Tool(Command("fake run")),
                 outputDirectory,
                 approveShrinkage: false);
             var provenance = new CliScrapeProvenance();
             provenance.Record(
-                ["fake"],
-                "--help",
-                Result("RAW ROOT HELP"));
-            provenance.PreserveGroupHelp(
-                ["fake"],
-                "RAW ROOT HELP\n\nCommands:\n  run  Discovered by supplemental inventory.");
+                ["fake", "group"],
+                "group --help",
+                new CliCommandResult
+                {
+                    StandardOutput = "RAW STDOUT",
+                    StandardError = "RAW STDERR",
+                    ExitCode = 0,
+                });
+            provenance.PreserveGroupHelp(["fake", "group"]);
 
             var path = await provenance.WriteCoverageFailureDiagnosticsAsync(
                 outputDirectory,
@@ -373,7 +377,8 @@ public class CommandCoverageGuardTests
                 CancellationToken.None);
             var json = await File.ReadAllTextAsync(path!);
 
-            await Assert.That(json).Contains("Discovered by supplemental inventory");
+            await Assert.That(json).Contains("RAW STDOUT");
+            await Assert.That(json).Contains("RAW STDERR");
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -225,6 +225,25 @@ public class CliScraperTraversalTests
         await Assert.That(logger.Warnings).Contains(warning =>
             warning.Exception is InvalidOperationException
             && warning.Message.Contains("Failed to validate subcommand discovery: fake parent"));
+
+        var outputDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "mp-cli-traversal-tests",
+            Guid.NewGuid().ToString("N"));
+        try
+        {
+            var diagnosticsPath = await scraper.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                CoverageFailure("fake parent child"),
+                CancellationToken.None);
+            var diagnostics = await File.ReadAllTextAsync(diagnosticsPath!);
+
+            await Assert.That(diagnostics).Contains("Manage parent resources.");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
     }
 
     [Test]
@@ -1086,6 +1105,30 @@ public class CliScraperTraversalTests
 
         return commands;
     }
+
+    private static CommandCoverageEvaluation CoverageFailure(string removedCommand) => new()
+    {
+        ManifestPath = "unused",
+        Manifest = new CommandCoverageManifest
+        {
+            FormatVersion = 1,
+            ToolName = "fake",
+            ToolVersion = "2.0",
+            CommandCount = 1,
+            CommandTreeSha256 = "unused",
+            Commands = ["fake sibling"],
+            CommandGroups = ["fake"],
+            Exclusions = [],
+        },
+        HasPreviousBaseline = true,
+        PreviousCommandCount = 2,
+        PreviousToolVersion = "1.0",
+        AddedCommands = [],
+        RemovedCommands = [removedCommand],
+        KnownGroupsWithoutChildren = ["fake parent"],
+        Violations = ["Known command groups lost all children: fake parent."],
+        ShrinkageApproved = false,
+    };
 
     private sealed class TestCobraScraper : CobraCliScraper
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -247,6 +247,49 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task SharedTraversal_Preserves_Mismatched_Parent_Help_For_Diagnostics()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage:
+                  fake <command>
+
+                Available Commands:
+                  parent: Manage parent resources
+                """,
+            ["parent --help"] = """
+                MISMATCHED PARENT RESPONSE
+
+                Usage:
+                  fake sibling [flags]
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        _ = await ScrapeAsync(scraper);
+
+        var outputDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "mp-cli-traversal-tests",
+            Guid.NewGuid().ToString("N"));
+        try
+        {
+            var diagnosticsPath = await scraper.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                CoverageFailure("fake parent child"),
+                CancellationToken.None);
+            var diagnostics = await File.ReadAllTextAsync(diagnosticsPath!);
+
+            await Assert.That(diagnostics).Contains("MISMATCHED PARENT RESPONSE");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task SharedTraversal_Detects_Command_On_Second_Usage_Line()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Attributes;
@@ -282,6 +283,89 @@ public class CliScraperTraversalTests
             var diagnostics = await File.ReadAllTextAsync(diagnosticsPath!);
 
             await Assert.That(diagnostics).Contains("MISMATCHED PARENT RESPONSE");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task SharedTraversal_Preserves_Known_Group_That_Became_A_Leaf()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage: fake <command>
+
+                Available Commands:
+                  parent: Manage parent resources
+                """,
+            ["parent --help"] = """
+                CURRENT PARENT LEAF HELP
+
+                Usage: fake parent [flags]
+
+                Flags:
+                  --value string   Supply a value
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+        scraper.PreserveRawHelpForCommandGroups(["fake parent"]);
+
+        _ = await ScrapeAsync(scraper);
+
+        var outputDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "mp-cli-traversal-tests",
+            Guid.NewGuid().ToString("N"));
+        try
+        {
+            var diagnosticsPath = await scraper.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                CoverageFailure("fake parent child"),
+                CancellationToken.None);
+            var diagnostics = await File.ReadAllTextAsync(diagnosticsPath!);
+
+            await Assert.That(diagnostics).Contains("CURRENT PARENT LEAF HELP");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Cached_Help_Is_Recorded_For_Coverage_Diagnostics()
+    {
+        using var cache = new HelpTextCache(NullLogger<HelpTextCache>.Instance);
+        cache.Set("fake parent", "CACHED PARENT HELP");
+        var scraper = new TestCobraScraper(
+            new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)),
+            cache: cache);
+
+        _ = await scraper.GetHelp(["fake", "parent"]);
+
+        var outputDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "mp-cli-traversal-tests",
+            Guid.NewGuid().ToString("N"));
+        try
+        {
+            var diagnosticsPath = await scraper.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                CoverageFailure("fake parent child"),
+                CancellationToken.None);
+            var diagnostics = await File.ReadAllTextAsync(diagnosticsPath!);
+            using var document = JsonDocument.Parse(diagnostics);
+            var missingHelpPaths = document.RootElement
+                .GetProperty("missingHelpPaths")
+                .EnumerateArray()
+                .Select(static element => element.GetString())
+                .ToArray();
+
+            await Assert.That(diagnostics).Contains("CACHED PARENT HELP");
+            await Assert.That(missingHelpPaths).DoesNotContain("fake parent");
         }
         finally
         {
@@ -1175,10 +1259,13 @@ public class CliScraperTraversalTests
 
     private sealed class TestCobraScraper : CobraCliScraper
     {
-        public TestCobraScraper(ICliCommandExecutor executor, ILogger? logger = null)
+        public TestCobraScraper(
+            ICliCommandExecutor executor,
+            ILogger? logger = null,
+            IHelpTextCache? cache = null)
             : base(
                 executor,
-                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                cache ?? new HelpTextCache(NullLogger<HelpTextCache>.Instance),
                 logger ?? NullLogger<TestCobraScraper>.Instance)
         {
         }
@@ -1202,6 +1289,9 @@ public class CliScraperTraversalTests
         public bool DeclaresCommandGroup(string helpText) => HelpDeclaresCommandGroup(helpText);
 
         public IReadOnlyList<string> GetSubcommands(string helpText) => ExtractSubcommands(helpText).ToList();
+
+        public Task<string?> GetHelp(string[] commandPath) =>
+            GetHelpTextAsync(commandPath, CancellationToken.None);
     }
 
     private sealed class RecordingLogger : ILogger

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -1127,7 +1127,7 @@ public class CliScraperTraversalTests
         RemovedCommands = [removedCommand],
         KnownGroupsWithoutChildren = ["fake parent"],
         Violations = ["Known command groups lost all children: fake parent."],
-        ShrinkageApproved = false,
+        ChangesApproved = false,
     };
 
     private sealed class TestCobraScraper : CobraCliScraper

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -568,7 +568,7 @@ public class CodeGeneratorOrchestrator
                 approveCommandCoverageShrinkage,
                 cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             AddScrapingError(result, htmlScraper.ToolName, ex, cliOnly: false);
         }
@@ -630,7 +630,7 @@ public class CodeGeneratorOrchestrator
             _logger.LogInformation("Type enhancement complete for {Tool}", toolName);
             return enhanced;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Type enhancement failed for {Tool}, using scraped types", toolName);
             return toolDefinition;
@@ -767,20 +767,33 @@ public class CodeGeneratorOrchestrator
 
         _logger.LogInformation("Scraped {Count} commands for {Tool}", allCommands.Count, cliScraper.ToolName);
 
-        if (allCommands.Count == 0)
-        {
-            // The CLI is present (IsAvailableAsync passed), so "not installed" is not the
-            // problem - the scraper failed to parse anything out of the help output.
-            return $"The {cliScraper.ToolName} CLI reported itself available but help scraping produced no commands. " +
-                   "Check the scraper's help-text parsing against the currently installed CLI version.";
-        }
-
         var completeToolDefinition = toolDefinition with
         {
             Commands = allCommands,
             ToolVersion = toolVersion,
             Errors = [],
         };
+        if (allCommands.Count == 0)
+        {
+            // The CLI is present (IsAvailableAsync passed), so "not installed" is not the
+            // problem - the scraper failed to parse anything out of the help output.
+            var coverage = CommandCoverageGuard.Evaluate(
+                completeToolDefinition,
+                outputDirectory,
+                approveCommandCoverageShrinkage);
+            result.CommandCoverage.Add(coverage);
+            var diagnosticsPath = await TryWriteCoverageFailureDiagnosticsAsync(
+                cliScraper as CliScraperBase,
+                outputDirectory,
+                coverage,
+                cancellationToken);
+            var diagnosticsMessage = diagnosticsPath is null
+                ? string.Empty
+                : $" Raw help diagnostics: {diagnosticsPath}.";
+            return $"The {cliScraper.ToolName} CLI reported itself available but help scraping produced no commands. " +
+                   $"Check the scraper's help-text parsing against the currently installed CLI version.{diagnosticsMessage}";
+        }
+
         if (_typeEnhancer is not null)
         {
             completeToolDefinition = await _typeEnhancer

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -706,7 +706,7 @@ public class CodeGeneratorOrchestrator
                     $"{failureReason} This is a CLI-only tool with no HTML fallback.");
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             AddScrapingError(result, cliScraper.ToolName, ex, cliOnly: true);
         }
@@ -984,7 +984,7 @@ public class CodeGeneratorOrchestrator
                 coverage,
                 cancellationToken);
         }
-        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        catch (Exception ex) when (ex is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
         {
             _logger.LogWarning(
                 ex,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -794,7 +794,8 @@ public class CodeGeneratorOrchestrator
             emittedPaths,
             fileSystemPathComparer,
             approveCommandCoverageShrinkage,
-            cancellationToken);
+            cancellationToken,
+            scrapeProvenanceProvider: cliScraper as CliScraperBase);
 
         _logger.LogInformation("Generated files for {Tool} ({Count} commands, {SubDomainCount} sub-domains)",
             cliScraper.ToolName, allCommands.Count, completeToolDefinition.SubDomainGroups.Count);
@@ -825,7 +826,8 @@ public class CodeGeneratorOrchestrator
         StringComparer? commandCoveragePathComparer = null,
         bool allowMissingCommandCoverageManifest = false,
         IReadOnlySet<string>? replaceableExistingPaths = null,
-        Func<IReadOnlyCollection<string>, CancellationToken, Task>? beforeWrite = null)
+        Func<IReadOnlyCollection<string>, CancellationToken, Task>? beforeWrite = null,
+        CliScraperBase? scrapeProvenanceProvider = null)
     {
         var globalOptions = tool.GetGlobalOptions();
         var normalizedCommands = GeneratorUtils.NormalizeCommandClassNames(tool.Commands);
@@ -859,21 +861,16 @@ public class CodeGeneratorOrchestrator
                 replaceableExistingPaths);
         }
 
-        var coverage = CommandCoverageGuard.Evaluate(
+        var coverage = await ValidateCommandCoverageAsync(
             normalizedTool,
             outputDirectory,
+            result,
             approveCommandCoverageShrinkage,
             commandCoverageBaselinePath,
             commandCoveragePathComparer,
-            allowMissingCommandCoverageManifest);
-        result.CommandCoverage.Add(coverage);
-
-        if (coverage.Violations.Count > 0)
-        {
-            throw new InvalidOperationException(
-                $"Command coverage validation failed for {tool.ToolName}:{Environment.NewLine}"
-                    + string.Join(Environment.NewLine, coverage.Violations.Select(violation => $"- {violation}")));
-        }
+            allowMissingCommandCoverageManifest,
+            scrapeProvenanceProvider,
+            cancellationToken);
 
         if (beforeWrite is not null)
         {
@@ -927,6 +924,73 @@ public class CodeGeneratorOrchestrator
                 enforceOutputContainment).ConfigureAwait(false);
             result.FilesGenerated.Add(
                 Path.Combine(toolDefinition.OutputDirectory, "AssemblyInfo.Generated.cs"));
+        }
+    }
+
+    private async Task<CommandCoverageEvaluation> ValidateCommandCoverageAsync(
+        CliToolDefinition tool,
+        string outputDirectory,
+        GenerationResult result,
+        bool approveCommandCoverageShrinkage,
+        string? commandCoverageBaselinePath,
+        StringComparer? commandCoveragePathComparer,
+        bool allowMissingCommandCoverageManifest,
+        CliScraperBase? scrapeProvenanceProvider,
+        CancellationToken cancellationToken)
+    {
+        var coverage = CommandCoverageGuard.Evaluate(
+            tool,
+            outputDirectory,
+            approveCommandCoverageShrinkage,
+            commandCoverageBaselinePath,
+            commandCoveragePathComparer,
+            allowMissingCommandCoverageManifest);
+        result.CommandCoverage.Add(coverage);
+
+        if (coverage.Violations.Count == 0)
+        {
+            return coverage;
+        }
+
+        var diagnosticsPath = await TryWriteCoverageFailureDiagnosticsAsync(
+            scrapeProvenanceProvider,
+            outputDirectory,
+            coverage,
+            cancellationToken);
+        var diagnosticsMessage = diagnosticsPath is null
+            ? string.Empty
+            : $"{Environment.NewLine}- Raw help diagnostics: {diagnosticsPath}";
+        throw new InvalidOperationException(
+            $"Command coverage validation failed for {tool.ToolName}:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, coverage.Violations.Select(violation => $"- {violation}"))
+                + diagnosticsMessage);
+    }
+
+    private async Task<string?> TryWriteCoverageFailureDiagnosticsAsync(
+        CliScraperBase? scrapeProvenanceProvider,
+        string outputDirectory,
+        CommandCoverageEvaluation coverage,
+        CancellationToken cancellationToken)
+    {
+        if (scrapeProvenanceProvider is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await scrapeProvenanceProvider.WriteCoverageFailureDiagnosticsAsync(
+                outputDirectory,
+                coverage,
+                cancellationToken);
+        }
+        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not persist raw help diagnostics for {Tool}",
+                coverage.Manifest.ToolName);
+            return null;
         }
     }
 
@@ -1451,6 +1515,13 @@ public class GenerationResult
             if (!coverage.HasPreviousBaseline)
             {
                 lines.Add("  - Baseline: created");
+            }
+            else
+            {
+                var previousVersion = coverage.PreviousToolVersion ?? "unknown version";
+                lines.Add(
+                    $"  - Baseline comparison: {coverage.PreviousCommandCount} commands at {previousVersion} "
+                    + $"-> {coverage.Manifest.CommandCount} commands at {version}");
             }
 
             AppendDiff(lines, coverage.ChangesApproved ? "Added (approved)" : "Added", coverage.AddedCommands);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -538,12 +538,13 @@ public class CodeGeneratorOrchestrator
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Processing {Tool}...", htmlScraper.ToolName);
+        CliGenerationFailure? cliFailure = null;
 
         try
         {
             if (useCliFirst && cliScrapersByTool.TryGetValue(htmlScraper.ToolName, out var cliScraper))
             {
-                var cliFailureReason = await GenerateFromCliAsync(
+                cliFailure = await GenerateFromCliAsync(
                     cliScraper,
                     outputDirectory,
                     result,
@@ -551,12 +552,12 @@ public class CodeGeneratorOrchestrator
                     fileSystemPathComparer,
                     approveCommandCoverageShrinkage,
                     cancellationToken);
-                if (cliFailureReason is null)
+                if (cliFailure is null)
                 {
                     return;
                 }
 
-                _logger.LogWarning("{Reason} Falling back to HTML scraper.", cliFailureReason);
+                _logger.LogWarning("{Reason} Falling back to HTML scraper.", cliFailure.Reason);
             }
 
             await GenerateFromHtmlAsync(
@@ -570,6 +571,11 @@ public class CodeGeneratorOrchestrator
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            if (cliFailure?.Coverage is not null)
+            {
+                result.CommandCoverage.Add(cliFailure.Coverage);
+            }
+
             AddScrapingError(result, htmlScraper.ToolName, ex, cliOnly: false);
         }
     }
@@ -692,7 +698,7 @@ public class CodeGeneratorOrchestrator
 
         try
         {
-            var failureReason = await GenerateFromCliAsync(
+            var failure = await GenerateFromCliAsync(
                 cliScraper,
                 outputDirectory,
                 result,
@@ -700,10 +706,15 @@ public class CodeGeneratorOrchestrator
                 fileSystemPathComparer,
                 approveCommandCoverageShrinkage,
                 cancellationToken);
-            if (failureReason is not null)
+            if (failure is not null)
             {
+                if (failure.Coverage is not null)
+                {
+                    result.CommandCoverage.Add(failure.Coverage);
+                }
+
                 throw new InvalidOperationException(
-                    $"{failureReason} This is a CLI-only tool with no HTML fallback.");
+                    $"{failure.Reason} This is a CLI-only tool with no HTML fallback.");
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -732,11 +743,11 @@ public class CodeGeneratorOrchestrator
 
     /// <summary>
     /// Scrapes a tool via its CLI scraper and generates code for it.
-    /// Returns null when generation completed, or a failure reason when it could not run.
+    /// Returns null when generation completed, or failure details when it could not run.
     /// Failure policy belongs to the caller: the HTML-scraper loop falls back, the
     /// CLI-only loop throws.
     /// </summary>
-    private async Task<string?> GenerateFromCliAsync(
+    private async Task<CliGenerationFailure?> GenerateFromCliAsync(
         ICliScraper cliScraper,
         string outputDirectory,
         GenerationResult result,
@@ -747,10 +758,20 @@ public class CodeGeneratorOrchestrator
     {
         if (!await cliScraper.IsAvailableAsync(cancellationToken))
         {
-            return $"The {cliScraper.ToolName} CLI is not available on PATH - check the tool's install step.";
+            return new CliGenerationFailure(
+                $"The {cliScraper.ToolName} CLI is not available on PATH - check the tool's install step.",
+                Coverage: null);
         }
 
         _logger.LogInformation("Using CLI scraper for {Tool}", cliScraper.ToolName);
+        var scrapeProvenanceProvider = cliScraper as CliScraperBase;
+        if (scrapeProvenanceProvider is not null)
+        {
+            var baselineGroups = CommandCoverageGuard.GetBaselineCommandGroups(
+                cliScraper.CreateToolDefinition(),
+                outputDirectory);
+            scrapeProvenanceProvider.PreserveRawHelpForCommandGroups(baselineGroups);
+        }
 
         var allCommands = new List<CliCommandDefinition>();
 
@@ -777,21 +798,22 @@ public class CodeGeneratorOrchestrator
         {
             // The CLI is present (IsAvailableAsync passed), so "not installed" is not the
             // problem - the scraper failed to parse anything out of the help output.
-            var coverage = CommandCoverageGuard.Evaluate(
+            var (coverage, diagnosticsPath) = await EvaluateCommandCoverageAsync(
                 completeToolDefinition,
                 outputDirectory,
-                approveCommandCoverageShrinkage);
-            result.CommandCoverage.Add(coverage);
-            var diagnosticsPath = await TryWriteCoverageFailureDiagnosticsAsync(
-                cliScraper as CliScraperBase,
-                outputDirectory,
-                coverage,
-                cancellationToken);
+                approveCommandCoverageShrinkage,
+                commandCoverageBaselinePath: null,
+                commandCoveragePathComparer: null,
+                allowMissingCommandCoverageManifest: false,
+                scrapeProvenanceProvider: scrapeProvenanceProvider,
+                cancellationToken: cancellationToken);
             var diagnosticsMessage = diagnosticsPath is null
                 ? string.Empty
                 : $" Raw help diagnostics: {diagnosticsPath}.";
-            return $"The {cliScraper.ToolName} CLI reported itself available but help scraping produced no commands. " +
-                   $"Check the scraper's help-text parsing against the currently installed CLI version.{diagnosticsMessage}";
+            return new CliGenerationFailure(
+                $"The {cliScraper.ToolName} CLI reported itself available but help scraping produced no commands. " +
+                $"Check the scraper's help-text parsing against the currently installed CLI version.{diagnosticsMessage}",
+                coverage);
         }
 
         if (_typeEnhancer is not null)
@@ -808,13 +830,17 @@ public class CodeGeneratorOrchestrator
             fileSystemPathComparer,
             approveCommandCoverageShrinkage,
             cancellationToken,
-            scrapeProvenanceProvider: cliScraper as CliScraperBase);
+            scrapeProvenanceProvider: scrapeProvenanceProvider);
 
         _logger.LogInformation("Generated files for {Tool} ({Count} commands, {SubDomainCount} sub-domains)",
             cliScraper.ToolName, allCommands.Count, completeToolDefinition.SubDomainGroups.Count);
 
         return null;
     }
+
+    private sealed record CliGenerationFailure(
+        string Reason,
+        CommandCoverageEvaluation? Coverage);
 
     /// <summary>
     /// Runs all generators for a tool and writes the results to disk.
@@ -951,13 +977,15 @@ public class CodeGeneratorOrchestrator
         CliScraperBase? scrapeProvenanceProvider,
         CancellationToken cancellationToken)
     {
-        var coverage = CommandCoverageGuard.Evaluate(
+        var (coverage, diagnosticsPath) = await EvaluateCommandCoverageAsync(
             tool,
             outputDirectory,
             approveCommandCoverageShrinkage,
             commandCoverageBaselinePath,
             commandCoveragePathComparer,
-            allowMissingCommandCoverageManifest);
+            allowMissingCommandCoverageManifest,
+            scrapeProvenanceProvider,
+            cancellationToken);
         result.CommandCoverage.Add(coverage);
 
         if (coverage.Violations.Count == 0)
@@ -965,11 +993,6 @@ public class CodeGeneratorOrchestrator
             return coverage;
         }
 
-        var diagnosticsPath = await TryWriteCoverageFailureDiagnosticsAsync(
-            scrapeProvenanceProvider,
-            outputDirectory,
-            coverage,
-            cancellationToken);
         var diagnosticsMessage = diagnosticsPath is null
             ? string.Empty
             : $"{Environment.NewLine}- Raw help diagnostics: {diagnosticsPath}";
@@ -977,6 +1000,34 @@ public class CodeGeneratorOrchestrator
             $"Command coverage validation failed for {tool.ToolName}:{Environment.NewLine}"
                 + string.Join(Environment.NewLine, coverage.Violations.Select(violation => $"- {violation}"))
                 + diagnosticsMessage);
+    }
+
+    private async Task<(CommandCoverageEvaluation Coverage, string? DiagnosticsPath)>
+        EvaluateCommandCoverageAsync(
+            CliToolDefinition tool,
+            string outputDirectory,
+            bool approveCommandCoverageShrinkage,
+            string? commandCoverageBaselinePath,
+            StringComparer? commandCoveragePathComparer,
+            bool allowMissingCommandCoverageManifest,
+            CliScraperBase? scrapeProvenanceProvider,
+            CancellationToken cancellationToken)
+    {
+        var coverage = CommandCoverageGuard.Evaluate(
+            tool,
+            outputDirectory,
+            approveCommandCoverageShrinkage,
+            commandCoverageBaselinePath,
+            commandCoveragePathComparer,
+            allowMissingCommandCoverageManifest);
+        var diagnosticsPath = coverage.Violations.Count == 0
+            ? null
+            : await TryWriteCoverageFailureDiagnosticsAsync(
+                scrapeProvenanceProvider,
+                outputDirectory,
+                coverage,
+                cancellationToken);
+        return (coverage, diagnosticsPath);
     }
 
     private async Task<string?> TryWriteCoverageFailureDiagnosticsAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CommandCoverageGuard.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CommandCoverageGuard.cs
@@ -471,6 +471,20 @@ internal static class CommandCoverageGuard
             tool.OutputDirectory,
             "Generated",
             $"{tool.NamespacePrefix}.CommandCoverage.json");
+
+    internal static IReadOnlySet<string> GetBaselineCommandGroups(
+        CliToolDefinition tool,
+        string outputDirectory) =>
+        ReadBaseline(
+                tool,
+                outputDirectory,
+                GetManifestPath(tool, outputDirectory),
+                fallbackManifestPath: null,
+                pathComparer: StringComparer.OrdinalIgnoreCase,
+                allowMissingManifest: false)
+            ?.CommandGroups
+            .ToHashSet(StringComparer.OrdinalIgnoreCase)
+        ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 }
 
 internal sealed record CommandCoverageManifest

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CommandCoverageGuard.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CommandCoverageGuard.cs
@@ -10,6 +10,8 @@ namespace ModularPipelines.OptionsGenerator.Generators;
 internal static class CommandCoverageGuard
 {
     private const int ManifestFormatVersion = 1;
+    private const int MaximumBlanketApprovedRemovals = 5;
+    private const int RepresentativeRemovalLimit = 10;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -84,7 +86,9 @@ internal static class CommandCoverageGuard
             knownGroupsWithoutChildren,
             hasSameVersionCommandSetDrift,
             tool.ToolVersion,
-            approveShrinkage);
+            approveShrinkage,
+            previous?.ToolVersion,
+            tool.ToolVersion);
 
         var manifest = CreateManifest(tool.ToolName, tool.ToolVersion, commands, exclusions);
 
@@ -93,11 +97,14 @@ internal static class CommandCoverageGuard
             ManifestPath = manifestPath,
             Manifest = manifest,
             HasPreviousBaseline = previous is not null,
+            PreviousCommandCount = previous?.CommandCount,
+            PreviousToolVersion = previous?.ToolVersion,
             AddedCommands = addedCommands,
             RemovedCommands = removedCommands,
             KnownGroupsWithoutChildren = knownGroupsWithoutChildren,
             Violations = violations,
-            ChangesApproved = approveShrinkage,
+            ChangesApproved = approveShrinkage
+                              && unapprovedRemovedCommands.Length <= MaximumBlanketApprovedRemovals,
         };
     }
 
@@ -168,7 +175,9 @@ internal static class CommandCoverageGuard
         IReadOnlyList<string> groupsWithoutChildren,
         bool hasSameVersionCommandSetDrift,
         string? toolVersion,
-        bool approveShrinkage)
+        bool approveShrinkage,
+        string? previousToolVersion,
+        string? currentToolVersion)
     {
         var violations = new List<string>();
 
@@ -202,6 +211,20 @@ internal static class CommandCoverageGuard
             }
 
             AddViolation(violations, "Known command groups lost all children", groupsWithoutChildren);
+        }
+        else if (unapprovedRemovedCommands.Count > MaximumBlanketApprovedRemovals)
+        {
+            var previousVersion = previousToolVersion ?? "unknown version";
+            var currentVersion = currentToolVersion ?? "unknown version";
+            var representativeRemovals = unapprovedRemovedCommands.Take(RepresentativeRemovalLimit);
+            var remainingCount = unapprovedRemovedCommands.Count - RepresentativeRemovalLimit;
+            var suffix = remainingCount > 0 ? $" (+{remainingCount} more)" : string.Empty;
+            violations.Add(
+                $"Blanket approval cannot authorize {unapprovedRemovedCommands.Count} command removals "
+                + $"from baseline {previousVersion} to current {currentVersion}; the maximum is "
+                + $"{MaximumBlanketApprovedRemovals}. Add explicit command coverage exclusions with "
+                + $"reviewed reasons for every additional removal. Representative removals: "
+                + $"{string.Join(", ", representativeRemovals)}{suffix}.");
         }
 
         return violations;
@@ -476,6 +499,10 @@ internal sealed record CommandCoverageEvaluation
     public required CommandCoverageManifest Manifest { get; init; }
 
     public required bool HasPreviousBaseline { get; init; }
+
+    public int? PreviousCommandCount { get; init; }
+
+    public string? PreviousToolVersion { get; init; }
 
     public required IReadOnlyList<string> AddedCommands { get; init; }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/OptionsGeneratorCommand.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/OptionsGeneratorCommand.cs
@@ -67,7 +67,7 @@ internal static class OptionsGeneratorCommand
             },
             ApproveCommandCoverageShrinkage: new Option<bool>("--approve-command-coverage-shrinkage")
             {
-                Description = "Explicitly approve same-version command-set changes, removed commands, and command groups losing all children. Sentinel and minimum coverage checks still apply.",
+                Description = "Explicitly approve same-version command-set changes, up to five undocumented removals, and command groups losing all children. Larger removals require documented exclusions with reviewed reasons. Sentinel and minimum coverage checks still apply.",
                 DefaultValueFactory = _ => false,
             },
             ChangeManifest: new Option<string?>("--change-manifest")

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -128,11 +128,11 @@ public partial class AwsCliScraper : CliScraperBase
             ? string.Join(" ", commandPath.Skip(1)) + " help"
             : "help";
 
-        var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
-        RecordHelpInvocation(
+        var result = await ExecuteAndRecordHelpCommandAsync(
             commandPath,
+            ExecutablePath,
             args,
-            result,
+            cancellationToken,
             preserveRawHelp: commandPath.Length <= 2);
 
         // AWS CLI outputs help to stdout

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -129,6 +129,11 @@ public partial class AwsCliScraper : CliScraperBase
             : "help";
 
         var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
+        RecordHelpInvocation(
+            commandPath,
+            args,
+            result,
+            preserveRawHelp: commandPath.Length <= 2);
 
         // AWS CLI outputs help to stdout
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
@@ -114,7 +114,11 @@ public partial class ChocolateyCliScraper : CliScraperBase
             ? string.Join(" ", commandPath.Skip(1)) + " -?"
             : "-?";
 
-        var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            args,
+            cancellationToken);
 
         // Chocolatey outputs help to stdout
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -38,14 +38,29 @@ internal sealed class CliScrapeProvenance
         };
     }
 
-    public void PreserveGroupHelp(IReadOnlyList<string> commandPath, string helpText)
+    public void RecordCacheHit(IReadOnlyList<string> commandPath, string helpText)
+    {
+        var path = string.Join(' ', commandPath);
+        _helpInvocations.TryAdd(path, new CliHelpInvocation
+        {
+            CommandPath = path,
+            Arguments = "<cached>",
+            ExitCode = 0,
+            StandardOutputLength = helpText.Length,
+            StandardErrorLength = 0,
+            OutputSha256 = Fingerprint(helpText),
+            RawHelp = helpText,
+            PreserveRawHelp = commandPath.Count == 1,
+        });
+    }
+
+    public void PreserveGroupHelp(IReadOnlyList<string> commandPath)
     {
         var path = string.Join(' ', commandPath);
         if (_helpInvocations.TryGetValue(path, out var invocation))
         {
             _helpInvocations[path] = invocation with
             {
-                RawHelp = helpText,
                 PreserveRawHelp = true,
             };
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -53,11 +53,6 @@ internal sealed class CliScrapeProvenance
         CommandCoverageEvaluation coverage,
         CancellationToken cancellationToken)
     {
-        if (coverage.RemovedCommands.Count == 0)
-        {
-            return null;
-        }
-
         var toolName = coverage.Manifest.ToolName;
         var requestedHelpPaths = coverage.RemovedCommands
             .Select(GetParentCommand)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -1,0 +1,159 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ModularPipelines.OptionsGenerator.Generators;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+internal sealed class CliScrapeProvenance
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly ConcurrentDictionary<string, CliHelpInvocation> _helpInvocations =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public void Record(
+        IReadOnlyList<string> commandPath,
+        string arguments,
+        CliCommandResult result,
+        bool preserveRawHelp = false)
+    {
+        var path = string.Join(' ', commandPath);
+        _helpInvocations[path] = new CliHelpInvocation
+        {
+            CommandPath = path,
+            Arguments = arguments,
+            ExitCode = result.ExitCode,
+            StandardOutputLength = result.StandardOutput.Length,
+            StandardErrorLength = result.StandardError.Length,
+            OutputSha256 = Fingerprint(result.CombinedOutput),
+            RawHelp = preserveRawHelp || commandPath.Count == 1
+                ? result.CombinedOutput
+                : null,
+        };
+    }
+
+    public void PreserveGroupHelp(IReadOnlyList<string> commandPath, string helpText)
+    {
+        var path = string.Join(' ', commandPath);
+        if (_helpInvocations.TryGetValue(path, out var invocation))
+        {
+            _helpInvocations[path] = invocation with { RawHelp = invocation.RawHelp ?? helpText };
+        }
+    }
+
+    public async Task<string?> WriteCoverageFailureDiagnosticsAsync(
+        string outputDirectory,
+        CommandCoverageEvaluation coverage,
+        CancellationToken cancellationToken)
+    {
+        if (coverage.RemovedCommands.Count == 0)
+        {
+            return null;
+        }
+
+        var toolName = coverage.Manifest.ToolName;
+        var requestedHelpPaths = coverage.RemovedCommands
+            .Select(GetParentCommand)
+            .Append(toolName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var invocations = requestedHelpPaths
+            .Select(path => _helpInvocations.GetValueOrDefault(path))
+            .Where(static invocation => invocation is not null)
+            .Select(static invocation => invocation!)
+            .ToArray();
+        var missingHelpPaths = requestedHelpPaths
+            .Where(path => !_helpInvocations.ContainsKey(path))
+            .ToArray();
+        var diagnostics = new CliCoverageFailureDiagnostics
+        {
+            ToolName = toolName,
+            BaselineToolVersion = coverage.PreviousToolVersion,
+            CurrentToolVersion = coverage.Manifest.ToolVersion,
+            BaselineCommandCount = coverage.PreviousCommandCount,
+            CurrentCommandCount = coverage.Manifest.CommandCount,
+            RemovedCommands = coverage.RemovedCommands,
+            RequestedHelpPaths = requestedHelpPaths,
+            MissingHelpPaths = missingHelpPaths,
+            HelpInvocations = invocations,
+        };
+
+        var diagnosticsPath = Path.Combine(
+            outputDirectory,
+            "artifacts",
+            "options-generator-diagnostics",
+            GetSafeToolDirectoryName(toolName),
+            "command-coverage-failure.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(diagnosticsPath)!);
+        await File.WriteAllTextAsync(
+            diagnosticsPath,
+            JsonSerializer.Serialize(diagnostics, JsonOptions) + Environment.NewLine,
+            cancellationToken);
+        return diagnosticsPath;
+    }
+
+    private static string GetParentCommand(string command)
+    {
+        var separator = command.LastIndexOf(' ');
+        return separator > 0 ? command[..separator] : command;
+    }
+
+    private static string GetSafeToolDirectoryName(string toolName)
+    {
+        var safeName = new string(toolName
+            .Select(character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_'
+                ? character
+                : '_')
+            .ToArray());
+        return safeName.Length > 0 ? safeName : "unknown-tool";
+    }
+
+    private static string Fingerprint(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+}
+
+internal sealed record CliHelpInvocation
+{
+    public required string CommandPath { get; init; }
+
+    public required string Arguments { get; init; }
+
+    public required int ExitCode { get; init; }
+
+    public required int StandardOutputLength { get; init; }
+
+    public required int StandardErrorLength { get; init; }
+
+    public required string OutputSha256 { get; init; }
+
+    public string? RawHelp { get; init; }
+}
+
+internal sealed record CliCoverageFailureDiagnostics
+{
+    public required string ToolName { get; init; }
+
+    public string? BaselineToolVersion { get; init; }
+
+    public string? CurrentToolVersion { get; init; }
+
+    public int? BaselineCommandCount { get; init; }
+
+    public required int CurrentCommandCount { get; init; }
+
+    public required IReadOnlyList<string> RemovedCommands { get; init; }
+
+    public required IReadOnlyList<string> RequestedHelpPaths { get; init; }
+
+    public required IReadOnlyList<string> MissingHelpPaths { get; init; }
+
+    public required IReadOnlyList<CliHelpInvocation> HelpInvocations { get; init; }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -22,7 +22,7 @@ internal sealed class CliScrapeProvenance
         IReadOnlyList<string> commandPath,
         string arguments,
         CliCommandResult result,
-        bool preserveRawHelp = false)
+        bool preserveRawHelp = true)
     {
         var path = string.Join(' ', commandPath);
         _helpInvocations[path] = new CliHelpInvocation
@@ -55,7 +55,7 @@ internal sealed class CliScrapeProvenance
     {
         var toolName = coverage.Manifest.ToolName;
         var requestedHelpPaths = coverage.RemovedCommands
-            .Select(GetParentCommand)
+            .SelectMany(GetAncestorCommands)
             .Append(toolName)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Order(StringComparer.OrdinalIgnoreCase)
@@ -95,10 +95,15 @@ internal sealed class CliScrapeProvenance
         return diagnosticsPath;
     }
 
-    private static string GetParentCommand(string command)
+    private static IEnumerable<string> GetAncestorCommands(string command)
     {
         var separator = command.LastIndexOf(' ');
-        return separator > 0 ? command[..separator] : command;
+        while (separator > 0)
+        {
+            command = command[..separator];
+            yield return command;
+            separator = command.LastIndexOf(' ');
+        }
     }
 
     private static string GetSafeToolDirectoryName(string toolName)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -44,7 +44,7 @@ internal sealed class CliScrapeProvenance
         var path = string.Join(' ', commandPath);
         if (_helpInvocations.TryGetValue(path, out var invocation))
         {
-            _helpInvocations[path] = invocation with { RawHelp = invocation.RawHelp ?? helpText };
+            _helpInvocations[path] = invocation with { RawHelp = helpText };
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -33,9 +33,8 @@ internal sealed class CliScrapeProvenance
             StandardOutputLength = result.StandardOutput.Length,
             StandardErrorLength = result.StandardError.Length,
             OutputSha256 = Fingerprint(result.CombinedOutput),
-            RawHelp = preserveRawHelp || commandPath.Count == 1 || result.ExitCode != 0
-                ? result.CombinedOutput
-                : null,
+            RawHelp = result.CombinedOutput,
+            PreserveRawHelp = preserveRawHelp || commandPath.Count == 1 || result.ExitCode != 0,
         };
     }
 
@@ -44,7 +43,21 @@ internal sealed class CliScrapeProvenance
         var path = string.Join(' ', commandPath);
         if (_helpInvocations.TryGetValue(path, out var invocation))
         {
-            _helpInvocations[path] = invocation with { RawHelp = helpText };
+            _helpInvocations[path] = invocation with
+            {
+                RawHelp = helpText,
+                PreserveRawHelp = true,
+            };
+        }
+    }
+
+    public void DiscardLeafHelp(IReadOnlyList<string> commandPath)
+    {
+        var path = string.Join(' ', commandPath);
+        if (_helpInvocations.TryGetValue(path, out var invocation)
+            && !invocation.PreserveRawHelp)
+        {
+            _helpInvocations[path] = invocation with { RawHelp = null };
         }
     }
 
@@ -135,6 +148,8 @@ internal sealed record CliHelpInvocation
     public required string OutputSha256 { get; init; }
 
     public string? RawHelp { get; init; }
+
+    internal bool PreserveRawHelp { get; init; }
 }
 
 internal sealed record CliCoverageFailureDiagnostics

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScrapeProvenance.cs
@@ -22,7 +22,7 @@ internal sealed class CliScrapeProvenance
         IReadOnlyList<string> commandPath,
         string arguments,
         CliCommandResult result,
-        bool preserveRawHelp = true)
+        bool preserveRawHelp = false)
     {
         var path = string.Join(' ', commandPath);
         _helpInvocations[path] = new CliHelpInvocation
@@ -33,7 +33,7 @@ internal sealed class CliScrapeProvenance
             StandardOutputLength = result.StandardOutput.Length,
             StandardErrorLength = result.StandardError.Length,
             OutputSha256 = Fingerprint(result.CombinedOutput),
-            RawHelp = preserveRawHelp || commandPath.Count == 1
+            RawHelp = preserveRawHelp || commandPath.Count == 1 || result.ExitCode != 0
                 ? result.CombinedOutput
                 : null,
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -392,6 +392,7 @@ public abstract partial class CliScraperBase : ICliScraper
 
         if (ShouldSkipPath(path, helpText))
         {
+            _scrapeProvenance.DiscardLeafHelp(path);
             return;
         }
 
@@ -404,7 +405,8 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         var subcommands = ExtractSubcommands(path, helpText).ToList();
-        if (subcommands.Count > 0 || HelpDeclaresCommandGroup(helpText))
+        var declaresCommandGroup = HelpDeclaresCommandGroup(helpText);
+        if (subcommands.Count > 0 || declaresCommandGroup)
         {
             _scrapeProvenance.PreserveGroupHelp(path, helpText);
         }
@@ -420,6 +422,11 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         await ParseAndWriteCommandAsync(path, helpText, subcommands, commandChannel, cancellationToken);
+        if (subcommands.Count == 0 && !declaresCommandGroup)
+        {
+            _scrapeProvenance.DiscardLeafHelp(path);
+        }
+
         await EnqueueSubcommandsAsync(
             path,
             subcommands,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -704,7 +704,7 @@ public abstract partial class CliScraperBase : ICliScraper
         string arguments,
         CancellationToken cancellationToken,
         string? workingDirectory = null,
-        bool preserveRawHelp = false)
+        bool preserveRawHelp = true)
     {
         var result = await Executor.ExecuteAsync(
             executablePath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -16,6 +16,7 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 public abstract partial class CliScraperBase : ICliScraper
 {
     private static readonly string[] DefaultUsageSynopsisHeadings = ["usage"];
+    private readonly CliScrapeProvenance _scrapeProvenance = new();
 
     protected readonly ICliCommandExecutor Executor;
     protected readonly IHelpTextCache HelpCache;
@@ -413,6 +414,11 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        if (subcommands.Count > 0)
+        {
+            _scrapeProvenance.PreserveGroupHelp(path, helpText);
+        }
+
         await ParseAndWriteCommandAsync(path, helpText, subcommands, commandChannel, cancellationToken);
         await EnqueueSubcommandsAsync(
             path,
@@ -663,6 +669,7 @@ public abstract partial class CliScraperBase : ICliScraper
             : "--help";
 
         var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
+        RecordHelpInvocation(commandPath, args, result);
 
         if (!ShouldAcceptHelpResult(commandPath, result))
         {
@@ -687,6 +694,26 @@ public abstract partial class CliScraperBase : ICliScraper
         Logger.LogWarning("No help text for command: {Command}", cacheKey);
         return null;
     }
+
+    /// <summary>
+    /// Retains raw help and execution provenance until coverage validation completes.
+    /// Failure diagnostics persist only the root and parent help relevant to removals.
+    /// </summary>
+    private protected void RecordHelpInvocation(
+        IReadOnlyList<string> commandPath,
+        string arguments,
+        CliCommandResult result,
+        bool preserveRawHelp = false) =>
+        _scrapeProvenance.Record(commandPath, arguments, result, preserveRawHelp);
+
+    internal Task<string?> WriteCoverageFailureDiagnosticsAsync(
+        string outputDirectory,
+        CommandCoverageEvaluation coverage,
+        CancellationToken cancellationToken) =>
+        _scrapeProvenance.WriteCoverageFailureDiagnosticsAsync(
+            outputDirectory,
+            coverage,
+            cancellationToken);
 
     /// <summary>
     /// Returns whether output from a help invocation is safe to parse.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -404,6 +404,11 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         var subcommands = ExtractSubcommands(path, helpText).ToList();
+        if (subcommands.Count > 0 || HelpDeclaresCommandGroup(helpText))
+        {
+            _scrapeProvenance.PreserveGroupHelp(path, helpText);
+        }
+
         try
         {
             ValidateSubcommandDiscovery(path, helpText, subcommands);
@@ -412,11 +417,6 @@ public abstract partial class CliScraperBase : ICliScraper
         {
             Logger.LogWarning(ex, "Failed to validate subcommand discovery: {Command}", string.Join(" ", path));
             return;
-        }
-
-        if (subcommands.Count > 0)
-        {
-            _scrapeProvenance.PreserveGroupHelp(path, helpText);
         }
 
         await ParseAndWriteCommandAsync(path, helpText, subcommands, commandChannel, cancellationToken);
@@ -668,8 +668,11 @@ public abstract partial class CliScraperBase : ICliScraper
             ? string.Join(" ", commandPath.Skip(1)) + " --help"
             : "--help";
 
-        var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
-        RecordHelpInvocation(commandPath, args, result);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            args,
+            cancellationToken);
 
         if (!ShouldAcceptHelpResult(commandPath, result))
         {
@@ -695,16 +698,22 @@ public abstract partial class CliScraperBase : ICliScraper
         return null;
     }
 
-    /// <summary>
-    /// Retains raw help and execution provenance until coverage validation completes.
-    /// Failure diagnostics persist only the root and parent help relevant to removals.
-    /// </summary>
-    private protected void RecordHelpInvocation(
+    private protected async Task<CliCommandResult> ExecuteAndRecordHelpCommandAsync(
         IReadOnlyList<string> commandPath,
+        string executablePath,
         string arguments,
-        CliCommandResult result,
-        bool preserveRawHelp = false) =>
+        CancellationToken cancellationToken,
+        string? workingDirectory = null,
+        bool preserveRawHelp = false)
+    {
+        var result = await Executor.ExecuteAsync(
+            executablePath,
+            arguments,
+            cancellationToken,
+            workingDirectory);
         _scrapeProvenance.Record(commandPath, arguments, result, preserveRawHelp);
+        return result;
+    }
 
     internal Task<string?> WriteCoverageFailureDiagnosticsAsync(
         string outputDirectory,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -17,6 +17,7 @@ public abstract partial class CliScraperBase : ICliScraper
 {
     private static readonly string[] DefaultUsageSynopsisHeadings = ["usage"];
     private readonly CliScrapeProvenance _scrapeProvenance = new();
+    private readonly HashSet<string> _knownCommandGroups = new(StringComparer.OrdinalIgnoreCase);
 
     protected readonly ICliCommandExecutor Executor;
     protected readonly IHelpTextCache HelpCache;
@@ -406,7 +407,7 @@ public abstract partial class CliScraperBase : ICliScraper
 
         var subcommands = ExtractSubcommands(path, helpText).ToList();
         var declaresCommandGroup = HelpDeclaresCommandGroup(helpText);
-        PreserveGroupHelp(path, helpText, subcommands, declaresCommandGroup);
+        PreserveGroupHelp(path, subcommands, declaresCommandGroup);
         if (!TryValidateSubcommandDiscovery(path, helpText, subcommands))
         {
             return;
@@ -426,13 +427,12 @@ public abstract partial class CliScraperBase : ICliScraper
 
     private void PreserveGroupHelp(
         string[] path,
-        string helpText,
         IReadOnlyCollection<string> subcommands,
         bool declaresCommandGroup)
     {
         if (subcommands.Count > 0 || declaresCommandGroup)
         {
-            _scrapeProvenance.PreserveGroupHelp(path, helpText);
+            _scrapeProvenance.PreserveGroupHelp(path);
         }
     }
 
@@ -458,7 +458,9 @@ public abstract partial class CliScraperBase : ICliScraper
         IReadOnlyCollection<string> subcommands,
         bool declaresCommandGroup)
     {
-        if (subcommands.Count == 0 && !declaresCommandGroup)
+        if (subcommands.Count == 0
+            && !declaresCommandGroup
+            && !_knownCommandGroups.Contains(string.Join(' ', path)))
         {
             _scrapeProvenance.DiscardLeafHelp(path);
         }
@@ -695,6 +697,11 @@ public abstract partial class CliScraperBase : ICliScraper
 
         if (HelpCache.TryGet(cacheKey, out var cached))
         {
+            if (!string.IsNullOrEmpty(cached))
+            {
+                _scrapeProvenance.RecordCacheHit(commandPath, cached);
+            }
+
             return cached;
         }
 
@@ -758,6 +765,12 @@ public abstract partial class CliScraperBase : ICliScraper
             outputDirectory,
             coverage,
             cancellationToken);
+
+    internal void PreserveRawHelpForCommandGroups(IEnumerable<string> commandGroups)
+    {
+        _knownCommandGroups.Clear();
+        _knownCommandGroups.UnionWith(commandGroups);
+    }
 
     /// <summary>
     /// Returns whether output from a help invocation is safe to parse.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -406,26 +406,14 @@ public abstract partial class CliScraperBase : ICliScraper
 
         var subcommands = ExtractSubcommands(path, helpText).ToList();
         var declaresCommandGroup = HelpDeclaresCommandGroup(helpText);
-        if (subcommands.Count > 0 || declaresCommandGroup)
+        PreserveGroupHelp(path, helpText, subcommands, declaresCommandGroup);
+        if (!TryValidateSubcommandDiscovery(path, helpText, subcommands))
         {
-            _scrapeProvenance.PreserveGroupHelp(path, helpText);
-        }
-
-        try
-        {
-            ValidateSubcommandDiscovery(path, helpText, subcommands);
-        }
-        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
-        {
-            Logger.LogWarning(ex, "Failed to validate subcommand discovery: {Command}", string.Join(" ", path));
             return;
         }
 
         await ParseAndWriteCommandAsync(path, helpText, subcommands, commandChannel, cancellationToken);
-        if (subcommands.Count == 0 && !declaresCommandGroup)
-        {
-            _scrapeProvenance.DiscardLeafHelp(path);
-        }
+        DiscardLeafHelp(path, subcommands, declaresCommandGroup);
 
         await EnqueueSubcommandsAsync(
             path,
@@ -434,6 +422,46 @@ public abstract partial class CliScraperBase : ICliScraper
             coordinator,
             visitedPaths,
             cancellationToken);
+    }
+
+    private void PreserveGroupHelp(
+        string[] path,
+        string helpText,
+        IReadOnlyCollection<string> subcommands,
+        bool declaresCommandGroup)
+    {
+        if (subcommands.Count > 0 || declaresCommandGroup)
+        {
+            _scrapeProvenance.PreserveGroupHelp(path, helpText);
+        }
+    }
+
+    private bool TryValidateSubcommandDiscovery(
+        string[] path,
+        string helpText,
+        IReadOnlyCollection<string> subcommands)
+    {
+        try
+        {
+            ValidateSubcommandDiscovery(path, helpText, subcommands);
+            return true;
+        }
+        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        {
+            Logger.LogWarning(ex, "Failed to validate subcommand discovery: {Command}", string.Join(" ", path));
+            return false;
+        }
+    }
+
+    private void DiscardLeafHelp(
+        string[] path,
+        IReadOnlyCollection<string> subcommands,
+        bool declaresCommandGroup)
+    {
+        if (subcommands.Count == 0 && !declaresCommandGroup)
+        {
+            _scrapeProvenance.DiscardLeafHelp(path);
+        }
     }
 
     private bool ShouldSkipDeepPath(string[] path)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -704,7 +704,7 @@ public abstract partial class CliScraperBase : ICliScraper
         string arguments,
         CancellationToken cancellationToken,
         string? workingDirectory = null,
-        bool preserveRawHelp = true)
+        bool preserveRawHelp = false)
     {
         var result = await Executor.ExecuteAsync(
             executablePath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -74,7 +74,8 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             var workingDirectory = usesHelpRepository
                 ? await GetHelpRepositoryAsync()
                 : null;
-            result = await Executor.ExecuteAsync(
+            result = await ExecuteAndRecordHelpCommandAsync(
+                commandPath,
                 ToolName,
                 arguments,
                 cancellationToken,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -75,7 +75,11 @@ public partial class GoCliScraper : CliScraperBase
             ? "help " + string.Join(" ", commandPath.Skip(1))
             : "help";
 
-        var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            args,
+            cancellationToken);
 
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)
             ? result.StandardOutput

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
@@ -76,7 +76,11 @@ public partial class JqCliScraper : CliScraperBase
         }
 
         // jq uses -h instead of --help
-        var result = await Executor.ExecuteAsync(ToolName, "-h", cancellationToken);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ToolName,
+            "-h",
+            cancellationToken);
 
         // jq outputs help to stderr
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MavenCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MavenCliScraper.cs
@@ -64,7 +64,11 @@ public partial class MavenCliScraper : CliScraperBase
         }
 
         // Maven uses -h for help
-        var result = await Executor.ExecuteAsync(ExecutablePath, "-h", cancellationToken);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            "-h",
+            cancellationToken);
 
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)
             ? result.StandardOutput

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PodmanCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PodmanCliScraper.cs
@@ -62,7 +62,8 @@ public partial class PodmanCliScraper : CobraCliScraper
         var arguments = commandPath.Length > 2
             ? string.Join(" ", commandPath.Skip(2)) + " --help"
             : "--help";
-        var result = await Executor.ExecuteAsync(
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
             composeProvider,
             arguments,
             cancellationToken);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SonarScannerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SonarScannerCliScraper.cs
@@ -71,7 +71,11 @@ public partial class SonarScannerCliScraper : CliScraperBase
             return cached;
         }
 
-        var result = await Executor.ExecuteAsync(ExecutablePath, "-h", cancellationToken);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            "-h",
+            cancellationToken);
 
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)
             ? result.StandardOutput

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -70,7 +70,11 @@ public partial class TerraformCliScraper : CliScraperBase
             ? string.Join(" ", commandPath.Skip(1)) + " -help"
             : "-help";
 
-        var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            args,
+            cancellationToken);
 
         // Terraform outputs help to stdout
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -71,7 +71,12 @@ public partial class YarnCliScraper : CliScraperBase
             : "--help";
 
         // Execute yarn from the project context directory
-        var result = await Executor.ExecuteAsync(ExecutablePath, args, cancellationToken, _yarnProjectDir);
+        var result = await ExecuteAndRecordHelpCommandAsync(
+            commandPath,
+            ExecutablePath,
+            args,
+            cancellationToken,
+            _yarnProjectDir);
 
         // Many CLIs output help to stderr when using --help
         var helpText = !string.IsNullOrEmpty(result.StandardOutput)


### PR DESCRIPTION
## Summary
- cap blanket command-coverage shrinkage approval at five undocumented removals
- compare current coverage against the committed nearby-version baseline and show representative removals
- preserve focused raw root/parent help plus invocation provenance on coverage failures and upload it from generation CI
- add truncated AWS and documented mass-exclusion regressions

## AWS verification
- current main baseline is AWS CLI 2.36.34 with 18,920 commands
- verified `aws apigateway get-model`, `aws ec2 modify-vpc-attribute`, and `aws efs create-file-system` remain present
- PR #4463's 2.36.35 snapshot removes 76 commands and will now fail even with blanket approval
- exact local 2.36.35 regeneration was attempted with an isolated official MSI, but the guarded process reached the mandated 2-GB limit; CI owns the expensive regeneration

## Validation
- OptionsGenerator tests: 1,174 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- scoped whitespace verification passed
- workflow YAML parsed successfully
- full format gate has one pre-existing whitespace error in untouched `IHelpTextCache.cs`

Closes #4465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Limited blanket approval for undocumented command removals to five commands.
  - Added baseline comparisons showing command counts and tool versions.
  - Added detailed command-coverage diagnostics, including relevant help text and missing commands.

- **Bug Fixes**
  - Improved detection and reporting of incomplete CLI scrapes.
  - Added support for documented exclusions when larger command removals are expected.
  - Ensured cancellation requests are propagated correctly.

- **Documentation**
  - Updated command-line option guidance and coverage workflow instructions.

- **Tests**
  - Added coverage for truncated scrapes, diagnostics, exclusions, cancellation, and baseline reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->