### PR TITLE
Model optional-value CLI switches

### DIFF
--- a/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Go.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Go.Options;
 
@@ -29,8 +30,8 @@ public record GoGetOptions : GoOptions
     /// <summary>
     /// The -u option.
     /// </summary>
-    [CliFlag("-u")]
-    public bool? U { get; set; }
+    [CliOption("-u", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? U { get; set; }
 
     /// <summary>
     /// The -tool option.

--- a/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Go.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Go.Options;
 
@@ -29,8 +30,8 @@ public record GoListOptions : GoOptions
     /// <summary>
     /// The -json option.
     /// </summary>
-    [CliFlag("-json")]
-    public bool? Json { get; set; }
+    [CliOption("-json", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? Json { get; set; }
 
     /// <summary>
     /// The -m option.

--- a/src/ModularPipelines.Go/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Go/PublicAPI.Unshipped.txt
@@ -95,7 +95,7 @@ ModularPipelines.Go.Options.GoGetOptions.Packages.get -> System.Collections.Gene
 ModularPipelines.Go.Options.GoGetOptions.Packages.set -> void
 ModularPipelines.Go.Options.GoGetOptions.T.get -> bool?
 ModularPipelines.Go.Options.GoGetOptions.T.set -> void
-ModularPipelines.Go.Options.GoGetOptions.U.get -> bool?
+ModularPipelines.Go.Options.GoGetOptions.U.get -> ModularPipelines.Models.CliOptionValue?
 ModularPipelines.Go.Options.GoGetOptions.U.set -> void
 ModularPipelines.Go.Options.GoInstallOptions
 ModularPipelines.Go.Options.GoInstallOptions.GoInstallOptions() -> void
@@ -107,7 +107,7 @@ ModularPipelines.Go.Options.GoListOptions.F.get -> string?
 ModularPipelines.Go.Options.GoListOptions.F.set -> void
 ModularPipelines.Go.Options.GoListOptions.GoListOptions() -> void
 ModularPipelines.Go.Options.GoListOptions.GoListOptions(ModularPipelines.Go.Options.GoListOptions! original) -> void
-ModularPipelines.Go.Options.GoListOptions.Json.get -> bool?
+ModularPipelines.Go.Options.GoListOptions.Json.get -> ModularPipelines.Models.CliOptionValue?
 ModularPipelines.Go.Options.GoListOptions.Json.set -> void
 ModularPipelines.Go.Options.GoListOptions.M.get -> bool?
 ModularPipelines.Go.Options.GoListOptions.M.set -> void

--- a/src/ModularPipelines.Yarn/Options/YarnVersionApplyOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnVersionApplyOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Yarn.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Yarn.Options;
 
@@ -41,8 +42,8 @@ public record YarnVersionApplyOptions : YarnOptions
     /// <summary>
     /// Specify a prerelease pattern to use when working with prerelease versions
     /// </summary>
-    [CliFlag("--prerelease")]
-    public bool? Prerelease { get; set; }
+    [CliOption("--prerelease", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? Prerelease { get; set; }
 
     /// <summary>
     /// Print version(s)/record(s) without actually bumping versions or recording deferred releases

--- a/test/ModularPipelines.Go.UnitTests/GoOptionsTests.cs
+++ b/test/ModularPipelines.Go.UnitTests/GoOptionsTests.cs
@@ -1,0 +1,25 @@
+using ModularPipelines.Go.Options;
+using ModularPipelines.Models;
+using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
+
+namespace ModularPipelines.Go.UnitTests;
+
+public class GoOptionsTests
+{
+    [Test]
+    public async Task Optional_Value_Options_Render_Bare_And_Explicit_Forms()
+    {
+        await AssertArguments(
+            BuildArguments(new GoGetOptions { U = CliOptionValue.Bare }),
+            ["-u"]);
+        await AssertArguments(
+            BuildArguments(new GoGetOptions { U = "patch" }),
+            ["-u=patch"]);
+        await AssertArguments(
+            BuildArguments(new GoListOptions { Json = CliOptionValue.Bare }),
+            ["-json"]);
+        await AssertArguments(
+            BuildArguments(new GoListOptions { Json = "Name,Dir" }),
+            ["-json=Name,Dir"]);
+    }
+}

--- a/test/ModularPipelines.Yarn.UnitTests/YarnOptionsTests.cs
+++ b/test/ModularPipelines.Yarn.UnitTests/YarnOptionsTests.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Models;
 using ModularPipelines.Yarn.Options;
 using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
 
@@ -5,6 +6,17 @@ namespace ModularPipelines.Yarn.UnitTests;
 
 public class YarnOptionsTests
 {
+    [Test]
+    public async Task Prerelease_Renders_Bare_And_Explicit_Forms()
+    {
+        await AssertArguments(
+            BuildArguments(new YarnVersionApplyOptions { Prerelease = CliOptionValue.Bare }),
+            ["--prerelease"]);
+        await AssertArguments(
+            BuildArguments(new YarnVersionApplyOptions { Prerelease = "rc.1" }),
+            ["--prerelease=rc.1"]);
+    }
+
     [Test]
     public async Task Dlx_Renders_Yarn_Options_Before_Command()
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GoCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GoCliScraperTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class GoCliScraperTests
+{
+    [Test]
+    [Arguments("get", "-u", "usage: go get [-t] [-u] [build flags] [packages]")]
+    [Arguments("list", "-json", "usage: go list [-f format] [-json] [-m] [packages]")]
+    public async Task Optional_Value_Flags_Retain_Bare_And_Valued_Forms(
+        string commandName,
+        string switchName,
+        string helpText)
+    {
+        var command = await new TestGoCliScraper().Parse(
+            ["go", commandName],
+            helpText);
+        var option = command!.Options.Single(item => item.SwitchName == switchName);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(option.ValueSeparator).IsEqualTo("=");
+            await Assert.That(option.PropertyType).IsEqualTo("CliOptionValue?");
+        }
+    }
+
+    private sealed class TestGoCliScraper : GoCliScraper
+    {
+        public TestGoCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<GoCliScraper>.Instance)
+        {
+        }
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -163,7 +163,7 @@ public class YarnCliScraperTests
             """;
 
         var command = await new TestYarnCliScraper().Parse(
-            ["yarn", "version", "apply"],
+            ["yarn", "version apply"],
             helpText);
         var prerelease = command!.Options.Single();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -172,7 +172,7 @@ public partial class GoCliScraper : CliScraperBase
         }
 
         var description = ExtractDescription(helpText);
-        var options = ParseOptions(helpText, usage.Synopsis);
+        var options = ParseOptions(commandParts, helpText, usage.Synopsis);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
@@ -303,13 +303,49 @@ public partial class GoCliScraper : CliScraperBase
     /// Format: -flag    description
     ///         -flag value    description
     /// </summary>
-    private static List<CliOptionDefinition> ParseOptions(string helpText, string? usageSynopsis)
+    private static List<CliOptionDefinition> ParseOptions(
+        IReadOnlyList<string> commandParts,
+        string helpText,
+        string? usageSynopsis)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         AddDocumentedOptions(GetOptionSectionLines(helpText), options, seenOptions);
         AddUsageOptions(usageSynopsis ?? string.Empty, options, seenOptions);
+        ApplyOptionalValueOptionShape(commandParts, options);
         return options;
+    }
+
+    private static void ApplyOptionalValueOptionShape(
+        IReadOnlyList<string> commandParts,
+        List<CliOptionDefinition> options)
+    {
+        var switchName = commandParts switch
+        {
+            ["get"] => "-u",
+            ["list"] => "-json",
+            _ => null,
+        };
+        if (switchName is null)
+        {
+            return;
+        }
+
+        var optionIndex = options.FindIndex(option => option.SwitchName == switchName);
+        if (optionIndex < 0)
+        {
+            return;
+        }
+
+        var option = options[optionIndex];
+        options[optionIndex] = option with
+        {
+            CSharpType = "string?",
+            IsFlag = false,
+            ValueArity = CliOptionValueArity.Optional,
+            ValueSeparator = "=",
+            IsSecret = GeneratorUtils.IsSecretOption(option.PropertyName, isFlag: false),
+        };
     }
 
     private static string[] GetOptionSectionLines(string helpText)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -482,6 +482,9 @@ public partial class YarnCliScraper : CliScraperBase
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var className = GenerateClassName([ToolName, .. commandParts]);
+        var normalizedCommandParts = commandParts
+            .SelectMany(static part => part.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .ToArray();
 
         // Try Clipanion-style "━━━ Options ━━━" section first (Yarn Berry)
         var optionsMatch = ClipanionOptionsSectionPattern().Match(helpText);
@@ -564,7 +567,7 @@ public partial class YarnCliScraper : CliScraperBase
 
             var hasValue = match.Groups["value"].Success;
             var hasOptionalValue = !hasValue
-                                   && IsOptionalValueOption(commandParts, longForm);
+                                   && IsOptionalValueOption(normalizedCommandParts, longForm);
             var isFlag = !hasValue && !hasOptionalValue;
             var isCountedFlag = isFlag
                                 && longForm.Equals("--verbose", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- model Go `-u` and `-json` as optional-value switches supporting bare and equals-separated forms
- normalize combined Yarn command path segments so `version apply --prerelease` keeps its optional identifier
- regenerate Go 1.27 and Yarn 4.18 options through the generator

## Validation
- OptionsGenerator scraper tests: Go 2/2, Yarn 7/7
- generated integration tests: Go 2/2, Yarn 3/3
- core optional-value renderer tests: 93/93
- OptionsGenerator, Go, and Yarn solution builds
- focused whitespace verification

Closes #4324