### PR TITLE
[Automated] Update pnpm CLI Options

### DIFF
--- a/src/ModularPipelines.Node/Generated/Pnpm.CommandCoverage.json
+++ b/src/ModularPipelines.Node/Generated/Pnpm.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pnpm",
-  "toolVersion": "11.24.0",
+  "toolVersion": "11.25.0",
   "commandCount": 17,
   "commandTreeSha256": "18696e1b021b815b55d2466263ab6d8af87d0d9de99a4f2adf93ef61a3961e51",
   "commands": [

--- a/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
@@ -201,7 +201,7 @@ public record PnpmAddOptions : PnpmOptions
     public string? TestPattern { get; set; }
 
     /// <summary>
-    /// The name operand.
+    /// The &lt;name&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Name { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmCreateOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PnpmCreateOptions : PnpmOptions
     public string? AllowBuild { get; set; }
 
     /// <summary>
-    /// The name operand.
+    /// The &lt;name&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Name { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PnpmInitOptions : PnpmOptions
     public string? Bare { get; set; }
 
     /// <summary>
-    /// Pin the pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing
+    /// Pin the latest pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing
     /// </summary>
     [CliFlag("--init-package-manager")]
     public bool? InitPackageManager { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
@@ -35,6 +35,12 @@ public record PnpmRunOptions(
     public string? Dir { get; set; }
 
     /// <summary>
+    /// Print the task graph a recursive run would execute, without running anything. With "--json", prints the tasks and their resolved dependency edges as JSON
+    /// </summary>
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
+
+    /// <summary>
     /// Output usage information
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]

--- a/src/ModularPipelines.Node/Options/PnpmStageApproveOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageApproveOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stage", "approve")]
-public record PnpmStageApproveOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string StageId
-) : PnpmOptions
+public record PnpmStageApproveOptions : PnpmOptions
 {
     /// <summary>
     /// Tells the registry whether the staged package should be public or restricted.
@@ -42,7 +40,7 @@ public record PnpmStageApproveOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]
@@ -95,5 +93,11 @@ public record PnpmStageApproveOptions(
     /// </summary>
     [CliOption("--test-pattern")]
     public string? TestPattern { get; set; }
+
+    /// <summary>
+    /// The &lt;stage-id&gt; operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? StageId { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmStageDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageDownloadOptions.Generated.cs
@@ -42,7 +42,7 @@ public record PnpmStageDownloadOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageListOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageListOptions.Generated.cs
@@ -40,7 +40,7 @@ public record PnpmStageListOptions : PnpmOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
@@ -40,7 +40,7 @@ public record PnpmStageOptions : PnpmOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStagePublishOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStagePublishOptions.Generated.cs
@@ -40,7 +40,7 @@ public record PnpmStagePublishOptions : PnpmOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageRejectOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageRejectOptions.Generated.cs
@@ -42,7 +42,7 @@ public record PnpmStageRejectOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageViewOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageViewOptions.Generated.cs
@@ -42,7 +42,7 @@ public record PnpmStageViewOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
@@ -107,7 +107,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> StageApproveAsync(PnpmStageApproveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StageApproveAsync(PnpmStageApproveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Node/Services/Pnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/Pnpm.Generated.cs
@@ -106,11 +106,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> StageApproveAsync(
-        PnpmStageApproveOptions options,
+        PnpmStageApproveOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmStageApproveOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pnpm** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pnpm (11.25.0): 17 commands, tree 18696e1b021b815b55d2466263ab6d8af87d0d9de99a4f2adf93ef61a3961e51

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator