### PR TITLE
Model required CLI alternative groups

### DIFF
--- a/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
@@ -10,6 +10,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Rust.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Rust.Options;
 
@@ -19,12 +20,33 @@ namespace ModularPipelines.Rust.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("add")]
-public record CargoAddOptions : CargoOptions
+public record CargoAddOptions : CargoOptions, IValidatableObject
 {
+    /// <summary>
+    /// Filesystem path to local crate to add
+    /// </summary>
+    [CliOption("--path")]
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Git repository location Without any other information, cargo will use latest commit on the main branch.
+    /// </summary>
+    [CliOption("--git")]
+    public string? Git { get; set; }
+
     /// <summary>
     /// The DEP operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Dep { get; set; }
+
+    /// <inheritdoc />
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (!(Dep?.Any() == true || !string.IsNullOrWhiteSpace(Path) || !string.IsNullOrWhiteSpace(Git)))
+        {
+            yield return new ValidationResult("At least one of Dep, Path, or Git must be specified.", [nameof(Dep), nameof(Path), nameof(Git)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
@@ -23,19 +23,175 @@ namespace ModularPipelines.Rust.Options;
 public record CargoAddOptions : CargoOptions, IValidatableObject
 {
     /// <summary>
+    /// Disable the default features
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Re-enable the default features
+    /// </summary>
+    [CliFlag("--default-features")]
+    public bool? DefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Mark the dependency as optional
+    /// </summary>
+    [CliFlag("--optional")]
+    public bool? Optional { get; set; }
+
+    /// <summary>
+    /// Mark the dependency as required
+    /// </summary>
+    [CliFlag("--no-optional")]
+    public bool? NoOptional { get; set; }
+
+    /// <summary>
+    /// Mark the dependency as public (unstable)
+    /// </summary>
+    [CliFlag("--public")]
+    public bool? Public { get; set; }
+
+    /// <summary>
+    /// Mark the dependency as private (unstable)
+    /// </summary>
+    [CliFlag("--no-public")]
+    public bool? NoPublic { get; set; }
+
+    /// <summary>
+    /// Rename the dependency
+    /// </summary>
+    [CliOption("--rename")]
+    public string? Rename { get; set; }
+
+    /// <summary>
+    /// Don't actually write the manifest
+    /// </summary>
+    [CliFlag("--dry-run", ShortForm = "-n")]
+    public bool? DryRun { get; set; }
+
+    /// <summary>
+    /// Do not print cargo log messages
+    /// </summary>
+    [CliFlag("--quiet", ShortForm = "-q")]
+    public bool? Quiet { get; set; }
+
+    /// <summary>
+    /// Coloring
+    /// </summary>
+    [CliOption("--color")]
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Override a configuration value
+    /// </summary>
+    [CliOption("--config")]
+    public string? Config { get; set; }
+
+    /// <summary>
+    /// Print help (see a summary with '-h')
+    /// </summary>
+    [CliFlag("--help", ShortForm = "-h")]
+    public bool? Help { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
+    /// <summary>
     /// Filesystem path to local crate to add
     /// </summary>
     [CliOption("--path")]
     public string? Path { get; set; }
 
     /// <summary>
-    /// Git repository location Without any other information, cargo will use latest commit on the main branch.
+    /// The path base to use when adding from a local crate (unstable).
+    /// </summary>
+    [CliOption("--base")]
+    public string? Base { get; set; }
+
+    /// <summary>
+    /// Git repository location
     /// </summary>
     [CliOption("--git")]
     public string? Git { get; set; }
 
     /// <summary>
-    /// The DEP operand.
+    /// Git branch to download the crate from
+    /// </summary>
+    [CliOption("--branch")]
+    public string? Branch { get; set; }
+
+    /// <summary>
+    /// Git tag to download the crate from
+    /// </summary>
+    [CliOption("--tag")]
+    public string? Tag { get; set; }
+
+    /// <summary>
+    /// Git reference to download the crate from
+    /// </summary>
+    [CliOption("--rev")]
+    public string? Rev { get; set; }
+
+    /// <summary>
+    /// Package registry for this dependency
+    /// </summary>
+    [CliOption("--registry")]
+    public string? Registry { get; set; }
+
+    /// <summary>
+    /// Add as development dependency
+    /// </summary>
+    [CliFlag("--dev")]
+    public bool? Dev { get; set; }
+
+    /// <summary>
+    /// Add as build dependency
+    /// </summary>
+    [CliFlag("--build")]
+    public bool? Build { get; set; }
+
+    /// <summary>
+    /// Add as dependency to the given target platform
+    /// </summary>
+    [CliOption("--target")]
+    public string? Target { get; set; }
+
+    /// <summary>
+    /// The &lt;DEP&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Dep { get; set; }

--- a/src/ModularPipelines.Rust/Options/CargoBenchOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoBenchOptions.Generated.cs
@@ -34,7 +34,7 @@ public record CargoBenchOptions : CargoOptions
     public bool? NoFailFast { get; set; }
 
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
@@ -62,6 +62,138 @@ public record CargoBenchOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Benchmark all packages in the workspace
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Exclude packages from the benchmark
+    /// </summary>
+    [CliOption("--exclude")]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    /// <summary>
+    /// Alias for --workspace (deprecated)
+    /// </summary>
+    [CliFlag("--all")]
+    public bool? All { get; set; }
+
+    /// <summary>
+    /// Benchmark only this package's library
+    /// </summary>
+    [CliFlag("--lib")]
+    public bool? Lib { get; set; }
+
+    /// <summary>
+    /// Benchmark all binaries
+    /// </summary>
+    [CliFlag("--bins")]
+    public bool? Bins { get; set; }
+
+    /// <summary>
+    /// Benchmark all examples
+    /// </summary>
+    [CliFlag("--examples")]
+    public bool? Examples { get; set; }
+
+    /// <summary>
+    /// Benchmark all targets that have `test = true` set
+    /// </summary>
+    [CliFlag("--tests")]
+    public bool? Tests { get; set; }
+
+    /// <summary>
+    /// Benchmark all targets that have `bench = true` set
+    /// </summary>
+    [CliFlag("--benches")]
+    public bool? Benches { get; set; }
+
+    /// <summary>
+    /// Benchmark all targets
+    /// </summary>
+    [CliFlag("--all-targets")]
+    public bool? AllTargets { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Build artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Output build graph in JSON (unstable)
+    /// </summary>
+    [CliFlag("--unit-graph")]
+    public bool? UnitGraph { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
     /// <summary>
     /// The BENCHNAME operand.

--- a/src/ModularPipelines.Rust/Options/CargoBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoBuildOptions.Generated.cs
@@ -28,7 +28,7 @@ public record CargoBuildOptions : CargoOptions
     public bool? FutureIncompatReport { get; set; }
 
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
@@ -56,5 +56,155 @@ public record CargoBuildOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Build all packages in the workspace
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Exclude packages from the build
+    /// </summary>
+    [CliOption("--exclude")]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    /// <summary>
+    /// Alias for --workspace (deprecated)
+    /// </summary>
+    [CliFlag("--all")]
+    public bool? All { get; set; }
+
+    /// <summary>
+    /// Build only this package's library
+    /// </summary>
+    [CliFlag("--lib")]
+    public bool? Lib { get; set; }
+
+    /// <summary>
+    /// Build all binaries
+    /// </summary>
+    [CliFlag("--bins")]
+    public bool? Bins { get; set; }
+
+    /// <summary>
+    /// Build all examples
+    /// </summary>
+    [CliFlag("--examples")]
+    public bool? Examples { get; set; }
+
+    /// <summary>
+    /// Build all targets that have `test = true` set
+    /// </summary>
+    [CliFlag("--tests")]
+    public bool? Tests { get; set; }
+
+    /// <summary>
+    /// Build all targets that have `bench = true` set
+    /// </summary>
+    [CliFlag("--benches")]
+    public bool? Benches { get; set; }
+
+    /// <summary>
+    /// Build all targets
+    /// </summary>
+    [CliFlag("--all-targets")]
+    public bool? AllTargets { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Build artifacts in release mode, with optimizations
+    /// </summary>
+    [CliFlag("--release", ShortForm = "-r")]
+    public bool? Release { get; set; }
+
+    /// <summary>
+    /// Build artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Do not abort the build as soon as there is an error
+    /// </summary>
+    [CliFlag("--keep-going")]
+    public bool? KeepGoing { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Copy final artifacts to this directory (unstable)
+    /// </summary>
+    [CliOption("--artifact-dir")]
+    public string? ArtifactDir { get; set; }
+
+    /// <summary>
+    /// Output build graph in JSON (unstable)
+    /// </summary>
+    [CliFlag("--unit-graph")]
+    public bool? UnitGraph { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
 }

--- a/src/ModularPipelines.Rust/Options/CargoCheckOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoCheckOptions.Generated.cs
@@ -28,7 +28,7 @@ public record CargoCheckOptions : CargoOptions
     public bool? FutureIncompatReport { get; set; }
 
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
@@ -56,5 +56,149 @@ public record CargoCheckOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Check all packages in the workspace
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Exclude packages from the check
+    /// </summary>
+    [CliOption("--exclude")]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    /// <summary>
+    /// Alias for --workspace (deprecated)
+    /// </summary>
+    [CliFlag("--all")]
+    public bool? All { get; set; }
+
+    /// <summary>
+    /// Check only this package's library
+    /// </summary>
+    [CliFlag("--lib")]
+    public bool? Lib { get; set; }
+
+    /// <summary>
+    /// Check all binaries
+    /// </summary>
+    [CliFlag("--bins")]
+    public bool? Bins { get; set; }
+
+    /// <summary>
+    /// Check all examples
+    /// </summary>
+    [CliFlag("--examples")]
+    public bool? Examples { get; set; }
+
+    /// <summary>
+    /// Check all targets that have `test = true` set
+    /// </summary>
+    [CliFlag("--tests")]
+    public bool? Tests { get; set; }
+
+    /// <summary>
+    /// Check all targets that have `bench = true` set
+    /// </summary>
+    [CliFlag("--benches")]
+    public bool? Benches { get; set; }
+
+    /// <summary>
+    /// Check all targets
+    /// </summary>
+    [CliFlag("--all-targets")]
+    public bool? AllTargets { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Do not abort the build as soon as there is an error
+    /// </summary>
+    [CliFlag("--keep-going")]
+    public bool? KeepGoing { get; set; }
+
+    /// <summary>
+    /// Check artifacts in release mode, with optimizations
+    /// </summary>
+    [CliFlag("--release", ShortForm = "-r")]
+    public bool? Release { get; set; }
+
+    /// <summary>
+    /// Check artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Output build graph in JSON (unstable)
+    /// </summary>
+    [CliFlag("--unit-graph")]
+    public bool? UnitGraph { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
 }

--- a/src/ModularPipelines.Rust/Options/CargoCleanOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoCleanOptions.Generated.cs
@@ -57,4 +57,52 @@ public record CargoCleanOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// Clean artifacts of the workspace members
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Whether or not to clean release artifacts
+    /// </summary>
+    [CliFlag("--release", ShortForm = "-r")]
+    public bool? Release { get; set; }
+
+    /// <summary>
+    /// Clean artifacts of the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoDocOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoDocOptions.Generated.cs
@@ -46,7 +46,7 @@ public record CargoDocOptions : CargoOptions
     public string? OutputFormat { get; set; }
 
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
@@ -74,5 +74,131 @@ public record CargoDocOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Document all packages in the workspace
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Exclude packages from the build
+    /// </summary>
+    [CliOption("--exclude")]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    /// <summary>
+    /// Alias for --workspace (deprecated)
+    /// </summary>
+    [CliFlag("--all")]
+    public bool? All { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Document only this package's library
+    /// </summary>
+    [CliFlag("--lib")]
+    public bool? Lib { get; set; }
+
+    /// <summary>
+    /// Document all binaries
+    /// </summary>
+    [CliFlag("--bins")]
+    public bool? Bins { get; set; }
+
+    /// <summary>
+    /// Document all examples
+    /// </summary>
+    [CliFlag("--examples")]
+    public bool? Examples { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Do not abort the build as soon as there is an error
+    /// </summary>
+    [CliFlag("--keep-going")]
+    public bool? KeepGoing { get; set; }
+
+    /// <summary>
+    /// Build artifacts in release mode, with optimizations
+    /// </summary>
+    [CliFlag("--release", ShortForm = "-r")]
+    public bool? Release { get; set; }
+
+    /// <summary>
+    /// Build artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Output build graph in JSON (unstable)
+    /// </summary>
+    [CliFlag("--unit-graph")]
+    public bool? UnitGraph { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
 }

--- a/src/ModularPipelines.Rust/Options/CargoInitOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoInitOptions.Generated.cs
@@ -22,7 +22,7 @@ namespace ModularPipelines.Rust.Options;
 public record CargoInitOptions : CargoOptions
 {
     /// <summary>
-    /// Initialize a new repository for the given version control system,
+    /// Initialize a new repository for the given version control system, overriding a global configuration. [possible values: git, hg, pijul, fossil, none]
     /// </summary>
     [CliOption("--vcs")]
     public string? Vcs { get; set; }
@@ -40,7 +40,7 @@ public record CargoInitOptions : CargoOptions
     public bool? Lib { get; set; }
 
     /// <summary>
-    /// Edition to set for the crate generated [possible values: 2015,
+    /// Edition to set for the crate generated [possible values: 2015, 2018, 2021, 2024]
     /// </summary>
     [CliOption("--edition")]
     public string? Edition { get; set; }
@@ -80,6 +80,24 @@ public record CargoInitOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
     /// <summary>
     /// The PATH operand.

--- a/src/ModularPipelines.Rust/Options/CargoInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoInstallOptions.Generated.cs
@@ -100,13 +100,13 @@ public record CargoInstallOptions : CargoOptions
     public bool? List { get; set; }
 
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
 
     /// <summary>
-    /// Build in debug mode (with the 'dev' profile) instead of release
+    /// Build in debug mode (with the 'dev' profile) instead of release mode
     /// </summary>
     [CliFlag("--debug")]
     public bool? Debug { get; set; }
@@ -134,6 +134,90 @@ public record CargoInstallOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
+    /// <summary>
+    /// Install all binaries
+    /// </summary>
+    [CliFlag("--bins")]
+    public bool? Bins { get; set; }
+
+    /// <summary>
+    /// Install all examples
+    /// </summary>
+    [CliFlag("--examples")]
+    public bool? Examples { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Do not abort the build as soon as there is an error
+    /// </summary>
+    [CliFlag("--keep-going")]
+    public bool? KeepGoing { get; set; }
+
+    /// <summary>
+    /// Install artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
 
     /// <summary>
     /// The [CRATE[@&lt;VER&gt;]] operand.

--- a/src/ModularPipelines.Rust/Options/CargoNewOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoNewOptions.Generated.cs
@@ -24,7 +24,7 @@ public record CargoNewOptions(
 ) : CargoOptions
 {
     /// <summary>
-    /// Initialize a new repository for the given version control system,
+    /// Initialize a new repository for the given version control system, overriding a global configuration. [possible values: git, hg, pijul, fossil, none]
     /// </summary>
     [CliOption("--vcs")]
     public string? Vcs { get; set; }
@@ -42,7 +42,7 @@ public record CargoNewOptions(
     public bool? Lib { get; set; }
 
     /// <summary>
-    /// Edition to set for the crate generated [possible values: 2015,
+    /// Edition to set for the crate generated [possible values: 2015, 2018, 2021, 2024]
     /// </summary>
     [CliOption("--edition")]
     public string? Edition { get; set; }
@@ -82,5 +82,23 @@ public record CargoNewOptions(
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
 }

--- a/src/ModularPipelines.Rust/Options/CargoPublishOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoPublishOptions.Generated.cs
@@ -75,4 +75,76 @@ public record CargoPublishOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// Publish all packages in the workspace
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Don't publish specified packages
+    /// </summary>
+    [CliOption("--exclude")]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Do not abort the build as soon as there is an error
+    /// </summary>
+    [CliFlag("--keep-going")]
+    public bool? KeepGoing { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoRemoveOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoRemoveOptions.Generated.cs
@@ -53,4 +53,46 @@ public record CargoRemoveOptions(
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// Remove from dev-dependencies
+    /// </summary>
+    [CliFlag("--dev")]
+    public bool? Dev { get; set; }
+
+    /// <summary>
+    /// Remove from build-dependencies
+    /// </summary>
+    [CliFlag("--build")]
+    public bool? Build { get; set; }
+
+    /// <summary>
+    /// Remove from target-dependencies
+    /// </summary>
+    [CliOption("--target")]
+    public string? Target { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoRunOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoRunOptions.Generated.cs
@@ -22,7 +22,7 @@ namespace ModularPipelines.Rust.Options;
 public record CargoRunOptions : CargoOptions
 {
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
@@ -50,6 +50,96 @@ public record CargoRunOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Do not abort the build as soon as there is an error
+    /// </summary>
+    [CliFlag("--keep-going")]
+    public bool? KeepGoing { get; set; }
+
+    /// <summary>
+    /// Build artifacts in release mode, with optimizations
+    /// </summary>
+    [CliFlag("--release", ShortForm = "-r")]
+    public bool? Release { get; set; }
+
+    /// <summary>
+    /// Build artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Output build graph in JSON (unstable)
+    /// </summary>
+    [CliFlag("--unit-graph")]
+    public bool? UnitGraph { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
     /// <summary>
     /// The [ARGS] operand.

--- a/src/ModularPipelines.Rust/Options/CargoSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoSearchOptions.Generated.cs
@@ -64,6 +64,24 @@ public record CargoSearchOptions : CargoOptions
     public bool? Help { get; set; }
 
     /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
+    /// <summary>
     /// The [QUERY] operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]

--- a/src/ModularPipelines.Rust/Options/CargoTestOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoTestOptions.Generated.cs
@@ -40,7 +40,7 @@ public record CargoTestOptions : CargoOptions
     public bool? FutureIncompatReport { get; set; }
 
     /// <summary>
-    /// Error format [possible values: human, short, json,
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
     /// </summary>
     [CliOption("--message-format")]
     public string? MessageFormat { get; set; }
@@ -68,6 +68,150 @@ public record CargoTestOptions : CargoOptions
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// Test all packages in the workspace
+    /// </summary>
+    [CliFlag("--workspace")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Exclude packages from the test
+    /// </summary>
+    [CliOption("--exclude")]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    /// <summary>
+    /// Alias for --workspace (deprecated)
+    /// </summary>
+    [CliFlag("--all")]
+    public bool? All { get; set; }
+
+    /// <summary>
+    /// Test only this package's library
+    /// </summary>
+    [CliFlag("--lib")]
+    public bool? Lib { get; set; }
+
+    /// <summary>
+    /// Test all binaries
+    /// </summary>
+    [CliFlag("--bins")]
+    public bool? Bins { get; set; }
+
+    /// <summary>
+    /// Test all examples
+    /// </summary>
+    [CliFlag("--examples")]
+    public bool? Examples { get; set; }
+
+    /// <summary>
+    /// Test all targets that have `test = true` set
+    /// </summary>
+    [CliFlag("--tests")]
+    public bool? Tests { get; set; }
+
+    /// <summary>
+    /// Test all targets that have `bench = true` set
+    /// </summary>
+    [CliFlag("--benches")]
+    public bool? Benches { get; set; }
+
+    /// <summary>
+    /// Test all targets (does not include doctests)
+    /// </summary>
+    [CliFlag("--all-targets")]
+    public bool? AllTargets { get; set; }
+
+    /// <summary>
+    /// Test only this library's documentation
+    /// </summary>
+    [CliFlag("--doc")]
+    public bool? Doc { get; set; }
+
+    /// <summary>
+    /// Space or comma separated list of features to activate
+    /// </summary>
+    [CliOption("--features", ShortForm = "-F")]
+    public IEnumerable<string>? Features { get; set; }
+
+    /// <summary>
+    /// Activate all available features
+    /// </summary>
+    [CliFlag("--all-features")]
+    public bool? AllFeatures { get; set; }
+
+    /// <summary>
+    /// Do not activate the `default` feature
+    /// </summary>
+    [CliFlag("--no-default-features")]
+    public bool? NoDefaultFeatures { get; set; }
+
+    /// <summary>
+    /// Number of parallel jobs, defaults to # of CPUs.
+    /// </summary>
+    [CliOption("--jobs", ShortForm = "-j")]
+    public string? Jobs { get; set; }
+
+    /// <summary>
+    /// Build artifacts in release mode, with optimizations
+    /// </summary>
+    [CliFlag("--release", ShortForm = "-r")]
+    public bool? Release { get; set; }
+
+    /// <summary>
+    /// Build artifacts with the specified profile
+    /// </summary>
+    [CliOption("--profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Directory for all generated artifacts
+    /// </summary>
+    [CliOption("--target-dir")]
+    public string? TargetDir { get; set; }
+
+    /// <summary>
+    /// Output build graph in JSON (unstable)
+    /// </summary>
+    [CliFlag("--unit-graph")]
+    public bool? UnitGraph { get; set; }
+
+    /// <summary>
+    /// Output a build timing report at the end of the build
+    /// </summary>
+    [CliFlag("--timings")]
+    public bool? Timings { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
 
     /// <summary>
     /// The TESTNAME operand.

--- a/src/ModularPipelines.Rust/Options/CargoUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoUninstallOptions.Generated.cs
@@ -52,6 +52,30 @@ public record CargoUninstallOptions : CargoOptions
     public bool? Help { get; set; }
 
     /// <summary>
+    /// Only uninstall the binary NAME
+    /// </summary>
+    [CliOption("--bin")]
+    public string? Bin { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
+    /// <summary>
     /// The [SPEC] operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]

--- a/src/ModularPipelines.Rust/Options/CargoUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoUpdateOptions.Generated.cs
@@ -70,6 +70,42 @@ public record CargoUpdateOptions : CargoOptions
     public bool? Help { get; set; }
 
     /// <summary>
+    /// Only update the workspace packages
+    /// </summary>
+    [CliFlag("--workspace", ShortForm = "-w")]
+    public bool? Workspace { get; set; }
+
+    /// <summary>
+    /// Path to Cargo.toml
+    /// </summary>
+    [CliOption("--manifest-path", ShortForm = "-m")]
+    public string? ManifestPath { get; set; }
+
+    /// <summary>
+    /// Ignore `rust-version` specification in packages
+    /// </summary>
+    [CliFlag("--ignore-rust-version")]
+    public bool? IgnoreRustVersion { get; set; }
+
+    /// <summary>
+    /// Assert that `Cargo.lock` will remain unchanged
+    /// </summary>
+    [CliFlag("--locked")]
+    public bool? Locked { get; set; }
+
+    /// <summary>
+    /// Run without accessing the network
+    /// </summary>
+    [CliFlag("--offline")]
+    public bool? Offline { get; set; }
+
+    /// <summary>
+    /// Equivalent to specifying both --locked and --offline
+    /// </summary>
+    [CliFlag("--frozen")]
+    public bool? Frozen { get; set; }
+
+    /// <summary>
     /// The [SPEC] operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]

--- a/src/ModularPipelines.Rust/Services/Cargo.Generated.cs
+++ b/src/ModularPipelines.Rust/Services/Cargo.Generated.cs
@@ -34,11 +34,11 @@ internal partial class Cargo : ICargo
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AddAsync(
-        CargoAddOptions? options = null,
+        CargoAddOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new CargoAddOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.Rust/Services/ICargo.Generated.cs
+++ b/src/ModularPipelines.Rust/Services/ICargo.Generated.cs
@@ -27,7 +27,7 @@ public partial interface ICargo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AddAsync(CargoAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AddAsync(CargoAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/test/ModularPipelines.Rust.UnitTests/CargoOptionsTests.cs
+++ b/test/ModularPipelines.Rust.UnitTests/CargoOptionsTests.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Context;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Rust.Options;
 using ModularPipelines.TestHelpers;
 
@@ -6,6 +7,47 @@ namespace ModularPipelines.Rust.UnitTests;
 
 public class CargoOptionsTests : TestBase
 {
+    [Test]
+    public async Task Add_Emits_Positional_Dependency_Source()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var commandLine = builder.Build(new CargoAddOptions { Dep = ["serde"] });
+
+        await Assert.That(commandLine.ToString()).IsEqualTo("cargo add serde");
+    }
+
+    [Test]
+    public async Task Add_Emits_Path_Dependency_Source()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var commandLine = builder.Build(new CargoAddOptions { Path = "../shared" });
+
+        await Assert.That(commandLine.ToString()).IsEqualTo("cargo add --path ../shared");
+    }
+
+    [Test]
+    public async Task Add_Emits_Git_Dependency_Source()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var commandLine = builder.Build(new CargoAddOptions { Git = "https://example.test/repo.git" });
+
+        await Assert.That(commandLine.ToString())
+            .IsEqualTo("cargo add --git https://example.test/repo.git");
+    }
+
+    [Test]
+    public async Task Add_Rejects_Missing_Dependency_Source()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        await Assert.That(() => builder.Build(new CargoAddOptions()))
+            .Throws<CommandOptionsValidationException>()
+            .And.HasMessageContaining("At least one of Dep, Path, or Git must be specified.");
+    }
+
     [Test]
     public async Task Preserves_PassThrough_Switch_After_Test_Arguments()
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -509,6 +509,44 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task Required_Alternative_Group_Requires_NonEmpty_ReadOnly_Collection()
+    {
+        var command = Command("ToolImportOptions", "ToolOptions", ["import"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--entries",
+                    PropertyName = "Entries",
+                    CSharpType = "IReadOnlyList<KeyValue>?",
+                },
+                new CliOptionDefinition
+                {
+                    SwitchName = "--file",
+                    PropertyName = "File",
+                    CSharpType = "string?",
+                },
+            ],
+            RequiredAlternativeGroups =
+            [
+                new CliRequiredAlternativeGroup
+                {
+                    Members =
+                    [
+                        new CliRequiredAlternativeMember { PropertyName = "Entries", OptionSwitch = "--entries" },
+                        new CliRequiredAlternativeMember { PropertyName = "File", OptionSwitch = "--file" },
+                    ],
+                },
+            ],
+        };
+
+        var options = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
+
+        await Assert.That(options).Contains("Entries?.Any() == true");
+    }
+
+    [Test]
     public async Task SubDomain_Generators_Expose_Kubectl_ClusterInfo_Parent()
     {
         var tool = Tool(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -444,6 +444,61 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task Required_Alternative_Group_Validates_Options_And_Requires_Service_Parameter()
+    {
+        var command = Command("ToolAddOptions", "ToolOptions", ["add"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--path",
+                    PropertyName = "Path",
+                    CSharpType = "string?",
+                },
+                new CliOptionDefinition
+                {
+                    SwitchName = "--git",
+                    PropertyName = "Git",
+                    CSharpType = "string?",
+                },
+            ],
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "DepId",
+                    CSharpType = "IEnumerable<string>?",
+                },
+            ],
+            RequiredAlternativeGroups =
+            [
+                new CliRequiredAlternativeGroup
+                {
+                    PropertyNames = ["DepId", "Path", "Git"],
+                },
+            ],
+        };
+        var tool = Tool(command);
+
+        var options = (await new OptionsClassGenerator().GenerateAsync(tool)).Single().Content;
+        var service = (await new ServiceImplementationGenerator().GenerateAsync(tool)).Single().Content;
+        var serviceInterface = (await new ServiceInterfaceGenerator().GenerateAsync(tool)).Single().Content;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(options).Contains("public record ToolAddOptions : ToolOptions, IValidatableObject");
+            await Assert.That(options).Contains("DepId?.Any() == true");
+            await Assert.That(options).Contains("!string.IsNullOrWhiteSpace(Path)");
+            await Assert.That(options).Contains("!string.IsNullOrWhiteSpace(Git)");
+            await Assert.That(options).Contains("At least one of DepId, Path, or Git must be specified.");
+            await Assert.That(service).Contains("ToolAddOptions options,");
+            await Assert.That(service).DoesNotContain("new ToolAddOptions()");
+            await Assert.That(serviceInterface).Contains("AddAsync(ToolAddOptions options,");
+        }
+    }
+
+    [Test]
     public async Task SubDomain_Generators_Expose_Kubectl_ClusterInfo_Parent()
     {
         var tool = Tool(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -475,7 +475,17 @@ public class GeneratorHardeningTests
             [
                 new CliRequiredAlternativeGroup
                 {
-                    PropertyNames = ["DepId", "Path", "Git"],
+                    Members =
+                    [
+                        new CliRequiredAlternativeMember
+                        {
+                            PropertyName = "DepId",
+                            PositionalArgumentPhase = CommandLinePhase.EarlyOperand,
+                            PositionalArgumentPositionIndex = 0,
+                        },
+                        new CliRequiredAlternativeMember { PropertyName = "Path", OptionSwitch = "--path" },
+                        new CliRequiredAlternativeMember { PropertyName = "Git", OptionSwitch = "--git" },
+                    ],
                 },
             ],
         };
@@ -834,6 +844,61 @@ public class GeneratorHardeningTests
                 .IsEqualTo("Filename");
             await Assert.That(resolvedCommand.PositionalArguments.Single().PropertyName)
                 .IsEqualTo("FilenameArgument");
+        }
+    }
+
+    [Test]
+    public async Task Required_Alternatives_Preserve_Option_And_Argument_Identity_After_Collision()
+    {
+        var command = Command("ToolCreateOptions", "ToolOptions", ["create"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--filename",
+                    PropertyName = "Filename",
+                    CSharpType = "string?",
+                },
+            ],
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Filename",
+                    CSharpType = "IEnumerable<string>?",
+                    PositionIndex = 0,
+                },
+            ],
+            RequiredAlternativeGroups =
+            [
+                new CliRequiredAlternativeGroup
+                {
+                    Members =
+                    [
+                        new CliRequiredAlternativeMember
+                        {
+                            PropertyName = "Filename",
+                            OptionSwitch = "--filename",
+                        },
+                        new CliRequiredAlternativeMember
+                        {
+                            PropertyName = "Filename",
+                            PositionalArgumentPhase = CommandLinePhase.EarlyOperand,
+                            PositionalArgumentPositionIndex = 0,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).Contains("!string.IsNullOrWhiteSpace(Filename)");
+            await Assert.That(generated).Contains("FilenameArgument?.Any() == true");
+            await Assert.That(generated).Contains("nameof(Filename), nameof(FilenameArgument)");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliOptionDefinitionTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliOptionDefinitionTests.cs
@@ -173,6 +173,30 @@ public class CliOptionDefinitionTests
         await Assert.That(option1).IsNotEqualTo(option2);
     }
 
+    [Test]
+    public async Task FindIndexBySwitch_Distinguishes_Case_Sensitive_Short_Options()
+    {
+        var options = new[]
+        {
+            new CliOptionDefinition
+            {
+                SwitchName = "--output",
+                ShortForm = "-o",
+                PropertyName = "Output",
+                CSharpType = "string?",
+            },
+            new CliOptionDefinition
+            {
+                SwitchName = "--remote-name",
+                ShortForm = "-O",
+                PropertyName = "RemoteName",
+                CSharpType = "bool?",
+            },
+        };
+
+        await Assert.That(CliOptionDefinition.FindIndexBySwitch(options, "-O")).IsEqualTo(1);
+    }
+
     #endregion
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -894,6 +894,53 @@ public class CliScraperTraversalTests
         await Assert.That(scraper.Skips("SSH")).IsFalse();
     }
 
+    [Test]
+    public async Task Cargo_Add_Models_Required_Dependency_Source_Alternatives()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Rust's package manager
+
+                Usage: cargo [OPTIONS] <COMMAND>
+
+                Commands:
+                  add  Add dependencies to a Cargo.toml manifest file
+
+                Options:
+                  -h, --help  Print help
+                """,
+            ["add --help"] = """
+                Add dependencies to a Cargo.toml manifest file
+
+                Usage: cargo add [OPTIONS] <DEP_ID|--path <PATH>|--git <URI>>...
+
+                Arguments:
+                  <DEP_ID|--path <PATH>|--git <URI>>...  Reference to a package to add
+
+                Options:
+                  -F, --features <FEATURES>  Features to activate
+
+                Source options:
+                      --path <PATH>  Filesystem path to local crate to add
+                      --git <URI>    Git repository location
+                """,
+        });
+
+        var command = (await ScrapeAsync(new TestCargoCliScraper(executor))).Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.PositionalArguments.Single().PropertyName).IsEqualTo("DepId");
+            await Assert.That(command.PositionalArguments.Single().IsRequired).IsFalse();
+            await Assert.That(command.Options.Select(option => option.PropertyName))
+                .Contains("Path")
+                .And.Contains("Git");
+            await Assert.That(command.RequiredAlternativeGroups.Single().PropertyNames)
+                .IsEquivalentTo(["DepId", "Path", "Git"]);
+        }
+    }
+
     private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)
     {
         var commands = new List<CliCommandDefinition>();
@@ -984,6 +1031,12 @@ public class CliScraperTraversalTests
             executor,
             new HelpTextCache(NullLogger<HelpTextCache>.Instance),
             NullLogger<PnpmCliScraper>.Instance);
+
+    private sealed class TestCargoCliScraper(ICliCommandExecutor executor)
+        : CargoCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<CargoCliScraper>.Instance);
 
     private sealed class ComposeProviderExecutor : ICliCommandExecutor
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -924,6 +924,10 @@ public class CliScraperTraversalTests
                 Source options:
                       --path <PATH>  Filesystem path to local crate to add
                       --git <URI>    Git repository location
+                      --registry <REGISTRY>  Package registry to use
+
+                Package Selection:
+                      --workspace  Add dependencies to every workspace package
                 """,
         });
 
@@ -935,7 +939,17 @@ public class CliScraperTraversalTests
             await Assert.That(command.PositionalArguments.Single().IsRequired).IsFalse();
             await Assert.That(command.Options.Select(option => option.PropertyName))
                 .Contains("Path")
-                .And.Contains("Git");
+                .And.Contains("Git")
+                .And.Contains("Registry")
+                .And.Contains("Workspace");
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Path").Description)
+                .IsEqualTo("Filesystem path to local crate to add");
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Git").Description)
+                .IsEqualTo("Git repository location");
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Registry").Description)
+                .IsEqualTo("Package registry to use");
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Workspace").Description)
+                .IsEqualTo("Add dependencies to every workspace package");
             await Assert.That(command.RequiredAlternativeGroups.Single().PropertyNames)
                 .IsEquivalentTo(["DepId", "Path", "Git"]);
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -925,6 +925,11 @@ public class CliScraperTraversalTests
                       --path <PATH>  Filesystem path to local crate to add
                       --git <URI>    Git repository location
                       --registry <REGISTRY>  Package registry to use
+                      --rename <NAME>
+                          Rename the dependency
+
+                          Example uses:
+                          - Depending on multiple versions of a crate
 
                 Package Selection:
                       --workspace  Add dependencies to every workspace package
@@ -948,6 +953,8 @@ public class CliScraperTraversalTests
                 .IsEqualTo("Git repository location");
             await Assert.That(command.Options.Single(option => option.PropertyName == "Registry").Description)
                 .IsEqualTo("Package registry to use");
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Rename").Description)
+                .IsEqualTo("Rename the dependency");
             await Assert.That(command.Options.Single(option => option.PropertyName == "Workspace").Description)
                 .IsEqualTo("Add dependencies to every workspace package");
             await Assert.That(command.RequiredAlternativeGroups.Single().PropertyNames)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -955,6 +955,42 @@ public class CliScraperTraversalTests
         }
     }
 
+    [Test]
+    public async Task Required_Alternatives_Keep_Colliding_Option_And_Operand_Members()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage: fake <command>
+
+                Available Commands:
+                  create  Create a file
+                """,
+            ["create --help"] = """
+                Usage: fake create (<FILENAME>|--filename <FILENAME>)
+
+                Arguments:
+                  <FILENAME>  Input file
+
+                Options:
+                  --filename string  Input file option
+                """,
+        });
+        var command = (await ScrapeAsync(new TestCobraScraper(executor))).Single();
+
+        var resolved = InheritedPropertyCollisionResolver.Resolve(new CliToolDefinition
+        {
+            ToolName = "fake",
+            NamespacePrefix = "Fake",
+            TargetNamespace = "ModularPipelines.Fake",
+            OutputDirectory = "src/ModularPipelines.Fake",
+            Commands = [command],
+        }).Commands.Single();
+
+        await Assert.That(resolved.RequiredAlternativeGroups.Single().PropertyNames)
+            .IsEquivalentTo(["Filename", "FilenameArgument"]);
+    }
+
     private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)
     {
         var commands = new List<CliCommandDefinition>();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -62,6 +62,51 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task SharedTraversal_Discards_Required_Alternatives_With_Command_Placeholders()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage:
+                  fake <command>
+
+                Available Commands:
+                  parent:  Manage parent resources
+                """,
+            ["parent --help"] = """
+                Usage:
+                  fake parent <command>
+                  fake parent --all
+
+                Available Commands:
+                  child:  Execute a child command
+
+                Flags:
+                  --all   Select all resources
+                """,
+            ["parent child --help"] = """
+                Execute a child command.
+
+                Usage:
+                  fake parent child [flags]
+
+                Flags:
+                  --value string   Supply a value
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        var commands = await ScrapeAsync(scraper);
+        var parent = commands.Single(command => command.FullCommand == "fake parent");
+
+        await Assert.That(parent.Options).Contains(option => option.SwitchName == "--all");
+        await Assert.That(parent.PositionalArguments).IsEmpty();
+        await Assert.That(parent.RequiredAlternativeGroups).IsEmpty();
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["fake parent", "fake parent child"]);
+    }
+
+    [Test]
     public async Task SharedTraversal_Preserves_Command_Operand_When_Only_Skipped_Children_Are_Extracted()
     {
         var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -978,6 +978,9 @@ public class CliScraperTraversalTests
 
                 Package Selection:
                       --workspace  Add dependencies to every workspace package
+
+                Examples:
+                      --pretend <VALUE>  This is documentation, not an option
                 """,
         });
 
@@ -992,6 +995,8 @@ public class CliScraperTraversalTests
                 .And.Contains("Git")
                 .And.Contains("Registry")
                 .And.Contains("Workspace");
+            await Assert.That(command.Options.Select(option => option.PropertyName))
+                .DoesNotContain("Pretend");
             await Assert.That(command.Options.Single(option => option.PropertyName == "Path").Description)
                 .IsEqualTo("Filesystem path to local crate to add");
             await Assert.That(command.Options.Single(option => option.PropertyName == "Git").Description)
@@ -1005,6 +1010,34 @@ public class CliScraperTraversalTests
             await Assert.That(command.RequiredAlternativeGroups.Single().PropertyNames)
                 .IsEquivalentTo(["DepId", "Path", "Git"]);
         }
+    }
+
+    [Test]
+    public async Task Unresolved_Inferred_Alternative_Does_Not_Drop_Command()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage: fake <command>
+
+                Available Commands:
+                  create  Create a target
+                """,
+            ["create --help"] = """
+                Usage: fake create (<TARGET>|--global)
+
+                Arguments:
+                  <TARGET>  Target name
+
+                Options:
+                  --known string  A command-local option
+                """,
+        });
+
+        var command = (await ScrapeAsync(new TestCobraScraper(executor))).Single();
+
+        await Assert.That(command.FullCommand).IsEqualTo("fake create");
+        await Assert.That(command.RequiredAlternativeGroups).IsEmpty();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -842,6 +842,22 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Collapses_Inline_Option_Aliases_Before_Modeling_Alternatives()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool clean (<TARGET>|(-a|--all))",
+            ["tool", "clean"]);
+        var members = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(members).IsEquivalentTo(["Target", "--all"]);
+            await Assert.That(result.PositionalArguments.Single().IsRequired).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task Does_Not_Infer_Optional_Switches_As_Required_Alternatives()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -786,6 +786,22 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Models_Standalone_Switch_On_Separate_Synopsis_As_Required_Alternative()
+    {
+        const string helpText = """
+            Usage:
+              tool clean <TARGET>
+              tool clean --all
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "clean"]);
+        var requiredSources = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        await Assert.That(requiredSources).IsEquivalentTo(["Target", "--all"]);
+    }
+
+    [Test]
     public async Task Does_Not_Flatten_Conjunctive_Alternative_Branches()
     {
         const string helpText = """
@@ -841,6 +857,29 @@ public class UsageSynopsisParserTests
             .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
 
         await Assert.That(requiredSources).IsEquivalentTo(["Formula", "--all"]);
+    }
+
+    [Test]
+    public async Task Models_Attached_Value_Option_As_Required_Alternative_Member()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool send (<FILE>|--data=<TEXT>)",
+            ["tool", "send"]);
+        var requiredSources = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        await Assert.That(requiredSources).IsEquivalentTo(["File", "--data"]);
+    }
+
+    [Test]
+    public async Task Splits_Parenthesized_Option_Aliases_Into_Real_Switches()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: git checkout (-p|--patch)",
+            ["git", "checkout"]);
+
+        await Assert.That(result.RequiredOptionSwitches).IsEquivalentTo(["-p", "--patch"]);
+        await Assert.That(result.RequiredOptionSwitches).DoesNotContain("-p|--patch");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -786,6 +786,20 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Does_Not_Flatten_Conjunctive_Alternative_Branches()
+    {
+        const string helpText = """
+            Usage:
+              tool copy <SOURCE> <DESTINATION>
+              tool copy --left <INPUT> --right <OUTPUT>
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "copy"]);
+
+        await Assert.That(result.RequiredAlternativeGroups).IsEmpty();
+    }
+
+    [Test]
     public async Task Models_Required_Inline_Option_Operand_Alternatives()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -800,6 +800,20 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Does_Not_Infer_Optional_Switches_As_Required_Alternatives()
+    {
+        const string helpText = """
+            Usage:
+              tool run [--json] <FILE>
+              tool run [--yaml] <FILE>
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "run"]);
+
+        await Assert.That(result.RequiredAlternativeGroups).IsEmpty();
+    }
+
+    [Test]
     public async Task Models_Required_Inline_Option_Operand_Alternatives()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -802,6 +802,22 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Collapses_Option_Aliases_Before_Counting_Alternative_Branches()
+    {
+        const string helpText = """
+            Usage:
+              tool clean <TARGET>
+              tool clean (-a|--all)
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "clean"]);
+        var requiredSources = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        await Assert.That(requiredSources).IsEquivalentTo(["Target", "--all"]);
+    }
+
+    [Test]
     public async Task Does_Not_Flatten_Conjunctive_Alternative_Branches()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -773,10 +773,45 @@ public class UsageSynopsisParserTests
 
         var result = UsageSynopsisParser.Parse(helpText, ["cargo", "add"]);
         var dependency = result.PositionalArguments.Single();
+        var requiredSources = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
 
-        await Assert.That(result.MatchedSynopsisCount).IsEqualTo(3);
-        await Assert.That(dependency.IsRequired).IsFalse();
-        await Assert.That(dependency.CSharpType).IsEqualTo("string?");
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.MatchedSynopsisCount).IsEqualTo(3);
+            await Assert.That(dependency.IsRequired).IsFalse();
+            await Assert.That(dependency.CSharpType).IsEqualTo("string?");
+            await Assert.That(requiredSources).IsEquivalentTo(["Dep", "--path", "--git"]);
+        }
+    }
+
+    [Test]
+    public async Task Models_Required_Inline_Option_Operand_Alternatives()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: cargo add [OPTIONS] <DEP_ID|--path <PATH>|--git <URI>>...",
+            ["cargo", "add"]);
+        var dependency = result.PositionalArguments.Single();
+        var requiredSources = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(dependency.PropertyName).IsEqualTo("DepId");
+            await Assert.That(dependency.IsRequired).IsFalse();
+            await Assert.That(requiredSources).IsEquivalentTo(["DepId", "--path", "--git"]);
+        }
+    }
+
+    [Test]
+    public async Task Does_Not_Model_Operand_Aliases_As_Separate_Required_Properties()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run <FILE|DIRECTORY>",
+            ["tool", "run"]);
+
+        await Assert.That(result.RequiredAlternativeGroups).IsEmpty();
+        await Assert.That(result.PositionalArguments.Single().PropertyName).IsEqualTo("File");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -818,6 +818,18 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Models_Standalone_Flags_As_Required_Alternative_Members()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: brew services stop (<formula>|--all)",
+            ["brew", "services", "stop"]);
+        var requiredSources = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        await Assert.That(requiredSources).IsEquivalentTo(["Formula", "--all"]);
+    }
+
+    [Test]
     public async Task Does_Not_Model_Operand_Aliases_As_Separate_Required_Properties()
     {
         var result = UsageSynopsisParser.Parse(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -832,6 +832,16 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Does_Not_Flatten_Parenthesized_Conjunctive_Alternative_Branches()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool clean (<TARGET>|(--force --all))",
+            ["tool", "clean"]);
+
+        await Assert.That(result.RequiredAlternativeGroups).IsEmpty();
+    }
+
+    [Test]
     public async Task Does_Not_Infer_Optional_Switches_As_Required_Alternatives()
     {
         const string helpText = """
@@ -861,6 +871,20 @@ public class UsageSynopsisParserTests
             await Assert.That(dependency.IsRequired).IsFalse();
             await Assert.That(requiredSources).IsEquivalentTo(["DepId", "--path", "--git"]);
         }
+    }
+
+    [Test]
+    public async Task Does_Not_Enforce_Inline_Group_Bypassed_By_Alternate_Synopsis()
+    {
+        const string helpText = """
+            Usage:
+              tool import (<FILE>|--url <URL>)
+              tool import --stdin
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "import"]);
+
+        await Assert.That(result.RequiredAlternativeGroups).IsEmpty();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -842,6 +842,16 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Does_Not_Treat_Conjunctive_Short_And_Long_Switches_As_Aliases()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool clean (<TARGET>|(-f --all))",
+            ["tool", "clean"]);
+
+        await Assert.That(result.RequiredAlternativeGroups).IsEmpty();
+    }
+
+    [Test]
     public async Task Collapses_Inline_Option_Aliases_Before_Modeling_Alternatives()
     {
         var result = UsageSynopsisParser.Parse(
@@ -855,6 +865,40 @@ public class UsageSynopsisParserTests
             await Assert.That(members).IsEquivalentTo(["Target", "--all"]);
             await Assert.That(result.PositionalArguments.Single().IsRequired).IsFalse();
         }
+    }
+
+    [Test]
+    public async Task Collapses_Comma_Separated_Option_Aliases()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool clean (<TARGET>|-a, --all)",
+            ["tool", "clean"]);
+        var members = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        await Assert.That(members).IsEquivalentTo(["Target", "--all"]);
+    }
+
+    [Test]
+    public async Task Preserves_Case_Distinct_Option_Alternatives()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool save (<TARGET>|-o|-O)",
+            ["tool", "save"]);
+        var members = result.RequiredAlternativeGroups.Single().Members
+            .Select(member => (member.OptionSwitch ?? member.PositionalPropertyName)!);
+
+        await Assert.That(members).IsEquivalentTo(["Target", "-o", "-O"]);
+    }
+
+    [Test]
+    public async Task Attached_Value_In_Nested_Group_Does_Not_Own_Following_Operand()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool run <[--format=VALUE] file>",
+            ["tool", "run"]);
+
+        await Assert.That(result.PositionalArguments.Single().AssociatedOptionSwitch).IsNull();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -705,7 +705,8 @@ public static partial class GeneratorUtils
         ArgumentNullException.ThrowIfNull(command);
 
         return command.RequiredOptions.Count > 0 ||
-               command.PositionalArguments.Any(p => p.IsRequired);
+               command.PositionalArguments.Any(p => p.IsRequired) ||
+               command.RequiredAlternativeGroups.Count > 0;
     }
 
     internal static IReadOnlyList<RequiredConstructorParameter> GetRequiredConstructorParameters(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
@@ -94,11 +94,28 @@ internal static class InheritedPropertyCollisionResolver
                         usedLocalNames),
                 })
             .ToArray();
+        var resolvedPropertyNames = command.Options
+            .Select((option, index) => (Original: option.PropertyName, Resolved: options[index].PropertyName))
+            .Concat(command.PositionalArguments.Select((argument, index) =>
+                (Original: argument.PropertyName, Resolved: positionalArguments[index].PropertyName)))
+            .GroupBy(static pair => pair.Original, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.First().Resolved,
+                StringComparer.Ordinal);
 
         return command with
         {
             Options = options,
             PositionalArguments = positionalArguments,
+            RequiredAlternativeGroups = command.RequiredAlternativeGroups
+                .Select(group => group with
+                {
+                    PropertyNames = group.PropertyNames
+                        .Select(propertyName => resolvedPropertyNames.GetValueOrDefault(propertyName, propertyName))
+                        .ToArray(),
+                })
+                .ToArray(),
             DocumentationExampleValues = command.DocumentationExampleValues
                 .ToDictionary(
                     pair => TryGetRename(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
@@ -94,16 +94,6 @@ internal static class InheritedPropertyCollisionResolver
                         usedLocalNames),
                 })
             .ToArray();
-        var resolvedPropertyNames = command.Options
-            .Select((option, index) => (Original: option.PropertyName, Resolved: options[index].PropertyName))
-            .Concat(command.PositionalArguments.Select((argument, index) =>
-                (Original: argument.PropertyName, Resolved: positionalArguments[index].PropertyName)))
-            .GroupBy(static pair => pair.Original, StringComparer.Ordinal)
-            .ToDictionary(
-                static group => group.Key,
-                static group => group.First().Resolved,
-                StringComparer.Ordinal);
-
         return command with
         {
             Options = options,
@@ -111,8 +101,15 @@ internal static class InheritedPropertyCollisionResolver
             RequiredAlternativeGroups = command.RequiredAlternativeGroups
                 .Select(group => group with
                 {
-                    PropertyNames = group.PropertyNames
-                        .Select(propertyName => resolvedPropertyNames.GetValueOrDefault(propertyName, propertyName))
+                    Members = group.Members
+                        .Select(member => member with
+                        {
+                            PropertyName = ResolveAlternativeMemberName(
+                                command,
+                                options,
+                                positionalArguments,
+                                member),
+                        })
                         .ToArray(),
                 })
                 .ToArray(),
@@ -129,6 +126,53 @@ internal static class InheritedPropertyCollisionResolver
                     StringComparer.Ordinal),
         };
     }
+
+    private static string ResolveAlternativeMemberName(
+        CliCommandDefinition command,
+        IReadOnlyList<CliOptionDefinition> options,
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
+        CliRequiredAlternativeMember member)
+    {
+        if (member.OptionSwitch is { } optionSwitch
+            && member.PositionalArgumentPhase is null
+            && member.PositionalArgumentPositionIndex is null)
+        {
+            var optionIndex = Enumerable.Range(0, command.Options.Count).FirstOrDefault(index =>
+                command.Options[index].SwitchName.Equals(optionSwitch, StringComparison.Ordinal),
+                -1);
+            if (optionIndex < 0)
+            {
+                throw InvalidAlternativeMember(command, member);
+            }
+
+            return options[optionIndex].PropertyName;
+        }
+
+        if (member.PositionalArgumentPhase is { } phase
+            && member.PositionalArgumentPositionIndex is { } positionIndex
+            && member.OptionSwitch is null)
+        {
+            var argumentIndex = Enumerable.Range(0, command.PositionalArguments.Count).FirstOrDefault(index =>
+                command.PositionalArguments[index].Phase == phase
+                && command.PositionalArguments[index].PositionIndex == positionIndex,
+                -1);
+            if (argumentIndex < 0)
+            {
+                throw InvalidAlternativeMember(command, member);
+            }
+
+            return positionalArguments[argumentIndex].PropertyName;
+        }
+
+        throw InvalidAlternativeMember(command, member);
+    }
+
+    private static InvalidOperationException InvalidAlternativeMember(
+        CliCommandDefinition command,
+        CliRequiredAlternativeMember member) =>
+        new(
+            $"Required alternative member {member.PropertyName} for {command.FullCommand} " +
+            "does not identify exactly one generated member.");
 
     private static IReadOnlyList<CliOptionDefinition> ResolveDuplicateOptionNames(
         IReadOnlyList<CliOptionDefinition> options,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
@@ -137,9 +137,7 @@ internal static class InheritedPropertyCollisionResolver
             && member.PositionalArgumentPhase is null
             && member.PositionalArgumentPositionIndex is null)
         {
-            var optionIndex = Enumerable.Range(0, command.Options.Count).FirstOrDefault(index =>
-                command.Options[index].SwitchName.Equals(optionSwitch, StringComparison.Ordinal),
-                -1);
+            var optionIndex = CliOptionDefinition.FindIndexBySwitch(command.Options, optionSwitch);
             if (optionIndex < 0)
             {
                 throw InvalidAlternativeMember(command, member);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -56,6 +56,7 @@ public class OptionsClassGenerator : ICodeGenerator
 
         sb.AppendLine("{");
         GenerateProperties(sb, command, positionalArguments, existingPropertyNames);
+        GenerateRequiredAlternativeValidation(sb, command, positionalArguments);
         sb.AppendLine("}");
 
         return sb.ToString();
@@ -83,7 +84,8 @@ public class OptionsClassGenerator : ICodeGenerator
             sb.AppendLine("using ModularPipelines.Models;");
         }
 
-        if (command.Options.Any(o => o.ValidationConstraints is not null))
+        if (command.Options.Any(o => o.ValidationConstraints is not null)
+            || command.RequiredAlternativeGroups.Count > 0)
         {
             sb.AppendLine("using System.ComponentModel.DataAnnotations;");
         }
@@ -183,15 +185,96 @@ public class OptionsClassGenerator : ICodeGenerator
 
             sb.AppendLine($"public record {command.ClassName}(");
             sb.AppendLine(string.Join($",{Environment.NewLine}", parameters));
-            sb.AppendLine($") : {command.ParentClassName}");
+            sb.AppendLine($") : {GetBaseTypes(command)}");
         }
         else
         {
-            sb.AppendLine($"public record {command.ClassName} : {command.ParentClassName}");
+            sb.AppendLine($"public record {command.ClassName} : {GetBaseTypes(command)}");
         }
 
         return existingNames;
     }
+
+    private static string GetBaseTypes(CliCommandDefinition command) =>
+        command.RequiredAlternativeGroups.Count > 0
+            ? $"{command.ParentClassName}, IValidatableObject"
+            : command.ParentClassName;
+
+    private static void GenerateRequiredAlternativeValidation(
+        StringBuilder sb,
+        CliCommandDefinition command,
+        IReadOnlyList<CliPositionalArgument> positionalArguments)
+    {
+        if (command.RequiredAlternativeGroups.Count == 0)
+        {
+            return;
+        }
+
+        sb.AppendLine("    /// <inheritdoc />");
+        sb.AppendLine("    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)");
+        sb.AppendLine("    {");
+        foreach (var group in command.RequiredAlternativeGroups)
+        {
+            var propertyNames = group.PropertyNames.Distinct(StringComparer.Ordinal).ToArray();
+            if (propertyNames.Length == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Required alternative group for {command.FullCommand} has no properties.");
+            }
+
+            var presenceExpression = string.Join(
+                " || ",
+                propertyNames.Select(propertyName => GetPresenceExpression(
+                    command,
+                    positionalArguments,
+                    propertyName)));
+            var memberNames = string.Join(", ", propertyNames.Select(propertyName => $"nameof({propertyName})"));
+            var message = $"At least one of {FormatChoice(propertyNames)} must be specified.";
+
+            sb.AppendLine($"        if (!({presenceExpression}))");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            yield return new ValidationResult({GeneratorUtils.FormatStringLiteral(message)}, [{memberNames}]);");
+            sb.AppendLine("        }");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine();
+    }
+
+    private static string GetPresenceExpression(
+        CliCommandDefinition command,
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
+        string propertyName)
+    {
+        var option = command.Options.FirstOrDefault(candidate => candidate.PropertyName == propertyName);
+        var csharpType = option?.PropertyType
+                         ?? positionalArguments.FirstOrDefault(candidate => candidate.PropertyName == propertyName)
+                             ?.CSharpType
+                         ?? throw new InvalidOperationException(
+                             $"Required alternative property {propertyName} was not generated for {command.FullCommand}.");
+
+        if (option?.IsFlag == true)
+        {
+            return $"{propertyName} == true";
+        }
+
+        if (csharpType.TrimEnd('?').Equals("string", StringComparison.Ordinal))
+        {
+            return $"!string.IsNullOrWhiteSpace({propertyName})";
+        }
+
+        return csharpType.Contains("IEnumerable<", StringComparison.Ordinal)
+            ? $"{propertyName}?.Any() == true"
+            : $"{propertyName} is not null";
+    }
+
+    private static string FormatChoice(IReadOnlyList<string> propertyNames) =>
+        propertyNames.Count switch
+        {
+            0 => "a required value",
+            1 => propertyNames[0],
+            2 => $"{propertyNames[0]} or {propertyNames[1]}",
+            _ => $"{string.Join(", ", propertyNames.Take(propertyNames.Count - 1))}, or {propertyNames[^1]}",
+        };
 
     private static void GenerateProperty(StringBuilder sb, CliOptionDefinition option)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -262,7 +262,7 @@ public class OptionsClassGenerator : ICodeGenerator
             return $"!string.IsNullOrWhiteSpace({propertyName})";
         }
 
-        return csharpType.Contains("IEnumerable<", StringComparison.Ordinal)
+        return CliOptionDefinition.TryGetCollectionShape(csharpType, out var isCollection) && isCollection
             ? $"{propertyName}?.Any() == true"
             : $"{propertyName} is not null";
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -51,6 +51,11 @@ public record CliCommandDefinition
     public IReadOnlyList<CliArgumentGroup> ArgumentGroups { get; init; } = [];
 
     /// <summary>
+    /// Command-level choices for which at least one generated property must be supplied.
+    /// </summary>
+    public IReadOnlyList<CliRequiredAlternativeGroup> RequiredAlternativeGroups { get; init; } = [];
+
+    /// <summary>
     /// Positional arguments for this command.
     /// </summary>
     public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -83,8 +83,8 @@ public record CliOptionDefinition
         IReadOnlyList<CliOptionDefinition> options,
         string optionSwitch) =>
         Enumerable.Range(0, options.Count).FirstOrDefault(index =>
-            options[index].SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
-            || options[index].ShortForm?.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase) == true,
+            options[index].SwitchName.Equals(optionSwitch, StringComparison.Ordinal)
+            || options[index].ShortForm?.Equals(optionSwitch, StringComparison.Ordinal) == true,
             -1);
 
     private static CollectionShapeResolution ResolveCollectionShape(string cSharpType)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -79,6 +79,14 @@ public record CliOptionDefinition
         return resolution.IsResolved;
     }
 
+    internal static int FindIndexBySwitch(
+        IReadOnlyList<CliOptionDefinition> options,
+        string optionSwitch) =>
+        Enumerable.Range(0, options.Count).FirstOrDefault(index =>
+            options[index].SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
+            || options[index].ShortForm?.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase) == true,
+            -1);
+
     private static CollectionShapeResolution ResolveCollectionShape(string cSharpType)
     {
         var source = $$"""

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliRequiredAlternativeGroup.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliRequiredAlternativeGroup.cs
@@ -1,0 +1,12 @@
+namespace ModularPipelines.OptionsGenerator.Models;
+
+/// <summary>
+/// A command-level constraint requiring at least one generated option or operand.
+/// </summary>
+public sealed record CliRequiredAlternativeGroup
+{
+    /// <summary>
+    /// Generated property names participating in the choice.
+    /// </summary>
+    public required IReadOnlyList<string> PropertyNames { get; init; }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliRequiredAlternativeGroup.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliRequiredAlternativeGroup.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Attributes;
+
 namespace ModularPipelines.OptionsGenerator.Models;
 
 /// <summary>
@@ -6,7 +8,38 @@ namespace ModularPipelines.OptionsGenerator.Models;
 public sealed record CliRequiredAlternativeGroup
 {
     /// <summary>
+    /// Generated members participating in the choice.
+    /// </summary>
+    public required IReadOnlyList<CliRequiredAlternativeMember> Members { get; init; }
+
+    /// <summary>
     /// Generated property names participating in the choice.
     /// </summary>
-    public required IReadOnlyList<string> PropertyNames { get; init; }
+    public IReadOnlyList<string> PropertyNames => Members.Select(static member => member.PropertyName).ToArray();
+}
+
+/// <summary>
+/// A generated option or positional argument participating in a required choice.
+/// </summary>
+public sealed record CliRequiredAlternativeMember
+{
+    /// <summary>
+    /// Current generated property name.
+    /// </summary>
+    public required string PropertyName { get; init; }
+
+    /// <summary>
+    /// Stable CLI switch identity, when this member is an option.
+    /// </summary>
+    public string? OptionSwitch { get; init; }
+
+    /// <summary>
+    /// Stable rendering phase identity, when this member is an operand.
+    /// </summary>
+    public CommandLinePhase? PositionalArgumentPhase { get; init; }
+
+    /// <summary>
+    /// Stable position within the rendering phase, when this member is an operand.
+    /// </summary>
+    public int? PositionalArgumentPositionIndex { get; init; }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -275,17 +275,14 @@ public partial class CargoCliScraper : CliScraperBase
         {
             var line = lines[index];
             var trimmed = line.Trim();
-            if (CargoOptionDeclarationPattern().IsMatch(line)
-                || (!string.IsNullOrEmpty(trimmed)
-                    && line.TakeWhile(char.IsWhiteSpace).Count() <= declarationIndentation))
+            if (string.IsNullOrEmpty(trimmed)
+                || CargoOptionDeclarationPattern().IsMatch(line)
+                || line.TakeWhile(char.IsWhiteSpace).Count() <= declarationIndentation)
             {
                 break;
             }
 
-            if (!string.IsNullOrEmpty(trimmed))
-            {
-                description.Add(trimmed);
-            }
+            description.Add(trimmed);
         }
 
         return string.Join(' ', description);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -196,11 +196,23 @@ public partial class CargoCliScraper : CliScraperBase
     private static List<CliOptionDefinition> ParseOptions(string helpText)
     {
         var options = new List<CliOptionDefinition>();
-        var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenOptions = new HashSet<string>(StringComparer.Ordinal);
         var lines = helpText.Split('\n');
+        var parsingOptionSection = false;
 
         for (var index = 0; index < lines.Length; index++)
         {
+            if (TryGetSectionHeading(lines[index], out var sectionHeading))
+            {
+                parsingOptionSection = IsOptionSectionHeading(sectionHeading);
+                continue;
+            }
+
+            if (!parsingOptionSection)
+            {
+                continue;
+            }
+
             var match = CargoOptionDeclarationPattern().Match(lines[index]);
             if (!match.Success)
             {
@@ -258,6 +270,17 @@ public partial class CargoCliScraper : CliScraperBase
 
         return options;
     }
+
+    private static bool TryGetSectionHeading(string line, out string heading)
+    {
+        heading = line.Trim();
+        return line.Length == line.TrimStart().Length
+               && heading.EndsWith(':');
+    }
+
+    private static bool IsOptionSectionHeading(string heading) =>
+        heading.Contains("option", StringComparison.OrdinalIgnoreCase)
+        || heading.EndsWith("selection:", StringComparison.OrdinalIgnoreCase);
 
     private static string GetOptionDescription(
         string[] lines,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -130,6 +130,7 @@ public partial class CargoCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
+        AddRequiredAlternativeOptions(options, helpText, usage);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
@@ -280,6 +281,97 @@ public partial class CargoCliScraper : CliScraperBase
         return options;
     }
 
+    private void AddRequiredAlternativeOptions(
+        ICollection<CliOptionDefinition> options,
+        string helpText,
+        UsageSynopsisParseResult usage)
+    {
+        var requiredSwitches = usage.RequiredAlternativeGroups
+            .SelectMany(static group => group.Members)
+            .Select(static member => member.OptionSwitch)
+            .Where(static optionSwitch => optionSwitch is not null)
+            .Select(static optionSwitch => optionSwitch!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (requiredSwitches.Length == 0)
+        {
+            return;
+        }
+
+        var lines = helpText.Split('\n');
+        foreach (var optionSwitch in requiredSwitches)
+        {
+            if (options.Any(option =>
+                    option.SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
+                    || option.ShortForm?.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase) == true))
+            {
+                continue;
+            }
+
+            for (var index = 0; index < lines.Length; index++)
+            {
+                var match = CargoOptionDeclarationPattern().Match(lines[index]);
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                var shortForm = match.Groups["short"].Value.Trim();
+                var longForm = match.Groups["long"].Value.Trim();
+                if (!longForm.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
+                    && !shortForm.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var switchName = string.IsNullOrEmpty(longForm) ? shortForm : longForm;
+                var propertyName = NormalizePropertyName(switchName)
+                                   ?? throw new InvalidOperationException(
+                                       $"Unable to normalize required Cargo alternative {switchName}.");
+                var valueHint = match.Groups["value"].Value.Trim();
+                var isFlag = string.IsNullOrEmpty(valueHint);
+                options.Add(new CliOptionDefinition
+                {
+                    SwitchName = switchName,
+                    ShortForm = string.IsNullOrEmpty(shortForm) ? null : shortForm,
+                    PropertyName = propertyName,
+                    CSharpType = isFlag ? "bool?" : "string?",
+                    Description = ExtractFollowingOptionDescription(lines, index),
+                    IsFlag = isFlag,
+                    ValueSeparator = " ",
+                    IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag),
+                });
+                break;
+            }
+        }
+    }
+
+    private static string ExtractFollowingOptionDescription(
+        IReadOnlyList<string> lines,
+        int declarationIndex)
+    {
+        var declarationIndentation = lines[declarationIndex].TakeWhile(char.IsWhiteSpace).Count();
+        var description = new List<string>();
+        for (var index = declarationIndex + 1; index < lines.Count; index++)
+        {
+            var line = lines[index];
+            var trimmed = line.Trim();
+            if (CargoOptionDeclarationPattern().IsMatch(line)
+                || (!string.IsNullOrEmpty(trimmed)
+                    && line.TakeWhile(char.IsWhiteSpace).Count() <= declarationIndentation))
+            {
+                break;
+            }
+
+            if (!string.IsNullOrEmpty(trimmed))
+            {
+                description.Add(trimmed);
+            }
+        }
+
+        return string.Join(' ', description);
+    }
+
     /// <summary>
     /// Checks if help text indicates the command has options.
     /// </summary>
@@ -322,6 +414,9 @@ public partial class CargoCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--[\w-]+)(?:\s+<(?<value>[^>]+)>)?\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex CargoOptionPattern();
+
+    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--[\w-]+)(?:\s+<(?<value>[^>]+)>)?(?:\s{2,}(?<desc>.*))?\s*$")]
+    private static partial Regex CargoOptionDeclarationPattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -130,7 +130,6 @@ public partial class CargoCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
-        AddRequiredAlternativeOptions(options, helpText, usage);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
@@ -194,33 +193,15 @@ public partial class CargoCliScraper : CliScraperBase
     /// Format: -V, --version    Print version info
     ///         --list           List installed commands
     /// </summary>
-    private List<CliOptionDefinition> ParseOptions(string helpText)
+    private static List<CliOptionDefinition> ParseOptions(string helpText)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var lines = helpText.Split('\n');
 
-        // Find "Options:" section
-        var optionsSectionMatch = OptionsSectionPattern().Match(helpText);
-        if (!optionsSectionMatch.Success)
+        for (var index = 0; index < lines.Length; index++)
         {
-            return options;
-        }
-
-        var sectionStart = optionsSectionMatch.Index + optionsSectionMatch.Length;
-        var sectionEnd = helpText.Length;
-
-        var nextSection = NextSectionPattern().Match(helpText, sectionStart);
-        if (nextSection.Success)
-        {
-            sectionEnd = nextSection.Index;
-        }
-
-        var section = helpText.Substring(sectionStart, sectionEnd - sectionStart);
-        var lines = section.Split('\n');
-
-        foreach (var line in lines)
-        {
-            var match = CargoOptionPattern().Match(line);
+            var match = CargoOptionDeclarationPattern().Match(lines[index]);
             if (!match.Success)
             {
                 continue;
@@ -229,7 +210,6 @@ public partial class CargoCliScraper : CliScraperBase
             var shortForm = match.Groups["short"].Value.Trim();
             var longForm = match.Groups["long"].Value.Trim();
             var valueHint = match.Groups["value"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(longForm) && string.IsNullOrEmpty(shortForm))
             {
@@ -238,12 +218,10 @@ public partial class CargoCliScraper : CliScraperBase
 
             var switchName = !string.IsNullOrEmpty(longForm) ? longForm : shortForm;
 
-            if (seenOptions.Contains(switchName))
+            if (!seenOptions.Add(switchName))
             {
                 continue;
             }
-
-            seenOptions.Add(switchName);
 
             var propertyName = NormalizePropertyName(switchName);
             if (propertyName is null)
@@ -266,7 +244,7 @@ public partial class CargoCliScraper : CliScraperBase
                 ShortForm = string.IsNullOrEmpty(shortForm) ? null : shortForm,
                 PropertyName = propertyName,
                 CSharpType = csharpType,
-                Description = description,
+                Description = GetOptionDescription(lines, index, match.Groups["desc"].Value),
                 IsFlag = isFlag,
                 IsRequired = false,
                 AcceptsMultipleValues = csharpType.Contains("IEnumerable"),
@@ -281,78 +259,19 @@ public partial class CargoCliScraper : CliScraperBase
         return options;
     }
 
-    private void AddRequiredAlternativeOptions(
-        ICollection<CliOptionDefinition> options,
-        string helpText,
-        UsageSynopsisParseResult usage)
-    {
-        var requiredSwitches = usage.RequiredAlternativeGroups
-            .SelectMany(static group => group.Members)
-            .Select(static member => member.OptionSwitch)
-            .Where(static optionSwitch => optionSwitch is not null)
-            .Select(static optionSwitch => optionSwitch!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (requiredSwitches.Length == 0)
-        {
-            return;
-        }
-
-        var lines = helpText.Split('\n');
-        foreach (var optionSwitch in requiredSwitches)
-        {
-            if (options.Any(option =>
-                    option.SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
-                    || option.ShortForm?.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase) == true))
-            {
-                continue;
-            }
-
-            for (var index = 0; index < lines.Length; index++)
-            {
-                var match = CargoOptionDeclarationPattern().Match(lines[index]);
-                if (!match.Success)
-                {
-                    continue;
-                }
-
-                var shortForm = match.Groups["short"].Value.Trim();
-                var longForm = match.Groups["long"].Value.Trim();
-                if (!longForm.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
-                    && !shortForm.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                var switchName = string.IsNullOrEmpty(longForm) ? shortForm : longForm;
-                var propertyName = NormalizePropertyName(switchName)
-                                   ?? throw new InvalidOperationException(
-                                       $"Unable to normalize required Cargo alternative {switchName}.");
-                var valueHint = match.Groups["value"].Value.Trim();
-                var isFlag = string.IsNullOrEmpty(valueHint);
-                options.Add(new CliOptionDefinition
-                {
-                    SwitchName = switchName,
-                    ShortForm = string.IsNullOrEmpty(shortForm) ? null : shortForm,
-                    PropertyName = propertyName,
-                    CSharpType = isFlag ? "bool?" : "string?",
-                    Description = ExtractFollowingOptionDescription(lines, index),
-                    IsFlag = isFlag,
-                    ValueSeparator = " ",
-                    IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag),
-                });
-                break;
-            }
-        }
-    }
-
-    private static string ExtractFollowingOptionDescription(
-        IReadOnlyList<string> lines,
-        int declarationIndex)
+    private static string GetOptionDescription(
+        string[] lines,
+        int declarationIndex,
+        string inlineDescription)
     {
         var declarationIndentation = lines[declarationIndex].TakeWhile(char.IsWhiteSpace).Count();
         var description = new List<string>();
-        for (var index = declarationIndex + 1; index < lines.Count; index++)
+        if (!string.IsNullOrWhiteSpace(inlineDescription))
+        {
+            description.Add(inlineDescription.Trim());
+        }
+
+        for (var index = declarationIndex + 1; index < lines.Length; index++)
         {
             var line = lines[index];
             var trimmed = line.Trim();
@@ -389,12 +308,6 @@ public partial class CargoCliScraper : CliScraperBase
     private static partial Regex CommandsSectionPattern();
 
     /// <summary>
-    /// Matches "Options:" section.
-    /// </summary>
-    [GeneratedRegex(@"Options:\s*\n", RegexOptions.IgnoreCase)]
-    private static partial Regex OptionsSectionPattern();
-
-    /// <summary>
     /// Matches command lines: "  build, b    Compile..."
     /// </summary>
     [GeneratedRegex(@"^\s{2,}(?<name>[\w-]+)(?:,\s*\w)?\s{2,}", RegexOptions.Multiline)]
@@ -412,9 +325,6 @@ public partial class CargoCliScraper : CliScraperBase
     ///       --list                List installed commands
     ///   -p, --package <SPEC>      Package to build
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--[\w-]+)(?:\s+<(?<value>[^>]+)>)?\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
-    private static partial Regex CargoOptionPattern();
-
     [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--[\w-]+)(?:\s+<(?<value>[^>]+)>)?(?:\s{2,}(?<desc>.*))?\s*$")]
     private static partial Regex CargoOptionDeclarationPattern();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -799,17 +799,36 @@ public abstract partial class CliScraperBase : ICliScraper
         return
         [
             .. command.RequiredAlternativeGroups,
-            .. usage.RequiredAlternativeGroups.Select(group => new CliRequiredAlternativeGroup
-            {
-                Members = group.Members
-                    .Select(member => ResolveRequiredAlternativeMember(command, member))
-                    .DistinctBy(GetRequiredAlternativeIdentity, StringComparer.OrdinalIgnoreCase)
-                    .ToArray(),
-            }),
+            .. usage.RequiredAlternativeGroups
+                .Select(group => TryResolveRequiredAlternativeGroup(command, group))
+                .OfType<CliRequiredAlternativeGroup>(),
         ];
     }
 
-    private static CliRequiredAlternativeMember ResolveRequiredAlternativeMember(
+    private static CliRequiredAlternativeGroup? TryResolveRequiredAlternativeGroup(
+        CliCommandDefinition command,
+        UsageRequiredAlternativeGroup group)
+    {
+        var members = group.Members
+            .Select(member => TryResolveRequiredAlternativeMember(command, member))
+            .ToArray();
+        if (members.Any(static member => member is null))
+        {
+            // Synopsis inference can reference an inherited, global, or filtered switch.
+            // Discard that inferred constraint without dropping the command itself.
+            return null;
+        }
+
+        return new CliRequiredAlternativeGroup
+        {
+            Members = members
+                .Select(static member => member!)
+                .DistinctBy(GetRequiredAlternativeIdentity, StringComparer.Ordinal)
+                .ToArray(),
+        };
+    }
+
+    private static CliRequiredAlternativeMember? TryResolveRequiredAlternativeMember(
         CliCommandDefinition command,
         UsageRequiredAlternativeMember member)
     {
@@ -818,9 +837,7 @@ public abstract partial class CliScraperBase : ICliScraper
             var optionIndex = CliOptionDefinition.FindIndexBySwitch(command.Options, optionSwitch);
             if (optionIndex < 0)
             {
-                throw new InvalidOperationException(
-                    $"{command.FullCommand} declares required alternative {optionSwitch}, " +
-                    "but no matching CliOptionDefinition was generated.");
+                return null;
             }
 
             return new CliRequiredAlternativeMember
@@ -839,9 +856,7 @@ public abstract partial class CliScraperBase : ICliScraper
                 -1);
             if (argumentIndex < 0)
             {
-                throw new InvalidOperationException(
-                    $"{command.FullCommand} declares required alternative {positionalPropertyName}, " +
-                    "but no matching CliPositionalArgument was generated.");
+                return null;
             }
 
             return new CliRequiredAlternativeMember
@@ -852,8 +867,7 @@ public abstract partial class CliScraperBase : ICliScraper
             };
         }
 
-        throw new InvalidOperationException(
-            $"{command.FullCommand} contains an unnamed required alternative member.");
+        return null;
     }
 
     private static string GetRequiredAlternativeIdentity(CliRequiredAlternativeMember member) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -815,12 +815,7 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         if (member.OptionSwitch is { } optionSwitch)
         {
-            var optionIndex = Enumerable.Range(0, command.Options.Count).FirstOrDefault(index =>
-                command.Options[index].SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
-                || command.Options[index].ShortForm?.Equals(
-                    optionSwitch,
-                    StringComparison.OrdinalIgnoreCase) == true,
-                -1);
+            var optionIndex = CliOptionDefinition.FindIndexBySwitch(command.Options, optionSwitch);
             if (optionIndex < 0)
             {
                 throw new InvalidOperationException(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -801,42 +801,70 @@ public abstract partial class CliScraperBase : ICliScraper
             .. command.RequiredAlternativeGroups,
             .. usage.RequiredAlternativeGroups.Select(group => new CliRequiredAlternativeGroup
             {
-                PropertyNames = group.Members
-                    .Select(member => ResolveRequiredAlternativeProperty(command, member))
-                    .Distinct(StringComparer.Ordinal)
+                Members = group.Members
+                    .Select(member => ResolveRequiredAlternativeMember(command, member))
+                    .DistinctBy(GetRequiredAlternativeIdentity, StringComparer.OrdinalIgnoreCase)
                     .ToArray(),
             }),
         ];
     }
 
-    private static string ResolveRequiredAlternativeProperty(
+    private static CliRequiredAlternativeMember ResolveRequiredAlternativeMember(
         CliCommandDefinition command,
         UsageRequiredAlternativeMember member)
     {
         if (member.OptionSwitch is { } optionSwitch)
         {
-            return command.Options.FirstOrDefault(option =>
-                       option.SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
-                       || option.ShortForm?.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase) == true)
-                   ?.PropertyName
-                   ?? throw new InvalidOperationException(
-                       $"{command.FullCommand} declares required alternative {optionSwitch}, " +
-                       "but no matching CliOptionDefinition was generated.");
+            var optionIndex = Enumerable.Range(0, command.Options.Count).FirstOrDefault(index =>
+                command.Options[index].SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
+                || command.Options[index].ShortForm?.Equals(
+                    optionSwitch,
+                    StringComparison.OrdinalIgnoreCase) == true,
+                -1);
+            if (optionIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"{command.FullCommand} declares required alternative {optionSwitch}, " +
+                    "but no matching CliOptionDefinition was generated.");
+            }
+
+            return new CliRequiredAlternativeMember
+            {
+                PropertyName = command.Options[optionIndex].PropertyName,
+                OptionSwitch = command.Options[optionIndex].SwitchName,
+            };
         }
 
         if (member.PositionalPropertyName is { } positionalPropertyName)
         {
-            return command.PositionalArguments.FirstOrDefault(argument =>
-                       argument.PropertyName.Equals(positionalPropertyName, StringComparison.OrdinalIgnoreCase))
-                   ?.PropertyName
-                   ?? throw new InvalidOperationException(
-                       $"{command.FullCommand} declares required alternative {positionalPropertyName}, " +
-                       "but no matching CliPositionalArgument was generated.");
+            var argumentIndex = Enumerable.Range(0, command.PositionalArguments.Count).FirstOrDefault(index =>
+                command.PositionalArguments[index].PropertyName.Equals(
+                    positionalPropertyName,
+                    StringComparison.OrdinalIgnoreCase),
+                -1);
+            if (argumentIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"{command.FullCommand} declares required alternative {positionalPropertyName}, " +
+                    "but no matching CliPositionalArgument was generated.");
+            }
+
+            return new CliRequiredAlternativeMember
+            {
+                PropertyName = command.PositionalArguments[argumentIndex].PropertyName,
+                PositionalArgumentPhase = command.PositionalArguments[argumentIndex].Phase,
+                PositionalArgumentPositionIndex = command.PositionalArguments[argumentIndex].PositionIndex,
+            };
         }
 
         throw new InvalidOperationException(
             $"{command.FullCommand} contains an unnamed required alternative member.");
     }
+
+    private static string GetRequiredAlternativeIdentity(CliRequiredAlternativeMember member) =>
+        member.OptionSwitch is { } optionSwitch
+            ? $"option:{optionSwitch}"
+            : $"operand:{member.PositionalArgumentPhase}:{member.PositionalArgumentPositionIndex}";
 
     /// <summary>
     /// Returns true positional operands, excluding values syntactically owned by an option switch.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -523,6 +523,7 @@ public abstract partial class CliScraperBase : ICliScraper
             {
                 HasOperandTakingUsage = usage.HasOperandTokens,
                 UsagePositionalArguments = usage.PositionalArguments,
+                RequiredAlternativeGroups = ResolveRequiredAlternativeGroups(command, usage),
             };
             command.ValidateOperandCoverage(
                 usage.HasOperandTokens,
@@ -785,6 +786,57 @@ public abstract partial class CliScraperBase : ICliScraper
         CliCommandDefinition command,
         UsageSynopsisParseResult usage) =>
         usage;
+
+    private static IReadOnlyList<CliRequiredAlternativeGroup> ResolveRequiredAlternativeGroups(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage)
+    {
+        if (usage.RequiredAlternativeGroups.Count == 0)
+        {
+            return command.RequiredAlternativeGroups;
+        }
+
+        return
+        [
+            .. command.RequiredAlternativeGroups,
+            .. usage.RequiredAlternativeGroups.Select(group => new CliRequiredAlternativeGroup
+            {
+                PropertyNames = group.Members
+                    .Select(member => ResolveRequiredAlternativeProperty(command, member))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray(),
+            }),
+        ];
+    }
+
+    private static string ResolveRequiredAlternativeProperty(
+        CliCommandDefinition command,
+        UsageRequiredAlternativeMember member)
+    {
+        if (member.OptionSwitch is { } optionSwitch)
+        {
+            return command.Options.FirstOrDefault(option =>
+                       option.SwitchName.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase)
+                       || option.ShortForm?.Equals(optionSwitch, StringComparison.OrdinalIgnoreCase) == true)
+                   ?.PropertyName
+                   ?? throw new InvalidOperationException(
+                       $"{command.FullCommand} declares required alternative {optionSwitch}, " +
+                       "but no matching CliOptionDefinition was generated.");
+        }
+
+        if (member.PositionalPropertyName is { } positionalPropertyName)
+        {
+            return command.PositionalArguments.FirstOrDefault(argument =>
+                       argument.PropertyName.Equals(positionalPropertyName, StringComparison.OrdinalIgnoreCase))
+                   ?.PropertyName
+                   ?? throw new InvalidOperationException(
+                       $"{command.FullCommand} declares required alternative {positionalPropertyName}, " +
+                       "but no matching CliPositionalArgument was generated.");
+        }
+
+        throw new InvalidOperationException(
+            $"{command.FullCommand} contains an unnamed required alternative member.");
+    }
 
     /// <summary>
     /// Returns true positional operands, excluding values syntactically owned by an option switch.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -141,14 +141,24 @@ public static class UsageSynopsisParser
     internal static UsageSynopsisParseResult RemoveCommandGroupPlaceholders(
         UsageSynopsisParseResult result)
     {
+        var commandGroupPlaceholders = result.PositionalArguments
+            .Where(IsCommandGroupPlaceholder)
+            .Select(static argument => argument.PropertyName)
+            .ToHashSet(StringComparer.Ordinal);
         var positionalArguments = result.PositionalArguments
-            .Where(argument => !IsCommandGroupPlaceholder(argument))
+            .Where(argument => !commandGroupPlaceholders.Contains(argument.PropertyName))
             .ToList();
 
         return result with
         {
             HasOperandTokens = positionalArguments.Count > 0 || result.UnparsedOperandTokens.Count > 0,
             PositionalArguments = positionalArguments,
+            RequiredAlternativeGroups =
+            [
+                .. result.RequiredAlternativeGroups.Where(group => group.Members.All(member =>
+                    member.PositionalPropertyName is not { } propertyName
+                    || !commandGroupPlaceholders.Contains(propertyName))),
+            ],
         };
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -188,7 +188,7 @@ public static class UsageSynopsisParser
                                || parsedOperands.UnparsedTokens.Count > 0,
             PositionalArguments = CliPositionalArgument.MergeDuplicates(parsedOperands.Arguments),
             UnparsedOperandTokens = parsedOperands.UnparsedTokens,
-            OptionSwitches = parsedOperands.OptionSwitches,
+            RequiredOptionSwitches = parsedOperands.RequiredOptionSwitches,
             SupportsRequiredAlternativeInference = SupportsRequiredAlternativeInference(
                 materializedOperandTokens),
             RequiredAlternativeGroups = ParseInlineRequiredAlternativeGroups(
@@ -252,7 +252,7 @@ public static class UsageSynopsisParser
             .Select(candidate => GetRequiredAlternativeMembers(new ParsedOperands(
                 candidate.PositionalArguments,
                 candidate.UnparsedOperandTokens,
-                candidate.OptionSwitches)))
+                candidate.RequiredOptionSwitches)))
             .ToArray();
         if (candidateMembers.Any(static members => members.Count == 0))
         {
@@ -312,10 +312,13 @@ public static class UsageSynopsisParser
         DistinctAlternativeMembers(
             operands.Arguments
                 .Where(static argument => argument.IsRequired)
-                .Select(static argument => argument.AssociatedOptionSwitch is { } optionSwitch
+                .Select(argument => argument.AssociatedOptionSwitch is { } optionSwitch
+                                    && operands.RequiredOptionSwitches.Contains(
+                                        optionSwitch,
+                                        StringComparer.OrdinalIgnoreCase)
                     ? new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch }
                     : new UsageRequiredAlternativeMember { PositionalPropertyName = argument.PropertyName })
-                .Concat(operands.OptionSwitches.Select(static optionSwitch =>
+                .Concat(operands.RequiredOptionSwitches.Select(static optionSwitch =>
                     new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch })));
 
     private static IReadOnlyList<UsageRequiredAlternativeMember> DistinctAlternativeMembers(
@@ -363,7 +366,7 @@ public static class UsageSynopsisParser
     {
         var arguments = new List<CliPositionalArgument>();
         var unparsedTokens = new List<string>();
-        var optionSwitches = new List<string>();
+        var requiredOptionSwitches = new List<string>();
         var prependOptionTerminatorToNextOperand = false;
         string? associatedOptionSwitch = null;
 
@@ -387,8 +390,13 @@ public static class UsageSynopsisParser
 
             if (TryGetOptionSwitch(operandToken, out var optionSwitch))
             {
+                var isRequiredOptionSwitch = IsRequiredUsageToken(operandToken);
                 associatedOptionSwitch = optionSwitch;
-                optionSwitches.Add(optionSwitch);
+                if (isRequiredOptionSwitch)
+                {
+                    requiredOptionSwitches.Add(optionSwitch);
+                }
+
                 continue;
             }
 
@@ -442,7 +450,10 @@ public static class UsageSynopsisParser
             AdvancePastOptionTerminatedOperand(groupedBehindOptionTerminator, ref phase);
         }
 
-        return new ParsedOperands(arguments, unparsedTokens, optionSwitches);
+        return new ParsedOperands(
+            arguments,
+            unparsedTokens,
+            requiredOptionSwitches);
     }
 
     private static IReadOnlyList<CliPositionalArgument> PreserveOptionTerminatorOnNestedGroup(
@@ -501,7 +512,7 @@ public static class UsageSynopsisParser
     private readonly record struct ParsedOperands(
         IReadOnlyList<CliPositionalArgument> Arguments,
         IReadOnlyList<string> UnparsedTokens,
-        IReadOnlyList<string> OptionSwitches);
+        IReadOnlyList<string> RequiredOptionSwitches);
 
     private static IEnumerable<string> SkipCommandAliases(IEnumerable<string> operandTokens)
     {
@@ -802,8 +813,7 @@ public static class UsageSynopsisParser
         CommandLinePhase phase)
     {
         var trimmed = TrimTrailingOperandPunctuation(token);
-        var isRequired = !trimmed.StartsWith('[')
-                         || HasRequiredSuffixOutsideOptionalPrefix(trimmed);
+        var isRequired = IsRequiredUsageToken(trimmed);
         var content = TrimWrapper(trimmed).Trim();
         var canonicalName = SelectCanonicalAlternative(content);
         if (HasMixedOptionOperandAlternatives(content))
@@ -864,6 +874,10 @@ public static class UsageSynopsisParser
             ? variadicPlaceholder
             : canonicalName;
     }
+
+    private static bool IsRequiredUsageToken(string token) =>
+        !token.StartsWith('[')
+        || HasRequiredSuffixOutsideOptionalPrefix(token);
 
     private static bool IsForwardedOptionTail(string token, string content) =>
         token.StartsWith('[')
@@ -1418,7 +1432,7 @@ public sealed record UsageSynopsisParseResult
 
     internal bool SupportsRequiredAlternativeInference { get; init; }
 
-    internal IReadOnlyList<string> OptionSwitches { get; init; } = [];
+    internal IReadOnlyList<string> RequiredOptionSwitches { get; init; } = [];
 
     public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -112,7 +112,9 @@ public static class UsageSynopsisParser
                 requirednessCandidates),
             RequiredAlternativeGroups =
             [
-                .. selected.RequiredAlternativeGroups,
+                .. selected.RequiredAlternativeGroups.Where(group =>
+                    requirednessCandidates.All(candidate =>
+                        CandidateSatisfiesRequiredAlternativeGroup(candidate, group))),
                 .. GetCrossSynopsisRequiredAlternativeGroups(
                     requirednessCandidates,
                     selected.PositionalArguments),
@@ -246,6 +248,23 @@ public static class UsageSynopsisParser
         }
 
         return groups;
+    }
+
+    private static bool CandidateSatisfiesRequiredAlternativeGroup(
+        UsageSynopsisParseResult candidate,
+        UsageRequiredAlternativeGroup group)
+    {
+        var candidateMemberKeys = GetRequiredAlternativeMembers(new ParsedOperands(
+                candidate.PositionalArguments,
+                candidate.UnparsedOperandTokens,
+                candidate.RequiredOptionSwitches))
+            .Concat(candidate.RequiredAlternativeGroups.SelectMany(static candidateGroup =>
+                candidateGroup.Members))
+            .Select(GetAlternativeMemberKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return group.Members.Any(member =>
+            candidateMemberKeys.Contains(GetAlternativeMemberKey(member)));
     }
 
     private static IReadOnlyList<UsageRequiredAlternativeGroup> GetCrossSynopsisRequiredAlternativeGroups(
@@ -1301,10 +1320,26 @@ public static class UsageSynopsisParser
         }
 
         return alternatives
-            .Select(GetOptionSwitch)
-            .OfType<string>()
+            .SelectMany(GetOptionSwitchesFromAlternative)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static IReadOnlyList<string> GetOptionSwitchesFromAlternative(string alternative)
+    {
+        var tokens = Tokenize(alternative);
+        var nestedSwitches = tokens
+            .Select(GetOptionSwitch)
+            .OfType<string>()
+            .ToArray();
+        if (nestedSwitches.Length > 1 && nestedSwitches.Length == tokens.Count)
+        {
+            return nestedSwitches;
+        }
+
+        return GetOptionSwitch(alternative) is { } optionSwitch
+            ? [optionSwitch]
+            : [];
     }
 
     private static string? GetOptionSwitch(string alternative)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -221,7 +221,7 @@ public static class UsageSynopsisParser
                 .Select(alternative => GetRequiredAlternativeMembers(
                     ParseOperandTokens(Tokenize(alternative), phase)))
                 .ToArray();
-            if (alternativeMembers.Any(static members => members.Count == 0))
+            if (alternativeMembers.Any(static members => members.Count != 1))
             {
                 continue;
             }
@@ -270,7 +270,7 @@ public static class UsageSynopsisParser
                 .Where(member => !commonKeys.Contains(GetAlternativeMemberKey(member)))
                 .ToArray())
             .ToArray();
-        if (branchMembers.Any(static members => members.Length == 0))
+        if (branchMembers.Any(static members => members.Length != 1))
         {
             return [];
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -259,10 +259,12 @@ public static class UsageSynopsisParser
         }
 
         var candidateMembers = candidates
-            .Select(candidate => GetRequiredAlternativeMembers(new ParsedOperands(
-                candidate.PositionalArguments,
-                candidate.UnparsedOperandTokens,
-                candidate.RequiredOptionSwitches)))
+            .Select(candidate => CollapseOptionAliases(
+                GetRequiredAlternativeMembers(new ParsedOperands(
+                    candidate.PositionalArguments,
+                    candidate.UnparsedOperandTokens,
+                    candidate.RequiredOptionSwitches)),
+                candidate.Synopsis ?? ""))
             .ToArray();
         if (candidateMembers.Any(static members => members.Count == 0))
         {
@@ -341,6 +343,38 @@ public static class UsageSynopsisParser
         members
             .DistinctBy(GetAlternativeMemberKey, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+
+    private static IReadOnlyList<UsageRequiredAlternativeMember> CollapseOptionAliases(
+        IReadOnlyList<UsageRequiredAlternativeMember> members,
+        string synopsis)
+    {
+        var aliasGroups = Tokenize(synopsis)
+            .Select(GetOptionSwitches)
+            .Where(static switches => switches.Count == 2
+                                      && switches.Any(IsShortOptionSwitch)
+                                      && switches.Any(IsLongOptionSwitch))
+            .ToArray();
+
+        return DistinctAlternativeMembers(members.Select(member =>
+        {
+            if (member.OptionSwitch is not { } optionSwitch)
+            {
+                return member;
+            }
+
+            var aliases = aliasGroups.FirstOrDefault(group =>
+                group.Contains(optionSwitch, StringComparer.OrdinalIgnoreCase));
+            return aliases is null
+                ? member
+                : member with { OptionSwitch = SelectPreferredOptionSwitch(aliases) };
+        }));
+    }
+
+    private static bool IsShortOptionSwitch(string optionSwitch) =>
+        optionSwitch.Length > 1 && optionSwitch[0] == '-' && optionSwitch[1] != '-';
+
+    private static bool IsLongOptionSwitch(string optionSwitch) =>
+        optionSwitch.StartsWith("--", StringComparison.Ordinal);
 
     private static string GetAlternativeMemberKey(UsageRequiredAlternativeMember member) =>
         member.OptionSwitch is { } optionSwitch

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -231,8 +231,10 @@ public static class UsageSynopsisParser
             }
 
             var alternativeMembers = alternatives
-                .Select(alternative => GetRequiredAlternativeMembers(
-                    ParseOperandTokens(Tokenize(alternative), phase)))
+                .Select(alternative => CollapseOptionAliases(
+                    GetRequiredAlternativeMembers(
+                        ParseOperandTokens(Tokenize(alternative), phase)),
+                    alternative))
                 .ToArray();
             if (alternativeMembers.Any(static members => members.Count != 1))
             {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -188,6 +188,7 @@ public static class UsageSynopsisParser
                                || parsedOperands.UnparsedTokens.Count > 0,
             PositionalArguments = CliPositionalArgument.MergeDuplicates(parsedOperands.Arguments),
             UnparsedOperandTokens = parsedOperands.UnparsedTokens,
+            OptionSwitches = parsedOperands.OptionSwitches,
             SupportsRequiredAlternativeInference = SupportsRequiredAlternativeInference(
                 materializedOperandTokens),
             RequiredAlternativeGroups = ParseInlineRequiredAlternativeGroups(
@@ -250,7 +251,8 @@ public static class UsageSynopsisParser
         var candidateMembers = candidates
             .Select(candidate => GetRequiredAlternativeMembers(new ParsedOperands(
                 candidate.PositionalArguments,
-                candidate.UnparsedOperandTokens)))
+                candidate.UnparsedOperandTokens,
+                candidate.OptionSwitches)))
             .ToArray();
         if (candidateMembers.Any(static members => members.Count == 0))
         {
@@ -307,11 +309,14 @@ public static class UsageSynopsisParser
 
     private static IReadOnlyList<UsageRequiredAlternativeMember> GetRequiredAlternativeMembers(
         ParsedOperands operands) =>
-        DistinctAlternativeMembers(operands.Arguments
-            .Where(static argument => argument.IsRequired)
-            .Select(static argument => argument.AssociatedOptionSwitch is { } optionSwitch
-                ? new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch }
-                : new UsageRequiredAlternativeMember { PositionalPropertyName = argument.PropertyName }));
+        DistinctAlternativeMembers(
+            operands.Arguments
+                .Where(static argument => argument.IsRequired)
+                .Select(static argument => argument.AssociatedOptionSwitch is { } optionSwitch
+                    ? new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch }
+                    : new UsageRequiredAlternativeMember { PositionalPropertyName = argument.PropertyName })
+                .Concat(operands.OptionSwitches.Select(static optionSwitch =>
+                    new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch })));
 
     private static IReadOnlyList<UsageRequiredAlternativeMember> DistinctAlternativeMembers(
         IEnumerable<UsageRequiredAlternativeMember> members) =>
@@ -358,6 +363,7 @@ public static class UsageSynopsisParser
     {
         var arguments = new List<CliPositionalArgument>();
         var unparsedTokens = new List<string>();
+        var optionSwitches = new List<string>();
         var prependOptionTerminatorToNextOperand = false;
         string? associatedOptionSwitch = null;
 
@@ -382,6 +388,7 @@ public static class UsageSynopsisParser
             if (TryGetOptionSwitch(operandToken, out var optionSwitch))
             {
                 associatedOptionSwitch = optionSwitch;
+                optionSwitches.Add(optionSwitch);
                 continue;
             }
 
@@ -435,7 +442,7 @@ public static class UsageSynopsisParser
             AdvancePastOptionTerminatedOperand(groupedBehindOptionTerminator, ref phase);
         }
 
-        return new ParsedOperands(arguments, unparsedTokens);
+        return new ParsedOperands(arguments, unparsedTokens, optionSwitches);
     }
 
     private static IReadOnlyList<CliPositionalArgument> PreserveOptionTerminatorOnNestedGroup(
@@ -493,7 +500,8 @@ public static class UsageSynopsisParser
 
     private readonly record struct ParsedOperands(
         IReadOnlyList<CliPositionalArgument> Arguments,
-        IReadOnlyList<string> UnparsedTokens);
+        IReadOnlyList<string> UnparsedTokens,
+        IReadOnlyList<string> OptionSwitches);
 
     private static IEnumerable<string> SkipCommandAliases(IEnumerable<string> operandTokens)
     {
@@ -1409,6 +1417,8 @@ public sealed record UsageSynopsisParseResult
     public bool HasOperandTokens { get; init; }
 
     internal bool SupportsRequiredAlternativeInference { get; init; }
+
+    internal IReadOnlyList<string> OptionSwitches { get; init; } = [];
 
     public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -296,12 +296,17 @@ public static class UsageSynopsisParser
     {
         foreach (var token in CollapseAlternatives(operandTokens))
         {
+            if (GetOptionSwitches(token).Count > 0)
+            {
+                return true;
+            }
+
             if (IsNonOperandSyntax(token))
             {
                 continue;
             }
 
-            return token.StartsWith('-') || IsPlaceholderToken(token);
+            return IsPlaceholderToken(token);
         }
 
         return false;
@@ -388,13 +393,16 @@ public static class UsageSynopsisParser
                 groupedBehindOptionTerminator,
                 ref associatedOptionSwitch);
 
-            if (TryGetOptionSwitch(operandToken, out var optionSwitch))
+            var optionSwitches = GetOptionSwitches(operandToken);
+            if (optionSwitches.Count > 0)
             {
                 var isRequiredOptionSwitch = IsRequiredUsageToken(operandToken);
-                associatedOptionSwitch = optionSwitch;
+                associatedOptionSwitch = HasInlineOptionValue(operandToken)
+                    ? null
+                    : SelectPreferredOptionSwitch(optionSwitches);
                 if (isRequiredOptionSwitch)
                 {
-                    requiredOptionSwitches.Add(optionSwitch);
+                    requiredOptionSwitches.AddRange(optionSwitches);
                 }
 
                 continue;
@@ -1198,26 +1206,53 @@ public static class UsageSynopsisParser
 
     private static bool TryGetOptionSwitch(string token, out string optionSwitch)
     {
+        var optionSwitches = GetOptionSwitches(token);
+        optionSwitch = SelectPreferredOptionSwitch(optionSwitches) ?? "";
+        return optionSwitch.Length > 0;
+    }
+
+    private static IReadOnlyList<string> GetOptionSwitches(string token)
+    {
         var content = TrimControlWrappers(token);
-        if (HasMixedOptionOperandAlternatives(content)
-            || HasLoneDashOperandAlternatives(content))
+        var alternatives = SplitTopLevelAlternatives(content);
+        if (alternatives.Count > 1
+            && alternatives.Any(IsOptionAlternative)
+            && alternatives.Any(IsOperandAlternative))
         {
-            optionSwitch = "";
-            return false;
+            return [];
         }
 
+        return alternatives
+            .Select(GetOptionSwitch)
+            .OfType<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string? GetOptionSwitch(string alternative)
+    {
+        var content = TrimControlWrappers(alternative);
         var endIndex = content.IndexOfAny([' ', '\t', '=']);
-        optionSwitch = content.TrimEnd(',', ':');
+        var optionSwitch = (endIndex < 0 ? content : content[..endIndex])
+            .TrimEnd('[', ',', ':');
         if (optionSwitch.Length > 1
-            && endIndex < 0
             && optionSwitch.StartsWith('-')
             && optionSwitch != "--")
         {
-            return true;
+            return optionSwitch;
         }
 
-        optionSwitch = "";
-        return false;
+        return null;
+    }
+
+    private static string? SelectPreferredOptionSwitch(IReadOnlyList<string> optionSwitches) =>
+        optionSwitches.FirstOrDefault(static optionSwitch => optionSwitch.StartsWith("--", StringComparison.Ordinal))
+        ?? optionSwitches.FirstOrDefault();
+
+    private static bool HasInlineOptionValue(string token)
+    {
+        var content = TrimControlWrappers(token);
+        return content.IndexOfAny([' ', '\t', '=']) > 1;
     }
 
     private static bool HasMixedOptionOperandAlternatives(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -393,18 +393,11 @@ public static class UsageSynopsisParser
                 groupedBehindOptionTerminator,
                 ref associatedOptionSwitch);
 
-            var optionSwitches = GetOptionSwitches(operandToken);
-            if (optionSwitches.Count > 0)
+            if (TryHandleOptionToken(
+                    operandToken,
+                    requiredOptionSwitches,
+                    ref associatedOptionSwitch))
             {
-                var isRequiredOptionSwitch = IsRequiredUsageToken(operandToken);
-                associatedOptionSwitch = HasInlineOptionValue(operandToken)
-                    ? null
-                    : SelectPreferredOptionSwitch(optionSwitches);
-                if (isRequiredOptionSwitch)
-                {
-                    requiredOptionSwitches.AddRange(optionSwitches);
-                }
-
                 continue;
             }
 
@@ -434,27 +427,14 @@ public static class UsageSynopsisParser
                 continue;
             }
 
-            var argument = ParseOperand(operandToken, arguments.Count, operandPhase);
-            if (argument is null)
-            {
-                unparsedTokens.Add(operandToken);
-                associatedOptionSwitch = null;
-                continue;
-            }
-
-            if (associatedOptionSwitch is not null)
-            {
-                argument = argument with { AssociatedOptionSwitch = associatedOptionSwitch };
-            }
-
-            if (groupedBehindOptionTerminator || prependOptionTerminatorToNextOperand)
-            {
-                argument = argument with { PrependOptionTerminator = true };
-            }
-
-            arguments.Add(argument);
-            prependOptionTerminatorToNextOperand = false;
-            associatedOptionSwitch = null;
+            ParseAndAddOperand(
+                operandToken,
+                operandPhase,
+                groupedBehindOptionTerminator,
+                arguments,
+                unparsedTokens,
+                ref prependOptionTerminatorToNextOperand,
+                ref associatedOptionSwitch);
             AdvancePastOptionTerminatedOperand(groupedBehindOptionTerminator, ref phase);
         }
 
@@ -496,6 +476,60 @@ public static class UsageSynopsisParser
         {
             phase = CommandLinePhase.LateOperand;
         }
+    }
+
+    private static bool TryHandleOptionToken(
+        string operandToken,
+        List<string> requiredOptionSwitches,
+        ref string? associatedOptionSwitch)
+    {
+        var optionSwitches = GetOptionSwitches(operandToken);
+        if (optionSwitches.Count == 0)
+        {
+            return false;
+        }
+
+        associatedOptionSwitch = HasInlineOptionValue(operandToken)
+            ? null
+            : SelectPreferredOptionSwitch(optionSwitches);
+        if (IsRequiredUsageToken(operandToken))
+        {
+            requiredOptionSwitches.AddRange(optionSwitches);
+        }
+
+        return true;
+    }
+
+    private static void ParseAndAddOperand(
+        string operandToken,
+        CommandLinePhase operandPhase,
+        bool groupedBehindOptionTerminator,
+        List<CliPositionalArgument> arguments,
+        List<string> unparsedTokens,
+        ref bool prependOptionTerminatorToNextOperand,
+        ref string? associatedOptionSwitch)
+    {
+        var argument = ParseOperand(operandToken, arguments.Count, operandPhase);
+        if (argument is null)
+        {
+            unparsedTokens.Add(operandToken);
+            associatedOptionSwitch = null;
+            return;
+        }
+
+        if (associatedOptionSwitch is not null)
+        {
+            argument = argument with { AssociatedOptionSwitch = associatedOptionSwitch };
+        }
+
+        if (groupedBehindOptionTerminator || prependOptionTerminatorToNextOperand)
+        {
+            argument = argument with { PrependOptionTerminator = true };
+        }
+
+        arguments.Add(argument);
+        prependOptionTerminatorToNextOperand = false;
+        associatedOptionSwitch = null;
     }
 
     private static CommandLinePhase TransitionPhase(
@@ -1247,7 +1281,7 @@ public static class UsageSynopsisParser
 
     private static string? SelectPreferredOptionSwitch(IReadOnlyList<string> optionSwitches) =>
         optionSwitches.FirstOrDefault(static optionSwitch => optionSwitch.StartsWith("--", StringComparison.Ordinal))
-        ?? optionSwitches.FirstOrDefault();
+        ?? (optionSwitches.Count > 0 ? optionSwitches[0] : null);
 
     private static bool HasInlineOptionValue(string token)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -110,6 +110,13 @@ public static class UsageSynopsisParser
             PositionalArguments = RelaxArgumentsMissingFromAlternatives(
                 selected.PositionalArguments,
                 requirednessCandidates),
+            RequiredAlternativeGroups =
+            [
+                .. selected.RequiredAlternativeGroups,
+                .. GetCrossSynopsisRequiredAlternativeGroups(
+                    requirednessCandidates,
+                    selected.PositionalArguments),
+            ],
         };
     }
 
@@ -170,7 +177,8 @@ public static class UsageSynopsisParser
             operandTokens = SkipCommandAliases(operandTokens);
         }
 
-        var parsedOperands = ParseOperandTokens(operandTokens, phase);
+        var materializedOperandTokens = operandTokens.ToArray();
+        var parsedOperands = ParseOperandTokens(materializedOperandTokens, phase);
         return new UsageSynopsisParseResult
         {
             Synopsis = synopsis,
@@ -180,7 +188,168 @@ public static class UsageSynopsisParser
                                || parsedOperands.UnparsedTokens.Count > 0,
             PositionalArguments = CliPositionalArgument.MergeDuplicates(parsedOperands.Arguments),
             UnparsedOperandTokens = parsedOperands.UnparsedTokens,
+            SupportsRequiredAlternativeInference = SupportsRequiredAlternativeInference(
+                materializedOperandTokens),
+            RequiredAlternativeGroups = ParseInlineRequiredAlternativeGroups(
+                materializedOperandTokens,
+                phase),
         };
+    }
+
+    private static IReadOnlyList<UsageRequiredAlternativeGroup> ParseInlineRequiredAlternativeGroups(
+        IEnumerable<string> operandTokens,
+        CommandLinePhase phase)
+    {
+        var groups = new List<UsageRequiredAlternativeGroup>();
+        foreach (var token in operandTokens)
+        {
+            var normalizedToken = TrimTrailingOperandPunctuation(token)
+                .TrimEnd('.', '…')
+                .Trim();
+            if (normalizedToken.StartsWith('[') || !IsWrapped(normalizedToken))
+            {
+                continue;
+            }
+
+            var alternatives = SplitTopLevelAlternatives(TrimWrapper(normalizedToken));
+            if (alternatives.Count <= 1)
+            {
+                continue;
+            }
+
+            var alternativeMembers = alternatives
+                .Select(alternative => GetRequiredAlternativeMembers(
+                    ParseOperandTokens(Tokenize(alternative), phase)))
+                .ToArray();
+            if (alternativeMembers.Any(static members => members.Count == 0))
+            {
+                continue;
+            }
+
+            var members = DistinctAlternativeMembers(alternativeMembers.SelectMany(static members => members));
+            if (members.Count > 1
+                && members.Any(static member => member.OptionSwitch is not null))
+            {
+                groups.Add(new UsageRequiredAlternativeGroup { Members = members });
+            }
+        }
+
+        return groups;
+    }
+
+    private static IReadOnlyList<UsageRequiredAlternativeGroup> GetCrossSynopsisRequiredAlternativeGroups(
+        IReadOnlyList<UsageSynopsisParseResult> candidates,
+        IReadOnlyList<CliPositionalArgument> selectedArguments)
+    {
+        if (candidates.Count <= 1
+            || candidates.Any(static candidate => !candidate.SupportsRequiredAlternativeInference))
+        {
+            return [];
+        }
+
+        var candidateMembers = candidates
+            .Select(candidate => GetRequiredAlternativeMembers(new ParsedOperands(
+                candidate.PositionalArguments,
+                candidate.UnparsedOperandTokens)))
+            .ToArray();
+        if (candidateMembers.Any(static members => members.Count == 0))
+        {
+            return [];
+        }
+
+        var commonKeys = candidateMembers[0]
+            .Select(GetAlternativeMemberKey)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var members in candidateMembers.Skip(1))
+        {
+            commonKeys.IntersectWith(members.Select(GetAlternativeMemberKey));
+        }
+
+        var branchMembers = candidateMembers
+            .Select(members => members
+                .Where(member => !commonKeys.Contains(GetAlternativeMemberKey(member)))
+                .ToArray())
+            .ToArray();
+        if (branchMembers.Any(static members => members.Length == 0))
+        {
+            return [];
+        }
+
+        var alternatives = DistinctAlternativeMembers(branchMembers.SelectMany(static members => members));
+        var selectedPropertyNames = selectedArguments
+            .Select(static argument => argument.PropertyName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (alternatives.Any(member => member.PositionalPropertyName is { } propertyName
+                                       && !selectedPropertyNames.Contains(propertyName)))
+        {
+            return [];
+        }
+
+        return alternatives.Count > 1
+            ? [new UsageRequiredAlternativeGroup { Members = alternatives }]
+            : [];
+    }
+
+    private static bool SupportsRequiredAlternativeInference(IEnumerable<string> operandTokens)
+    {
+        foreach (var token in CollapseAlternatives(operandTokens))
+        {
+            if (IsNonOperandSyntax(token))
+            {
+                continue;
+            }
+
+            return token.StartsWith('-') || IsPlaceholderToken(token);
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<UsageRequiredAlternativeMember> GetRequiredAlternativeMembers(
+        ParsedOperands operands) =>
+        DistinctAlternativeMembers(operands.Arguments
+            .Where(static argument => argument.IsRequired)
+            .Select(static argument => argument.AssociatedOptionSwitch is { } optionSwitch
+                ? new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch }
+                : new UsageRequiredAlternativeMember { PositionalPropertyName = argument.PropertyName }));
+
+    private static IReadOnlyList<UsageRequiredAlternativeMember> DistinctAlternativeMembers(
+        IEnumerable<UsageRequiredAlternativeMember> members) =>
+        members
+            .DistinctBy(GetAlternativeMemberKey, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static string GetAlternativeMemberKey(UsageRequiredAlternativeMember member) =>
+        member.OptionSwitch is { } optionSwitch
+            ? $"option:{optionSwitch}"
+            : $"operand:{member.PositionalPropertyName}";
+
+    private static IReadOnlyList<string> SplitTopLevelAlternatives(string content)
+    {
+        var alternatives = new List<string>();
+        var closingDelimiters = new Stack<char>();
+        var start = 0;
+        for (var index = 0; index < content.Length; index++)
+        {
+            var character = content[index];
+            if (TryGetClosingDelimiter(character, out var closingDelimiter))
+            {
+                closingDelimiters.Push(closingDelimiter);
+            }
+            else if (closingDelimiters.TryPeek(out var expectedDelimiter)
+                     && character == expectedDelimiter)
+            {
+                closingDelimiters.Pop();
+            }
+            else if (character == '|' && closingDelimiters.Count == 0)
+            {
+                alternatives.Add(content[start..index].Trim());
+                start = index + 1;
+            }
+        }
+
+        alternatives.Add(content[start..].Trim());
+        return alternatives.Where(static alternative => alternative.Length > 0).ToArray();
     }
 
     private static ParsedOperands ParseOperandTokens(
@@ -1239,7 +1408,38 @@ public sealed record UsageSynopsisParseResult
 
     public bool HasOperandTokens { get; init; }
 
+    internal bool SupportsRequiredAlternativeInference { get; init; }
+
     public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];
 
     public IReadOnlyList<string> UnparsedOperandTokens { get; init; } = [];
+
+    public IReadOnlyList<UsageRequiredAlternativeGroup> RequiredAlternativeGroups { get; init; } = [];
+}
+
+/// <summary>
+/// A required choice recovered from one or more usage synopses.
+/// </summary>
+public sealed record UsageRequiredAlternativeGroup
+{
+    /// <summary>
+    /// Option switches and positional properties participating in the choice.
+    /// </summary>
+    public required IReadOnlyList<UsageRequiredAlternativeMember> Members { get; init; }
+}
+
+/// <summary>
+/// An option or positional operand participating in a required usage choice.
+/// </summary>
+public sealed record UsageRequiredAlternativeMember
+{
+    /// <summary>
+    /// Option spelling when this member is supplied through a named option.
+    /// </summary>
+    public string? OptionSwitch { get; init; }
+
+    /// <summary>
+    /// Generated positional property name when this member is a true operand.
+    /// </summary>
+    public string? PositionalPropertyName { get; init; }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -99,6 +99,9 @@ public static class UsageSynopsisParser
             ? [.. sameCommandCandidates
                 .Where(candidate => suppliedSynopsisSet.Contains(candidate.Synopsis ?? ""))]
             : sameCommandCandidates;
+        var requirednessCandidateMemberKeys = requirednessCandidates
+            .Select(GetRequiredAlternativeMemberKeys)
+            .ToArray();
 
         return selected with
         {
@@ -113,8 +116,9 @@ public static class UsageSynopsisParser
             RequiredAlternativeGroups =
             [
                 .. selected.RequiredAlternativeGroups.Where(group =>
-                    requirednessCandidates.All(candidate =>
-                        CandidateSatisfiesRequiredAlternativeGroup(candidate, group))),
+                    requirednessCandidateMemberKeys.All(candidateMemberKeys =>
+                        group.Members.Any(member => candidateMemberKeys.Contains(
+                            GetAlternativeMemberKey(member))))),
                 .. GetCrossSynopsisRequiredAlternativeGroups(
                     requirednessCandidates,
                     selected.PositionalArguments),
@@ -231,10 +235,14 @@ public static class UsageSynopsisParser
             }
 
             var alternativeMembers = alternatives
-                .Select(alternative => CollapseOptionAliases(
-                    GetRequiredAlternativeMembers(
-                        ParseOperandTokens(Tokenize(alternative), phase)),
-                    alternative))
+                .Select(alternative =>
+                {
+                    var normalizedAlternative = NormalizeCommaSeparatedOptionAliases(alternative);
+                    return CollapseOptionAliases(
+                        GetRequiredAlternativeMembers(
+                            ParseOperandTokens(Tokenize(normalizedAlternative), phase)),
+                        alternative);
+                })
                 .ToArray();
             if (alternativeMembers.Any(static members => members.Count != 1))
             {
@@ -252,22 +260,16 @@ public static class UsageSynopsisParser
         return groups;
     }
 
-    private static bool CandidateSatisfiesRequiredAlternativeGroup(
-        UsageSynopsisParseResult candidate,
-        UsageRequiredAlternativeGroup group)
-    {
-        var candidateMemberKeys = GetRequiredAlternativeMembers(new ParsedOperands(
+    private static IReadOnlySet<string> GetRequiredAlternativeMemberKeys(
+        UsageSynopsisParseResult candidate) =>
+        GetRequiredAlternativeMembers(new ParsedOperands(
                 candidate.PositionalArguments,
                 candidate.UnparsedOperandTokens,
                 candidate.RequiredOptionSwitches))
             .Concat(candidate.RequiredAlternativeGroups.SelectMany(static candidateGroup =>
                 candidateGroup.Members))
             .Select(GetAlternativeMemberKey)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        return group.Members.Any(member =>
-            candidateMemberKeys.Contains(GetAlternativeMemberKey(member)));
-    }
+            .ToHashSet(StringComparer.Ordinal);
 
     private static IReadOnlyList<UsageRequiredAlternativeGroup> GetCrossSynopsisRequiredAlternativeGroups(
         IReadOnlyList<UsageSynopsisParseResult> candidates,
@@ -294,7 +296,7 @@ public static class UsageSynopsisParser
 
         var commonKeys = candidateMembers[0]
             .Select(GetAlternativeMemberKey)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .ToHashSet(StringComparer.Ordinal);
         foreach (var members in candidateMembers.Skip(1))
         {
             commonKeys.IntersectWith(members.Select(GetAlternativeMemberKey));
@@ -353,7 +355,7 @@ public static class UsageSynopsisParser
                 .Select(argument => argument.AssociatedOptionSwitch is { } optionSwitch
                                     && operands.RequiredOptionSwitches.Contains(
                                         optionSwitch,
-                                        StringComparer.OrdinalIgnoreCase)
+                                        StringComparer.Ordinal)
                     ? new UsageRequiredAlternativeMember { OptionSwitch = optionSwitch }
                     : new UsageRequiredAlternativeMember { PositionalPropertyName = argument.PropertyName })
                 .Concat(operands.RequiredOptionSwitches.Select(static optionSwitch =>
@@ -362,18 +364,24 @@ public static class UsageSynopsisParser
     private static IReadOnlyList<UsageRequiredAlternativeMember> DistinctAlternativeMembers(
         IEnumerable<UsageRequiredAlternativeMember> members) =>
         members
-            .DistinctBy(GetAlternativeMemberKey, StringComparer.OrdinalIgnoreCase)
+            .DistinctBy(GetAlternativeMemberKey, StringComparer.Ordinal)
             .ToArray();
 
     private static IReadOnlyList<UsageRequiredAlternativeMember> CollapseOptionAliases(
         IReadOnlyList<UsageRequiredAlternativeMember> members,
         string synopsis)
     {
+        var commaSeparatedAliases = synopsis.Contains(',')
+            ? [GetOptionSwitches(synopsis)]
+            : Array.Empty<IReadOnlyList<string>>();
         var aliasGroups = Tokenize(synopsis)
+            .Where(static token => token.Contains('|'))
             .Select(GetOptionSwitches)
+            .Concat(commaSeparatedAliases)
             .Where(static switches => switches.Count == 2
                                       && switches.Any(IsShortOptionSwitch)
                                       && switches.Any(IsLongOptionSwitch))
+            .DistinctBy(static switches => string.Join("\0", switches), StringComparer.Ordinal)
             .ToArray();
 
         return DistinctAlternativeMembers(members.Select(member =>
@@ -384,11 +392,26 @@ public static class UsageSynopsisParser
             }
 
             var aliases = aliasGroups.FirstOrDefault(group =>
-                group.Contains(optionSwitch, StringComparer.OrdinalIgnoreCase));
+                group.Contains(optionSwitch, StringComparer.Ordinal));
             return aliases is null
                 ? member
                 : member with { OptionSwitch = SelectPreferredOptionSwitch(aliases) };
         }));
+    }
+
+    private static string NormalizeCommaSeparatedOptionAliases(string alternative)
+    {
+        if (!alternative.Contains(','))
+        {
+            return alternative;
+        }
+
+        var optionSwitches = GetOptionSwitches(alternative);
+        return optionSwitches.Count == 2
+               && optionSwitches.Any(IsShortOptionSwitch)
+               && optionSwitches.Any(IsLongOptionSwitch)
+            ? string.Join('|', optionSwitches)
+            : alternative;
     }
 
     private static bool IsShortOptionSwitch(string optionSwitch) =>
@@ -400,7 +423,7 @@ public static class UsageSynopsisParser
     private static string GetAlternativeMemberKey(UsageRequiredAlternativeMember member) =>
         member.OptionSwitch is { } optionSwitch
             ? $"option:{optionSwitch}"
-            : $"operand:{member.PositionalPropertyName}";
+            : $"operand:{member.PositionalPropertyName?.ToUpperInvariant()}";
 
     private static IReadOnlyList<string> SplitTopLevelAlternatives(string content)
     {
@@ -1305,9 +1328,18 @@ public static class UsageSynopsisParser
 
     private static bool TryGetOptionSwitch(string token, out string optionSwitch)
     {
-        var optionSwitches = GetOptionSwitches(token);
-        optionSwitch = SelectPreferredOptionSwitch(optionSwitches) ?? "";
-        return optionSwitch.Length > 0;
+        var content = TrimControlWrappers(token).TrimEnd('[', ',', ':');
+        if (content.IndexOfAny([' ', '\t', '=']) >= 0
+            || content.Length <= 1
+            || !content.StartsWith('-')
+            || content == "--")
+        {
+            optionSwitch = "";
+            return false;
+        }
+
+        optionSwitch = content;
+        return true;
     }
 
     private static IReadOnlyList<string> GetOptionSwitches(string token)
@@ -1323,7 +1355,7 @@ public static class UsageSynopsisParser
 
         return alternatives
             .SelectMany(GetOptionSwitchesFromAlternative)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(StringComparer.Ordinal)
             .ToArray();
     }
 


### PR DESCRIPTION
Closes #4453.\n\n## Summary\n- model required CLI alternative groups from inline and multi-synopsis usage\n- generate command-level validation while keeping each alternative nullable\n- recover Cargo add's multiline --path and --git options\n- regenerate Cargo add API and exact argv coverage\n\n## Validation\n- OptionsGenerator Release build: passed, 0 warnings\n- OptionsGenerator tests: 1,188 passed\n- Rust Release build: passed, 0 warnings\n- Rust tests: 7 passed\n- Cargo 1.98.0 regeneration: deterministic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for commands requiring at least one option from a defined set of alternatives.
  * Generated command options now validate that at least one alternative is provided.
  * Improved Cargo command parsing for dependency sources such as paths, Git repositories, registries, and workspace dependencies.
  * Generated service methods now require options when alternative inputs are mandatory.

* **Bug Fixes**
  * Improved handling of command syntax alternatives, aliases, and property name collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->