### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
+++ b/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "go",
-  "toolVersion": "go version go1.27.0 windows/amd64",
+  "toolVersion": "go version go1.27.0 linux/amd64",
   "commandCount": 32,
   "commandTreeSha256": "548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f",
   "commands": [


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- go (go version go1.27.0 linux/amd64): 32 commands, tree 548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator