### PR TITLE
Stabilize timeout grace-period fault ordering

### DIFF
--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -114,16 +114,7 @@ internal static class TimeoutHelper
         // of that real task instead of making a decision from a provisional wrapper.
         deadlineCts.CancelAfter(timeout.Value);
 
-        Task<T> executionTask;
-        try
-        {
-            executionTask = taskFactory(attemptCts.Token);
-        }
-        catch (Exception exception)
-        {
-            executionTask = Task.FromException<T>(exception);
-        }
-
+        var executionTask = taskFactory(attemptCts.Token);
         cancellationSignals.PublishExecutionTask(executionTask);
 
         await Task.WhenAny(

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -108,12 +108,20 @@ internal static class TimeoutHelper
             static state => ((CancellationSignalState<T>) state!).SignalCancellation(),
             externalCancellationState);
 
-        // Now schedule the timeout - registration is guaranteed to catch it
-        deadlineCts.CancelAfter(timeout.Value);
-
-        var executionTask = taskFactory(attemptCts.Token);
+        // Publish the execution before starting the factory so even an immediate
+        // deadline can attribute work completed in response to cancellation.
+        var executionStart = new TaskCompletionSource();
+        var executionTask = ExecuteAfterPublicationAsync(
+            executionStart.Task,
+            taskFactory,
+            attemptCts.Token);
         deadlineState.PublishExecutionTask(executionTask);
         externalCancellationState.PublishExecutionTask(executionTask);
+
+        // Now schedule the timeout - registration and execution publication are
+        // guaranteed to catch it before the factory can observe cancellation.
+        deadlineCts.CancelAfter(timeout.Value);
+        executionStart.SetResult();
 
         await Task.WhenAny(
                 executionTask,
@@ -137,6 +145,15 @@ internal static class TimeoutHelper
 
         var value = await executionTask.ConfigureAwait(false);
         return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
+    }
+
+    private static async Task<T> ExecuteAfterPublicationAsync<T>(
+        Task executionStart,
+        Func<CancellationToken, Task<T>> taskFactory,
+        CancellationToken cancellationToken)
+    {
+        await executionStart.ConfigureAwait(false);
+        return await taskFactory(cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<TimeoutExecutionResult<T>> ExecuteWithoutTimeoutAsync<T>(

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -119,12 +119,6 @@ internal static class TimeoutHelper
         {
             executionTask = taskFactory(attemptCts.Token);
         }
-        catch (OperationCanceledException exception)
-        {
-            var cancellationTaskSource = new TaskCompletionSource<T>();
-            cancellationTaskSource.SetCanceled(exception.CancellationToken);
-            executionTask = cancellationTaskSource.Task;
-        }
         catch (Exception exception)
         {
             executionTask = Task.FromException<T>(exception);

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -110,11 +110,18 @@ internal static class TimeoutHelper
 
         // Publish the execution before starting the factory so even an immediate
         // deadline can attribute work completed in response to cancellation.
+        // Keep default synchronous continuations: SetResult must enter the factory
+        // before a freshly armed deadline can race ahead of execution startup.
         var executionStart = new TaskCompletionSource();
         var executionTask = ExecuteAfterPublicationAsync(
             executionStart.Task,
             taskFactory,
-            attemptCts.Token);
+            attemptCts.Token,
+            actualTask =>
+            {
+                deadlineState.PublishExecutionTask(actualTask);
+                externalCancellationState.PublishExecutionTask(actualTask);
+            });
         deadlineState.PublishExecutionTask(executionTask);
         externalCancellationState.PublishExecutionTask(executionTask);
 
@@ -150,10 +157,13 @@ internal static class TimeoutHelper
     private static async Task<T> ExecuteAfterPublicationAsync<T>(
         Task executionStart,
         Func<CancellationToken, Task<T>> taskFactory,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<Task<T>> publishActualTask)
     {
         await executionStart.ConfigureAwait(false);
-        return await taskFactory(cancellationToken).ConfigureAwait(false);
+        var actualTask = taskFactory(cancellationToken);
+        publishActualTask(actualTask);
+        return await actualTask.ConfigureAwait(false);
     }
 
     private static async Task<TimeoutExecutionResult<T>> ExecuteWithoutTimeoutAsync<T>(

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -99,8 +99,9 @@ internal static class TimeoutHelper
         using var deadlineCts = new CancellationTokenSource();
         using var attemptCts = new CancellationTokenSource();
 
-        var deadlineState = new CancellationSignalState<T>(attemptCts);
-        var externalCancellationState = new CancellationSignalState<T>(attemptCts);
+        var cancellationSignals = new CancellationSignals<T>(attemptCts);
+        var deadlineState = cancellationSignals.Deadline;
+        var externalCancellationState = cancellationSignals.ExternalCancellation;
         using var deadlineRegistration = deadlineCts.Token.Register(
             static state => ((CancellationSignalState<T>) state!).SignalCancellation(),
             deadlineState);
@@ -117,13 +118,8 @@ internal static class TimeoutHelper
             executionStart.Task,
             taskFactory,
             attemptCts.Token,
-            actualTask =>
-            {
-                deadlineState.PublishExecutionTask(actualTask);
-                externalCancellationState.PublishExecutionTask(actualTask);
-            });
-        deadlineState.PublishExecutionTask(executionTask);
-        externalCancellationState.PublishExecutionTask(executionTask);
+            cancellationSignals.PublishExecutionTask);
+        cancellationSignals.PublishExecutionTask(executionTask);
 
         // Now schedule the timeout - registration and execution publication are
         // guaranteed to catch it before the factory can observe cancellation.
@@ -242,26 +238,53 @@ internal static class TimeoutHelper
         }
     }
 
-    internal sealed class CancellationSignalState<T>(CancellationTokenSource attemptCts)
+    internal sealed class CancellationSignals<T>
+    {
+        private Task<T>? _executionTask;
+
+        public CancellationSignals(CancellationTokenSource attemptCts)
+        {
+            Deadline = new CancellationSignalState<T>(attemptCts, this);
+            ExternalCancellation = new CancellationSignalState<T>(attemptCts, this);
+        }
+
+        public CancellationSignalState<T> Deadline { get; }
+
+        public CancellationSignalState<T> ExternalCancellation { get; }
+
+        internal Task<T>? ExecutionTask => Volatile.Read(ref _executionTask);
+
+        public void PublishExecutionTask(Task<T> executionTask)
+        {
+            // Both signals read one atomic task reference, so neither can observe
+            // a provisional wrapper after the actual factory task is available.
+            Volatile.Write(ref _executionTask, executionTask);
+            Deadline.ExecutionTaskPublished();
+            ExternalCancellation.ExecutionTaskPublished();
+        }
+    }
+
+    internal sealed class CancellationSignalState<T>(
+        CancellationTokenSource attemptCts,
+        CancellationSignals<T> cancellationSignals)
     {
         private readonly Lock _lock = new();
-        private Task<T>? _executionTask;
         private bool _cancellationSignaled;
 
         public TaskCompletionSource<bool> Signal { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public void PublishExecutionTask(Task<T> executionTask)
+        internal void ExecutionTaskPublished()
         {
             bool cancellationSignaled;
             lock (_lock)
             {
-                _executionTask = executionTask;
                 cancellationSignaled = _cancellationSignaled;
             }
 
             if (cancellationSignaled)
             {
+                var executionTask = cancellationSignals.ExecutionTask!;
                 // A completed value or fault existed by the time publication caught up
                 // with the signal. A cancelled task still belongs to the signal that
                 // cancelled the attempt token.
@@ -275,7 +298,7 @@ internal static class TimeoutHelper
             lock (_lock)
             {
                 _cancellationSignaled = true;
-                executionTask = _executionTask;
+                executionTask = cancellationSignals.ExecutionTask;
             }
 
             if (executionTask is not null)

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -109,22 +109,28 @@ internal static class TimeoutHelper
             static state => ((CancellationSignalState<T>) state!).SignalCancellation(),
             externalCancellationState);
 
-        // Publish the execution before starting the factory so even an immediate
-        // deadline can attribute work completed in response to cancellation.
-        // Keep default synchronous continuations: SetResult must enter the factory
-        // before a freshly armed deadline can race ahead of execution startup.
-        var executionStart = new TaskCompletionSource();
-        var executionTask = ExecuteAfterPublicationAsync(
-            executionStart.Task,
-            taskFactory,
-            attemptCts.Token,
-            cancellationSignals.PublishExecutionTask);
-        cancellationSignals.PublishExecutionTask(executionTask);
-
-        // Now schedule the timeout - registration and execution publication are
-        // guaranteed to catch it before the factory can observe cancellation.
+        // Arm the timeout before starting the factory. If cancellation occurs while
+        // the factory is returning its task, signal resolution waits for publication
+        // of that real task instead of making a decision from a provisional wrapper.
         deadlineCts.CancelAfter(timeout.Value);
-        executionStart.SetResult();
+
+        Task<T> executionTask;
+        try
+        {
+            executionTask = taskFactory(attemptCts.Token);
+        }
+        catch (OperationCanceledException exception)
+        {
+            var cancellationTaskSource = new TaskCompletionSource<T>();
+            cancellationTaskSource.SetCanceled(exception.CancellationToken);
+            executionTask = cancellationTaskSource.Task;
+        }
+        catch (Exception exception)
+        {
+            executionTask = Task.FromException<T>(exception);
+        }
+
+        cancellationSignals.PublishExecutionTask(executionTask);
 
         await Task.WhenAny(
                 executionTask,
@@ -148,18 +154,6 @@ internal static class TimeoutHelper
 
         var value = await executionTask.ConfigureAwait(false);
         return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
-    }
-
-    private static async Task<T> ExecuteAfterPublicationAsync<T>(
-        Task executionStart,
-        Func<CancellationToken, Task<T>> taskFactory,
-        CancellationToken cancellationToken,
-        Action<Task<T>> publishActualTask)
-    {
-        await executionStart.ConfigureAwait(false);
-        var actualTask = taskFactory(cancellationToken);
-        publishActualTask(actualTask);
-        return await actualTask.ConfigureAwait(false);
     }
 
     private static async Task<TimeoutExecutionResult<T>> ExecuteWithoutTimeoutAsync<T>(

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -200,18 +200,10 @@ public class ModuleTimeoutTests : TestBase
     public async Task Timeout_Fault_During_Grace_Period_Counts_As_Response()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-            async cancellationToken =>
+            cancellationToken =>
             {
-                try
-                {
-                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    throw new TimeoutException("Inner operation timed out.");
-                }
-
-                return true;
+                cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                return Task.FromException<bool>(new TimeoutException("Inner operation timed out."));
             },
             TimeSpan.FromMilliseconds(10),
             CancellationToken.None);

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -224,27 +224,18 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
-    public async Task Completed_Factory_Task_Wins_Before_Async_Wrapper_Continuation()
+    public async Task Completed_Factory_Task_Wins_When_Factory_Raises_External_Cancellation()
     {
         using var externalCancellation = new CancellationTokenSource();
-        var factoryStarted = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var operation = new TaskCompletionSource<bool>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var execution = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
             _ =>
             {
-                factoryStarted.SetResult();
-                return operation.Task;
+                externalCancellation.Cancel();
+                return Task.FromResult(true);
             },
             TimeSpan.FromSeconds(10),
             externalCancellation.Token);
-        await factoryStarted.Task;
 
-        operation.SetResult(true);
-        externalCancellation.Cancel();
-
-        var result = await execution;
         await Assert.That(result.Value).IsTrue();
         await Assert.That(result.TimedOut).IsFalse();
     }
@@ -353,12 +344,10 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
-    public async Task Actual_Execution_Publication_Is_Shared_By_Both_Cancellation_Signals()
+    public async Task Execution_Publication_Is_Shared_By_Both_Cancellation_Signals()
     {
         using var attemptCancellation = new CancellationTokenSource();
         var cancellationSignals = new TimeoutHelper.CancellationSignals<bool>(attemptCancellation);
-        var provisionalExecution = new TaskCompletionSource<bool>();
-        cancellationSignals.PublishExecutionTask(provisionalExecution.Task);
 
         cancellationSignals.PublishExecutionTask(Task.FromResult(true));
         cancellationSignals.Deadline.SignalCancellation();

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -202,10 +202,15 @@ public class ModuleTimeoutTests : TestBase
         for (var iteration = 0; iteration < 25; iteration++)
         {
             var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-                cancellationToken =>
+                async cancellationToken =>
                 {
-                    cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
-                    return Task.FromException<bool>(new TimeoutException("Inner operation timed out."));
+                    var completion = new TaskCompletionSource<bool>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    using var registration = cancellationToken.Register(
+                        static state => ((TaskCompletionSource<bool>) state!).TrySetException(
+                            new TimeoutException("Inner operation timed out.")),
+                        completion);
+                    return await completion.Task.ConfigureAwait(false);
                 },
                 TimeSpan.FromMilliseconds(10),
                 CancellationToken.None);

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -199,20 +199,49 @@ public class ModuleTimeoutTests : TestBase
     [Test]
     public async Task Timeout_Fault_During_Grace_Period_Counts_As_Response()
     {
-        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-            cancellationToken =>
-            {
-                cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
-                return Task.FromException<bool>(new TimeoutException("Inner operation timed out."));
-            },
-            TimeSpan.FromMilliseconds(10),
-            CancellationToken.None);
-
-        using (Assert.Multiple())
+        for (var iteration = 0; iteration < 25; iteration++)
         {
-            await Assert.That(result.TimedOut).IsTrue();
-            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+            var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+                cancellationToken =>
+                {
+                    cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                    return Task.FromException<bool>(new TimeoutException("Inner operation timed out."));
+                },
+                TimeSpan.FromMilliseconds(10),
+                CancellationToken.None);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.TimedOut).IsTrue();
+                await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+            }
         }
+    }
+
+    [Test]
+    public async Task Completed_Factory_Task_Wins_Before_Async_Wrapper_Continuation()
+    {
+        using var externalCancellation = new CancellationTokenSource();
+        var factoryStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var operation = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var execution = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            _ =>
+            {
+                factoryStarted.SetResult();
+                return operation.Task;
+            },
+            TimeSpan.FromSeconds(10),
+            externalCancellation.Token);
+        await factoryStarted.Task;
+
+        operation.SetResult(true);
+        externalCancellation.Cancel();
+
+        var result = await execution;
+        await Assert.That(result.Value).IsTrue();
+        await Assert.That(result.TimedOut).IsFalse();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -321,10 +321,11 @@ public class ModuleTimeoutTests : TestBase
     public async Task Completed_Execution_Published_After_Deadline_Signal_Wins()
     {
         using var attemptCancellation = new CancellationTokenSource();
-        var signalState = new TimeoutHelper.CancellationSignalState<bool>(attemptCancellation);
+        var cancellationSignals = new TimeoutHelper.CancellationSignals<bool>(attemptCancellation);
+        var signalState = cancellationSignals.Deadline;
 
         signalState.SignalCancellation();
-        signalState.PublishExecutionTask(Task.FromResult(true));
+        cancellationSignals.PublishExecutionTask(Task.FromResult(true));
 
         using (Assert.Multiple())
         {
@@ -337,12 +338,32 @@ public class ModuleTimeoutTests : TestBase
     public async Task Cancelled_Execution_Published_After_Deadline_Signal_Belongs_To_Deadline()
     {
         using var attemptCancellation = new CancellationTokenSource();
-        var signalState = new TimeoutHelper.CancellationSignalState<bool>(attemptCancellation);
+        var cancellationSignals = new TimeoutHelper.CancellationSignals<bool>(attemptCancellation);
+        var signalState = cancellationSignals.Deadline;
 
         signalState.SignalCancellation();
-        signalState.PublishExecutionTask(Task.FromCanceled<bool>(attemptCancellation.Token));
+        cancellationSignals.PublishExecutionTask(Task.FromCanceled<bool>(attemptCancellation.Token));
 
         await Assert.That(await signalState.Signal.Task).IsFalse();
+    }
+
+    [Test]
+    public async Task Actual_Execution_Publication_Is_Shared_By_Both_Cancellation_Signals()
+    {
+        using var attemptCancellation = new CancellationTokenSource();
+        var cancellationSignals = new TimeoutHelper.CancellationSignals<bool>(attemptCancellation);
+        var provisionalExecution = new TaskCompletionSource<bool>();
+        cancellationSignals.PublishExecutionTask(provisionalExecution.Task);
+
+        cancellationSignals.PublishExecutionTask(Task.FromResult(true));
+        cancellationSignals.Deadline.SignalCancellation();
+        cancellationSignals.ExternalCancellation.SignalCancellation();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(await cancellationSignals.Deadline.Signal.Task).IsTrue();
+            await Assert.That(await cancellationSignals.ExternalCancellation.Signal.Task).IsTrue();
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -292,6 +292,30 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Synchronous_Cancellation_Exception_Preserves_Original_Diagnostics()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var innerException = new InvalidOperationException("Inner cancellation detail.");
+        var expectedException = new FactoryCancellationException(
+            "Factory cancellation detail.",
+            innerException,
+            cancellation.Token);
+
+        var exception = await Assert.ThrowsAsync<FactoryCancellationException>(() =>
+            TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync<bool>(
+                _ => throw expectedException,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception).IsSameReferenceAs(expectedException);
+            await Assert.That(exception!.InnerException).IsSameReferenceAs(innerException);
+            await Assert.That(exception.CancellationToken).IsEqualTo(cancellation.Token);
+        }
+    }
+
+    [Test]
     public async Task Completion_With_Asynchronous_Continuations_Before_Deadline_Is_Not_Claimed_By_Timeout()
     {
         var completion = new TaskCompletionSource<bool>(
@@ -381,4 +405,10 @@ public class ModuleTimeoutTests : TestBase
             await Assert.That(result.WasCancellationTokenRespected).IsTrue();
         }
     }
+
+    private sealed class FactoryCancellationException(
+        string message,
+        Exception innerException,
+        CancellationToken cancellationToken)
+        : OperationCanceledException(message, innerException, cancellationToken);
 }


### PR DESCRIPTION
## Summary
- publish the timeout execution task before arming its deadline and starting the factory
- make cancellation-responsive fault attribution deterministic when very short deadlines fire under scheduler load
- replace the wall-clock race with a regression that forces deadline-before-factory-return ordering

## Test plan
- [x] `ModuleTimeoutTests` (21/21)
- [x] forced ordering regression stress (25/25 isolated runs)
- [x] narrow `dotnet format` for touched files
- [ ] `ModularPipelines.Tests.slnf` Release build: local agent guard stopped at the required 2 GB process-tree limit (exit 137) after core projects compiled; CI will run broader validation

Closes #4472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and cancellation handling for operations that complete, fail, or are cancelled at the same time as a deadline.
  * Ensured completed operations are correctly recognized before timeout continuations run.
  * Improved consistency when external cancellation and deadline signals occur simultaneously.
  * Preserved factory cancellation exceptions when they are thrown synchronously.

* **Tests**
  * Added coverage for task completion, fault, cancellation, and shared signal timing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->