### PR TITLE
Render Kustomize scalar maps in one flag

### DIFF
--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCreateOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Kubernetes.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Kubernetes.Options;
 
@@ -23,8 +24,8 @@ public record KustomizeCreateOptions : KustomizeOptions
     /// <summary>
     /// Add one or more common annotations.
     /// </summary>
-    [CliOption("--annotations", Format = OptionFormat.EqualsSeparated)]
-    public string? Annotations { get; set; }
+    [CliOption("--annotations", Format = OptionFormat.EqualsSeparated, CollectionSeparator = ",")]
+    public IReadOnlyList<KeyValue>? Annotations { get; set; }
 
     /// <summary>
     /// Search for kubernetes resources in the current directory to be added to the kustomization file.
@@ -41,8 +42,8 @@ public record KustomizeCreateOptions : KustomizeOptions
     /// <summary>
     /// Add one or more common labels.
     /// </summary>
-    [CliOption("--labels", Format = OptionFormat.EqualsSeparated)]
-    public string? Labels { get; set; }
+    [CliOption("--labels", Format = OptionFormat.EqualsSeparated, CollectionSeparator = ",")]
+    public IReadOnlyList<KeyValue>? Labels { get; set; }
 
     /// <summary>
     /// Sets the value of the namePrefix field in the kustomization file.

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCreateOptions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Kubernetes.Options;
-using ModularPipelines.Models;
 
 namespace ModularPipelines.Kubernetes.Options;
 
@@ -24,8 +23,8 @@ public record KustomizeCreateOptions : KustomizeOptions
     /// <summary>
     /// Add one or more common annotations.
     /// </summary>
-    [CliOption("--annotations", Format = OptionFormat.EqualsSeparated)]
-    public IReadOnlyList<KeyValue>? Annotations { get; set; }
+    [CliOption("--annotations", Format = OptionFormat.EqualsSeparated, CollectionSeparator = ",")]
+    public IEnumerable<string>? Annotations { get; set; }
 
     /// <summary>
     /// Search for kubernetes resources in the current directory to be added to the kustomization file.
@@ -42,8 +41,8 @@ public record KustomizeCreateOptions : KustomizeOptions
     /// <summary>
     /// Add one or more common labels.
     /// </summary>
-    [CliOption("--labels", Format = OptionFormat.EqualsSeparated)]
-    public IReadOnlyList<KeyValue>? Labels { get; set; }
+    [CliOption("--labels", Format = OptionFormat.EqualsSeparated, CollectionSeparator = ",")]
+    public IEnumerable<string>? Labels { get; set; }
 
     /// <summary>
     /// Sets the value of the namePrefix field in the kustomization file.

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCreateOptions.Generated.cs
@@ -24,7 +24,7 @@ public record KustomizeCreateOptions : KustomizeOptions
     /// <summary>
     /// Add one or more common annotations.
     /// </summary>
-    [CliOption("--annotations", Format = OptionFormat.EqualsSeparated, CollectionSeparator = ",")]
+    [CliOption("--annotations", Format = OptionFormat.EqualsSeparated)]
     public IReadOnlyList<KeyValue>? Annotations { get; set; }
 
     /// <summary>
@@ -42,7 +42,7 @@ public record KustomizeCreateOptions : KustomizeOptions
     /// <summary>
     /// Add one or more common labels.
     /// </summary>
-    [CliOption("--labels", Format = OptionFormat.EqualsSeparated, CollectionSeparator = ",")]
+    [CliOption("--labels", Format = OptionFormat.EqualsSeparated)]
     public IReadOnlyList<KeyValue>? Labels { get; set; }
 
     /// <summary>

--- a/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
+++ b/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
@@ -22,6 +22,27 @@ public class KubernetesCommandRenderingTests : TestBase
     }
 
     [Test]
+    public async Task Kustomize_Create_Joins_Map_Entries()
+    {
+        var result = await GetResult(new KustomizeCreateOptions
+        {
+            Annotations =
+            [
+                new KeyValue("owner", "platform"),
+                new KeyValue("tier", "backend"),
+            ],
+            Labels =
+            [
+                new KeyValue("app", "web"),
+                new KeyValue("environment", "test"),
+            ],
+        });
+
+        await Assert.That(result.CommandInput).IsEqualTo(
+            "kustomize create --annotations=owner=platform,tier=backend --labels=app=web,environment=test");
+    }
+
+    [Test]
     public async Task Auth_CanI_List_Does_Not_Require_A_Verb()
     {
         var result = await GetResult(new KubernetesAuthCanIOptions(null!) { List = true });

--- a/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
+++ b/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
@@ -1,7 +1,6 @@
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Kubernetes.Options;
-using ModularPipelines.Models;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 
@@ -22,25 +21,25 @@ public class KubernetesCommandRenderingTests : TestBase
     }
 
     [Test]
-    public async Task Kustomize_Create_Renders_Map_Entries_Independently()
+    public async Task Kustomize_Create_Joins_Scalar_Map_Entries()
     {
         var result = await GetResult(new KustomizeCreateOptions
         {
             Annotations =
             [
-                new KeyValue("owners", "alice,bob"),
-                new KeyValue("tier", "backend"),
+                "owners:alice",
+                "tier:backend",
             ],
             Labels =
             [
-                new KeyValue("app", "web"),
-                new KeyValue("environment", "test"),
+                "app:web",
+                "environment:test",
             ],
         });
 
         await Assert.That(result.CommandInput).IsEqualTo(
-            "kustomize create --annotations=owners=alice,bob --annotations=tier=backend "
-            + "--labels=app=web --labels=environment=test");
+            "kustomize create --annotations=owners:alice,tier:backend "
+            + "--labels=app:web,environment:test");
     }
 
     [Test]

--- a/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
+++ b/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
@@ -22,13 +22,13 @@ public class KubernetesCommandRenderingTests : TestBase
     }
 
     [Test]
-    public async Task Kustomize_Create_Joins_Map_Entries()
+    public async Task Kustomize_Create_Renders_Map_Entries_Independently()
     {
         var result = await GetResult(new KustomizeCreateOptions
         {
             Annotations =
             [
-                new KeyValue("owner", "platform"),
+                new KeyValue("owners", "alice,bob"),
                 new KeyValue("tier", "backend"),
             ],
             Labels =
@@ -39,7 +39,8 @@ public class KubernetesCommandRenderingTests : TestBase
         });
 
         await Assert.That(result.CommandInput).IsEqualTo(
-            "kustomize create --annotations=owner=platform,tier=backend --labels=app=web,environment=test");
+            "kustomize create --annotations=owners=alice,bob --annotations=tier=backend "
+            + "--labels=app=web --labels=environment=test");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
@@ -82,11 +82,14 @@ public class KustomizeCliScraperTests
     }
 
     [Test]
-    [Arguments("string", "")]
-    [Arguments("stringToString", " (default [])")]
-    public async Task Create_Map_Options_Preserve_Structured_Values(
+    [Arguments("string", "", "IEnumerable<string>?", false, ",")]
+    [Arguments("stringToString", " (default [])", "IReadOnlyList<KeyValue>?", true, null)]
+    public async Task Create_Map_Option_Rendering_Matches_Cobra_Type(
         string typeHint,
-        string defaultDescription)
+        string defaultDescription,
+        string expectedType,
+        bool expectedIsKeyValue,
+        string? expectedCollectionSeparator)
     {
         var command = await new TestKustomizeCliScraper().Parse(
             ["kustomize", "create"],
@@ -107,9 +110,11 @@ public class KustomizeCliScraperTests
         {
             await Assert.That(options).Count().IsEqualTo(2);
             await Assert.That(options.Select(option => option.CSharpType))
-                .IsEquivalentTo(["IReadOnlyList<KeyValue>?", "IReadOnlyList<KeyValue>?"]);
-            await Assert.That(options.All(option => option.IsKeyValue)).IsTrue();
-            await Assert.That(options.All(option => option.CollectionSeparator is null)).IsTrue();
+                .IsEquivalentTo([expectedType, expectedType]);
+            await Assert.That(options.All(option => option.IsKeyValue == expectedIsKeyValue)).IsTrue();
+            await Assert.That(options.All(
+                    option => option.CollectionSeparator == expectedCollectionSeparator))
+                .IsTrue();
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
@@ -82,13 +82,14 @@ public class KustomizeCliScraperTests
     }
 
     [Test]
-    [Arguments("string", "", "IEnumerable<string>?", false, ",")]
-    [Arguments("stringToString", " (default [])", "IReadOnlyList<KeyValue>?", true, null)]
+    [Arguments("string", "", "IEnumerable<string>?", false, false, ",")]
+    [Arguments("stringToString", " (default [])", "IReadOnlyList<KeyValue>?", true, false, null)]
     public async Task Create_Map_Option_Rendering_Matches_Cobra_Type(
         string typeHint,
         string defaultDescription,
         string expectedType,
         bool expectedIsKeyValue,
+        bool expectedAcceptsMultipleValues,
         string? expectedCollectionSeparator)
     {
         var command = await new TestKustomizeCliScraper().Parse(
@@ -112,6 +113,9 @@ public class KustomizeCliScraperTests
             await Assert.That(options.Select(option => option.CSharpType))
                 .IsEquivalentTo([expectedType, expectedType]);
             await Assert.That(options.All(option => option.IsKeyValue == expectedIsKeyValue)).IsTrue();
+            await Assert.That(options.All(
+                    option => option.AcceptsMultipleValues == expectedAcceptsMultipleValues))
+                .IsTrue();
             await Assert.That(options.All(
                     option => option.CollectionSeparator == expectedCollectionSeparator))
                 .IsTrue();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
@@ -109,7 +109,7 @@ public class KustomizeCliScraperTests
             await Assert.That(options.Select(option => option.CSharpType))
                 .IsEquivalentTo(["IReadOnlyList<KeyValue>?", "IReadOnlyList<KeyValue>?"]);
             await Assert.That(options.All(option => option.IsKeyValue)).IsTrue();
-            await Assert.That(options.All(option => option.CollectionSeparator == ",")).IsTrue();
+            await Assert.That(options.All(option => option.CollectionSeparator is null)).IsTrue();
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
@@ -81,6 +81,38 @@ public class KustomizeCliScraperTests
         }
     }
 
+    [Test]
+    [Arguments("string", "")]
+    [Arguments("stringToString", " (default [])")]
+    public async Task Create_Map_Options_Preserve_Structured_Values(
+        string typeHint,
+        string defaultDescription)
+    {
+        var command = await new TestKustomizeCliScraper().Parse(
+            ["kustomize", "create"],
+            $$"""
+              Usage:
+                kustomize create [flags]
+
+              Flags:
+                    --annotations {{typeHint}}   Add one or more common annotations.{{defaultDescription}}
+                    --labels {{typeHint}}        Add one or more common labels.{{defaultDescription}}
+              """);
+
+        var options = command!.Options
+            .Where(option => option.SwitchName is "--annotations" or "--labels")
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(options).Count().IsEqualTo(2);
+            await Assert.That(options.Select(option => option.CSharpType))
+                .IsEquivalentTo(["IReadOnlyList<KeyValue>?", "IReadOnlyList<KeyValue>?"]);
+            await Assert.That(options.All(option => option.IsKeyValue)).IsTrue();
+            await Assert.That(options.All(option => option.CollectionSeparator == ",")).IsTrue();
+        }
+    }
+
     private sealed class TestKustomizeCliScraper(ICliCommandExecutor? executor = null)
         : KustomizeCliScraper(
             executor ?? new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -409,6 +409,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
                     IsRequired = false,
                     AcceptsMultipleValues = isArray,
                     IsKeyValue = isKeyValue,
+                    CollectionSeparator = isKeyValue ? "," : null,
                     IsNumeric = isInteger || isFloat,
                     ValueSeparator = separator,
                     ValueArity = hasOptionalValue

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -411,9 +411,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
                     IsKeyValue = isKeyValue,
                     IsNumeric = isInteger || isFloat,
                     ValueSeparator = separator,
-                    CollectionSeparator = isArray
-                        ? GetCollectionSeparator(commandParts, longForm, actualType, description)
-                        : null,
                     ValueArity = hasOptionalValue
                         ? CliOptionValueArity.Optional
                         : CliOptionValueArity.Required,
@@ -498,15 +495,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
         string switchName,
         string typeHint,
         string description) => typeHint;
-
-    /// <summary>
-    /// Returns the separator used when a scalar CLI option accepts a collection in one value.
-    /// </summary>
-    protected virtual string? GetCollectionSeparator(
-        string[] commandParts,
-        string switchName,
-        string typeHint,
-        string description) => null;
 
     /// <summary>
     /// Applies tool-specific normalization before option descriptions are generated.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -409,7 +409,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
                     IsRequired = false,
                     AcceptsMultipleValues = isArray,
                     IsKeyValue = isKeyValue,
-                    CollectionSeparator = isKeyValue ? "," : null,
                     IsNumeric = isInteger || isFloat,
                     ValueSeparator = separator,
                     ValueArity = hasOptionalValue

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -411,6 +411,9 @@ public abstract partial class CobraCliScraper : CliScraperBase
                     IsKeyValue = isKeyValue,
                     IsNumeric = isInteger || isFloat,
                     ValueSeparator = separator,
+                    CollectionSeparator = isArray
+                        ? GetCollectionSeparator(commandParts, longForm, actualType, description)
+                        : null,
                     ValueArity = hasOptionalValue
                         ? CliOptionValueArity.Optional
                         : CliOptionValueArity.Required,
@@ -495,6 +498,15 @@ public abstract partial class CobraCliScraper : CliScraperBase
         string switchName,
         string typeHint,
         string description) => typeHint;
+
+    /// <summary>
+    /// Returns the separator used when a scalar CLI option accepts a collection in one value.
+    /// </summary>
+    protected virtual string? GetCollectionSeparator(
+        string[] commandParts,
+        string switchName,
+        string typeHint,
+        string description) => null;
 
     /// <summary>
     /// Applies tool-specific normalization before option descriptions are generated.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
@@ -83,31 +83,30 @@ public partial class KustomizeCliScraper : CobraCliScraper
     /// Kustomize 5.8 registers create annotations and labels as scalar strings, then
     /// parses one comma-separated key:value value into a map.
     /// </summary>
-    protected override string? GetCollectionSeparator(
+    protected override IReadOnlyList<CliOptionDefinition> ApplyOptionFixes(
         string[] commandParts,
-        string switchName,
-        string typeHint,
-        string description) =>
-        IsCreateScalarMapOption(commandParts, switchName, typeHint)
-            ? ","
-            : base.GetCollectionSeparator(commandParts, switchName, typeHint, description);
+        IReadOnlyList<CliOptionDefinition> options)
+    {
+        if (commandParts is not ["create"])
+        {
+            return options;
+        }
 
-    protected override bool IsRepeatableOption(
-        string[] commandParts,
-        string switchName,
-        string typeHint,
-        string description,
-        string helpText) =>
-        IsCreateScalarMapOption(commandParts, switchName, typeHint)
-        || base.IsRepeatableOption(commandParts, switchName, typeHint, description, helpText);
-
-    private static bool IsCreateScalarMapOption(
-        IReadOnlyList<string> commandParts,
-        string switchName,
-        string typeHint) =>
-        commandParts is ["create"]
-        && switchName is "--annotations" or "--labels"
-        && typeHint.Equals("string", StringComparison.OrdinalIgnoreCase);
+        return options
+            .Select(option => option is
+            {
+                SwitchName: "--annotations" or "--labels",
+                CSharpType: "string?",
+            }
+                    ? option with
+                    {
+                        CSharpType = "IEnumerable<string>?",
+                        CollectionSeparator = ",",
+                        IsKeyValue = false,
+                    }
+                    : option)
+            .ToArray();
+    }
 
     /// <summary>
     /// Kustomize validates buildmetadata operands but omits them from Cobra's Use value.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
@@ -80,6 +80,20 @@ public partial class KustomizeCliScraper : CobraCliScraper
     }
 
     /// <summary>
+    /// Kustomize 5.8 exposes create annotations and labels as strings, but parses
+    /// their comma-separated key/value entries into maps.
+    /// </summary>
+    protected override string NormalizeOptionTypeHint(
+        string[] commandParts,
+        string switchName,
+        string typeHint,
+        string description) =>
+        commandParts is ["create"]
+        && switchName is "--annotations" or "--labels"
+            ? "stringToString"
+            : base.NormalizeOptionTypeHint(commandParts, switchName, typeHint, description);
+
+    /// <summary>
     /// Kustomize validates buildmetadata operands but omits them from Cobra's Use value.
     /// </summary>
     protected override IEnumerable<string> GetAdditionalUsageSynopses(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
@@ -80,18 +80,34 @@ public partial class KustomizeCliScraper : CobraCliScraper
     }
 
     /// <summary>
-    /// Kustomize 5.8 exposes create annotations and labels as strings, but parses
-    /// their comma-separated key/value entries into maps.
+    /// Kustomize 5.8 registers create annotations and labels as scalar strings, then
+    /// parses one comma-separated key:value value into a map.
     /// </summary>
-    protected override string NormalizeOptionTypeHint(
+    protected override string? GetCollectionSeparator(
         string[] commandParts,
         string switchName,
         string typeHint,
         string description) =>
+        IsCreateScalarMapOption(commandParts, switchName, typeHint)
+            ? ","
+            : base.GetCollectionSeparator(commandParts, switchName, typeHint, description);
+
+    protected override bool IsRepeatableOption(
+        string[] commandParts,
+        string switchName,
+        string typeHint,
+        string description,
+        string helpText) =>
+        IsCreateScalarMapOption(commandParts, switchName, typeHint)
+        || base.IsRepeatableOption(commandParts, switchName, typeHint, description, helpText);
+
+    private static bool IsCreateScalarMapOption(
+        IReadOnlyList<string> commandParts,
+        string switchName,
+        string typeHint) =>
         commandParts is ["create"]
         && switchName is "--annotations" or "--labels"
-            ? "stringToString"
-            : base.NormalizeOptionTypeHint(commandParts, switchName, typeHint, description);
+        && typeHint.Equals("string", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Kustomize validates buildmetadata operands but omits them from Cobra's Use value.


### PR DESCRIPTION
## Summary
- follow Kustomize v5.8.1's actual `StringVar` registration for `create --annotations` and `--labels`
- retain collection-shaped caller storage, but join entries into one comma-separated `key:value` scalar option
- add a Cobra scraper extension point for tool-specific collection separators and regenerate Kustomize options
- cover both scalar-string and real `stringToString` help types without conflating their rendering semantics

## Validation
- official Kustomize v5.8.1 execution: joined annotations/labels produced every expected map entry
- Kustomize scraper tests: 6/6 passed
- Kubernetes command rendering tests: 10/10 passed
- OptionsGenerator solution Release build: passed, 0 warnings/errors
- Kubernetes solution Release build: passed, 0 warnings/errors
- touched-file whitespace verification: passed

Closes #4448