### PR TITLE
Preserve required Vault command-group subcommands

### DIFF
--- a/src/ModularPipelines.Vault/Options/VaultAuditOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultAuditOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("audit")]
-public record VaultAuditOptions : VaultOptions
+public record VaultAuditOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultAuthOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultAuthOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("auth")]
-public record VaultAuthOptions : VaultOptions
+public record VaultAuthOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultKvMetadataOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultKvMetadataOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("kv", "metadata")]
-public record VaultKvMetadataOptions : VaultOptions
+public record VaultKvMetadataOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultKvOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultKvOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("kv")]
-public record VaultKvOptions : VaultOptions
+public record VaultKvOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultLeaseOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultLeaseOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("lease")]
-public record VaultLeaseOptions : VaultOptions
+public record VaultLeaseOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultNamespaceOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultNamespaceOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("namespace")]
-public record VaultNamespaceOptions : VaultOptions
+public record VaultNamespaceOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultOperatorOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultOperatorOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("operator")]
-public record VaultOperatorOptions : VaultOptions
+public record VaultOperatorOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultOperatorRaftOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultOperatorRaftOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("operator", "raft")]
-public record VaultOperatorRaftOptions : VaultOptions
+public record VaultOperatorRaftOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultOperatorRaftSnapshotOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultOperatorRaftSnapshotOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("operator", "raft", "snapshot")]
-public record VaultOperatorRaftSnapshotOptions : VaultOptions
+public record VaultOperatorRaftSnapshotOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPkiOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPkiOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("pki")]
-public record VaultPkiOptions : VaultOptions
+public record VaultPkiOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPluginOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPluginOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("plugin")]
-public record VaultPluginOptions : VaultOptions
+public record VaultPluginOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPluginRuntimeOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPluginRuntimeOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("plugin", "runtime")]
-public record VaultPluginRuntimeOptions : VaultOptions
+public record VaultPluginRuntimeOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPolicyOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("policy")]
-public record VaultPolicyOptions : VaultOptions
+public record VaultPolicyOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultPrintOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultPrintOptions.Generated.cs
@@ -19,6 +19,8 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("print")]
-public record VaultPrintOptions : VaultOptions
+public record VaultPrintOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
 }

--- a/src/ModularPipelines.Vault/Options/VaultSecretsOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultSecretsOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("secrets")]
-public record VaultSecretsOptions : VaultOptions
+public record VaultSecretsOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultTokenOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTokenOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("token")]
-public record VaultTokenOptions : VaultOptions
+public record VaultTokenOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultTransformOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTransformOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("transform")]
-public record VaultTransformOptions : VaultOptions
+public record VaultTransformOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Options/VaultTransitOptions.Generated.cs
+++ b/src/ModularPipelines.Vault/Options/VaultTransitOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Vault.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("transit")]
-public record VaultTransitOptions : VaultOptions
+public record VaultTransitOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Subcommand
+) : VaultOptions
 {
     /// <summary>
     /// The args operand.

--- a/src/ModularPipelines.Vault/Services/IVault.Generated.cs
+++ b/src/ModularPipelines.Vault/Services/IVault.Generated.cs
@@ -77,7 +77,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AuditAsync(VaultAuditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AuditAsync(VaultAuditOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -127,7 +127,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AuthAsync(VaultAuthOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AuthAsync(VaultAuthOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -237,7 +237,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> KvMetadataAsync(VaultKvMetadataOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> KvMetadataAsync(VaultKvMetadataOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -267,7 +267,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> KvAsync(VaultKvOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> KvAsync(VaultKvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -327,7 +327,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> LeaseAsync(VaultLeaseOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> LeaseAsync(VaultLeaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -437,7 +437,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> NamespaceAsync(VaultNamespaceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NamespaceAsync(VaultNamespaceOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -527,7 +527,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OperatorAsync(VaultOperatorOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> OperatorAsync(VaultOperatorOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -587,7 +587,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OperatorRaftAsync(VaultOperatorRaftOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> OperatorRaftAsync(VaultOperatorRaftOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -617,7 +617,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> OperatorRaftSnapshotAsync(VaultOperatorRaftSnapshotOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> OperatorRaftSnapshotAsync(VaultOperatorRaftSnapshotOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -767,7 +767,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PkiAsync(VaultPkiOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PkiAsync(VaultPkiOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     public Task<CommandResult> PkiReissueAsync(VaultPkiReissueOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
@@ -820,7 +820,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PluginAsync(VaultPluginOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginAsync(VaultPluginOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -890,7 +890,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PluginRuntimeAsync(VaultPluginRuntimeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginRuntimeAsync(VaultPluginRuntimeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -940,7 +940,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PolicyAsync(VaultPolicyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PolicyAsync(VaultPolicyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -970,7 +970,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> PrintAsync(VaultPrintOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PrintAsync(VaultPrintOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1040,7 +1040,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> SecretsAsync(VaultSecretsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SecretsAsync(VaultSecretsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1120,7 +1120,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TokenAsync(VaultTokenOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TokenAsync(VaultTokenOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1170,7 +1170,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TransformAsync(VaultTransformOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TransformAsync(VaultTransformOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -1200,7 +1200,7 @@ public partial interface IVault
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> TransitAsync(VaultTransitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TransitAsync(VaultTransitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Vault/Services/Vault.Generated.cs
+++ b/src/ModularPipelines.Vault/Services/Vault.Generated.cs
@@ -79,11 +79,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AuditAsync(
-        VaultAuditOptions? options = null,
+        VaultAuditOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultAuditOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -124,11 +124,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AuthAsync(
-        VaultAuthOptions? options = null,
+        VaultAuthOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultAuthOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -223,11 +223,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> KvMetadataAsync(
-        VaultKvMetadataOptions? options = null,
+        VaultKvMetadataOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultKvMetadataOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -250,11 +250,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> KvAsync(
-        VaultKvOptions? options = null,
+        VaultKvOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultKvOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -304,11 +304,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> LeaseAsync(
-        VaultLeaseOptions? options = null,
+        VaultLeaseOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultLeaseOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -403,11 +403,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> NamespaceAsync(
-        VaultNamespaceOptions? options = null,
+        VaultNamespaceOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultNamespaceOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -484,11 +484,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> OperatorAsync(
-        VaultOperatorOptions? options = null,
+        VaultOperatorOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultOperatorOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -538,11 +538,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> OperatorRaftAsync(
-        VaultOperatorRaftOptions? options = null,
+        VaultOperatorRaftOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultOperatorRaftOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -565,11 +565,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> OperatorRaftSnapshotAsync(
-        VaultOperatorRaftSnapshotOptions? options = null,
+        VaultOperatorRaftSnapshotOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultOperatorRaftSnapshotOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -700,11 +700,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PkiAsync(
-        VaultPkiOptions? options = null,
+        VaultPkiOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPkiOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -754,11 +754,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PluginAsync(
-        VaultPluginOptions? options = null,
+        VaultPluginOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPluginOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -817,11 +817,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PluginRuntimeAsync(
-        VaultPluginRuntimeOptions? options = null,
+        VaultPluginRuntimeOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPluginRuntimeOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -862,11 +862,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PolicyAsync(
-        VaultPolicyOptions? options = null,
+        VaultPolicyOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPolicyOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -889,11 +889,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> PrintAsync(
-        VaultPrintOptions? options = null,
+        VaultPrintOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultPrintOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -952,11 +952,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> SecretsAsync(
-        VaultSecretsOptions? options = null,
+        VaultSecretsOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultSecretsOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -1024,11 +1024,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TokenAsync(
-        VaultTokenOptions? options = null,
+        VaultTokenOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultTokenOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -1069,11 +1069,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TransformAsync(
-        VaultTransformOptions? options = null,
+        VaultTransformOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultTransformOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -1096,11 +1096,11 @@ internal partial class Vault : IVault
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> TransitAsync(
-        VaultTransitOptions? options = null,
+        VaultTransitOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new VaultTransitOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -104,6 +104,9 @@
       <_Parameter1>ModularPipelines.Trivy.UnitTests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>ModularPipelines.Vault.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>ModularPipelines.TestHelpers</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/test/ModularPipelines.Vault.UnitTests/VaultOptionsTests.cs
+++ b/test/ModularPipelines.Vault.UnitTests/VaultOptionsTests.cs
@@ -1,0 +1,28 @@
+using ModularPipelines.Context;
+using ModularPipelines.TestHelpers;
+using ModularPipelines.Vault.Options;
+
+namespace ModularPipelines.Vault.UnitTests;
+
+public class VaultOptionsTests : TestBase
+{
+    [Test]
+    public async Task Audit_Group_Renders_Required_Subcommand()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var commandLine = builder.Build(new VaultAuditOptions("disable"));
+
+        await Assert.That(commandLine.ToString()).IsEqualTo("vault audit disable");
+    }
+
+    [Test]
+    public async Task Audit_Group_Rejects_Missing_Subcommand()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        await Assert.That(() => builder.Build(new VaultAuditOptions(default!)))
+            .Throws<ArgumentException>()
+            .And.HasMessageContaining("VaultAuditOptions.Subcommand");
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/VaultCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/VaultCliScraperTests.cs
@@ -9,6 +9,29 @@ namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
 public class VaultCliScraperTests
 {
     [Test]
+    public async Task Shared_Traversal_Preserves_Required_Subcommand()
+    {
+        var scraper = new VaultCliScraper(
+            new VaultHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<VaultCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var audit = commands.Single(command => command.FullCommand == "vault audit");
+        using (Assert.Multiple())
+        {
+            await Assert.That(audit.PositionalArguments[0].PropertyName).IsEqualTo("Subcommand");
+            await Assert.That(audit.PositionalArguments[0].IsRequired).IsTrue();
+            await Assert.That(commands.Select(command => command.FullCommand))
+                .Contains("vault audit disable");
+        }
+    }
+
+    [Test]
     public async Task Command_Group_Preserves_Subcommand_And_Optional_Args()
     {
         const string helpText = """
@@ -53,5 +76,57 @@ public class VaultCliScraperTests
             var usage = ParseUsageSynopsis(commandPath, helpText);
             return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
         }
+    }
+
+    private sealed class VaultHelpExecutor : ICliCommandExecutor
+    {
+        private static readonly IReadOnlyDictionary<string, string> Responses =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["--help"] = """
+                    Usage: vault <command> [args]
+
+                    Other commands:
+                        audit       Interact with audit devices
+                    """,
+                ["audit --help"] = """
+                    Usage: vault audit <subcommand> [options] [args]
+
+                    This command groups subcommands for interacting with Vault's audit devices.
+
+                    Subcommands:
+                        disable    Disables an audit device
+                    """,
+                ["audit disable --help"] = """
+                    Usage: vault audit disable [options]
+
+                    Options:
+                        -address=<string>    Address of the Vault server
+                    """,
+            };
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            if (!Responses.TryGetValue(arguments, out var response))
+            {
+                throw new InvalidOperationException($"Unexpected invocation: {command} {arguments}");
+            }
+
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = response,
+                StandardError = string.Empty,
+                ExitCode = 0,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -142,6 +142,11 @@ public abstract partial class CliScraperBase : ICliScraper
     protected virtual bool GlobalOptionsBeforeSubcommands => true;
 
     /// <summary>
+    /// Gets whether generic command-group operands remain executable arguments after child discovery.
+    /// </summary>
+    protected virtual bool PreserveCommandGroupPlaceholders => false;
+
+    /// <summary>
     /// The validated union of scraped and supplemental global options.
     /// </summary>
     protected IReadOnlyList<CliOptionDefinition> EffectiveGlobalOptions =>
@@ -474,7 +479,8 @@ public abstract partial class CliScraperBase : ICliScraper
         // select one of those children rather than representing an executable argument.
         // Handle this centrally so individual adapters cannot leave synthetic operands on
         // command groups such as docker compose, docker context, or minikube addons.
-        if (subcommands.Any(IsTraversableSubcommand))
+        if (!PreserveCommandGroupPlaceholders
+            && subcommands.Any(IsTraversableSubcommand))
         {
             usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
@@ -47,6 +47,9 @@ public partial class VaultCliScraper : CliScraperBase
         "--help", "-h", "--version", "help", "version", "debug"
     };
 
+    /// <inheritdoc />
+    protected override bool PreserveCommandGroupPlaceholders => true;
+
     /// <summary>
     /// Extracts subcommand names from vault help text.
     /// </summary>


### PR DESCRIPTION
Closes #4450

## Summary
- Preserve executable command-group operands during Vault child traversal.
- Regenerate 18 Vault group records plus matching interfaces/services with required subcommands.
- Add full traversal, exact argv, and missing-subcommand regression coverage.

## Validation
- Vault unit tests: 3/3 passed with coverage.
- OptionsGenerator tests: 1195/1195 passed with coverage.
- OptionsGenerator Release build: 0 warnings, 0 errors.
- Vault Release build: 0 warnings, 0 errors.
- Touched-file whitespace verification: passed.
- Vault regeneration workflow: https://github.com/thomhurst/ModularPipelines/actions/runs/33501135580
- Generated child PR #4477 passed CI/review and merged into this branch.

Local full Vault regeneration hit the mandated 2 GB agent guard at 2.25 GB and was not retried. The repository generation workflow completed the same pinned Vault 2.0.4 regeneration and solution build successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vault CLI command discovery so required subcommands, including `vault audit`, are preserved and rendered correctly.
  - Added support for recognizing nested commands such as `vault audit disable`.

- **Tests**
  - Added coverage for Vault command rendering, missing subcommands, and complete CLI help traversal.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->