### PR TITLE
Add typed distributed capabilities

### DIFF
--- a/docs/docs/distributed/architecture.md
+++ b/docs/docs/distributed/architecture.md
@@ -164,7 +164,7 @@ This guarantees no result is missed regardless of timing.
 
 Module results are serialized via `ModuleResultSerializer` using `System.Text.Json`. The `ModuleTypeRegistry` maintains a mapping from module type names to their concrete .NET types, so results can be deserialized back to the correct `ModuleResult<T>`.
 
-The `ReadOnlySetJsonConverter` handles `IReadOnlySet<string>` fields (used in `ModuleAssignment.RequiredCapabilities` and `WorkerRegistration.Capabilities`), which `System.Text.Json` cannot deserialize by default.
+The `ReadOnlySetJsonConverter` keeps `IReadOnlySet<Capability>` fields (used in `ModuleAssignment.RequiredCapabilities` and `WorkerRegistration.Capabilities`) as plain string arrays on the wire.
 
 ## Implementing a Custom Coordinator
 
@@ -186,7 +186,7 @@ public sealed class MyCustomCoordinator : IDistributedCoordinator
         throw new NotImplementedException();
 
     public Task<ModuleAssignment?> DequeueModuleAsync(
-        IReadOnlySet<string> workerCapabilities,
+        IReadOnlySet<Capability> workerCapabilities,
         CancellationToken cancellationToken) =>
         throw new NotImplementedException();
 

--- a/docs/docs/distributed/capabilities.md
+++ b/docs/docs/distributed/capabilities.md
@@ -9,14 +9,14 @@ Not every worker can execute every module. Some modules need Docker, others need
 
 ## Worker Capabilities
 
-Workers advertise their capabilities when they register with the coordinator. Capabilities are simple strings that describe what the worker can do.
+Workers advertise typed `Capability` values when they register with the coordinator. Built-in values provide discoverable names, while implicit string conversion still supports custom capabilities.
 
 ```csharp
 builder.AddDistributedMode(o =>
 {
     o.InstanceIndex = 1;
     o.TotalInstances = 4;
-    o.Capabilities = new List<string> { "docker", "gpu" };
+    o.Capabilities = [Capability.Docker, Capability.Gpu, "high-memory"];
 });
 ```
 
@@ -24,15 +24,16 @@ builder.AddDistributedMode(o =>
 
 By default, `AutoDetectOsCapability` is `true`, which automatically adds the current operating system as a capability:
 
-- Windows runners advertise `"windows"`
-- Linux runners advertise `"linux"`
-- macOS runners advertise `"macos"`
+- Windows runners advertise `Capability.Windows`
+- Linux runners advertise `Capability.Linux`
+- macOS runners advertise `Capability.MacOS`
+- FreeBSD runners advertise `Capability.FreeBSD`
 
-This means modules with `[RequiresCapability("linux")]` will only run on Linux workers without any extra configuration.
+Attribute arguments must be compile-time constants, so use the corresponding `Capability.Names` values. For example, modules with `[RequiresCapability(Capability.Names.Linux)]` only run on Linux workers without extra configuration.
 
 ### Auto-Detected OS from Platform Conditions
 
-When a module has a `[RunIf<OnLinux>]`, `[RunIf<OnWindows>]`, `[RunIf<OnMacOS>]`, or `[RunIf<OnFreeBSD>]` attribute, the framework automatically adds the corresponding OS capability requirement to its assignment. This keeps the attribute set DRY — you don't need to add both `[RunIf<OnLinux>]` and `[RequiresCapability("linux")]` to the same module.
+When a module has a `[RunIf<OnLinux>]`, `[RunIf<OnWindows>]`, `[RunIf<OnMacOS>]`, or `[RunIf<OnFreeBSD>]` attribute, the framework automatically adds the corresponding OS capability requirement to its assignment. This keeps the attribute set DRY — you don't need to add both `[RunIf<OnLinux>]` and `[RequiresCapability(Capability.Names.Linux)]` to the same module.
 
 ```csharp
 // The "linux" capability is auto-detected — no [RequiresCapability] needed
@@ -53,7 +54,7 @@ public class LinuxBuildModule : Module<string>
 Mark a module with `[RequiresCapability]` to restrict which workers can execute it. The module will only be assigned to workers that have **all** required capabilities.
 
 ```csharp
-[RequiresCapability("docker")]
+[RequiresCapability(Capability.Names.Docker)]
 public class DockerBuildModule : Module<string>
 {
     protected override async Task<string> ExecuteAsync(
@@ -68,11 +69,10 @@ public class DockerBuildModule : Module<string>
 
 ### Multiple Capabilities
 
-You can stack multiple attributes. The module will only run on a worker that has **all** of them:
+Pass multiple names to one attribute or stack attributes. Both forms require **all** declared capabilities:
 
 ```csharp
-[RequiresCapability("linux")]
-[RequiresCapability("docker")]
+[RequiresCapability(Capability.Names.Linux, Capability.Names.Docker)]
 public class LinuxDockerModule : Module<string>
 {
     protected override async Task<string> ExecuteAsync(

--- a/docs/docs/distributed/configuration.md
+++ b/docs/docs/distributed/configuration.md
@@ -16,7 +16,7 @@ builder.AddDistributedMode(o =>
 {
     o.InstanceIndex = 0;
     o.TotalInstances = 4;
-    o.Capabilities = ["docker", "gpu"];
+    o.Capabilities = [Capability.Docker, Capability.Gpu];
     o.RunIdentifier = Environment.GetEnvironmentVariable("RUN_IDENTIFIER");
     o.CapabilityTimeout = TimeSpan.FromMinutes(5);
     o.ModuleResultTimeout = TimeSpan.FromMinutes(45);
@@ -28,7 +28,7 @@ builder.AddDistributedMode(o =>
 |----------|------|---------|-------------|
 | `InstanceIndex` | `int` | `0` | This instance's index. `0` = master, `> 0` = worker. Can be overridden by the `MODULAR_PIPELINES_INSTANCE` environment variable. |
 | `TotalInstances` | `int` | `1` | Total number of instances (master + workers). |
-| `Capabilities` | `IReadOnlyList<string>` | `[]` | Capabilities this worker advertises. Modules with `[RequiresCapability]` will only be assigned to workers that have matching capabilities. |
+| `Capabilities` | `IReadOnlyList<Capability>` | `[]` | Capabilities this worker advertises. Built-in values are available from `Capability`; strings convert implicitly for custom values. |
 | `RunIdentifier` | `string?` | `null` | Identifier shared by every process in this pipeline run. |
 | `CapabilityTimeout` | `TimeSpan` | `TimeSpan.FromMinutes(5)` | Maximum time to wait for worker registration before distributing work among the available workers. |
 | `ModuleResultTimeout` | `TimeSpan` | `TimeSpan.FromMinutes(45)` | Default maximum time to wait for a distributed module result. Use `TimeSpan.Zero` to wait indefinitely. |
@@ -52,6 +52,8 @@ You can also bind from configuration:
 ```csharp
 builder.AddDistributedMode(builder.Configuration.GetSection("Distributed"));
 ```
+
+Configuration binding converts the string array to `Capability` values. Distributed wire payloads also remain plain JSON strings.
 
 ## RedisDistributedOptions
 

--- a/docs/docs/distributed/configuration.md
+++ b/docs/docs/distributed/configuration.md
@@ -32,7 +32,7 @@ builder.AddDistributedMode(o =>
 | `RunIdentifier` | `string?` | `null` | Identifier shared by every process in this pipeline run. |
 | `CapabilityTimeout` | `TimeSpan` | `TimeSpan.FromMinutes(5)` | Maximum time to wait for worker registration before distributing work among the available workers. |
 | `ModuleResultTimeout` | `TimeSpan` | `TimeSpan.FromMinutes(45)` | Default maximum time to wait for a distributed module result. Use `TimeSpan.Zero` to wait indefinitely. |
-| `AutoDetectOsCapability` | `bool` | `true` | Automatically add the current OS as a capability (`"windows"`, `"linux"`, or `"macos"`). |
+| `AutoDetectOsCapability` | `bool` | `true` | Automatically add the current OS as a capability (`"windows"`, `"linux"`, `"macos"`, or `"freebsd"`). |
 
 ### Configuration from appsettings.json
 

--- a/docs/docs/distributed/github-actions.md
+++ b/docs/docs/distributed/github-actions.md
@@ -135,6 +135,7 @@ If you have a Redis instance accessible from the internet (or via a VPN), use it
 using ModularPipelines;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
+using ModularPipelines.Distributed;
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.Redis.Extensions;
 using ModularPipelines.Extensions;

--- a/docs/docs/distributed/github-actions.md
+++ b/docs/docs/distributed/github-actions.md
@@ -178,7 +178,7 @@ public class RestoreModule : Module<string>
     }
 }
 
-[RequiresCapability("linux")]
+[RequiresCapability(Capability.Names.Linux)]
 [DependsOn<RestoreModule>]
 public class LinuxBuildModule : Module<string>
 {
@@ -191,7 +191,7 @@ public class LinuxBuildModule : Module<string>
     }
 }
 
-[RequiresCapability("windows")]
+[RequiresCapability(Capability.Names.Windows)]
 [DependsOn<RestoreModule>]
 public class WindowsBuildModule : Module<string>
 {
@@ -204,7 +204,7 @@ public class WindowsBuildModule : Module<string>
     }
 }
 
-[RequiresCapability("macos")]
+[RequiresCapability(Capability.Names.MacOS)]
 [DependsOn<RestoreModule>]
 public class MacBuildModule : Module<string>
 {

--- a/docs/docs/distributed/overview.md
+++ b/docs/docs/distributed/overview.md
@@ -33,9 +33,9 @@ The coordinator is the shared communication layer between master and workers. It
 
 ### Capabilities
 
-Workers advertise what they can do (e.g. `"linux"`, `"docker"`, `"gpu"`). Modules declare what they need via `[RequiresCapability]` attributes. The coordinator only assigns a module to a worker that has all required capabilities.
+Workers advertise what they can do through typed values such as `Capability.Linux`, `Capability.Docker`, and `Capability.Gpu`. Modules declare what they need via `[RequiresCapability]` attributes using compile-time `Capability.Names` constants. The coordinator only assigns a module to a worker that has all required capabilities.
 
-If `AutoDetectOsCapability` is enabled (the default), workers automatically advertise their operating system (`"windows"`, `"linux"`, or `"macos"`).
+If `AutoDetectOsCapability` is enabled (the default), workers automatically advertise their operating system through the matching well-known capability.
 
 ## Architecture Diagram
 

--- a/src/ModularPipelines.Distributed.Redis/Coordination/RedisDistributedCoordinator.cs
+++ b/src/ModularPipelines.Distributed.Redis/Coordination/RedisDistributedCoordinator.cs
@@ -48,7 +48,7 @@ internal sealed class RedisDistributedCoordinator : IDistributedCoordinator
         await _subscriber.PublishAsync(RedisChannel.Literal(_keys.WorkAvailableChannel), "1");
     }
 
-    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> workerCapabilities, CancellationToken cancellationToken)
+    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken)
     {
         // Check if completion was already signalled before subscribing
         var completionFlag = await _database.StringGetAsync(_keys.CompletionFlag);
@@ -235,7 +235,7 @@ for i, item in ipairs(items) do
 end
 return nil";
 
-    private async Task<ModuleAssignment?> TryScanAndClaimAsync(IReadOnlySet<string> workerCapabilities)
+    private async Task<ModuleAssignment?> TryScanAndClaimAsync(IReadOnlySet<Capability> workerCapabilities)
     {
         var capsJson = JsonSerializer.Serialize(workerCapabilities.ToArray());
         var result = await _database.ScriptEvaluateAsync(

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -48,7 +48,7 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
         }
     }
 
-    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> workerCapabilities, CancellationToken cancellationToken)
+    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken)
     {
         // The master's worker loop dequeues from the pending queue.
         // Uses a semaphore signal instead of polling to avoid busy-waiting.
@@ -90,7 +90,7 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
         return null;
     }
 
-    private ModuleAssignment? TryScanPendingQueue(IReadOnlySet<string> workerCapabilities)
+    private ModuleAssignment? TryScanPendingQueue(IReadOnlySet<Capability> workerCapabilities)
     {
         var pendingCount = _state.PendingAssignments.Count;
         for (var i = 0; i < pendingCount; i++)

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
@@ -53,7 +53,7 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
         throw new NotSupportedException("Workers do not enqueue work. The master pushes assignments via hub callbacks.");
     }
 
-    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> workerCapabilities, CancellationToken cancellationToken)
+    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -86,7 +86,7 @@ internal class DistributedPipelineHub(
     /// <summary>
     /// Called by workers to request work when idle.
     /// </summary>
-    public async Task RequestWork(HashSet<string> capabilities)
+    public async Task RequestWork(HashSet<Capability> capabilities)
     {
         var state = _masterState;
 

--- a/src/ModularPipelines.GitHub/PipelineWriters/DistributedGitHubPipelineFileWriter.cs
+++ b/src/ModularPipelines.GitHub/PipelineWriters/DistributedGitHubPipelineFileWriter.cs
@@ -170,7 +170,7 @@ internal sealed class DistributedGitHubPipelineFileWriter : IBuildSystemPipeline
     {
         var declaredCapabilities = moduleType
             .GetCustomAttributes<RequiresCapabilityAttribute>(inherit: true)
-            .Select(attribute => attribute.Capability);
+            .SelectMany(attribute => attribute.Capabilities);
         var operatingSystemConditions = moduleType
             .GetCustomAttributes(inherit: true)
             .OfType<IConditionAttribute>()

--- a/src/ModularPipelines/Attributes/RequiresCapabilityAttribute.cs
+++ b/src/ModularPipelines/Attributes/RequiresCapabilityAttribute.cs
@@ -1,17 +1,25 @@
 namespace ModularPipelines.Attributes;
 
 /// <summary>
-/// Declares that a module requires a specific capability to execute.
-/// In distributed mode, the module will only be assigned to workers that advertise this capability.
-/// Multiple attributes create AND logic (all capabilities required).
+/// Declares capabilities that a module requires to execute.
+/// In distributed mode, the module will only be assigned to workers that advertise every capability.
+/// Multiple attributes and multiple values within one attribute both create AND logic.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
 public sealed class RequiresCapabilityAttribute : Attribute
 {
-    public RequiresCapabilityAttribute(string capability)
+    public RequiresCapabilityAttribute(params string[] capabilities)
     {
-        Capability = capability;
+        ArgumentNullException.ThrowIfNull(capabilities);
+        if (capabilities.Length == 0 || capabilities.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException(
+                "At least one non-empty capability is required.",
+                nameof(capabilities));
+        }
+
+        Capabilities = Array.AsReadOnly([.. capabilities]);
     }
 
-    public string Capability { get; }
+    public IReadOnlyList<string> Capabilities { get; }
 }

--- a/src/ModularPipelines/Distributed/Capabilities/CapabilityMatcher.cs
+++ b/src/ModularPipelines/Distributed/Capabilities/CapabilityMatcher.cs
@@ -15,14 +15,13 @@ public static class CapabilityMatcher
     /// <summary>
     /// Checks if the given capabilities satisfy a module assignment's requirements.
     /// </summary>
-    public static bool CanExecute(ModuleAssignment assignment, IReadOnlySet<string> workerCapabilities)
+    public static bool CanExecute(ModuleAssignment assignment, IReadOnlySet<Capability> workerCapabilities)
     {
         if (assignment.RequiredCapabilities.Count == 0)
         {
             return true;
         }
 
-        return assignment.RequiredCapabilities.All(
-            required => workerCapabilities.Contains(required, StringComparer.OrdinalIgnoreCase));
+        return assignment.RequiredCapabilities.All(workerCapabilities.Contains);
     }
 }

--- a/src/ModularPipelines/Distributed/Capabilities/OsCapabilityDetector.cs
+++ b/src/ModularPipelines/Distributed/Capabilities/OsCapabilityDetector.cs
@@ -5,28 +5,31 @@ namespace ModularPipelines.Distributed.Capabilities;
 
 internal static class OsCapabilityDetector
 {
-    public static IReadOnlyList<string> Detect()
+    public static IReadOnlyList<Capability> Detect()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return OperatingSystemConditions.GetWorkerCapabilities(OperatingSystemConditions.Windows);
+            return ToCapabilities(OperatingSystemConditions.Windows);
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return OperatingSystemConditions.GetWorkerCapabilities(OperatingSystemConditions.Linux);
+            return ToCapabilities(OperatingSystemConditions.Linux);
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            return OperatingSystemConditions.GetWorkerCapabilities(OperatingSystemConditions.MacOS);
+            return ToCapabilities(OperatingSystemConditions.MacOS);
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
         {
-            return OperatingSystemConditions.GetWorkerCapabilities(OperatingSystemConditions.FreeBSD);
+            return ToCapabilities(OperatingSystemConditions.FreeBSD);
         }
 
         return [];
     }
+
+    private static IReadOnlyList<Capability> ToCapabilities(string operatingSystem) =>
+        [.. OperatingSystemConditions.GetWorkerCapabilities(operatingSystem).Select(static name => new Capability(name))];
 }

--- a/src/ModularPipelines/Distributed/Capability.cs
+++ b/src/ModularPipelines/Distributed/Capability.cs
@@ -108,7 +108,10 @@ internal sealed class CapabilityJsonConverter : JsonConverter<Capability>
     public override void Write(
         Utf8JsonWriter writer,
         Capability value,
-        JsonSerializerOptions options)
+        JsonSerializerOptions options) =>
+        WriteValue(writer, value);
+
+    internal static void WriteValue(Utf8JsonWriter writer, Capability value)
     {
         if (string.IsNullOrWhiteSpace(value.Name))
         {

--- a/src/ModularPipelines/Distributed/Capability.cs
+++ b/src/ModularPipelines/Distributed/Capability.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ModularPipelines.Distributed;
+
+/// <summary>
+/// Identifies a capability that a distributed worker can provide.
+/// </summary>
+[TypeConverter(typeof(CapabilityTypeConverter))]
+[JsonConverter(typeof(CapabilityJsonConverter))]
+public readonly struct Capability : IEquatable<Capability>
+{
+    private readonly string? _name;
+
+    /// <summary>
+    /// Initializes a capability with its wire-format name.
+    /// </summary>
+    public Capability(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _name = name;
+    }
+
+    /// <summary>
+    /// Gets the wire-format capability name.
+    /// </summary>
+    public string Name => _name ?? string.Empty;
+
+    /// <summary>Windows operating system capability.</summary>
+    public static Capability Windows { get; } = new(Names.Windows);
+
+    /// <summary>Linux operating system capability.</summary>
+    public static Capability Linux { get; } = new(Names.Linux);
+
+    /// <summary>macOS operating system capability.</summary>
+    public static Capability MacOS { get; } = new(Names.MacOS);
+
+    /// <summary>FreeBSD operating system capability.</summary>
+    public static Capability FreeBSD { get; } = new(Names.FreeBSD);
+
+    /// <summary>Docker capability.</summary>
+    public static Capability Docker { get; } = new(Names.Docker);
+
+    /// <summary>GPU capability.</summary>
+    public static Capability Gpu { get; } = new(Names.Gpu);
+
+    /// <inheritdoc />
+    public bool Equals(Capability other) =>
+        StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Capability other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
+
+    /// <inheritdoc />
+    public override string ToString() => Name;
+
+    public static bool operator ==(Capability left, Capability right) => left.Equals(right);
+
+    public static bool operator !=(Capability left, Capability right) => !left.Equals(right);
+
+    public static implicit operator Capability(string name) => new(name);
+
+    public static implicit operator string(Capability capability) => capability.Name;
+
+    /// <summary>
+    /// Compile-time capability names suitable for attribute arguments.
+    /// </summary>
+    public static class Names
+    {
+        public const string Windows = "windows";
+        public const string Linux = "linux";
+        public const string MacOS = "macos";
+        public const string FreeBSD = "freebsd";
+        public const string Docker = "docker";
+        public const string Gpu = "gpu";
+    }
+}
+
+internal sealed class CapabilityTypeConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) =>
+        sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+    public override object? ConvertFrom(
+        ITypeDescriptorContext? context,
+        CultureInfo? culture,
+        object value) =>
+        value is string name
+            ? new Capability(name)
+            : base.ConvertFrom(context, culture, value);
+}
+
+internal sealed class CapabilityJsonConverter : JsonConverter<Capability>
+{
+    public override Capability Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) =>
+        reader.TokenType == JsonTokenType.String
+            ? new Capability(reader.GetString()!)
+            : throw new JsonException("Expected a capability string.");
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        Capability value,
+        JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.Name);
+}

--- a/src/ModularPipelines/Distributed/Capability.cs
+++ b/src/ModularPipelines/Distributed/Capability.cs
@@ -108,6 +108,13 @@ internal sealed class CapabilityJsonConverter : JsonConverter<Capability>
     public override void Write(
         Utf8JsonWriter writer,
         Capability value,
-        JsonSerializerOptions options) =>
+        JsonSerializerOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(value.Name))
+        {
+            throw new JsonException("A capability name cannot be empty.");
+        }
+
         writer.WriteStringValue(value.Name);
+    }
 }

--- a/src/ModularPipelines/Distributed/Coordination/InMemoryDistributedCoordinator.cs
+++ b/src/ModularPipelines/Distributed/Coordination/InMemoryDistributedCoordinator.cs
@@ -27,7 +27,7 @@ internal class InMemoryDistributedCoordinator : IDistributedCoordinator
         return Task.CompletedTask;
     }
 
-    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> workerCapabilities, CancellationToken cancellationToken)
+    public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/ModularPipelines/Distributed/DistributedOptions.cs
+++ b/src/ModularPipelines/Distributed/DistributedOptions.cs
@@ -14,7 +14,7 @@ public class DistributedOptions
     /// </summary>
     public string? RunIdentifier { get; set; }
 
-    public IReadOnlyList<string> Capabilities { get; set; } = [];
+    public IReadOnlyList<Capability> Capabilities { get; set; } = [];
 
     public TimeSpan CapabilityTimeout { get; set; } = TimeSpan.FromMinutes(5);
 

--- a/src/ModularPipelines/Distributed/IDistributedCoordinator.cs
+++ b/src/ModularPipelines/Distributed/IDistributedCoordinator.cs
@@ -8,7 +8,7 @@ public interface IDistributedCoordinator
 {
     // Work Queue
     Task EnqueueModuleAsync(ModuleAssignment assignment, CancellationToken cancellationToken);
-    Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> workerCapabilities, CancellationToken cancellationToken);
+    Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken);
 
     // Results
     Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken);

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -262,7 +262,7 @@ internal class DistributedModuleExecutor(
     {
         // Build master's capabilities (same logic as WorkerModuleExecutor)
         var options = _options.Value;
-        var capabilities = new HashSet<string>(options.Capabilities, StringComparer.OrdinalIgnoreCase);
+        var capabilities = new HashSet<Capability>(options.Capabilities);
         if (options.AutoDetectOsCapability)
         {
             capabilities.UnionWith(OsCapabilityDetector.Detect());

--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -49,8 +49,9 @@ internal class DistributedWorkPublisher(
         var requiredCapabilities = moduleType
             .GetCustomAttributes(typeof(RequiresCapabilityAttribute), true)
             .Cast<RequiresCapabilityAttribute>()
-            .Select(a => a.Capability)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .SelectMany(static attribute => attribute.Capabilities)
+            .Select(static name => new Capability(name))
+            .ToHashSet();
 
         var conditionAttributes = moduleType.GetCustomAttributes(true).OfType<IConditionAttribute>().ToArray();
         var operatingSystemRoutes = GetOperatingSystemRoutes(module, conditionAttributes);
@@ -136,7 +137,7 @@ internal class DistributedWorkPublisher(
     }
 
     private static void AddExplicitOperatingSystemRoutes(
-        ISet<string> requiredCapabilities,
+        ISet<Capability> requiredCapabilities,
         ICollection<OperatingSystemConditions.OperatingSystemRoute> routes)
     {
         foreach (var capability in requiredCapabilities.ToArray())
@@ -152,7 +153,7 @@ internal class DistributedWorkPublisher(
     }
 
     private static void AddOperatingSystemCapabilities(
-        ISet<string> requiredCapabilities,
+        ISet<Capability> requiredCapabilities,
         IReadOnlyList<OperatingSystemConditions.OperatingSystemRoute> routes)
     {
         var effectiveOperatingSystems = IntersectRoutes(routes);

--- a/src/ModularPipelines/Distributed/ModuleAssignment.cs
+++ b/src/ModularPipelines/Distributed/ModuleAssignment.cs
@@ -7,7 +7,7 @@ public record ModuleAssignment(
     string ModuleTypeName,
     string ResultTypeName,
     [property: JsonConverter(typeof(ReadOnlySetJsonConverter))]
-    IReadOnlySet<string> RequiredCapabilities,
+    IReadOnlySet<Capability> RequiredCapabilities,
     DateTimeOffset AssignedAt,
     ModuleAssignmentConfiguration Configuration,
     IReadOnlyList<SerializedModuleResult>? DependencyResults = null)

--- a/src/ModularPipelines/Distributed/Serialization/ReadOnlySetJsonConverter.cs
+++ b/src/ModularPipelines/Distributed/Serialization/ReadOnlySetJsonConverter.cs
@@ -48,7 +48,7 @@ public sealed class ReadOnlySetJsonConverter : JsonConverter<IReadOnlySet<Capabi
         writer.WriteStartArray();
         foreach (var item in value)
         {
-            writer.WriteStringValue(item.Name);
+            CapabilityJsonConverter.WriteValue(writer, item);
         }
 
         writer.WriteEndArray();

--- a/src/ModularPipelines/Distributed/Serialization/ReadOnlySetJsonConverter.cs
+++ b/src/ModularPipelines/Distributed/Serialization/ReadOnlySetJsonConverter.cs
@@ -5,12 +5,12 @@ using System.Text.Json.Serialization;
 namespace ModularPipelines.Distributed.Serialization;
 
 /// <summary>
-/// Serializes case-insensitive read-only string sets used by distributed messages.
+/// Serializes read-only capability sets as plain JSON string arrays.
 /// </summary>
-public sealed class ReadOnlySetJsonConverter : JsonConverter<IReadOnlySet<string>>
+public sealed class ReadOnlySetJsonConverter : JsonConverter<IReadOnlySet<Capability>>
 {
     /// <inheritdoc />
-    public override IReadOnlySet<string> Read(
+    public override IReadOnlySet<Capability> Read(
         ref Utf8JsonReader reader,
         Type typeToConvert,
         JsonSerializerOptions options)
@@ -20,7 +20,7 @@ public sealed class ReadOnlySetJsonConverter : JsonConverter<IReadOnlySet<string
             throw new JsonException("Expected a JSON array.");
         }
 
-        var values = new List<string>();
+        var values = new List<Capability>();
         while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
         {
             if (reader.TokenType != JsonTokenType.String)
@@ -28,7 +28,7 @@ public sealed class ReadOnlySetJsonConverter : JsonConverter<IReadOnlySet<string
                 throw new JsonException("Expected a string value.");
             }
 
-            values.Add(reader.GetString()!);
+            values.Add(new Capability(reader.GetString()!));
         }
 
         if (reader.TokenType != JsonTokenType.EndArray)
@@ -36,19 +36,19 @@ public sealed class ReadOnlySetJsonConverter : JsonConverter<IReadOnlySet<string
             throw new JsonException("Unexpected end of JSON array.");
         }
 
-        return values.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        return values.ToFrozenSet();
     }
 
     /// <inheritdoc />
     public override void Write(
         Utf8JsonWriter writer,
-        IReadOnlySet<string> value,
+        IReadOnlySet<Capability> value,
         JsonSerializerOptions options)
     {
         writer.WriteStartArray();
         foreach (var item in value)
         {
-            writer.WriteStringValue(item);
+            writer.WriteStringValue(item.Name);
         }
 
         writer.WriteEndArray();

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
@@ -105,9 +105,9 @@ internal class WorkerModuleExecutor(
         return executedModules;
     }
 
-    private static HashSet<string> BuildCapabilities(DistributedOptions options)
+    private static HashSet<Capability> BuildCapabilities(DistributedOptions options)
     {
-        var capabilities = new HashSet<string>(options.Capabilities, StringComparer.OrdinalIgnoreCase);
+        var capabilities = new HashSet<Capability>(options.Capabilities);
         if (options.AutoDetectOsCapability)
         {
             capabilities.UnionWith(OsCapabilityDetector.Detect());
@@ -116,7 +116,7 @@ internal class WorkerModuleExecutor(
         return capabilities;
     }
 
-    private async Task RegisterWorkerAsync(int instanceIndex, HashSet<string> capabilities, CancellationToken cancellationToken)
+    private async Task RegisterWorkerAsync(int instanceIndex, HashSet<Capability> capabilities, CancellationToken cancellationToken)
     {
         var registration = new WorkerRegistration(
             WorkerIndex: instanceIndex,

--- a/src/ModularPipelines/Distributed/WorkerRegistration.cs
+++ b/src/ModularPipelines/Distributed/WorkerRegistration.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.Distributed;
 public record WorkerRegistration(
     int WorkerIndex,
     [property: JsonConverter(typeof(ReadOnlySetJsonConverter))]
-    IReadOnlySet<string> Capabilities,
+    IReadOnlySet<Capability> Capabilities,
     DateTimeOffset RegisteredAt)
 {
     /// <summary>

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -362,7 +362,7 @@ internal sealed class RunReportService(
     private async Task PublishWorkerMetricsAsync(CancellationToken cancellationToken)
     {
         var options = distributedOptions.Value;
-        var capabilities = new HashSet<string>(options.Capabilities, StringComparer.OrdinalIgnoreCase);
+        var capabilities = new HashSet<Capability>(options.Capabilities);
         if (options.AutoDetectOsCapability)
         {
             capabilities.UnionWith(OsCapabilityDetector.Detect());

--- a/src/ModularPipelines/OperatingSystemConditions.cs
+++ b/src/ModularPipelines/OperatingSystemConditions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using ModularPipelines.Distributed;
 using ModularPipelines.Engine.Attributes;
 
 namespace ModularPipelines;
@@ -13,16 +14,16 @@ namespace ModularPipelines;
 internal static class OperatingSystemConditions
 {
     /// <summary>Capability identifier for Windows-only modules.</summary>
-    public const string Windows = "windows";
+    public const string Windows = Capability.Names.Windows;
 
     /// <summary>Capability identifier for Linux-only modules.</summary>
-    public const string Linux = "linux";
+    public const string Linux = Capability.Names.Linux;
 
     /// <summary>Capability identifier for macOS-only modules.</summary>
-    public const string MacOS = "macos";
+    public const string MacOS = Capability.Names.MacOS;
 
     /// <summary>Capability identifier for FreeBSD-only modules.</summary>
-    public const string FreeBSD = "freebsd";
+    public const string FreeBSD = Capability.Names.FreeBSD;
 
     private const string AlternativeCapabilityPrefix = "operating-system:";
     private static readonly string[] OperatingSystems = [Windows, Linux, MacOS, FreeBSD];

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -637,7 +637,7 @@ public sealed class PipelineBuilder
 
         public async Task EnqueueModuleAsync(ModuleAssignment a, CancellationToken ct) => await (await GetAsync(ct)).EnqueueModuleAsync(a, ct);
 
-        public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> c, CancellationToken ct) => await (await GetAsync(ct)).DequeueModuleAsync(c, ct);
+        public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> c, CancellationToken ct) => await (await GetAsync(ct)).DequeueModuleAsync(c, ct);
 
         public async Task PublishResultAsync(SerializedModuleResult r, CancellationToken ct) => await (await GetAsync(ct)).PublishResultAsync(r, ct);
 

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -78,6 +78,8 @@
 *REMOVED*ModularPipelines.Attributes.PlanningSafeDependsOnBaseAttribute.PlanningSafeDependsOnBaseAttribute() -> void
 *REMOVED*ModularPipelines.Attributes.PriorityAttribute.Priority.get -> ModularPipelines.Enums.ModulePriority
 *REMOVED*ModularPipelines.Attributes.PriorityAttribute.PriorityAttribute(ModularPipelines.Enums.ModulePriority priority) -> void
+*REMOVED*ModularPipelines.Attributes.RequiresCapabilityAttribute.Capability.get -> string!
+*REMOVED*ModularPipelines.Attributes.RequiresCapabilityAttribute.RequiresCapabilityAttribute(string! capability) -> void
 *REMOVED*ModularPipelines.Attributes.RunConditionAttribute
 *REMOVED*ModularPipelines.Attributes.RunConditionAttribute.RunConditionAttribute() -> void
 *REMOVED*ModularPipelines.Attributes.RunIfAllAttribute
@@ -352,6 +354,7 @@
 *REMOVED*ModularPipelines.Distributed.ArtifactOptions.TimeToLiveSeconds.set -> void
 *REMOVED*ModularPipelines.Distributed.DistributedOptions.CapabilityTimeoutSeconds.get -> int
 *REMOVED*ModularPipelines.Distributed.DistributedOptions.CapabilityTimeoutSeconds.set -> void
+*REMOVED*ModularPipelines.Distributed.DistributedOptions.Capabilities.get -> System.Collections.Generic.IReadOnlyList<string!>!
 *REMOVED*ModularPipelines.Distributed.DistributedOptions.ExecutionIdentifier.get -> string?
 *REMOVED*ModularPipelines.Distributed.DistributedOptions.ExecutionIdentifier.set -> void
 *REMOVED*ModularPipelines.Distributed.DistributedOptions.ModuleResultTimeoutSeconds.get -> int
@@ -360,11 +363,13 @@
 *REMOVED*ModularPipelines.Distributed.IArtifactContext.DownloadAsync(string! producerModuleTypeName, string! artifactName, string! destinationPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
 *REMOVED*ModularPipelines.Distributed.IArtifactContext.PublishDirectoryAsync(string! artifactName, string! directoryPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<ModularPipelines.Distributed.ArtifactReference!>!
 *REMOVED*ModularPipelines.Distributed.IArtifactContext.PublishFileAsync(string! artifactName, string! filePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<ModularPipelines.Distributed.ArtifactReference!>!
+*REMOVED*ModularPipelines.Distributed.IDistributedCoordinator.DequeueModuleAsync(System.Collections.Generic.IReadOnlySet<string!>! workerCapabilities, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<ModularPipelines.Distributed.ModuleAssignment?>!
 *REMOVED*ModularPipelines.Distributed.ModuleAssignment.Configuration.get -> ModularPipelines.Distributed.ModuleAssignmentConfig!
 *REMOVED*ModularPipelines.Distributed.ModuleAssignment.Deconstruct(out string! ModuleTypeName, out string! ResultTypeName, out System.Collections.Generic.IReadOnlySet<string!>! RequiredCapabilities, out string? MatrixTarget, out System.DateTimeOffset AssignedAt, out ModularPipelines.Distributed.ModuleAssignmentConfig! Configuration, out System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults) -> void
 *REMOVED*ModularPipelines.Distributed.ModuleAssignment.MatrixTarget.get -> string?
 *REMOVED*ModularPipelines.Distributed.ModuleAssignment.MatrixTarget.init -> void
 *REMOVED*ModularPipelines.Distributed.ModuleAssignment.ModuleAssignment(string! ModuleTypeName, string! ResultTypeName, System.Collections.Generic.IReadOnlySet<string!>! RequiredCapabilities, string? MatrixTarget, System.DateTimeOffset AssignedAt, ModularPipelines.Distributed.ModuleAssignmentConfig! Configuration, System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults = null) -> void
+*REMOVED*ModularPipelines.Distributed.ModuleAssignment.RequiredCapabilities.get -> System.Collections.Generic.IReadOnlySet<string!>!
 *REMOVED*ModularPipelines.Distributed.ModuleAssignmentConfig
 *REMOVED*ModularPipelines.Distributed.ModuleAssignmentConfig.AlwaysRun.get -> bool
 *REMOVED*ModularPipelines.Distributed.ModuleAssignmentConfig.AlwaysRun.init -> void
@@ -375,8 +380,11 @@
 *REMOVED*ModularPipelines.Distributed.ModuleAssignmentConfig.RetryCount.init -> void
 *REMOVED*ModularPipelines.Distributed.ModuleAssignmentConfig.TimeoutSeconds.get -> double?
 *REMOVED*ModularPipelines.Distributed.ModuleAssignmentConfig.TimeoutSeconds.init -> void
+*REMOVED*ModularPipelines.Distributed.WorkerRegistration.Capabilities.get -> System.Collections.Generic.IReadOnlySet<string!>!
+*REMOVED*ModularPipelines.Distributed.WorkerRegistration.Deconstruct(out int WorkerIndex, out System.Collections.Generic.IReadOnlySet<string!>! Capabilities, out System.DateTimeOffset RegisteredAt) -> void
 *REMOVED*ModularPipelines.Distributed.WorkerRegistration.ExecutionIdentifier.get -> string?
 *REMOVED*ModularPipelines.Distributed.WorkerRegistration.ExecutionIdentifier.init -> void
+*REMOVED*ModularPipelines.Distributed.WorkerRegistration.WorkerRegistration(int WorkerIndex, System.Collections.Generic.IReadOnlySet<string!>! Capabilities, System.DateTimeOffset RegisteredAt) -> void
 *REMOVED*ModularPipelines.Engine.IDependencyGraphExporter
 *REMOVED*ModularPipelines.Engine.IDependencyGraphExporter.ExportAsync(ModularPipelines.Enums.DependencyGraphFormat format, string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*ModularPipelines.Engine.IDependencyGraphExporter.RenderAsync(ModularPipelines.Enums.DependencyGraphFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
@@ -979,6 +987,8 @@
 *REMOVED*override ModularPipelines.Distributed.ModuleAssignmentConfig.Equals(object? obj) -> bool
 *REMOVED*override ModularPipelines.Distributed.ModuleAssignmentConfig.GetHashCode() -> int
 *REMOVED*override ModularPipelines.Distributed.ModuleAssignmentConfig.ToString() -> string!
+*REMOVED*override ModularPipelines.Distributed.Serialization.ReadOnlySetJsonConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.Collections.Generic.IReadOnlySet<string!>!
+*REMOVED*override ModularPipelines.Distributed.Serialization.ReadOnlySetJsonConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.Collections.Generic.IReadOnlySet<string!>! value, System.Text.Json.JsonSerializerOptions! options) -> void
 *REMOVED*override ModularPipelines.Engine.RunHistoryQuery.Equals(object? obj) -> bool
 *REMOVED*override ModularPipelines.Engine.RunHistoryQuery.GetHashCode() -> int
 *REMOVED*override ModularPipelines.Engine.RunHistoryQuery.ToString() -> string!
@@ -1103,6 +1113,7 @@
 *REMOVED*static ModularPipelines.Context.ContextExtensions.IsRunningInCI(this ModularPipelines.Context.IPipelineContext! context) -> bool
 *REMOVED*static ModularPipelines.Context.ContextExtensions.IsRunningLocally(this ModularPipelines.Context.IPipelineContext! context) -> bool
 *REMOVED*static ModularPipelines.Context.ContextExtensions.TryGetService<T>(this ModularPipelines.Context.IPipelineContext! context) -> T?
+*REMOVED*static ModularPipelines.Distributed.Capabilities.CapabilityMatcher.CanExecute(ModularPipelines.Distributed.ModuleAssignment! assignment, System.Collections.Generic.IReadOnlySet<string!>! workerCapabilities) -> bool
 *REMOVED*static ModularPipelines.Distributed.Extensions.ArtifactContextExtensions.Artifacts(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Distributed.IArtifactContext!
 *REMOVED*static ModularPipelines.Distributed.Extensions.ArtifactContextExtensions.Artifacts(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Distributed.IArtifactContext!
 *REMOVED*static ModularPipelines.Distributed.ModuleAssignmentConfig.operator !=(ModularPipelines.Distributed.ModuleAssignmentConfig? left, ModularPipelines.Distributed.ModuleAssignmentConfig? right) -> bool
@@ -1247,6 +1258,8 @@ ModularPipelines.Attributes.ExecutionHintAttribute.ExecutionHint.get -> ModularP
 ModularPipelines.Attributes.ExecutionHintAttribute.ExecutionHintAttribute(ModularPipelines.Enums.ExecutionHint executionHint) -> void
 ModularPipelines.Attributes.PriorityAttribute.Priority.get -> ModularPipelines.ModulePriority
 ModularPipelines.Attributes.PriorityAttribute.PriorityAttribute(ModularPipelines.ModulePriority priority) -> void
+ModularPipelines.Attributes.RequiresCapabilityAttribute.Capabilities.get -> System.Collections.Generic.IReadOnlyList<string!>!
+ModularPipelines.Attributes.RequiresCapabilityAttribute.RequiresCapabilityAttribute(params string![]! capabilities) -> void
 ModularPipelines.CommandResult
 ModularPipelines.CommandResult.CommandInput.get -> string!
 ModularPipelines.CommandResult.CommandInput.init -> void
@@ -1439,8 +1452,15 @@ ModularPipelines.DependsOnModulesWithTagAttribute.DependsOnModulesWithTagAttribu
 ModularPipelines.DependsOnModulesWithTagAttribute.Tag.get -> string!
 ModularPipelines.Distributed.ArtifactOptions.TimeToLive.get -> System.TimeSpan
 ModularPipelines.Distributed.ArtifactOptions.TimeToLive.set -> void
+ModularPipelines.Distributed.Capability
+ModularPipelines.Distributed.Capability.Capability() -> void
+ModularPipelines.Distributed.Capability.Capability(string! name) -> void
+ModularPipelines.Distributed.Capability.Equals(ModularPipelines.Distributed.Capability other) -> bool
+ModularPipelines.Distributed.Capability.Name.get -> string!
+ModularPipelines.Distributed.Capability.Names
 ModularPipelines.Distributed.DistributedOptions.CapabilityTimeout.get -> System.TimeSpan
 ModularPipelines.Distributed.DistributedOptions.CapabilityTimeout.set -> void
+ModularPipelines.Distributed.DistributedOptions.Capabilities.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.Capability>!
 ModularPipelines.Distributed.DistributedOptions.ModuleResultTimeout.get -> System.TimeSpan
 ModularPipelines.Distributed.DistributedOptions.ModuleResultTimeout.set -> void
 ModularPipelines.Distributed.DistributedOptions.RunIdentifier.get -> string?
@@ -1449,9 +1469,13 @@ ModularPipelines.Distributed.IArtifactContext.DownloadAsync(string! producerModu
 ModularPipelines.Distributed.IArtifactContext.DownloadAsync<TProducerModule>(string! artifactName, string! destinationPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 ModularPipelines.Distributed.IArtifactContext.PublishDirectoryAsync(string! artifactName, string! directoryPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Distributed.ArtifactReference!>!
 ModularPipelines.Distributed.IArtifactContext.PublishFileAsync(string! artifactName, string! filePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Distributed.ArtifactReference!>!
+ModularPipelines.Distributed.IDistributedCoordinator.DequeueModuleAsync(System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! workerCapabilities, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<ModularPipelines.Distributed.ModuleAssignment?>!
 ModularPipelines.Distributed.ModuleAssignment.Configuration.get -> ModularPipelines.Distributed.ModuleAssignmentConfiguration!
-ModularPipelines.Distributed.ModuleAssignment.Deconstruct(out string! ModuleTypeName, out string! ResultTypeName, out System.Collections.Generic.IReadOnlySet<string!>! RequiredCapabilities, out System.DateTimeOffset AssignedAt, out ModularPipelines.Distributed.ModuleAssignmentConfiguration! Configuration, out System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults) -> void
-ModularPipelines.Distributed.ModuleAssignment.ModuleAssignment(string! ModuleTypeName, string! ResultTypeName, System.Collections.Generic.IReadOnlySet<string!>! RequiredCapabilities, System.DateTimeOffset AssignedAt, ModularPipelines.Distributed.ModuleAssignmentConfiguration! Configuration, System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults = null) -> void
+*REMOVED*ModularPipelines.Distributed.ModuleAssignment.Deconstruct(out string! ModuleTypeName, out string! ResultTypeName, out System.Collections.Generic.IReadOnlySet<string!>! RequiredCapabilities, out System.DateTimeOffset AssignedAt, out ModularPipelines.Distributed.ModuleAssignmentConfiguration! Configuration, out System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults) -> void
+*REMOVED*ModularPipelines.Distributed.ModuleAssignment.ModuleAssignment(string! ModuleTypeName, string! ResultTypeName, System.Collections.Generic.IReadOnlySet<string!>! RequiredCapabilities, System.DateTimeOffset AssignedAt, ModularPipelines.Distributed.ModuleAssignmentConfiguration! Configuration, System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults = null) -> void
+ModularPipelines.Distributed.ModuleAssignment.Deconstruct(out string! ModuleTypeName, out string! ResultTypeName, out System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! RequiredCapabilities, out System.DateTimeOffset AssignedAt, out ModularPipelines.Distributed.ModuleAssignmentConfiguration! Configuration, out System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults) -> void
+ModularPipelines.Distributed.ModuleAssignment.ModuleAssignment(string! ModuleTypeName, string! ResultTypeName, System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! RequiredCapabilities, System.DateTimeOffset AssignedAt, ModularPipelines.Distributed.ModuleAssignmentConfiguration! Configuration, System.Collections.Generic.IReadOnlyList<ModularPipelines.Distributed.SerializedModuleResult!>? DependencyResults = null) -> void
+ModularPipelines.Distributed.ModuleAssignment.RequiredCapabilities.get -> System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>!
 ModularPipelines.Distributed.ModuleAssignment.SatisfiedConditionGroups.get -> System.Collections.Generic.IReadOnlyList<string!>!
 ModularPipelines.Distributed.ModuleAssignment.SatisfiedConditionGroups.init -> void
 ModularPipelines.Distributed.ModuleAssignmentConfiguration
@@ -1466,6 +1490,9 @@ ModularPipelines.Distributed.ModuleAssignmentConfiguration.TimeoutSeconds.get ->
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.TimeoutSeconds.init -> void
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.get -> string?
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.init -> void
+ModularPipelines.Distributed.WorkerRegistration.Capabilities.get -> System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>!
+ModularPipelines.Distributed.WorkerRegistration.Deconstruct(out int WorkerIndex, out System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! Capabilities, out System.DateTimeOffset RegisteredAt) -> void
+ModularPipelines.Distributed.WorkerRegistration.WorkerRegistration(int WorkerIndex, System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! Capabilities, System.DateTimeOffset RegisteredAt) -> void
 ModularPipelines.Enums.ExecutionHint
 ModularPipelines.Enums.ExecutionHint.CpuBound = 1 -> ModularPipelines.Enums.ExecutionHint
 ModularPipelines.Enums.ExecutionHint.Default = 0 -> ModularPipelines.Enums.ExecutionHint
@@ -2305,6 +2332,12 @@ abstract ModularPipelines.RunConditionAttribute.EvaluateAsync(ModularPipelines.I
 abstract ModularPipelines.RunConditionAttribute.Logic.get -> ModularPipelines.ConditionLogic
 abstract ModularPipelines.SyncModule.Execute(ModularPipelines.IModuleContext! context, System.Threading.CancellationToken cancellationToken) -> void
 abstract ModularPipelines.SyncModule<T>.Execute(ModularPipelines.IModuleContext! context, System.Threading.CancellationToken cancellationToken) -> T
+const ModularPipelines.Distributed.Capability.Names.Docker = "docker" -> string!
+const ModularPipelines.Distributed.Capability.Names.FreeBSD = "freebsd" -> string!
+const ModularPipelines.Distributed.Capability.Names.Gpu = "gpu" -> string!
+const ModularPipelines.Distributed.Capability.Names.Linux = "linux" -> string!
+const ModularPipelines.Distributed.Capability.Names.MacOS = "macos" -> string!
+const ModularPipelines.Distributed.Capability.Names.Windows = "windows" -> string!
 const ModularPipelines.Generated.RuntimeMetadataRegistry.CurrentCommandMetadataSchemaVersion = 4 -> int
 const ModularPipelines.Reporting.PipelineRunReport.CurrentSchemaVersion = 4 -> int
 const ModularPipelines.Tracing.PipelineTelemetry.CommandDurationTag = "modular_pipelines.command.duration_ms" -> string!
@@ -2334,9 +2367,14 @@ override ModularPipelines.CommandResult.ToString() -> string!
 override ModularPipelines.DependsOnModulesInCategoryAttribute.ShouldDependOn(System.Type! candidateModule, ModularPipelines.Context.IDependencyContext! context) -> bool
 override ModularPipelines.DependsOnModulesWithAttributeAttribute<TAttribute>.ShouldDependOn(System.Type! candidateModule, ModularPipelines.Context.IDependencyContext! context) -> bool
 override ModularPipelines.DependsOnModulesWithTagAttribute.ShouldDependOn(System.Type! candidateModule, ModularPipelines.Context.IDependencyContext! context) -> bool
+override ModularPipelines.Distributed.Capability.Equals(object? obj) -> bool
+override ModularPipelines.Distributed.Capability.GetHashCode() -> int
+override ModularPipelines.Distributed.Capability.ToString() -> string!
 override ModularPipelines.Distributed.ModuleAssignmentConfiguration.Equals(object? obj) -> bool
 override ModularPipelines.Distributed.ModuleAssignmentConfiguration.GetHashCode() -> int
 override ModularPipelines.Distributed.ModuleAssignmentConfiguration.ToString() -> string!
+override ModularPipelines.Distributed.Serialization.ReadOnlySetJsonConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>!
+override ModularPipelines.Distributed.Serialization.ReadOnlySetJsonConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! value, System.Text.Json.JsonSerializerOptions! options) -> void
 override ModularPipelines.FileSystem.FilePath.Equals(object? obj) -> bool
 override ModularPipelines.FileSystem.FilePath.GetHashCode() -> int
 override ModularPipelines.FileSystem.FilePath.ToString() -> string!
@@ -2535,6 +2573,17 @@ static ModularPipelines.Context.ContextExtensions.GetRequiredConfigValue(this Mo
 static ModularPipelines.Context.ContextExtensions.IsRunningIn(this ModularPipelines.IPipelineContext! context, ModularPipelines.Enums.BuildSystem buildSystem) -> bool
 static ModularPipelines.Context.ContextExtensions.IsRunningInCI(this ModularPipelines.IPipelineContext! context) -> bool
 static ModularPipelines.Context.ContextExtensions.IsRunningLocally(this ModularPipelines.IPipelineContext! context) -> bool
+static ModularPipelines.Distributed.Capabilities.CapabilityMatcher.CanExecute(ModularPipelines.Distributed.ModuleAssignment! assignment, System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>! workerCapabilities) -> bool
+static ModularPipelines.Distributed.Capability.Docker.get -> ModularPipelines.Distributed.Capability
+static ModularPipelines.Distributed.Capability.FreeBSD.get -> ModularPipelines.Distributed.Capability
+static ModularPipelines.Distributed.Capability.Gpu.get -> ModularPipelines.Distributed.Capability
+static ModularPipelines.Distributed.Capability.implicit operator ModularPipelines.Distributed.Capability(string! name) -> ModularPipelines.Distributed.Capability
+static ModularPipelines.Distributed.Capability.implicit operator string!(ModularPipelines.Distributed.Capability capability) -> string!
+static ModularPipelines.Distributed.Capability.Linux.get -> ModularPipelines.Distributed.Capability
+static ModularPipelines.Distributed.Capability.MacOS.get -> ModularPipelines.Distributed.Capability
+static ModularPipelines.Distributed.Capability.operator !=(ModularPipelines.Distributed.Capability left, ModularPipelines.Distributed.Capability right) -> bool
+static ModularPipelines.Distributed.Capability.operator ==(ModularPipelines.Distributed.Capability left, ModularPipelines.Distributed.Capability right) -> bool
+static ModularPipelines.Distributed.Capability.Windows.get -> ModularPipelines.Distributed.Capability
 static ModularPipelines.Distributed.Extensions.DistributedPipelineBuilderExtensions.AddDistributedArtifactStore<TStore>(this ModularPipelines.PipelineBuilder! builder) -> ModularPipelines.PipelineBuilder!
 static ModularPipelines.Distributed.Extensions.DistributedPipelineBuilderExtensions.AddDistributedArtifactStoreFactory<TFactory>(this ModularPipelines.PipelineBuilder! builder) -> ModularPipelines.PipelineBuilder!
 static ModularPipelines.Distributed.ModuleAssignmentConfiguration.operator !=(ModularPipelines.Distributed.ModuleAssignmentConfiguration? left, ModularPipelines.Distributed.ModuleAssignmentConfiguration? right) -> bool

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorTests.cs
@@ -73,7 +73,7 @@ public class RedisDistributedCoordinatorTests
             .ReturnsAsync(RedisResult.Create((RedisValue) json));
 
         var result = await _coordinator.DequeueModuleAsync(
-            new HashSet<string>(), CancellationToken.None);
+            new HashSet<Capability>(), CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.ModuleTypeName).IsEqualTo("Test.Module");
@@ -92,7 +92,7 @@ public class RedisDistributedCoordinatorTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
         var result = await _coordinator.DequeueModuleAsync(
-            new HashSet<string> { "linux" }, cts.Token);
+            new HashSet<Capability> { "linux" }, cts.Token);
 
         await Assert.That(result).IsNull();
     }
@@ -110,7 +110,7 @@ public class RedisDistributedCoordinatorTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
         var result = await _coordinator.DequeueModuleAsync(
-            new HashSet<string>(), cts.Token);
+            new HashSet<Capability>(), cts.Token);
 
         await Assert.That(result).IsNull();
     }
@@ -213,19 +213,19 @@ public class RedisDistributedCoordinatorTests
             .ReturnsAsync("1");
 
         var result = await _coordinator.DequeueModuleAsync(
-            new HashSet<string>(), CancellationToken.None);
+            new HashSet<Capability>(), CancellationToken.None);
 
         await Assert.That(result).IsNull();
     }
 
     private static ModuleAssignment CreateAssignment(
         string moduleTypeName,
-        HashSet<string>? requiredCapabilities = null)
+        HashSet<Capability>? requiredCapabilities = null)
     {
         return new ModuleAssignment(
             ModuleTypeName: moduleTypeName,
             ResultTypeName: "System.String",
-            RequiredCapabilities: requiredCapabilities ?? new HashSet<string>(),
+            RequiredCapabilities: requiredCapabilities ?? new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
     }
@@ -244,7 +244,7 @@ public class RedisDistributedCoordinatorTests
     {
         return new WorkerRegistration(
             WorkerIndex: workerIndex,
-            Capabilities: new HashSet<string> { "linux" },
+            Capabilities: new HashSet<Capability> { "linux" },
             RegisteredAt: DateTimeOffset.UtcNow);
     }
 }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/DistributedPipelineHubTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/DistributedPipelineHubTests.cs
@@ -15,7 +15,7 @@ public class DistributedPipelineHubTests
         var worker = new WorkerState
         {
             ConnectionId = "connection-1",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
         worker.TryAssign(CreateAssignment("CurrentModule"));
         state.Workers[worker.ConnectionId] = worker;
@@ -54,7 +54,7 @@ public class DistributedPipelineHubTests
         return new ModuleAssignment(
             moduleTypeName,
             "System.String",
-            FrozenSet<string>.Empty,
+            FrozenSet<Capability>.Empty,
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false));
     }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRIntegrationTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRIntegrationTests.cs
@@ -47,10 +47,10 @@ public class SignalRIntegrationTests
             var connection = BuildClient(serverHost.AdvertisedUrl, options.HubPath);
             await connection.StartAsync();
 
-            // Act — invoke RegisterWorker with a WorkerRegistration containing HashSet<string>
+            // Act — invoke RegisterWorker with a WorkerRegistration containing HashSet<Capability>
             var registration = new WorkerRegistration(
                 WorkerIndex: 1,
-                Capabilities: new HashSet<string> { "linux", "x64" },
+                Capabilities: new HashSet<Capability> { "linux", "x64" },
                 RegisteredAt: DateTimeOffset.UtcNow);
 
             await connection.InvokeAsync(HubMethodNames.RegisterWorker, registration, null);
@@ -88,7 +88,7 @@ public class SignalRIntegrationTests
 
             // Register first (required by hub)
             await connection.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+                new WorkerRegistration(1, new HashSet<Capability>(), DateTimeOffset.UtcNow),
                 null);
 
             // Pre-create a result waiter
@@ -149,14 +149,14 @@ public class SignalRIntegrationTests
 
             // Register as idle worker
             await connection.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow),
+                new WorkerRegistration(1, new HashSet<Capability> { "linux" }, DateTimeOffset.UtcNow),
                 null);
 
             // Enqueue work via master state (simulating master coordinator)
             var moduleAssignment = new ModuleAssignment(
                 ModuleTypeName: "MyModule",
                 ResultTypeName: "System.Int32",
-                RequiredCapabilities: new HashSet<string>(),
+                RequiredCapabilities: new HashSet<Capability>(),
                 AssignedAt: DateTimeOffset.UtcNow,
                 Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -164,7 +164,7 @@ public class SignalRIntegrationTests
 
             // Request work — triggers server to dequeue and push assignment
             await connection.InvokeAsync(HubMethodNames.RequestWork,
-                new HashSet<string> { "linux" });
+                new HashSet<Capability> { "linux" });
 
             // Wait for assignment to arrive
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -233,31 +233,31 @@ public class SignalRIntegrationTests
             await Task.WhenAll(worker1.StartAsync(), worker2.StartAsync(), worker3.StartAsync());
 
             await worker1.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow),
+                new WorkerRegistration(1, new HashSet<Capability> { "linux" }, DateTimeOffset.UtcNow),
                 null);
             await worker2.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(2, new HashSet<string> { "windows" }, DateTimeOffset.UtcNow),
+                new WorkerRegistration(2, new HashSet<Capability> { "windows" }, DateTimeOffset.UtcNow),
                 null);
             await worker3.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(3, new HashSet<string> { "linux", "docker" }, DateTimeOffset.UtcNow),
+                new WorkerRegistration(3, new HashSet<Capability> { "linux", "docker" }, DateTimeOffset.UtcNow),
                 null);
 
             // Enqueue 3 modules with different capability requirements
             var windowsModule = new ModuleAssignment(
                 "WindowsBuildModule", "System.String",
-                new HashSet<string> { "windows" },
+                new HashSet<Capability> { "windows" },
                 DateTimeOffset.UtcNow,
                 new ModuleAssignmentConfiguration(null, 0, false));
 
             var dockerModule = new ModuleAssignment(
                 "DockerBuildModule", "System.String",
-                new HashSet<string> { "linux", "docker" },
+                new HashSet<Capability> { "linux", "docker" },
                 DateTimeOffset.UtcNow,
                 new ModuleAssignmentConfiguration(null, 0, false));
 
             var genericModule = new ModuleAssignment(
                 "GenericModule", "System.String",
-                new HashSet<string>(),
+                new HashSet<Capability>(),
                 DateTimeOffset.UtcNow,
                 new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -266,9 +266,9 @@ public class SignalRIntegrationTests
             masterState.PendingAssignments.Enqueue(genericModule);
 
             // All workers request work
-            await worker1.InvokeAsync(HubMethodNames.RequestWork, new HashSet<string> { "linux" });
-            await worker2.InvokeAsync(HubMethodNames.RequestWork, new HashSet<string> { "windows" });
-            await worker3.InvokeAsync(HubMethodNames.RequestWork, new HashSet<string> { "linux", "docker" });
+            await worker1.InvokeAsync(HubMethodNames.RequestWork, new HashSet<Capability> { "linux" });
+            await worker2.InvokeAsync(HubMethodNames.RequestWork, new HashSet<Capability> { "windows" });
+            await worker3.InvokeAsync(HubMethodNames.RequestWork, new HashSet<Capability> { "linux", "docker" });
 
             // Wait for all assignments to be distributed
             allAssigned.Wait(TimeSpan.FromSeconds(5));
@@ -323,10 +323,10 @@ public class SignalRIntegrationTests
             await Task.WhenAll(worker1.StartAsync(), worker2.StartAsync());
 
             await worker1.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+                new WorkerRegistration(1, new HashSet<Capability>(), DateTimeOffset.UtcNow),
                 null);
             await worker2.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(2, new HashSet<string>(), DateTimeOffset.UtcNow),
+                new WorkerRegistration(2, new HashSet<Capability>(), DateTimeOffset.UtcNow),
                 null);
 
             // Pre-create result waiter for the master side
@@ -394,7 +394,7 @@ public class SignalRIntegrationTests
 
             await worker.StartAsync();
             await worker.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+                new WorkerRegistration(1, new HashSet<Capability>(), DateTimeOffset.UtcNow),
                 null);
 
             // Set up result waiters and enqueue 3 modules
@@ -408,12 +408,12 @@ public class SignalRIntegrationTests
                 resultTasks[moduleName] = tcs;
 
                 masterState.PendingAssignments.Enqueue(new ModuleAssignment(
-                    moduleName, "System.String", new HashSet<string>(),
+                    moduleName, "System.String", new HashSet<Capability>(),
                     DateTimeOffset.UtcNow, new ModuleAssignmentConfiguration(null, 0, false)));
             }
 
             // Worker requests work — will get first assignment, then re-request after each publish
-            await worker.InvokeAsync(HubMethodNames.RequestWork, new HashSet<string>());
+            await worker.InvokeAsync(HubMethodNames.RequestWork, new HashSet<Capability>());
 
             // Wait for all results
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
@@ -84,7 +84,7 @@ public class SignalRMasterCoordinatorTests
         var disconnectedWorker = new WorkerState
         {
             ConnectionId = "disconnected-worker",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
         var pending = state.TrackPendingReconnect(disconnectedWorker, assignment)!;
         pending.TryMakeAvailableForRedispatch();
@@ -92,7 +92,7 @@ public class SignalRMasterCoordinatorTests
         var worker = new WorkerState
         {
             ConnectionId = "reconnected-worker",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
 
         var restored = state.TryRestoreReconnect(
@@ -131,7 +131,7 @@ public class SignalRMasterCoordinatorTests
         var state = new SignalRMasterState();
         var coordinator = CreateCoordinator(state);
 
-        var registration = new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow);
+        var registration = new WorkerRegistration(1, new HashSet<Capability> { "linux" }, DateTimeOffset.UtcNow);
         await coordinator.RegisterWorkerAsync(registration, CancellationToken.None);
 
         await Assert.That(state.Registrations.Count).IsEqualTo(1);
@@ -145,9 +145,9 @@ public class SignalRMasterCoordinatorTests
         var coordinator = CreateCoordinator(state);
 
         await coordinator.RegisterWorkerAsync(
-            new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow), CancellationToken.None);
+            new WorkerRegistration(1, new HashSet<Capability>(), DateTimeOffset.UtcNow), CancellationToken.None);
         await coordinator.RegisterWorkerAsync(
-            new WorkerRegistration(2, new HashSet<string>(), DateTimeOffset.UtcNow), CancellationToken.None);
+            new WorkerRegistration(2, new HashSet<Capability>(), DateTimeOffset.UtcNow), CancellationToken.None);
 
         var workers = await coordinator.GetRegisteredWorkersAsync(CancellationToken.None);
         await Assert.That(workers.Count).IsEqualTo(2);
@@ -199,7 +199,7 @@ public class SignalRMasterCoordinatorTests
         state.Workers["conn-1"] = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, new HashSet<Capability> { "linux" }, DateTimeOffset.UtcNow),
         };
 
         var hubContext = new Mock<IHubContext<DistributedPipelineHub>>();
@@ -215,7 +215,7 @@ public class SignalRMasterCoordinatorTests
         // Enqueue a module requiring "linux"
         var assignment = new ModuleAssignment(
             "LinuxModule", "System.String",
-            new HashSet<string> { "linux" },
+            new HashSet<Capability> { "linux" },
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -242,7 +242,7 @@ public class SignalRMasterCoordinatorTests
         var disconnectedWorker = new WorkerState
         {
             ConnectionId = "disconnected-worker",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
         var pending = state.TrackPendingReconnect(disconnectedWorker, assignment)!;
         pending.TryMakeAvailableForRedispatch();
@@ -250,7 +250,7 @@ public class SignalRMasterCoordinatorTests
         var retryWorker = new WorkerState
         {
             ConnectionId = "retry-worker",
-            Registration = new WorkerRegistration(2, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(2, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
         state.Workers[retryWorker.ConnectionId] = retryWorker;
 
@@ -310,7 +310,7 @@ public class SignalRMasterCoordinatorTests
         state.Workers["conn-1"] = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, new HashSet<string> { "windows" }, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, new HashSet<Capability> { "windows" }, DateTimeOffset.UtcNow),
         };
 
         var coordinator = CreateCoordinator(state);
@@ -318,7 +318,7 @@ public class SignalRMasterCoordinatorTests
         // Enqueue a module requiring "linux" — no match
         var assignment = new ModuleAssignment(
             "LinuxModule", "System.String",
-            new HashSet<string> { "linux" },
+            new HashSet<Capability> { "linux" },
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -332,7 +332,7 @@ public class SignalRMasterCoordinatorTests
     {
         return new ModuleAssignment(
             moduleTypeName, "System.String",
-            new HashSet<string>(),
+            new HashSet<Capability>(),
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false));
     }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -11,7 +11,7 @@ public class SignalRMasterStateTests
         var worker = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
 
         var result = worker.TryAssign(CreateAssignment());
@@ -25,7 +25,7 @@ public class SignalRMasterStateTests
         var worker = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
 
         worker.TryAssign(CreateAssignment());
@@ -40,7 +40,7 @@ public class SignalRMasterStateTests
         var worker = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
 
         worker.TryAssign(CreateAssignment());
@@ -61,11 +61,11 @@ public class SignalRMasterStateTests
             state.Workers[$"conn-{i}"] = new WorkerState
             {
                 ConnectionId = $"conn-{i}",
-                Registration = new WorkerRegistration(i, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+                Registration = new WorkerRegistration(i, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
             };
-            state.Registrations[i] = new WorkerRegistration(i, FrozenSet<string>.Empty, DateTimeOffset.UtcNow);
+            state.Registrations[i] = new WorkerRegistration(i, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow);
             state.PendingAssignments.Enqueue(new ModuleAssignment(
-                $"Module{i}", "System.String", FrozenSet<string>.Empty,
+                $"Module{i}", "System.String", FrozenSet<Capability>.Empty,
                 DateTimeOffset.UtcNow, new ModuleAssignmentConfiguration(null, 0, false)));
             state.ResultWaiters[$"Module{i}"] = new TaskCompletionSource<SerializedModuleResult>();
         }));
@@ -96,7 +96,7 @@ public class SignalRMasterStateTests
             new ModuleAssignment(
                 "TestModule",
                 "System.String",
-                FrozenSet<string>.Empty,
+                FrozenSet<Capability>.Empty,
                 DateTimeOffset.UtcNow,
                 new ModuleAssignmentConfiguration(null, 0, false)));
 
@@ -152,7 +152,7 @@ public class SignalRMasterStateTests
         var replacement = new WorkerState
         {
             ConnectionId = "replacement",
-            Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
 
         await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
@@ -184,7 +184,7 @@ public class SignalRMasterStateTests
             var worker = new WorkerState
             {
                 ConnectionId = $"connection-{i}",
-                Registration = new WorkerRegistration(1, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+                Registration = new WorkerRegistration(1, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
             };
 
             var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -375,7 +375,7 @@ public class SignalRMasterStateTests
         return new WorkerState
         {
             ConnectionId = connectionId,
-            Registration = new WorkerRegistration(workerIndex, FrozenSet<string>.Empty, DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(workerIndex, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow),
         };
     }
 
@@ -384,7 +384,7 @@ public class SignalRMasterStateTests
         return new ModuleAssignment(
             "TestModule",
             "System.String",
-            FrozenSet<string>.Empty,
+            FrozenSet<Capability>.Empty,
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false));
     }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRWorkerCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRWorkerCoordinatorTests.cs
@@ -21,7 +21,7 @@ public class SignalRWorkerCoordinatorTests
         var assignment = new ModuleAssignment(
             "TestModule",
             "System.String",
-            FrozenSet<string>.Empty,
+            FrozenSet<Capability>.Empty,
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false));
 

--- a/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityMatcherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityMatcherTests.cs
@@ -10,13 +10,13 @@ public class CapabilityMatcherTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: "Test.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string>(),
+            RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
-            Capabilities: new HashSet<string> { "linux" },
+            Capabilities: new HashSet<Capability> { "linux" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         var result = CapabilityMatcher.CanExecute(assignment, worker);
@@ -30,13 +30,13 @@ public class CapabilityMatcherTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: "Test.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "docker", "linux" },
+            RequiredCapabilities: new HashSet<Capability> { "docker", "linux" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
-            Capabilities: new HashSet<string> { "docker", "linux", "high-memory" },
+            Capabilities: new HashSet<Capability> { "docker", "linux", "high-memory" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         var result = CapabilityMatcher.CanExecute(assignment, worker);
@@ -50,13 +50,13 @@ public class CapabilityMatcherTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: "Test.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "docker" },
+            RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
-            Capabilities: new HashSet<string> { "linux" },
+            Capabilities: new HashSet<Capability> { "linux" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         var result = CapabilityMatcher.CanExecute(assignment, worker);
@@ -70,13 +70,13 @@ public class CapabilityMatcherTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: "Test.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "Docker" },
+            RequiredCapabilities: new HashSet<Capability> { "Docker" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
-            Capabilities: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "docker" },
+            Capabilities: new HashSet<Capability> { "docker" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         var result = CapabilityMatcher.CanExecute(assignment, worker);

--- a/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityTests.cs
@@ -55,6 +55,13 @@ public class CapabilityTests
     }
 
     [Test]
+    public async Task Default_Capability_Cannot_Be_Serialized()
+    {
+        await Assert.That(() => JsonSerializer.Serialize(default(Capability)))
+            .Throws<JsonException>();
+    }
+
+    [Test]
     public async Task Implicit_String_Conversions_Preserve_Custom_Names()
     {
         Capability capability = "high-memory";

--- a/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Distributed.UnitTests.Capabilities;
+
+public class CapabilityTests
+{
+    [Test]
+    public async Task Equality_Is_Case_Insensitive()
+    {
+        Capability upper = "Docker";
+        Capability lower = "docker";
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(upper).IsEqualTo(lower);
+            await Assert.That(upper.GetHashCode()).IsEqualTo(lower.GetHashCode());
+            await Assert.That(new HashSet<Capability> { upper }.Contains(lower)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Known_Names_Work_For_Attributes()
+    {
+        var attribute = new RequiresCapabilityAttribute(
+            Capability.Names.Linux,
+            Capability.Names.Docker);
+
+        await Assert.That(attribute.Capabilities)
+            .IsEquivalentTo([Capability.Linux.Name, Capability.Docker.Name]);
+    }
+
+    [Test]
+    public async Task Attribute_Copies_Capability_Names()
+    {
+        var names = new[] { Capability.Names.Docker };
+        var attribute = new RequiresCapabilityAttribute(names);
+
+        names[0] = Capability.Names.Gpu;
+
+        await Assert.That(attribute.Capabilities).IsEquivalentTo([Capability.Names.Docker]);
+    }
+
+    [Test]
+    public async Task Json_Wire_Format_Is_A_Plain_String()
+    {
+        var json = JsonSerializer.Serialize(Capability.Docker);
+        var roundTripped = JsonSerializer.Deserialize<Capability>(json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(json).IsEqualTo("\"docker\"");
+            await Assert.That(roundTripped).IsEqualTo(Capability.Docker);
+        }
+    }
+
+    [Test]
+    public async Task Implicit_String_Conversions_Preserve_Custom_Names()
+    {
+        Capability capability = "high-memory";
+        string name = capability;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(capability.Name).IsEqualTo("high-memory");
+            await Assert.That(name).IsEqualTo("high-memory");
+        }
+    }
+
+    [Test]
+    public async Task Empty_Name_Is_Rejected()
+    {
+        await Assert.That(() => new Capability(" "))
+            .Throws<ArgumentException>();
+    }
+}

--- a/test/ModularPipelines.Distributed.UnitTests/Configuration/DistributedOptionsTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Configuration/DistributedOptionsTests.cs
@@ -33,7 +33,8 @@ public class DistributedOptionsTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(options.Capabilities).IsEquivalentTo(["docker", "gpu"]);
+            await Assert.That(options.Capabilities)
+                .IsEquivalentTo([Capability.Docker, Capability.Gpu]);
             await Assert.That(options.CapabilityTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
         }
     }

--- a/test/ModularPipelines.Distributed.UnitTests/Coordination/InMemoryDistributedCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Coordination/InMemoryDistributedCoordinatorTests.cs
@@ -26,7 +26,7 @@ public class InMemoryDistributedCoordinatorTests
 
         var registration = new WorkerRegistration(
             WorkerIndex: 1,
-            Capabilities: new HashSet<string> { "linux" },
+            Capabilities: new HashSet<Capability> { "linux" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         await coordinator.RegisterWorkerAsync(registration, CancellationToken.None);
@@ -52,7 +52,7 @@ public class InMemoryDistributedCoordinatorTests
         var dockerAssignment = new ModuleAssignment(
             ModuleTypeName: "Docker.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "docker" },
+            RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -61,7 +61,7 @@ public class InMemoryDistributedCoordinatorTests
         // Worker without docker capability should not get the assignment
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
         var result = await coordinator.DequeueModuleAsync(
-            new HashSet<string> { "linux" }, cts.Token);
+            new HashSet<Capability> { "linux" }, cts.Token);
 
         await Assert.That(result).IsNull();
     }

--- a/test/ModularPipelines.Distributed.UnitTests/DependencyResultPropagationTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/DependencyResultPropagationTests.cs
@@ -74,7 +74,7 @@ public class DependencyResultPropagationTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: typeof(ConsumerModule).FullName!,
             ResultTypeName: typeof(string).FullName!,
-            RequiredCapabilities: new HashSet<string>(),
+            RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false),
             DependencyResults: [serializedDep]);
@@ -118,7 +118,7 @@ public class DependencyResultPropagationTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: typeof(IndependentModule).FullName!,
             ResultTypeName: typeof(int).FullName!,
-            RequiredCapabilities: new HashSet<string>(),
+            RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false),
             DependencyResults: null);
@@ -134,7 +134,7 @@ public class DependencyResultPropagationTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: typeof(IndependentModule).FullName!,
             ResultTypeName: typeof(int).FullName!,
-            RequiredCapabilities: new HashSet<string>(),
+            RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false),
             DependencyResults: []);

--- a/test/ModularPipelines.Distributed.UnitTests/Integration/CapabilityRoutingIntegrationTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Integration/CapabilityRoutingIntegrationTests.cs
@@ -13,7 +13,7 @@ public class CapabilityRoutingIntegrationTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: "Docker.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "docker" },
+            RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -21,7 +21,7 @@ public class CapabilityRoutingIntegrationTests
 
         // Worker with docker capability
         var result = await coordinator.DequeueModuleAsync(
-            new HashSet<string> { "linux", "docker" }, CancellationToken.None);
+            new HashSet<Capability> { "linux", "docker" }, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.ModuleTypeName).IsEqualTo("Docker.Module");
@@ -35,7 +35,7 @@ public class CapabilityRoutingIntegrationTests
         var assignment = new ModuleAssignment(
             ModuleTypeName: "Docker.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "docker" },
+            RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
@@ -44,7 +44,7 @@ public class CapabilityRoutingIntegrationTests
         // Worker without docker capability - should timeout
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
         var result = await coordinator.DequeueModuleAsync(
-            new HashSet<string> { "linux" }, cts.Token);
+            new HashSet<Capability> { "linux" }, cts.Token);
 
         await Assert.That(result).IsNull();
     }
@@ -54,25 +54,25 @@ public class CapabilityRoutingIntegrationTests
     {
         var dockerWorker = new WorkerRegistration(
             WorkerIndex: 1,
-            Capabilities: new HashSet<string> { "linux", "docker" },
+            Capabilities: new HashSet<Capability> { "linux", "docker" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         var plainWorker = new WorkerRegistration(
             WorkerIndex: 2,
-            Capabilities: new HashSet<string> { "linux" },
+            Capabilities: new HashSet<Capability> { "linux" },
             RegisteredAt: DateTimeOffset.UtcNow);
 
         var dockerAssignment = new ModuleAssignment(
             ModuleTypeName: "Docker.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string> { "docker" },
+            RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 
         var plainAssignment = new ModuleAssignment(
             ModuleTypeName: "Plain.Module",
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string>(),
+            RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
 

--- a/test/ModularPipelines.Distributed.UnitTests/Integration/DistributedPipelineIntegrationTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Integration/DistributedPipelineIntegrationTests.cs
@@ -63,7 +63,7 @@ public class DistributedPipelineIntegrationTests
 
         // Simulate worker: dequeue the assignment
         var workerAssignment = await coordinator.DequeueModuleAsync(
-            new HashSet<string>(), CancellationToken.None);
+            new HashSet<Capability>(), CancellationToken.None);
         await Assert.That(workerAssignment).IsNotNull();
 
         // Simulate worker producing a serialized result

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -191,7 +191,7 @@ public class DistributedModuleExecutorTests
         public Task EnqueueModuleAsync(ModuleAssignment assignment, CancellationToken cancellationToken)
             => inner.EnqueueModuleAsync(assignment, cancellationToken);
 
-        public Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> workerCapabilities, CancellationToken cancellationToken)
+        public Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken)
             => Task.FromResult<ModuleAssignment?>(null);
 
         public Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
@@ -1277,7 +1277,7 @@ public class DistributedModuleExecutorTests
             .Returns<string, CancellationToken>((_, token) =>
                 Task.FromCanceled<SerializedModuleResult>(token));
         coordinator.Setup(c => c.DequeueModuleAsync(
-                It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<IReadOnlySet<Capability>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((ModuleAssignment?) null);
         coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
@@ -1323,7 +1323,7 @@ public class DistributedModuleExecutorTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(publishException);
         coordinator.Setup(c => c.DequeueModuleAsync(
-                It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<IReadOnlySet<Capability>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((ModuleAssignment?) null);
         coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
@@ -1369,7 +1369,7 @@ public class DistributedModuleExecutorTests
             .Returns<ModuleAssignment, CancellationToken>(
                 (_, token) => Task.Delay(Timeout.InfiniteTimeSpan, token));
         coordinator.Setup(c => c.DequeueModuleAsync(
-                It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<IReadOnlySet<Capability>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((ModuleAssignment?) null);
         coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
@@ -1527,7 +1527,7 @@ public class DistributedModuleExecutorTests
         var executionTask = executor.ExecuteAsync([module]);
         await noDequeue.WorkerQueryStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await coordinator.RegisterWorkerAsync(
-            new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+            new WorkerRegistration(1, new HashSet<Capability>(), DateTimeOffset.UtcNow),
             CancellationToken.None);
         noDequeue.ReleaseWorkerQuery();
         await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -1577,7 +1577,7 @@ public class DistributedModuleExecutorTests
         var coordinator = new Mock<IDistributedCoordinator>();
         var registeredWorkers = new List<WorkerRegistration>
         {
-            new(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+            new(1, new HashSet<Capability>(), DateTimeOffset.UtcNow),
         };
         coordinator.Setup(c => c.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => registeredWorkers.AsReadOnly());

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
@@ -155,6 +155,14 @@ public class DistributedWorkPublisherTests
             CancellationToken cancellationToken) => Task.FromResult(string.Empty);
     }
 
+    [RequiresCapability(Capability.Names.Linux, Capability.Names.Docker)]
+    private sealed class MultipleCapabilitiesModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(string.Empty);
+    }
+
     [RunIfAny<OnLinux, FalseCondition>]
     [RunIf<OnWindows>]
     private sealed class ConflictingMixedGenericAlternativeModule : Module<string>
@@ -408,6 +416,26 @@ public class DistributedWorkPublisherTests
         var assignment = publisher.CreateAssignment(new WorkerOnlyConditionGroupModule());
 
         await Assert.That(assignment.RequiredCapabilities).IsEmpty();
+    }
+
+    [Test]
+    public async Task CreateAssignment_Flattens_Multiple_Capabilities_From_One_Attribute()
+    {
+        var coordinator = new InMemoryDistributedCoordinator();
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(MultipleCapabilitiesModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var resultRegistry = new ModuleResultRegistry();
+        var publisher = new DistributedWorkPublisher(
+            coordinator,
+            typeRegistry,
+            serializer,
+            resultRegistry);
+
+        var assignment = publisher.CreateAssignment(new MultipleCapabilitiesModule());
+
+        await Assert.That(assignment.RequiredCapabilities)
+            .IsEquivalentTo([Capability.Linux, Capability.Docker]);
     }
 
     [Test]

--- a/test/ModularPipelines.Distributed.UnitTests/Serialization/ReadOnlySetJsonConverterTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Serialization/ReadOnlySetJsonConverterTests.cs
@@ -13,10 +13,10 @@ public class ReadOnlySetJsonConverterTests
     [Test]
     public async Task RoundTrip_PreservesValuesAndCaseInsensitiveComparison()
     {
-        IReadOnlySet<string> expected = new HashSet<string> { "Docker", "GPU" };
+        IReadOnlySet<Capability> expected = new HashSet<Capability> { "Docker", "GPU" };
 
         var json = JsonSerializer.Serialize(expected, JsonOptions);
-        var actual = JsonSerializer.Deserialize<IReadOnlySet<string>>(json, JsonOptions);
+        var actual = JsonSerializer.Deserialize<IReadOnlySet<Capability>>(json, JsonOptions);
 
         await Assert.That(actual).IsNotNull();
         await Assert.That(actual!).IsEquivalentTo(expected);
@@ -29,7 +29,7 @@ public class ReadOnlySetJsonConverterTests
         var expected = new ModuleAssignment(
             "BuildModule",
             "System.String",
-            new HashSet<string> { "Docker" },
+            new HashSet<Capability> { "Docker" },
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfiguration(null, 0, false))
         {
@@ -50,7 +50,7 @@ public class ReadOnlySetJsonConverterTests
     {
         var expected = new WorkerRegistration(
             1,
-            new HashSet<string> { "Docker" },
+            new HashSet<Capability> { "Docker" },
             DateTimeOffset.UtcNow)
         {
             UnattributedCommandCount = 3,

--- a/test/ModularPipelines.Distributed.UnitTests/Serialization/ReadOnlySetJsonConverterTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Serialization/ReadOnlySetJsonConverterTests.cs
@@ -63,4 +63,16 @@ public class ReadOnlySetJsonConverterTests
         await Assert.That(actual!.Capabilities.Contains("docker")).IsTrue();
         await Assert.That(actual.UnattributedCommandCount).IsEqualTo(3);
     }
+
+    [Test]
+    public async Task WorkerRegistration_Rejects_Default_Capabilities()
+    {
+        var registration = new WorkerRegistration(
+            1,
+            new HashSet<Capability> { default },
+            DateTimeOffset.UtcNow);
+
+        await Assert.That(() => JsonSerializer.Serialize(registration))
+            .Throws<JsonException>();
+    }
 }

--- a/test/ModularPipelines.GitHub.UnitTests/Engine/DistributedPipelineWriterTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/Engine/DistributedPipelineWriterTests.cs
@@ -138,7 +138,7 @@ public class DistributedPipelineWriterTests : TestBase
             "run: dotnet run --project 'src/My Pipeline'\"'\"'s/Pipeline.csproj' -c Release");
     }
 
-    [RequiresCapability("linux")]
+    [RequiresCapability("linux", "docker")]
     private sealed class LinuxModule : SimpleTestModule<bool>
     {
         protected override bool Result => true;

--- a/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
+++ b/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
@@ -9,7 +9,7 @@ public static class DistributedCoordinatorContract
         Task? waitUntilReady = null)
     {
         var assignment = CreateAssignment("Contract.EnqueueDequeue");
-        var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<string>(), CancellationToken.None);
+        var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<Capability>(), CancellationToken.None);
 
         await WaitUntilReadyAsync(waitUntilReady);
         await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
@@ -39,7 +39,7 @@ public static class DistributedCoordinatorContract
         IDistributedCoordinator coordinator,
         Task? waitUntilReady = null)
     {
-        var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<string>(), CancellationToken.None);
+        var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<Capability>(), CancellationToken.None);
 
         await WaitUntilReadyAsync(waitUntilReady);
         await coordinator.SignalCompletionAsync(CancellationToken.None);
@@ -61,7 +61,7 @@ public static class DistributedCoordinatorContract
         return new ModuleAssignment(
             ModuleTypeName: moduleTypeName,
             ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string>(),
+            RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(null, 0, false));
     }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -2999,7 +2999,7 @@ public class RunReportTests
         var coordinator = new Mock<IDistributedCoordinator>();
         coordinator.Setup(x => x.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([
-                new WorkerRegistration(1, new HashSet<string>(), runStartedAt)
+                new WorkerRegistration(1, new HashSet<Capability>(), runStartedAt)
                 {
                     UnattributedCommandCount = 3,
                     ModuleCommandCounts = new Dictionary<string, int>(StringComparer.Ordinal)
@@ -3007,7 +3007,7 @@ public class RunReportTests
                         [moduleTypeIdentifier] = 3,
                     },
                 },
-                new WorkerRegistration(2, new HashSet<string>(), runStartedAt)
+                new WorkerRegistration(2, new HashSet<Capability>(), runStartedAt)
                 {
                     UnattributedCommandCount = 0,
                     ModuleCommandCounts = new Dictionary<string, int>(StringComparer.Ordinal),
@@ -3204,7 +3204,7 @@ public class RunReportTests
         coordinator.Setup(x => x.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             [
-                new WorkerRegistration(1, new HashSet<string>(), runStartedAt)
+                new WorkerRegistration(1, new HashSet<Capability>(), runStartedAt)
                 {
                     UnattributedCommandCount = 0,
                     ModuleCommandCounts = new Dictionary<string, int>(StringComparer.Ordinal)
@@ -3214,7 +3214,7 @@ public class RunReportTests
                 },
                 .. collectedRemoteWorkerIndex == 1
                     ? Array.Empty<WorkerRegistration>()
-                    : [new WorkerRegistration(2, new HashSet<string>(), runStartedAt)],
+                    : [new WorkerRegistration(2, new HashSet<Capability>(), runStartedAt)],
             ]);
         var commandExecutionCounter = new CommandExecutionCounter();
         commandExecutionCounter.AddRemote(
@@ -3288,7 +3288,7 @@ public class RunReportTests
             var coordinator = new Mock<IDistributedCoordinator>();
             coordinator.Setup(x => x.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync([
-                    new WorkerRegistration(1, new HashSet<string>(), runStartedAt)
+                    new WorkerRegistration(1, new HashSet<Capability>(), runStartedAt)
                     {
                         UnattributedCommandCount = 0,
                         ModuleCommandCounts = new Dictionary<string, int>(StringComparer.Ordinal)
@@ -3296,7 +3296,7 @@ public class RunReportTests
                             [moduleTypeIdentifier] = 3,
                         },
                     },
-                    new WorkerRegistration(2, new HashSet<string>(), runStartedAt),
+                    new WorkerRegistration(2, new HashSet<Capability>(), runStartedAt),
                 ]);
             var commandExecutionCounter = new CommandExecutionCounter();
             commandExecutionCounter.Add(firstType, count: 5);
@@ -3361,7 +3361,7 @@ public class RunReportTests
         });
         var incompleteRegistration = new WorkerRegistration(
             1,
-            new HashSet<string>(),
+            new HashSet<Capability>(),
             runStartedAt);
         var pollingCount = 0;
         var coordinator = new Mock<IDistributedCoordinator>();
@@ -3473,7 +3473,7 @@ public class RunReportTests
         var coordinator = new Mock<IDistributedCoordinator>();
         coordinator.Setup(x => x.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([
-                new WorkerRegistration(1, new HashSet<string>(), runStartedAt)
+                new WorkerRegistration(1, new HashSet<Capability>(), runStartedAt)
                 {
                     UnattributedCommandCount = 3,
                 },
@@ -3527,12 +3527,12 @@ public class RunReportTests
         var coordinator = new Mock<IDistributedCoordinator>();
         coordinator.Setup(x => x.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([
-                new WorkerRegistration(1, new HashSet<string>(), runStartedAt.AddMinutes(-5))
+                new WorkerRegistration(1, new HashSet<Capability>(), runStartedAt.AddMinutes(-5))
                 {
                     RunIdentifier = runIdentifier,
                     UnattributedCommandCount = 3,
                 },
-                new WorkerRegistration(2, new HashSet<string>(), runStartedAt.AddMinutes(5))
+                new WorkerRegistration(2, new HashSet<Capability>(), runStartedAt.AddMinutes(5))
                 {
                     RunIdentifier = "previous-run",
                     UnattributedCommandCount = 99,


### PR DESCRIPTION
Closes #4375

## Summary
- add a case-insensitive `Capability` value type with built-in values and compile-time `Names` constants
- migrate distributed runtime APIs and transports to typed capabilities while preserving plain-string JSON/configuration
- support multiple required capabilities in one attribute and document the v4 API

## Validation
- API analyzer build: 0 warnings, 0 errors
- ModularPipelines.Distributed.UnitTests: 117 passed
- ModularPipelines.Distributed.SignalR.UnitTests: 41 passed
- ModularPipelines.Distributed.Redis.UnitTests: 45 passed, 3 environment-dependent skips
- RunReportTests: 94 passed
- changed-path formatting verification: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed capabilities with built-in Docker, GPU, Windows, Linux, macOS, and FreeBSD values.
  * Capability requirements can now include multiple values in a single declaration.
  * Custom capabilities continue to support string conversion.
  * Configuration and distributed communication retain readable string-based capability formats.

* **Documentation**
  * Updated distributed pipeline guidance with typed capability examples, OS detection details, and multi-capability requirements.

* **Bug Fixes**
  * Improved consistency and case-insensitive behavior when matching worker capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->