### PR TITLE
Stabilize archive extraction cancellation test

### DIFF
--- a/test/ModularPipelines.UnitTests/Api/ArtifactContextApiTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/ArtifactContextApiTests.cs
@@ -331,36 +331,53 @@ public class ArtifactContextApiTests
     [Test]
     public async Task Directory_Archive_Extraction_Observes_Cancellation()
     {
-        var archivePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.zip");
-        var destinationDirectory = Directory.CreateTempSubdirectory("artifact-extraction-");
+        await using var archiveStream = new MemoryStream();
+        using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, leaveOpen: true))
+        await using (var entryStream = archive.CreateEntry(
+                         "payload.bin",
+                         CompressionLevel.NoCompression).Open())
+        {
+            await entryStream.WriteAsync(new byte[1024 * 1024]);
+        }
+
+        var archiveBytes = archiveStream.ToArray();
+        for (var iteration = 0; iteration < 10; iteration++)
+        {
+            await VerifyArchiveExtractionCancellationAsync(archiveBytes, iteration);
+        }
+    }
+
+    private static async Task VerifyArchiveExtractionCancellationAsync(
+        byte[] archiveBytes,
+        int iteration)
+    {
+        var destinationDirectory = Directory.CreateTempSubdirectory(
+            $"artifact-extraction-{iteration}-");
+        await using var archiveStream = new MemoryStream(archiveBytes, writable: false);
+        await using var blockingStream = new BlockingReadStream(archiveStream);
+        using var archiveToExtract = new ZipArchive(
+            blockingStream,
+            ZipArchiveMode.Read,
+            leaveOpen: true);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        blockingStream.BlockReads();
+        var extractionTask = ArtifactContextImpl.ExtractDirectoryArchiveAsync(
+            archiveToExtract,
+            destinationDirectory.FullName,
+            cancellationTokenSource.Token);
 
         try
         {
-            await using (var archiveStream = File.Create(archivePath))
-            using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create))
-            await using (var entryStream = archive.CreateEntry(
-                             "payload.bin",
-                             CompressionLevel.NoCompression).Open())
-            {
-                var buffer = new byte[64 * 1024];
-                for (var index = 0; index < 1024; index++)
-                {
-                    await entryStream.WriteAsync(buffer);
-                }
-            }
-
-            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
-            using var archiveToExtract = ZipFile.OpenRead(archivePath);
-
+            await blockingStream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellationTokenSource.Cancel();
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                ArtifactContextImpl.ExtractDirectoryArchiveAsync(
-                    archiveToExtract,
-                    destinationDirectory.FullName,
-                    cancellationTokenSource.Token));
+                extractionTask);
         }
         finally
         {
-            File.Delete(archivePath);
+            await cancellationTokenSource.CancelAsync();
+            blockingStream.ReleaseReads();
+            await extractionTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             destinationDirectory.Delete(recursive: true);
         }
     }
@@ -445,6 +462,76 @@ public class ArtifactContextApiTests
             IModuleContext context,
             CancellationToken cancellationToken)
             => Task.FromResult(string.Empty);
+    }
+
+    private sealed class BlockingReadStream(Stream inner) : Stream
+    {
+        private readonly TaskCompletionSource _readStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseReads = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _blockReads;
+
+        public Task ReadStarted => _readStarted.Task;
+
+        public override bool CanRead => inner.CanRead;
+
+        public override bool CanSeek => inner.CanSeek;
+
+        public override bool CanWrite => inner.CanWrite;
+
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public void BlockReads() => _blockReads = true;
+
+        public void ReleaseReads() => _releaseReads.TrySetResult();
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            inner.Read(buffer, offset, count);
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            await WaitForReleaseAsync(cancellationToken);
+            return await inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            await WaitForReleaseAsync(cancellationToken);
+            return await inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            inner.Write(buffer, offset, count);
+
+        private Task WaitForReleaseAsync(CancellationToken cancellationToken)
+        {
+            if (!_blockReads)
+            {
+                return Task.CompletedTask;
+            }
+
+            _readStarted.TrySetResult();
+            return _releaseReads.Task.WaitAsync(cancellationToken);
+        }
     }
 
     [PublishArtifactOnReady]

--- a/test/ModularPipelines.UnitTests/Api/ArtifactContextApiTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/ArtifactContextApiTests.cs
@@ -371,7 +371,7 @@ public class ArtifactContextApiTests
             await blockingStream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
             cancellationTokenSource.Cancel();
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                extractionTask);
+                extractionTask.WaitAsync(TimeSpan.FromSeconds(5)));
         }
         finally
         {

--- a/test/ModularPipelines.UnitTests/Api/ArtifactContextApiTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/ArtifactContextApiTests.cs
@@ -354,17 +354,18 @@ public class ArtifactContextApiTests
         var destinationDirectory = Directory.CreateTempSubdirectory(
             $"artifact-extraction-{iteration}-");
         await using var archiveStream = new MemoryStream(archiveBytes, writable: false);
-        await using var blockingStream = new BlockingReadStream(archiveStream);
+        await using var blockingStream = new SwitchableBlockingReadStream(archiveStream);
         using var archiveToExtract = new ZipArchive(
             blockingStream,
             ZipArchiveMode.Read,
             leaveOpen: true);
         using var cancellationTokenSource = new CancellationTokenSource();
-        blockingStream.BlockReads();
-        var extractionTask = ArtifactContextImpl.ExtractDirectoryArchiveAsync(
-            archiveToExtract,
-            destinationDirectory.FullName,
-            cancellationTokenSource.Token);
+        blockingStream.BlockReads(cancellationTokenSource.Token);
+        var extractionTask = Task.Run(() =>
+            ArtifactContextImpl.ExtractDirectoryArchiveAsync(
+                archiveToExtract,
+                destinationDirectory.FullName,
+                cancellationTokenSource.Token));
 
         try
         {
@@ -375,6 +376,7 @@ public class ArtifactContextApiTests
         }
         finally
         {
+            // Ensure cleanup also cancels when setup or an assertion fails before the explicit cancellation.
             await cancellationTokenSource.CancelAsync();
             blockingStream.ReleaseReads();
             await extractionTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
@@ -464,13 +466,14 @@ public class ArtifactContextApiTests
             => Task.FromResult(string.Empty);
     }
 
-    private sealed class BlockingReadStream(Stream inner) : Stream
+    private sealed class SwitchableBlockingReadStream(Stream inner) : Stream
     {
         private readonly TaskCompletionSource _readStarted = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource _releaseReads = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        private bool _blockReads;
+        private volatile bool _blockReads;
+        private CancellationToken _blockingCancellationToken;
 
         public Task ReadStarted => _readStarted.Task;
 
@@ -488,14 +491,27 @@ public class ArtifactContextApiTests
             set => inner.Position = value;
         }
 
-        public void BlockReads() => _blockReads = true;
+        public void BlockReads(CancellationToken cancellationToken)
+        {
+            _blockingCancellationToken = cancellationToken;
+            _blockReads = true;
+        }
 
         public void ReleaseReads() => _releaseReads.TrySetResult();
 
         public override void Flush() => inner.Flush();
 
-        public override int Read(byte[] buffer, int offset, int count) =>
-            inner.Read(buffer, offset, count);
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            WaitForRelease();
+            return inner.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            WaitForRelease();
+            return inner.Read(buffer);
+        }
 
         public override async Task<int> ReadAsync(
             byte[] buffer,
@@ -531,6 +547,17 @@ public class ArtifactContextApiTests
 
             _readStarted.TrySetResult();
             return _releaseReads.Task.WaitAsync(cancellationToken);
+        }
+
+        private void WaitForRelease()
+        {
+            if (!_blockReads)
+            {
+                return;
+            }
+
+            _readStarted.TrySetResult();
+            _releaseReads.Task.Wait(_blockingCancellationToken);
         }
     }
 


### PR DESCRIPTION
Closes #4479

Replaces the runner-speed-dependent timer cancellation with a deterministic stream checkpoint, repeats the scenario ten times, and guarantees cleanup after the extraction task settles.

Validation: ArtifactContextApiTests 19/19 passed; formatting verification passed.