### PR TITLE
[Automated] Update cargo CLI Options

### DIFF
--- a/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
@@ -22,7 +22,7 @@ namespace ModularPipelines.Rust.Options;
 public record CargoAddOptions : CargoOptions
 {
     /// <summary>
-    /// The DEP operand.
+    /// The &lt;DEP&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Dep { get; set; }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **cargo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- cargo (cargo 1.98.0 (797e8a9bc 2026-08-05)): 16 commands, tree f8b1c0ec09c6f1a8fbc12f34c9e244131aa2869c068c7f752c8da91976b1ec19

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator