### PR TITLE
Preserve remote module failure diagnostics

### DIFF
--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -264,7 +264,10 @@ internal class DistributedWorkPublisher(
             }
 
             var depResultTypeName = ModuleTypeRegistry.GetResultTypeName(depType) ?? "System.Object";
-            var serialized = _serializer.Serialize(result, depType.FullName!, depResultTypeName, workerIndex: -1);
+            var workerIndex = result.ExceptionOrDefault is RemoteModuleException { WorkerIndex: { } origin }
+                ? origin
+                : -1;
+            var serialized = _serializer.Serialize(result, depType.FullName!, depResultTypeName, workerIndex);
 
             // Compress large results to stay within transport payload limits.
             if (serialized.SerializedJson.Length > CompressionThresholdBytes)

--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -264,7 +264,7 @@ internal class DistributedWorkPublisher(
             }
 
             var depResultTypeName = ModuleTypeRegistry.GetResultTypeName(depType) ?? "System.Object";
-            var workerIndex = result.ExceptionOrDefault is RemoteModuleException { WorkerIndex: { } origin }
+            var workerIndex = result is ModuleResult { WorkerIndex: { } origin }
                 ? origin
                 : -1;
             var serialized = _serializer.Serialize(result, depType.FullName!, depResultTypeName, workerIndex);

--- a/src/ModularPipelines/Distributed/RemoteModuleException.cs
+++ b/src/ModularPipelines/Distributed/RemoteModuleException.cs
@@ -1,3 +1,5 @@
+using System.Runtime.ExceptionServices;
+
 namespace ModularPipelines.Distributed;
 
 /// <summary>
@@ -24,6 +26,10 @@ public sealed class RemoteModuleException : Exception
         OriginalMessage = originalMessage;
         RemoteStackTrace = remoteStackTrace;
         WorkerIndex = workerIndex;
+        if (!string.IsNullOrEmpty(remoteStackTrace))
+        {
+            ExceptionDispatchInfo.SetRemoteStackTrace(this, remoteStackTrace);
+        }
     }
 
     /// <summary>
@@ -52,10 +58,13 @@ public sealed class RemoteModuleException : Exception
         : $"Remote execution threw {OriginalExceptionType}: {OriginalMessage}";
 
     /// <inheritdoc />
-    public override string? StackTrace => RemoteStackTrace;
+    public override string? StackTrace => base.StackTrace;
 
     internal void AttachWorkerIndex(int workerIndex)
     {
-        WorkerIndex ??= workerIndex;
+        if (workerIndex >= 0)
+        {
+            WorkerIndex ??= workerIndex;
+        }
     }
 }

--- a/src/ModularPipelines/Distributed/RemoteModuleException.cs
+++ b/src/ModularPipelines/Distributed/RemoteModuleException.cs
@@ -1,0 +1,61 @@
+namespace ModularPipelines.Distributed;
+
+/// <summary>
+/// Represents an exception thrown by a module on a remote distributed worker when the
+/// original exception type cannot be reconstructed safely in the current process.
+/// </summary>
+public sealed class RemoteModuleException : Exception
+{
+    /// <summary>
+    /// Initialises a new instance of the <see cref="RemoteModuleException"/> class.
+    /// </summary>
+    /// <param name="originalExceptionType">The fully qualified type name of the original exception.</param>
+    /// <param name="originalMessage">The original exception message.</param>
+    /// <param name="remoteStackTrace">The stack trace captured on the remote worker.</param>
+    /// <param name="workerIndex">The distributed worker index, when known.</param>
+    public RemoteModuleException(
+        string originalExceptionType,
+        string originalMessage,
+        string? remoteStackTrace,
+        int? workerIndex = null)
+        : base(originalMessage)
+    {
+        OriginalExceptionType = originalExceptionType;
+        OriginalMessage = originalMessage;
+        RemoteStackTrace = remoteStackTrace;
+        WorkerIndex = workerIndex;
+    }
+
+    /// <summary>
+    /// Gets the fully qualified type name of the exception thrown by the worker.
+    /// </summary>
+    public string OriginalExceptionType { get; }
+
+    /// <summary>
+    /// Gets the original exception message returned by the worker.
+    /// </summary>
+    public string OriginalMessage { get; }
+
+    /// <summary>
+    /// Gets the stack trace captured on the worker.
+    /// </summary>
+    public string? RemoteStackTrace { get; }
+
+    /// <summary>
+    /// Gets the index of the distributed worker that returned the failure, when known.
+    /// </summary>
+    public int? WorkerIndex { get; private set; }
+
+    /// <inheritdoc />
+    public override string Message => WorkerIndex is { } workerIndex
+        ? $"Remote worker {workerIndex} threw {OriginalExceptionType}: {OriginalMessage}"
+        : $"Remote execution threw {OriginalExceptionType}: {OriginalMessage}";
+
+    /// <inheritdoc />
+    public override string? StackTrace => RemoteStackTrace;
+
+    internal void AttachWorkerIndex(int workerIndex)
+    {
+        WorkerIndex ??= workerIndex;
+    }
+}

--- a/src/ModularPipelines/Distributed/RemoteModuleException.cs
+++ b/src/ModularPipelines/Distributed/RemoteModuleException.cs
@@ -57,9 +57,6 @@ public sealed class RemoteModuleException : Exception
         ? $"Remote worker {workerIndex} threw {OriginalExceptionType}: {OriginalMessage}"
         : $"Remote execution threw {OriginalExceptionType}: {OriginalMessage}";
 
-    /// <inheritdoc />
-    public override string? StackTrace => base.StackTrace;
-
     internal void AttachWorkerIndex(int workerIndex)
     {
         if (workerIndex >= 0)

--- a/src/ModularPipelines/Distributed/Serialization/ModuleResultSerializer.cs
+++ b/src/ModularPipelines/Distributed/Serialization/ModuleResultSerializer.cs
@@ -80,6 +80,7 @@ internal class ModuleResultSerializer
                 $"Cannot deserialize result for module '{serialized.ModuleTypeName}': type not found in registry.");
         var resultType = typeof(ModuleResult<>).MakeGenericType(resolved.ResultType);
         var result = JsonSerializer.Deserialize(serialized.SerializedJson, resultType, _options) as ModuleResult;
+        int? workerIndex = serialized.WorkerIndex >= 0 ? serialized.WorkerIndex : null;
         if (result?.ExceptionOrDefault is RemoteModuleException remoteException)
         {
             remoteException.AttachWorkerIndex(serialized.WorkerIndex);
@@ -91,6 +92,7 @@ internal class ModuleResultSerializer
             {
                 ModuleType = resolved.ModuleType,
                 TypeName = ModuleTypeIdentifier.Get(resolved.ModuleType),
+                WorkerIndex = workerIndex,
             };
     }
 }

--- a/src/ModularPipelines/Distributed/Serialization/ModuleResultSerializer.cs
+++ b/src/ModularPipelines/Distributed/Serialization/ModuleResultSerializer.cs
@@ -80,6 +80,11 @@ internal class ModuleResultSerializer
                 $"Cannot deserialize result for module '{serialized.ModuleTypeName}': type not found in registry.");
         var resultType = typeof(ModuleResult<>).MakeGenericType(resolved.ResultType);
         var result = JsonSerializer.Deserialize(serialized.SerializedJson, resultType, _options) as ModuleResult;
+        if (result?.ExceptionOrDefault is RemoteModuleException remoteException)
+        {
+            remoteException.AttachWorkerIndex(serialized.WorkerIndex);
+        }
+
         return result is null
             ? null
             : result with

--- a/src/ModularPipelines/ModuleResult.cs
+++ b/src/ModularPipelines/ModuleResult.cs
@@ -492,7 +492,6 @@ public abstract record ModuleResult<T> : ModuleResult
 /// </remarks>
 internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
 {
-    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Exception types are validated against the System namespace before activation.")]
     public override Exception? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Null)
@@ -500,6 +499,13 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
             return null;
         }
 
+        var (typeName, message, stackTrace) = ReadExceptionData(ref reader);
+        return CreateException(typeName, message, stackTrace);
+    }
+
+    private static (string? TypeName, string? Message, string? StackTrace) ReadExceptionData(
+        ref Utf8JsonReader reader)
+    {
         string? typeName = null;
         string? message = null;
         string? stackTrace = null;
@@ -532,6 +538,28 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
             }
         }
 
+        return (typeName, message, stackTrace);
+    }
+
+    private static Exception CreateException(string? typeName, string? message, string? stackTrace)
+    {
+        var systemException = TryCreateSystemException(typeName, message);
+        if (systemException is not null)
+        {
+            return systemException;
+        }
+
+        return typeName is null
+            ? new Exception(message ?? "Deserialized exception")
+            : new RemoteModuleException(
+                typeName,
+                message ?? "Deserialized exception",
+                stackTrace);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Exception types are validated against the System namespace before activation.")]
+    private static Exception? TryCreateSystemException(string? typeName, string? message)
+    {
         // Try to reconstruct the original exception type if possible
         // Security: Only allow well-known exception types from System namespace
         if (typeName != null)
@@ -555,12 +583,7 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
             }
         }
 
-        return typeName is null
-            ? new Exception(message ?? "Deserialized exception")
-            : new RemoteModuleException(
-                typeName,
-                message ?? "Deserialized exception",
-                stackTrace);
+        return null;
     }
 
     public override void Write(Utf8JsonWriter writer, Exception value, JsonSerializerOptions options)

--- a/src/ModularPipelines/ModuleResult.cs
+++ b/src/ModularPipelines/ModuleResult.cs
@@ -58,6 +58,12 @@ public abstract record ModuleResult : IModuleResult
     [JsonInclude]
     public string? TypeName { get; init; }
 
+    /// <summary>
+    /// Gets the distributed worker index that produced this result, when known.
+    /// </summary>
+    [JsonIgnore]
+    public int? WorkerIndex { get; internal init; }
+
     // === Safe accessors (no exceptions) ===
 
     /// <inheritdoc />
@@ -384,6 +390,7 @@ public abstract record ModuleResult<T> : ModuleResult
             EndTime = failure.EndTime,
             Status = failure.Status,
             ModuleType = failure.ModuleType,
+            WorkerIndex = failure.WorkerIndex,
         };
 
     /// <summary>
@@ -400,6 +407,7 @@ public abstract record ModuleResult<T> : ModuleResult
             EndTime = skipped.EndTime,
             Status = skipped.Status,
             ModuleType = skipped.ModuleType,
+            WorkerIndex = skipped.WorkerIndex,
         };
 
     // === Internal factory methods ===

--- a/src/ModularPipelines/ModuleResult.cs
+++ b/src/ModularPipelines/ModuleResult.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using ModularPipelines.Distributed;
 using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
@@ -460,7 +461,7 @@ public abstract record ModuleResult<T> : ModuleResult
 
 /// <summary>
 /// JSON converter for Exception objects. Serializes essential exception data
-/// and deserializes to a wrapper exception preserving the message.
+/// and deserializes unknown types to a wrapper preserving their diagnostics.
 /// </summary>
 /// <remarks>
 /// <para><strong>Security Considerations:</strong></para>
@@ -485,7 +486,8 @@ public abstract record ModuleResult<T> : ModuleResult
 /// </list>
 /// <para>
 /// On deserialization, only well-known exception types from the System namespace are
-/// reconstructed. Unknown types fall back to a generic Exception to prevent type injection.
+/// reconstructed. Unknown types become <see cref="RemoteModuleException"/> instances to
+/// prevent type injection while retaining their original diagnostics.
 /// </para>
 /// </remarks>
 internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
@@ -500,6 +502,7 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
 
         string? typeName = null;
         string? message = null;
+        string? stackTrace = null;
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
@@ -521,6 +524,9 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
                         message = reader.GetString();
                         break;
                     case "StackTrace":
+                        stackTrace = reader.TokenType == JsonTokenType.Null
+                            ? null
+                            : reader.GetString();
                         break;
                 }
             }
@@ -549,11 +555,12 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
             }
         }
 
-        // NOTE: StackTrace is intentionally not restored during deserialization.
-        // Setting the StackTrace property via reflection is fragile and can cause issues.
-        // The original stack trace is preserved in the JSON for diagnostic purposes,
-        // but deserialized exceptions will have a new stack trace from deserialization.
-        return new Exception(message ?? "Deserialized exception");
+        return typeName is null
+            ? new Exception(message ?? "Deserialized exception")
+            : new RemoteModuleException(
+                typeName,
+                message ?? "Deserialized exception",
+                stackTrace);
     }
 
     public override void Write(Utf8JsonWriter writer, Exception value, JsonSerializerOptions options)
@@ -562,9 +569,15 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
 
         // Security: Use FullName instead of AssemblyQualifiedName to avoid leaking
         // assembly version, culture, and public key token information
-        writer.WriteString("Type", value.GetType().FullName);
-        writer.WriteString("Message", value.Message);
-        writer.WriteString("StackTrace", value.StackTrace);
+        var remoteException = value as RemoteModuleException;
+        var typeName = remoteException?.OriginalExceptionType ?? value.GetType().FullName;
+        var message = remoteException?.OriginalMessage ?? value.Message;
+        var stackTrace = remoteException?.RemoteStackTrace ?? value.StackTrace;
+
+        writer.WriteString("Type", typeName);
+        writer.WriteString("Message", message);
+        writer.WriteString("StackTrace", stackTrace);
+
         writer.WriteEndObject();
     }
 }

--- a/src/ModularPipelines/ModuleResult.cs
+++ b/src/ModularPipelines/ModuleResult.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -546,15 +547,27 @@ internal sealed class ExceptionJsonConverter : JsonConverter<Exception>
         var systemException = TryCreateSystemException(typeName, message);
         if (systemException is not null)
         {
-            return systemException;
+            return RestoreRemoteStackTrace(systemException, stackTrace);
         }
 
         return typeName is null
-            ? new Exception(message ?? "Deserialized exception")
+            ? RestoreRemoteStackTrace(
+                new Exception(message ?? "Deserialized exception"),
+                stackTrace)
             : new RemoteModuleException(
                 typeName,
                 message ?? "Deserialized exception",
                 stackTrace);
+    }
+
+    private static Exception RestoreRemoteStackTrace(Exception exception, string? stackTrace)
+    {
+        if (!string.IsNullOrEmpty(stackTrace))
+        {
+            ExceptionDispatchInfo.SetRemoteStackTrace(exception, stackTrace);
+        }
+
+        return exception;
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Exception types are validated against the System namespace before activation.")]

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1489,6 +1489,14 @@ ModularPipelines.Distributed.ModuleAssignmentConfiguration.RetryCount.get -> int
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.RetryCount.init -> void
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.TimeoutSeconds.get -> double?
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.TimeoutSeconds.init -> void
+ModularPipelines.Distributed.RemoteModuleException
+ModularPipelines.Distributed.RemoteModuleException.OriginalExceptionType.get -> string!
+ModularPipelines.Distributed.RemoteModuleException.OriginalMessage.get -> string!
+ModularPipelines.Distributed.RemoteModuleException.RemoteModuleException(string! originalExceptionType, string! originalMessage, string? remoteStackTrace, int? workerIndex = null) -> void
+ModularPipelines.Distributed.RemoteModuleException.RemoteStackTrace.get -> string?
+ModularPipelines.Distributed.RemoteModuleException.WorkerIndex.get -> int?
+override ModularPipelines.Distributed.RemoteModuleException.Message.get -> string!
+override ModularPipelines.Distributed.RemoteModuleException.StackTrace.get -> string?
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.get -> string?
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.init -> void
 ModularPipelines.Distributed.WorkerRegistration.Capabilities.get -> System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>!

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1496,7 +1496,6 @@ ModularPipelines.Distributed.RemoteModuleException.RemoteModuleException(string!
 ModularPipelines.Distributed.RemoteModuleException.RemoteStackTrace.get -> string?
 ModularPipelines.Distributed.RemoteModuleException.WorkerIndex.get -> int?
 override ModularPipelines.Distributed.RemoteModuleException.Message.get -> string!
-override ModularPipelines.Distributed.RemoteModuleException.StackTrace.get -> string?
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.get -> string?
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.init -> void
 ModularPipelines.Distributed.WorkerRegistration.Capabilities.get -> System.Collections.Generic.IReadOnlySet<ModularPipelines.Distributed.Capability>!
@@ -1865,6 +1864,7 @@ ModularPipelines.ModuleResult.Status.get -> ModularPipelines.ModuleStatus
 ModularPipelines.ModuleResult.Status.init -> void
 ModularPipelines.ModuleResult.TypeName.get -> string?
 ModularPipelines.ModuleResult.TypeName.init -> void
+ModularPipelines.ModuleResult.WorkerIndex.get -> int?
 ModularPipelines.ModuleResult<T>
 ModularPipelines.ModuleResult<T>.Failure
 ModularPipelines.ModuleResult<T>.Failure.Deconstruct(out System.Exception! Exception) -> void

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
@@ -251,6 +251,7 @@ public class DistributedWorkPublisherTests
             StartTime = now,
             EndTime = now,
             Status = ModuleStatus.Failed,
+            WorkerIndex = 3,
         };
         resultRegistry.RegisterResult(typeof(DependencyModule), depResult);
         var publisher = new DistributedWorkPublisher(
@@ -268,6 +269,44 @@ public class DistributedWorkPublisherTests
         var relayedException = relayedResult!.ExceptionOrDefault as RemoteModuleException;
         await Assert.That(relayedException).IsNotNull();
         await Assert.That(relayedException!.WorkerIndex).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task CreateAssignment_Preserves_System_Dependency_Failure_Worker_Index()
+    {
+        var coordinator = new InMemoryDistributedCoordinator();
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DependencyModule));
+        typeRegistry.Register(typeof(ConsumerModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var resultRegistry = new ModuleResultRegistry();
+        var now = DateTimeOffset.UtcNow;
+        ModuleResult<DepResult> depResult = new ModuleResult<DepResult>.Failure(
+            new InvalidOperationException("worker failed"))
+        {
+            Name = nameof(DependencyModule),
+            TypeName = typeof(DependencyModule).FullName,
+            Duration = TimeSpan.Zero,
+            StartTime = now,
+            EndTime = now,
+            Status = ModuleStatus.Failed,
+            WorkerIndex = 3,
+        };
+        resultRegistry.RegisterResult(typeof(DependencyModule), depResult);
+        var publisher = new DistributedWorkPublisher(
+            coordinator,
+            typeRegistry,
+            serializer,
+            resultRegistry);
+
+        var assignment = publisher.CreateAssignment(new ConsumerModule());
+
+        var serializedDependency = assignment.DependencyResults!.Single();
+        await Assert.That(serializedDependency.WorkerIndex).IsEqualTo(3);
+        var relayedResult = serializer.Deserialize(serializedDependency);
+        await Assert.That(relayedResult!.ExceptionOrDefault)
+            .IsTypeOf<InvalidOperationException>();
+        await Assert.That(((ModuleResult) relayedResult).WorkerIndex).IsEqualTo(3);
     }
 
     [Test]

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
@@ -233,6 +233,44 @@ public class DistributedWorkPublisherTests
     }
 
     [Test]
+    public async Task CreateAssignment_Preserves_Dependency_Failure_Worker_Index()
+    {
+        var coordinator = new InMemoryDistributedCoordinator();
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DependencyModule));
+        typeRegistry.Register(typeof(ConsumerModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var resultRegistry = new ModuleResultRegistry();
+        var now = DateTimeOffset.UtcNow;
+        ModuleResult<DepResult> depResult = new ModuleResult<DepResult>.Failure(
+            new RemoteModuleException("WorkerException", "worker failed", "remote stack", workerIndex: 3))
+        {
+            Name = nameof(DependencyModule),
+            TypeName = typeof(DependencyModule).FullName,
+            Duration = TimeSpan.Zero,
+            StartTime = now,
+            EndTime = now,
+            Status = ModuleStatus.Failed,
+        };
+        resultRegistry.RegisterResult(typeof(DependencyModule), depResult);
+        var publisher = new DistributedWorkPublisher(
+            coordinator,
+            typeRegistry,
+            serializer,
+            resultRegistry);
+
+        var assignment = publisher.CreateAssignment(new ConsumerModule());
+
+        await Assert.That(assignment.DependencyResults).IsNotNull();
+        var serializedDependency = assignment.DependencyResults!.Single();
+        await Assert.That(serializedDependency.WorkerIndex).IsEqualTo(3);
+        var relayedResult = serializer.Deserialize(serializedDependency);
+        var relayedException = relayedResult!.ExceptionOrDefault as RemoteModuleException;
+        await Assert.That(relayedException).IsNotNull();
+        await Assert.That(relayedException!.WorkerIndex).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task CreateAssignment_Includes_Fluent_DependencyResults()
     {
         var coordinator = new InMemoryDistributedCoordinator();

--- a/test/ModularPipelines.Distributed.UnitTests/Serialization/ModuleResultSerializerTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Serialization/ModuleResultSerializerTests.cs
@@ -107,6 +107,7 @@ public class ModuleResultSerializerTests
                 .IsEqualTo(typeof(WorkerException).FullName);
             await Assert.That(remoteException.OriginalMessage).IsEqualTo("worker failed");
             await Assert.That(remoteException.WorkerIndex).IsEqualTo(7);
+            await Assert.That(((ModuleResult) deserialized).WorkerIndex).IsEqualTo(7);
             await Assert.That(remoteException.RemoteStackTrace)
                 .Contains(nameof(CaptureWorkerException));
             await Assert.That(remoteException.StackTrace)
@@ -147,6 +148,7 @@ public class ModuleResultSerializerTests
             .IsEqualTo("worker failed");
         await Assert.That(deserialized.ExceptionOrDefault.StackTrace)
             .Contains(nameof(CaptureSystemException));
+        await Assert.That(((ModuleResult) deserialized).WorkerIndex).IsEqualTo(7);
     }
 
     [Test]

--- a/test/ModularPipelines.Distributed.UnitTests/Serialization/ModuleResultSerializerTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Serialization/ModuleResultSerializerTests.cs
@@ -110,20 +110,20 @@ public class ModuleResultSerializerTests
             await Assert.That(remoteException.RemoteStackTrace)
                 .Contains(nameof(CaptureWorkerException));
             await Assert.That(remoteException.StackTrace)
-                .IsEqualTo(remoteException.RemoteStackTrace);
+                .Contains(remoteException.RemoteStackTrace!);
             await Assert.That(remoteException.Message)
                 .IsEqualTo($"Remote worker 7 threw {typeof(WorkerException).FullName}: worker failed");
         }
     }
 
     [Test]
-    public async Task Deserialize_System_Exception_Preserves_Exception_Type()
+    public async Task Deserialize_System_Exception_Preserves_Type_And_Remote_Stack_Trace()
     {
         var registry = new ModuleTypeRegistry();
         registry.Register(typeof(SimpleModule));
         var serializer = new ModuleResultSerializer(registry);
         ModuleResult<SimpleResult> result = new ModuleResult<SimpleResult>.Failure(
-            new InvalidOperationException("worker failed"))
+            CaptureSystemException())
         {
             Name = nameof(SimpleModule),
             TypeName = typeof(SimpleModule).FullName,
@@ -145,6 +145,8 @@ public class ModuleResultSerializerTests
             .IsTypeOf<InvalidOperationException>();
         await Assert.That(deserialized.ExceptionOrDefault!.Message)
             .IsEqualTo("worker failed");
+        await Assert.That(deserialized.ExceptionOrDefault.StackTrace)
+            .Contains(nameof(CaptureSystemException));
     }
 
     [Test]
@@ -170,6 +172,18 @@ public class ModuleResultSerializerTests
             throw new WorkerException("worker failed");
         }
         catch (WorkerException exception)
+        {
+            return exception;
+        }
+    }
+
+    private static InvalidOperationException CaptureSystemException()
+    {
+        try
+        {
+            throw new InvalidOperationException("worker failed");
+        }
+        catch (InvalidOperationException exception)
         {
             return exception;
         }

--- a/test/ModularPipelines.Distributed.UnitTests/Serialization/ModuleResultSerializerTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Serialization/ModuleResultSerializerTests.cs
@@ -8,6 +8,8 @@ namespace ModularPipelines.Distributed.UnitTests.Serialization;
 
 public class ModuleResultSerializerTests
 {
+    private sealed class WorkerException(string message) : Exception(message);
+
     private class SimpleResult
     {
         public string Name { get; set; } = string.Empty;
@@ -73,6 +75,79 @@ public class ModuleResultSerializerTests
     }
 
     [Test]
+    public async Task Deserialize_Custom_Exception_Preserves_Remote_Diagnostics()
+    {
+        var registry = new ModuleTypeRegistry();
+        registry.Register(typeof(SimpleModule));
+        var serializer = new ModuleResultSerializer(registry);
+        var originalException = CaptureWorkerException();
+        ModuleResult<SimpleResult> result = new ModuleResult<SimpleResult>.Failure(originalException)
+        {
+            Name = nameof(SimpleModule),
+            TypeName = typeof(SimpleModule).FullName,
+            Duration = TimeSpan.Zero,
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+            Status = ModuleStatus.Failed,
+        };
+
+        var serialized = serializer.Serialize(
+            result,
+            typeof(SimpleModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 7);
+
+        var deserialized = serializer.Deserialize(serialized);
+        var remoteException = deserialized!.ExceptionOrDefault as RemoteModuleException;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(remoteException).IsNotNull();
+            await Assert.That(remoteException!.OriginalExceptionType)
+                .IsEqualTo(typeof(WorkerException).FullName);
+            await Assert.That(remoteException.OriginalMessage).IsEqualTo("worker failed");
+            await Assert.That(remoteException.WorkerIndex).IsEqualTo(7);
+            await Assert.That(remoteException.RemoteStackTrace)
+                .Contains(nameof(CaptureWorkerException));
+            await Assert.That(remoteException.StackTrace)
+                .IsEqualTo(remoteException.RemoteStackTrace);
+            await Assert.That(remoteException.Message)
+                .IsEqualTo($"Remote worker 7 threw {typeof(WorkerException).FullName}: worker failed");
+        }
+    }
+
+    [Test]
+    public async Task Deserialize_System_Exception_Preserves_Exception_Type()
+    {
+        var registry = new ModuleTypeRegistry();
+        registry.Register(typeof(SimpleModule));
+        var serializer = new ModuleResultSerializer(registry);
+        ModuleResult<SimpleResult> result = new ModuleResult<SimpleResult>.Failure(
+            new InvalidOperationException("worker failed"))
+        {
+            Name = nameof(SimpleModule),
+            TypeName = typeof(SimpleModule).FullName,
+            Duration = TimeSpan.Zero,
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+            Status = ModuleStatus.Failed,
+        };
+
+        var serialized = serializer.Serialize(
+            result,
+            typeof(SimpleModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 7);
+
+        var deserialized = serializer.Deserialize(serialized);
+
+        await Assert.That(deserialized!.ExceptionOrDefault)
+            .IsTypeOf<InvalidOperationException>();
+        await Assert.That(deserialized.ExceptionOrDefault!.Message)
+            .IsEqualTo("worker failed");
+    }
+
+    [Test]
     public async Task Serialized_Result_Preserves_Six_Parameter_Constructor()
     {
         var constructor = typeof(SerializedModuleResult).GetConstructor(
@@ -86,5 +161,17 @@ public class ModuleResultSerializerTests
         ]);
 
         await Assert.That(constructor).IsNotNull();
+    }
+
+    private static WorkerException CaptureWorkerException()
+    {
+        try
+        {
+            throw new WorkerException("worker failed");
+        }
+        catch (WorkerException exception)
+        {
+            return exception;
+        }
     }
 }


### PR DESCRIPTION
Closes #4383.

## Summary
- wrap non-reconstructable worker exceptions in RemoteModuleException
- preserve original type, message, remote stack trace, and worker index
- keep well-known System exception reconstruction unchanged
- expose the additive diagnostic API and synchronize PublicAPI

## Validation
- ModularPipelines.Distributed.UnitTests: 112 passed
- ModuleResultContractTests: 25 passed
- core Release build with EnableCiAnalyzers=true: passed
- scoped whitespace verification: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preserving remote worker exception details, including the original type, message, stack trace, and worker index.
  * Remote failures now display clearer context when their original exception type cannot be restored locally.

* **Bug Fixes**
  * Improved exception serialization and deserialization so diagnostic information is retained across distributed execution.
  * Recognized system exception types now retain their original type, message, and stack trace.
  * Dependency failures now preserve the worker index that produced them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->