### PR TITLE
Preserve required multi-synopsis operands

### DIFF
--- a/src/ModularPipelines.Podman/Options/PodmanComposeCpOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanComposeCpOptions.Generated.cs
@@ -18,7 +18,10 @@ namespace ModularPipelines.Podman.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("compose", "cp")]
-public record PodmanComposeCpOptions : PodmanOptions
+public record PodmanComposeCpOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string ServiceSrcPath,
+    [property: CliArgument(1, Phase = CommandLinePhase.Passthrough, Required = true)] string DestPath
+) : PodmanOptions
 {
     /// <summary>
     /// Include containers created by the run command
@@ -49,17 +52,5 @@ public record PodmanComposeCpOptions : PodmanOptions
     /// </summary>
     [CliOption("--index", Format = OptionFormat.EqualsSeparated)]
     public int? Index { get; set; }
-
-    /// <summary>
-    /// The SERVICE:SRC_PATH operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public string? ServiceSrcPath { get; set; }
-
-    /// <summary>
-    /// The DEST_PATH operand.
-    /// </summary>
-    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
-    public string? DestPath { get; set; }
 
 }

--- a/src/ModularPipelines.Podman/Services/IPodmanCompose.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/IPodmanCompose.Generated.cs
@@ -83,7 +83,7 @@ public interface IPodmanCompose
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CpAsync(PodmanComposeCpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CpAsync(PodmanComposeCpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Services/PodmanCompose.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanCompose.Generated.cs
@@ -125,11 +125,11 @@ public class PodmanCompose : IPodmanCompose
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> CpAsync(
-        PodmanComposeCpOptions? options = null,
+        PodmanComposeCpOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PodmanComposeCpOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/test/ModularPipelines.Podman.UnitTests/PodmanComposeOptionsTests.cs
+++ b/test/ModularPipelines.Podman.UnitTests/PodmanComposeOptionsTests.cs
@@ -1,0 +1,27 @@
+using ModularPipelines.Podman.Options;
+using static ModularPipelines.TestHelpers.OptionsRenderingTestHelper;
+
+namespace ModularPipelines.Podman.UnitTests;
+
+public class PodmanComposeOptionsTests
+{
+    [Test]
+    public async Task Compose_Cp_Renders_Source_And_Destination_In_Order()
+    {
+        var arguments = BuildArguments(new PodmanComposeCpOptions(
+            "api:/tmp/report.txt",
+            "./report.txt"));
+
+        await AssertArguments(arguments, ["api:/tmp/report.txt", "./report.txt"]);
+    }
+
+    [Test]
+    public async Task Compose_Cp_Rejects_Missing_Source()
+    {
+        var options = new PodmanComposeCpOptions(null!, "./report.txt");
+
+        var exception = Assert.Throws<ArgumentException>(() => BuildArguments(options));
+
+        await Assert.That(exception.ParamName).IsEqualTo(nameof(options.ServiceSrcPath));
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -786,6 +786,27 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Keeps_Required_Operand_Positions_Across_Renamed_Alternate_Forms()
+    {
+        const string helpText = """
+            Usage:
+              podman compose cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-
+              podman compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+            """;
+
+        var result = UsageSynopsisParser.Parse(
+            helpText,
+            ["podman", "compose", "cp"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.PositionalArguments).Count().IsEqualTo(2);
+            await Assert.That(result.PositionalArguments.All(argument => argument.IsRequired)).IsTrue();
+            await Assert.That(result.PositionalArguments.All(argument => argument.CSharpType == "string")).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Models_Standalone_Switch_On_Separate_Synopsis_As_Required_Alternative()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -679,11 +679,10 @@ public static class UsageSynopsisParser
 
         return selectedArguments
             .Select(argument => alternatives.All(alternative =>
-                alternative.PositionalArguments.Any(candidate =>
-                    candidate.IsRequired
-                    && candidate.PropertyName.Equals(
-                        argument.PropertyName,
-                        StringComparison.OrdinalIgnoreCase)))
+                IsRequiredInAlternative(
+                    argument,
+                    selectedArguments.Count,
+                    alternative.PositionalArguments))
                     ? argument
                     : argument with
                     {
@@ -691,6 +690,27 @@ public static class UsageSynopsisParser
                         IsRequired = false,
                     })
             .ToList();
+    }
+
+    private static bool IsRequiredInAlternative(
+        CliPositionalArgument selectedArgument,
+        int selectedArgumentCount,
+        IReadOnlyList<CliPositionalArgument> alternativeArguments)
+    {
+        if (alternativeArguments.Any(candidate =>
+                candidate.IsRequired
+                && candidate.PropertyName.Equals(
+                    selectedArgument.PropertyName,
+                    StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        return alternativeArguments.Count == selectedArgumentCount
+               && alternativeArguments.Any(candidate =>
+                   candidate.IsRequired
+                   && candidate.PositionIndex == selectedArgument.PositionIndex
+                   && candidate.Phase == selectedArgument.Phase);
     }
 
     private static IReadOnlyList<string> ExtractSynopses(


### PR DESCRIPTION
## Summary
- preserve required positional slots when equal-arity usage synopses rename their placeholders
- regenerate Podman Compose `cp` options and service signatures so source and destination are mandatory
- cover parser requiredness, exact argv ordering, and missing-source rejection

## Validation
- OptionsGenerator tests: 1,235 passed
- Podman tests: 3 passed
- OptionsGenerator Release solution build: succeeded, 0 warnings
- Podman Release solution build: succeeded, 0 warnings
- scoped whitespace verification: passed
- Podman 5.8.4 regeneration repeated deterministically (255-command tree hash unchanged)

Closes #4449