### PR TITLE
Preserve CLI placeholders in generated docs

### DIFF
--- a/src/ModularPipelines.Chocolatey/Options/ChocoFindOptions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Options/ChocoFindOptions.Generated.cs
@@ -204,7 +204,7 @@ public record ChocoFindOptions : ChocoOptions
     public bool? IncludeConfiguredSources { get; set; }
 
     /// <summary>
-    /// The filter operand.
+    /// The &lt;filter&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Filter { get; set; }

--- a/src/ModularPipelines.Chocolatey/Options/ChocoListOptions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Options/ChocoListOptions.Generated.cs
@@ -161,7 +161,7 @@ public record ChocoListOptions : ChocoOptions
     public bool? IgnorePinned { get; set; }
 
     /// <summary>
-    /// The filter operand.
+    /// The &lt;filter&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Filter { get; set; }

--- a/src/ModularPipelines.Chocolatey/Options/ChocoSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Options/ChocoSearchOptions.Generated.cs
@@ -204,7 +204,7 @@ public record ChocoSearchOptions : ChocoOptions
     public bool? IncludeConfiguredSources { get; set; }
 
     /// <summary>
-    /// The filter operand.
+    /// The &lt;filter&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Filter { get; set; }

--- a/src/ModularPipelines.Chocolatey/Options/ChocoUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Options/ChocoUninstallOptions.Generated.cs
@@ -127,7 +127,7 @@ public record ChocoUninstallOptions(
     public string? Version { get; set; }
 
     /// <summary>
-    /// The pkg2 pkgN operand.
+    /// The &lt;pkg2&gt; &lt;pkgN&gt; operand.
     /// </summary>
     [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
     public IEnumerable<string>? Pkg2PkgN { get; set; }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ChocolateyCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ChocolateyCliScraperTests.cs
@@ -32,14 +32,15 @@ public class ChocolateyCliScraperTests
     }
 
     [Test]
-    [Arguments("install", "<pkg> [<pkg2> <pkgN>]", "Pkg2PkgN")]
-    [Arguments("uninstall", "<pkg> [<pkg2> <pkgN>]", "Pkg2PkgN")]
-    [Arguments("upgrade", "<pkg> [<pkg2> <pkgN>]", "Pkg2PkgN")]
-    [Arguments("new", "<name> [<property=value> <propertyN=valueN>]", "PropertyValuePropertyNValueN")]
+    [Arguments("install", "<pkg> [<pkg2> <pkgN>]", "Pkg2PkgN", "The <pkg2> <pkgN> operand.")]
+    [Arguments("uninstall", "<pkg> [pkg2 pkgN]", "Pkg2PkgN", "The <pkg2> <pkgN> operand.")]
+    [Arguments("upgrade", "<pkg> [<pkg2> <pkgN>]", "Pkg2PkgN", "The <pkg2> <pkgN> operand.")]
+    [Arguments("new", "<name> [<property=value> <propertyN=valueN>]", "PropertyValuePropertyNValueN", "The <property=value> <propertyN=valueN> operand.")]
     public async Task Repeatable_Operand_Groups_Become_Collections(
         string commandName,
         string operands,
-        string expectedPropertyName)
+        string expectedPropertyName,
+        string expectedDescription)
     {
         var helpText = $"""
             Chocolatey v2.5.1
@@ -63,6 +64,7 @@ public class ChocolateyCliScraperTests
             await Assert.That(argument.CSharpType).IsEqualTo("IEnumerable<string>?");
             await Assert.That(argument.IsRequired).IsFalse();
             await Assert.That(argument.IsVariadic).IsTrue();
+            await Assert.That(argument.Description).IsEqualTo(expectedDescription);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -165,6 +165,30 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Documents_Only_The_Canonical_Placeholder()
+    {
+        var alternatives = UsageSynopsisParser.Parse(
+            "Usage: newman run [options] <collection|URL>",
+            ["newman", "run"]);
+        var optionalQualifiers = UsageSynopsisParser.Parse(
+            "Usage: pulumi env get [<org-name>/][<project-name>/]<environment-name>[@<version>] [property-path]",
+            ["pulumi", "env", "get"]);
+        var compound = UsageSynopsisParser.Parse(
+            "Usage: pulumi env clone [<org-name>/]<src-project-name>/<src-environment-name> [<dest-project-name>/]<dest-environment-name>",
+            ["pulumi", "env", "clone"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(alternatives.PositionalArguments[0].Description)
+                .IsEqualTo("The collection operand.");
+            await Assert.That(optionalQualifiers.PositionalArguments[0].Description)
+                .IsEqualTo("The <environment-name> operand.");
+            await Assert.That(compound.PositionalArguments[0].Description)
+                .IsEqualTo("The <src-environment-name> operand.");
+        }
+    }
+
+    [Test]
     public async Task Command_Group_Placeholders_Remain_Executable_Operands()
     {
         var parsed = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -189,6 +189,17 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Preserves_Variadic_Placeholder_In_Operand_Documentation()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool upload <FILES...>",
+            ["tool", "upload"]);
+
+        await Assert.That(result.PositionalArguments.Single().Description)
+            .IsEqualTo("The <FILES...> operand.");
+    }
+
+    [Test]
     public async Task Command_Group_Placeholders_Remain_Executable_Operands()
     {
         var parsed = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -137,6 +137,34 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Preserves_Placeholder_Notation_In_Operand_Documentation()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: choco uninstall <pkg> [<pkg2> <pkgN>] packages.config output=<path>",
+            ["choco", "uninstall"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.PositionalArguments.Select(argument => argument.Description!))
+                .IsEquivalentTo(
+                [
+                    "The <pkg> operand.",
+                    "The <pkg2> <pkgN> operand.",
+                    "The packages.config operand.",
+                    "The output=<path> operand.",
+                ]);
+            await Assert.That(GeneratorUtils.EscapeXmlComment(result.PositionalArguments[0].Description))
+                .IsEqualTo("The &lt;pkg&gt; operand.");
+            await Assert.That(GeneratorUtils.EscapeXmlComment(result.PositionalArguments[1].Description))
+                .IsEqualTo("The &lt;pkg2&gt; &lt;pkgN&gt; operand.");
+            await Assert.That(GeneratorUtils.EscapeXmlComment(result.PositionalArguments[2].Description))
+                .IsEqualTo("The packages.config operand.");
+            await Assert.That(GeneratorUtils.EscapeXmlComment(result.PositionalArguments[3].Description))
+                .IsEqualTo("The output=&lt;path&gt; operand.");
+        }
+    }
+
+    [Test]
     public async Task Command_Group_Placeholders_Remain_Executable_Operands()
     {
         var parsed = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
@@ -293,6 +293,7 @@ public partial class ChocolateyCliScraper : CliScraperBase
                     ? argument with
                     {
                         CSharpType = "IEnumerable<string>?",
+                        Description = GetRepeatableOperandDescription(argument.PropertyName),
                         IsRequired = false,
                         IsVariadic = true,
                     }
@@ -301,6 +302,13 @@ public partial class ChocolateyCliScraper : CliScraperBase
                 return normalized with { PositionIndex = index };
             })
             .ToArray();
+
+    private static string GetRepeatableOperandDescription(string propertyName) => propertyName switch
+    {
+        "Pkg2PkgN" => "The <pkg2> <pkgN> operand.",
+        "PropertyValuePropertyNValueN" => "The <property=value> <propertyN=valueN> operand.",
+        _ => throw new ArgumentOutOfRangeException(nameof(propertyName)),
+    };
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -603,6 +603,7 @@ public static class UsageSynopsisParser
                          || canonicalName.EndsWith(" ...", StringComparison.Ordinal)
                          || IsForwardedOptionTail(trimmed, content);
         canonicalName = canonicalName.TrimEnd('.', '…').Trim();
+        var documentationName = GetOperandDocumentationName(trimmed, canonicalName);
 
         if (canonicalName.StartsWith('-'))
         {
@@ -624,8 +625,23 @@ public static class UsageSynopsisParser
             IsVariadic = isVariadic,
             PositionIndex = positionIndex,
             Phase = phase,
-            Description = $"The {canonicalName} operand.",
+            Description = $"The {documentationName} operand.",
         };
+    }
+
+    private static string GetOperandDocumentationName(string token, string canonicalName)
+    {
+        var sourceName = token.Trim();
+        if (sourceName.StartsWith('[') && sourceName.EndsWith(']'))
+        {
+            sourceName = sourceName[1..^1].Trim();
+        }
+
+        sourceName = sourceName.TrimEnd('.', '…').Trim();
+        var placeholderStart = sourceName.IndexOf('<');
+        return placeholderStart >= 0 && sourceName.IndexOf('>', placeholderStart + 1) > placeholderStart + 1
+            ? sourceName
+            : canonicalName;
     }
 
     private static bool IsForwardedOptionTail(string token, string content) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -629,20 +629,10 @@ public static class UsageSynopsisParser
         };
     }
 
-    private static string GetOperandDocumentationName(string token, string canonicalName)
-    {
-        var sourceName = token.Trim();
-        if (sourceName.StartsWith('[') && sourceName.EndsWith(']'))
-        {
-            sourceName = sourceName[1..^1].Trim();
-        }
-
-        sourceName = sourceName.TrimEnd('.', '…').Trim();
-        var placeholderStart = sourceName.IndexOf('<');
-        return placeholderStart >= 0 && sourceName.IndexOf('>', placeholderStart + 1) > placeholderStart + 1
-            ? sourceName
+    private static string GetOperandDocumentationName(string token, string canonicalName) =>
+        token.Contains($"<{canonicalName}>", StringComparison.Ordinal)
+            ? $"<{canonicalName}>"
             : canonicalName;
-    }
 
     private static bool IsForwardedOptionTail(string token, string content) =>
         token.StartsWith('[')

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -629,10 +629,19 @@ public static class UsageSynopsisParser
         };
     }
 
-    private static string GetOperandDocumentationName(string token, string canonicalName) =>
-        token.Contains($"<{canonicalName}>", StringComparison.Ordinal)
-            ? $"<{canonicalName}>"
+    private static string GetOperandDocumentationName(string token, string canonicalName)
+    {
+        var placeholder = $"<{canonicalName}>";
+        if (token.Contains(placeholder, StringComparison.Ordinal))
+        {
+            return placeholder;
+        }
+
+        var variadicPlaceholder = $"<{canonicalName}...>";
+        return token.Contains(variadicPlaceholder, StringComparison.Ordinal)
+            ? variadicPlaceholder
             : canonicalName;
+    }
 
     private static bool IsForwardedOptionTail(string token, string content) =>
         token.StartsWith('[')


### PR DESCRIPTION
## Summary
- preserve CLI metavariable delimiters in operand descriptions and XML-escape them during generation
- restore Chocolatey's implied repeatable placeholder notation
- regenerate affected Chocolatey 2.7.4 docs

## Validation
- OptionsGenerator solution build (Release)
- 1,185 OptionsGenerator tests
- Chocolatey solution build (Release)
- 4 Chocolatey tests
- deterministic pinned Chocolatey 2.7.4 regeneration (aggregate SHA-256 unchanged)

The initial 20-way local regeneration exceeded the mandated 2 GB agent guard before writing files. Regeneration and determinism validation then completed with serialized traversal without raising the guard.

Closes #4452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Generated CLI operand descriptions now provide clearer guidance for repeatable package and property arguments.
  - Operand documentation preserves placeholder notation, including angle brackets, assignment syntax, compound names, and XML escaping.
  - Documentation consistently uses the canonical placeholder when multiple operand forms are available.

- **Tests**
  - Added coverage for repeatable operands, placeholder formatting, alternative operand forms, and XML-escaped descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->