### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Go.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Go.Options;
 
@@ -29,8 +30,8 @@ public record GoGetOptions : GoOptions
     /// <summary>
     /// The -u=patch flag (not -u patch) also instructs get to update dependencies, but changes the default to select patch releases.
     /// </summary>
-    [CliOption("-u", Format = OptionFormat.EqualsSeparated)]
-    public string? U { get; set; }
+    [CliOption("-u", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? U { get; set; }
 
     /// <summary>
     /// The -tool flag instructs go to add a matching tool line to go.mod for each listed package. If -tool is used with @none, the line will be removed. See 'go help tool' for more information.

--- a/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
@@ -23,8 +23,8 @@ public record GoTestOptions : GoOptions
     /// <summary>
     /// Pass the remainder of the command line (everything after -args) to the test binary, uninterpreted and unchanged. Because this flag consumes the remainder of the command line, the package list (if present) must appear before this flag.
     /// </summary>
-    [CliFlag("-args", Phase = CommandLinePhase.Terminal)]
-    public bool? Args { get; set; }
+    [CliOption("-args", GroupValues = true, Phase = CommandLinePhase.Terminal)]
+    public IEnumerable<string>? Args { get; set; }
 
     /// <summary>
     /// Compile the test binary to pkg.test in the current directory but do not run it (where pkg is the last element of the package's import path). The file name or target directory can be changed with the -o flag.


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- go (go version go1.27.0 linux/amd64): 32 commands, tree 548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator