### PR TITLE
Require structured CLI operands

### DIFF
--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -69,12 +69,7 @@ internal sealed class CommandLineBuilder(
         var commandModel = _commandModelProvider.GetCommandModel(options.GetType());
         var additionalArguments = options.AdditionalArguments?.ToList() ?? [];
         var manualArgs = options.Arguments?.ToList() ?? [];
-        var requiredOperandMatch = MatchManualRequiredOperands(
-            commandModel,
-            options,
-            manualArgs);
-        var manualOptionTerminatorRemains = options.ArgumentsContainOptionTerminator
-                                            && !requiredOperandMatch.ConsumedOptionTerminator;
+        var manualOptionTerminatorRemains = options.ArgumentsContainOptionTerminator;
         ValidateAdditionalArguments(additionalArguments);
 
         var terminalCommandModel = commandModel
@@ -91,8 +86,6 @@ internal sealed class CommandLineBuilder(
             additionalArguments,
             options,
             isGlobalOption: true,
-            manualRequiredOperands: null,
-            requiredOperandMatch.MaterializedValues,
             ref emittedOptionTerminator,
             out var globalOptionTerminatorIndex,
             out _);
@@ -102,8 +95,6 @@ internal sealed class CommandLineBuilder(
             additionalArguments,
             options,
             isGlobalOption: false,
-            requiredOperandMatch.ManualValues,
-            requiredOperandMatch.MaterializedValues,
             ref emittedOptionTerminator,
             out var commandOptionTerminatorIndex,
             out var commandLateOperandIndex);
@@ -120,9 +111,7 @@ internal sealed class CommandLineBuilder(
             [.. terminalCommandModel.Where(static part => part is ArgumentPart)],
             options,
             ref terminalArgumentTerminatorState,
-            out var terminalArgumentOptionTerminatorIndex,
-            requiredOperandMatch.ManualValues,
-            requiredOperandMatch.MaterializedValues);
+            out var terminalArgumentOptionTerminatorIndex);
         modelEmittedOptionTerminator |= terminalArgumentOptionTerminatorIndex is not null;
 
         // Keep recognized manual options ahead of a marker emitted by a structured argument
@@ -261,8 +250,6 @@ internal sealed class CommandLineBuilder(
         IReadOnlyList<AdditionalCommandLineArgument> additionalArguments,
         CommandLineToolOptions options,
         bool isGlobalOption,
-        IReadOnlyDictionary<ArgumentPart, string>? manualRequiredOperands,
-        IReadOnlyDictionary<ArgumentPart, IReadOnlyList<string>> materializedRequiredOperands,
         ref bool emittedOptionTerminator,
         out int? emittedOptionTerminatorIndex,
         out int? lateOperandIndex)
@@ -291,9 +278,7 @@ internal sealed class CommandLineBuilder(
                 phaseModel,
                 options,
                 ref emittedOptionTerminator,
-                out var phaseOptionTerminatorIndex,
-                manualRequiredOperands,
-                materializedRequiredOperands);
+                out var phaseOptionTerminatorIndex);
             if (emittedOptionTerminatorIndex is null
                 && phaseOptionTerminatorIndex is { } phaseIndex)
             {
@@ -466,97 +451,6 @@ internal sealed class CommandLineBuilder(
             options,
             preserveTerminalOptions: false);
         return [.. extracted.Global, .. extracted.Command];
-    }
-
-    private static RequiredOperandMatch MatchManualRequiredOperands(
-        IReadOnlyList<PropertyCommandLinePart> commandModel,
-        CommandLineToolOptions options,
-        List<string> manualArgs)
-    {
-        var requiredOperands = commandModel
-            .OfType<ArgumentPart>()
-            .Where(part => !part.IsGlobalOption
-                           && part.Attribute.Required)
-            .OrderBy(static part => CommandLinePhaseOrder.GetRenderOrder(part.Phase))
-            .ThenBy(static part => part.Attribute.Position)
-            .ToList();
-        var materializedValues = requiredOperands.ToDictionary(
-            static part => part,
-            part => (IReadOnlyList<string>) CommandArgumentBuilder.GetValues(part.Getter(options)));
-        var missingRequiredOperands = requiredOperands
-            .Where(part => materializedValues[part].Count == 0)
-            .ToList();
-        if (missingRequiredOperands.Count == 0 || manualArgs.Count == 0)
-        {
-            return new RequiredOperandMatch(
-                new Dictionary<ArgumentPart, string>(),
-                materializedValues,
-                false);
-        }
-
-        IReadOnlyList<int> operandIndices;
-        if (options.ArgumentsContainToolOptions)
-        {
-            var classifiedArguments = manualArgs.ToList();
-            var classifiedOperandIndices = new List<int>();
-            _ = ExtractRecognizedManualOptionsByScope(
-                classifiedArguments,
-                commandModel.Where(static part => part.IsGlobalOption).ToList(),
-                commandModel.Where(static part => !part.IsGlobalOption).ToList(),
-                options,
-                preserveTerminalOptions: false,
-                positionalArgumentIndices: classifiedOperandIndices);
-            operandIndices = classifiedOperandIndices;
-        }
-        else
-        {
-            operandIndices = Enumerable.Range(0, manualArgs.Count)
-                .Where(index => manualArgs[index] != "--")
-                .ToList();
-        }
-
-        var matchedOperandCount = Math.Min(missingRequiredOperands.Count, operandIndices.Count);
-        var matchedRequiredOperands = missingRequiredOperands.Take(matchedOperandCount).ToList();
-        var matchedOperandIndices = SelectRequiredOperandIndices(matchedRequiredOperands, operandIndices);
-        var result = new Dictionary<ArgumentPart, string>(matchedOperandCount);
-        var indicesToRemove = new HashSet<int>();
-        var consumedOptionTerminator = false;
-        for (var index = 0; index < matchedOperandCount; index++)
-        {
-            var operandIndex = matchedOperandIndices[index];
-            var requiredOperand = matchedRequiredOperands[index];
-            result.Add(requiredOperand, manualArgs[operandIndex]);
-            indicesToRemove.Add(operandIndex);
-            if (requiredOperand.Attribute.PrependOptionTerminator
-                && operandIndex > 0
-                && manualArgs[operandIndex - 1] == "--")
-            {
-                indicesToRemove.Add(operandIndex - 1);
-                consumedOptionTerminator = true;
-            }
-        }
-
-        foreach (var index in indicesToRemove.OrderDescending())
-        {
-            manualArgs.RemoveAt(index);
-        }
-
-        return new RequiredOperandMatch(result, materializedValues, consumedOptionTerminator);
-    }
-
-    private static IReadOnlyList<int> SelectRequiredOperandIndices(
-        IReadOnlyList<ArgumentPart> requiredOperands,
-        IReadOnlyList<int> candidateIndices)
-    {
-        var lateOperandOrder = CommandLinePhaseOrder.GetRenderOrder(CommandLinePhase.LateOperand);
-        var trailingOperandCount = requiredOperands.Count(part =>
-            CommandLinePhaseOrder.GetRenderOrder(part.Phase) >= lateOperandOrder);
-        var leadingOperandCount = requiredOperands.Count - trailingOperandCount;
-        return
-        [
-            .. candidateIndices.Take(leadingOperandCount),
-            .. candidateIndices.TakeLast(trailingOperandCount),
-        ];
     }
 
     private static ExtractedManualOptions ExtractRecognizedManualOptionsByScope(
@@ -1089,11 +983,6 @@ internal sealed class CommandLineBuilder(
     {
         public static ExtractedManualOptions Empty { get; } = new([], [], false);
     }
-
-    private readonly record struct RequiredOperandMatch(
-        IReadOnlyDictionary<ArgumentPart, string> ManualValues,
-        IReadOnlyDictionary<ArgumentPart, IReadOnlyList<string>> MaterializedValues,
-        bool ConsumedOptionTerminator);
 
     private readonly record struct ManualOptionMatch(
         int ArgumentCount,

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -69,7 +69,7 @@ internal sealed class CommandLineBuilder(
         var commandModel = _commandModelProvider.GetCommandModel(options.GetType());
         var additionalArguments = options.AdditionalArguments?.ToList() ?? [];
         var manualArgs = options.Arguments?.ToList() ?? [];
-        var manualOptionTerminatorRemains = options.ArgumentsContainOptionTerminator;
+        var hasManualOptionTerminator = options.ArgumentsContainOptionTerminator;
         ValidateAdditionalArguments(additionalArguments);
 
         var terminalCommandModel = commandModel
@@ -106,7 +106,7 @@ internal sealed class CommandLineBuilder(
 
         var modelEmittedOptionTerminator = emittedOptionTerminator;
         var terminalArgumentTerminatorState = emittedOptionTerminator
-                                              || manualOptionTerminatorRemains;
+                                              || hasManualOptionTerminator;
         var terminalArgumentArgs = _commandArgumentBuilder.BuildArguments(
             [.. terminalCommandModel.Where(static part => part is ArgumentPart)],
             options,
@@ -117,7 +117,7 @@ internal sealed class CommandLineBuilder(
         // Keep recognized manual options ahead of a marker emitted by a structured argument
         // or declared in the manual arguments or run settings; leave manual positional operands in place.
         var pendingTerminatorState = modelEmittedOptionTerminator
-                                     || manualOptionTerminatorRemains;
+                                     || hasManualOptionTerminator;
         var runSettingsArgs = _commandArgumentBuilder.BuildArguments(
             RunSettingsCommandModel,
             options,
@@ -140,7 +140,7 @@ internal sealed class CommandLineBuilder(
             commandParts,
             manualArgs,
             extractedManualOptions,
-            manualOptionTerminatorRemains,
+            hasManualOptionTerminator,
             terminatorEmittedBeforeProperties,
             modelEmittedOptionTerminator,
             hasOptionTerminator);
@@ -160,7 +160,7 @@ internal sealed class CommandLineBuilder(
         InsertManualArgumentsBeforeLateOperands(
             propertyArgs,
             manualArgs,
-            manualOptionTerminatorRemains,
+            hasManualOptionTerminator,
             commandLateOperandIndex,
             propertyArgs.Count - propertyArgumentCountBeforeManualOptions);
 
@@ -294,11 +294,11 @@ internal sealed class CommandLineBuilder(
     private static void InsertManualArgumentsBeforeLateOperands(
         List<string> propertyArgs,
         List<string> manualArgs,
-        bool manualOptionTerminatorRemains,
+        bool hasManualOptionTerminator,
         int? lateOperandIndex,
         int insertedManualOptionCount)
     {
-        if (!manualOptionTerminatorRemains
+        if (!hasManualOptionTerminator
             || lateOperandIndex is not { } insertionIndex
             || manualArgs.Count == 0)
         {
@@ -357,7 +357,7 @@ internal sealed class CommandLineBuilder(
         IReadOnlyCollection<string> commandParts,
         IReadOnlyCollection<string> manualArgs,
         ExtractedManualOptions extractedManualOptions,
-        bool manualOptionTerminatorRemains,
+        bool hasManualOptionTerminator,
         bool terminatorEmittedBeforeProperties,
         bool emittedOptionTerminator,
         bool hasOptionTerminator)
@@ -369,7 +369,7 @@ internal sealed class CommandLineBuilder(
                 + "Remove the marker source or use options without a subcommand.");
         }
 
-        if (manualOptionTerminatorRemains
+        if (hasManualOptionTerminator
             && !manualArgs.Contains("--", StringComparer.Ordinal))
         {
             throw new ArgumentException(
@@ -387,7 +387,7 @@ internal sealed class CommandLineBuilder(
                 + "Remove either the terminal option or the '--' source.");
         }
 
-        if (manualOptionTerminatorRemains && emittedOptionTerminator)
+        if (hasManualOptionTerminator && emittedOptionTerminator)
         {
             throw new InvalidOperationException(
                 "Manual arguments cannot supply an end-of-options marker after one was already "
@@ -458,8 +458,7 @@ internal sealed class CommandLineBuilder(
         IReadOnlyList<PropertyCommandLinePart> globalCommandModel,
         IReadOnlyList<PropertyCommandLinePart> commandSpecificModel,
         CommandLineToolOptions options,
-        bool preserveTerminalOptions,
-        ICollection<int>? positionalArgumentIndices = null)
+        bool preserveTerminalOptions)
     {
         var commandModel = globalCommandModel.Concat(commandSpecificModel).ToList();
         var flagsByName = commandModel
@@ -500,8 +499,7 @@ internal sealed class CommandLineBuilder(
             preserveTerminalOptions,
             globalOptions,
             commandOptions,
-            remainingArguments,
-            positionalArgumentIndices);
+            remainingArguments);
 
         if (globalOptions.Count == 0
             && commandOptions.Count == 0
@@ -527,8 +525,7 @@ internal sealed class CommandLineBuilder(
         bool preserveTerminalOptions,
         List<string> globalOptions,
         List<string> commandOptions,
-        List<string> remainingArguments,
-        ICollection<int>? positionalArgumentIndices)
+        List<string> remainingArguments)
     {
         var hasTerminalOptions = false;
         for (var index = 0; index < optionParsingCount;)
@@ -547,11 +544,6 @@ internal sealed class CommandLineBuilder(
             if (match is null)
             {
                 remainingArguments.Add(manualArgs[index]);
-                if (manualArgs[index] != "--")
-                {
-                    positionalArgumentIndices?.Add(index);
-                }
-
                 index++;
                 continue;
             }
@@ -573,11 +565,7 @@ internal sealed class CommandLineBuilder(
             index += match.Value.ArgumentCount;
         }
 
-        AppendOptionTerminatedArguments(
-            manualArgs,
-            optionParsingCount,
-            remainingArguments,
-            positionalArgumentIndices);
+        remainingArguments.AddRange(manualArgs.Skip(optionParsingCount));
 
         return hasTerminalOptions;
     }
@@ -631,19 +619,6 @@ internal sealed class CommandLineBuilder(
         var boundary = manualArgs.IndexOf("--", matchStart, match.ArgumentCount);
         var hasArgumentsAfterMatch = matchStart + match.ArgumentCount < manualArgs.Count;
         return boundary >= 0 && hasArgumentsAfterMatch ? boundary : null;
-    }
-
-    private static void AppendOptionTerminatedArguments(
-        List<string> manualArgs,
-        int optionParsingCount,
-        List<string> remainingArguments,
-        ICollection<int>? positionalArgumentIndices)
-    {
-        remainingArguments.AddRange(manualArgs.Skip(optionParsingCount));
-        for (var index = optionParsingCount + 1; index < manualArgs.Count; index++)
-        {
-            positionalArgumentIndices?.Add(index);
-        }
     }
 
     private static ManualOptionMatch? TryMatchManualOption(

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -32,28 +32,14 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         IReadOnlyList<PropertyCommandLinePart> commandModel,
         object optionsObject,
         ref bool emittedOptionTerminator,
-        out int? emittedOptionTerminatorIndex,
-        IReadOnlyDictionary<ArgumentPart, string>? manualRequiredOperands = null,
-        IReadOnlyDictionary<ArgumentPart, IReadOnlyList<string>>? materializedRequiredOperands = null)
+        out int? emittedOptionTerminatorIndex)
     {
         var optionsType = optionsObject.GetType();
         var arguments = commandModel.OfType<ArgumentPart>().ToList();
         var flagsAndOptions = commandModel.Where(p => p is FlagPart or OptionPart).ToList();
         var argumentValues = arguments.ToDictionary(
             static argument => argument,
-            argument => materializedRequiredOperands?.TryGetValue(argument, out var values) == true
-                ? values
-                : GetValues(argument.Getter(optionsObject)));
-        if (manualRequiredOperands is not null)
-        {
-            foreach (var (argument, value) in manualRequiredOperands)
-            {
-                if (argumentValues.TryGetValue(argument, out var values) && values.Count == 0)
-                {
-                    argumentValues[argument] = [value];
-                }
-            }
-        }
+            argument => (IReadOnlyList<string>) GetValues(argument.Getter(optionsObject)));
 
         var renderedOptionValues = flagsAndOptions.ToDictionary(
             static part => part,

--- a/src/ModularPipelines/Helpers/Internal/ICommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/ICommandArgumentBuilder.cs
@@ -38,18 +38,10 @@ internal interface ICommandArgumentBuilder
     /// <param name="emittedOptionTerminatorIndex">
     /// The index of the terminator emitted by this render, or <see langword="null"/> when none was emitted.
     /// </param>
-    /// <param name="manualRequiredOperands">
-    /// Manual values mapped to the required structured operands they supply.
-    /// </param>
-    /// <param name="materializedRequiredOperands">
-    /// Required operand values already materialized while matching manual operands.
-    /// </param>
     /// <returns>A list of string arguments ready to be passed to a CLI tool.</returns>
     IReadOnlyList<string> BuildArguments(
         IReadOnlyList<PropertyCommandLinePart> commandModel,
         object optionsObject,
         ref bool emittedOptionTerminator,
-        out int? emittedOptionTerminatorIndex,
-        IReadOnlyDictionary<ArgumentPart, string>? manualRequiredOperands = null,
-        IReadOnlyDictionary<ArgumentPart, IReadOnlyList<string>>? materializedRequiredOperands = null);
+        out int? emittedOptionTerminatorIndex);
 }

--- a/test/ModularPipelines.Chocolatey.UnitTests/ChocolateyOptionsTests.cs
+++ b/test/ModularPipelines.Chocolatey.UnitTests/ChocolateyOptionsTests.cs
@@ -7,6 +7,34 @@ namespace ModularPipelines.Chocolatey.UnitTests;
 public class ChocolateyOptionsTests : TestBase
 {
     [Test]
+    public async Task Default_Action_Commands_Render_Without_Operands()
+    {
+        object[] options =
+        [
+            new ChocoListOptions(),
+            new ChocoFeatureOptions(),
+            new ChocoPinOptions(),
+            new ChocoSourceOptions(),
+        ];
+
+        foreach (var option in options)
+        {
+            await AssertArguments(BuildArguments(option), []);
+        }
+    }
+
+    [Test]
+    public async Task Optional_Structured_Operands_Render_In_Position()
+    {
+        await AssertArguments(
+            BuildArguments(new ChocoListOptions { Filter = "git" }),
+            ["git"]);
+        await AssertArguments(
+            BuildArguments(new ChocoFeatureOptions { List = "enable" }),
+            ["enable"]);
+    }
+
+    [Test]
     public async Task Package_Group_Renders_Each_Package_As_A_Separate_Argument()
     {
         var arguments = BuildArguments(new ChocoInstallOptions("first")

--- a/test/ModularPipelines.Pulumi.UnitTests/PulumiOptionsTests.cs
+++ b/test/ModularPipelines.Pulumi.UnitTests/PulumiOptionsTests.cs
@@ -23,13 +23,13 @@ public class PulumiOptionsTests : TestBase
     }
 
     [Test]
-    public async Task Legacy_Env_Run_Constructor_Uses_Manual_Command_Operand()
+    public async Task Env_Run_Uses_Structured_Command_And_Arguments()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        var commandLine = builder.Build(new PulumiEnvRunOptions("development")
+        var commandLine = builder.Build(new PulumiEnvRunOptions("development", "echo")
         {
-            Arguments = ["echo", "hello"],
+            Args = ["hello"],
         });
 
         await Assert.That(commandLine.ToString())
@@ -37,14 +37,13 @@ public class PulumiOptionsTests : TestBase
     }
 
     [Test]
-    public async Task Legacy_Env_Run_Consumes_Manual_Option_Terminator()
+    public async Task Env_Run_Structured_Command_Emits_Option_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        var commandLine = builder.Build(new PulumiEnvRunOptions("development")
+        var commandLine = builder.Build(new PulumiEnvRunOptions("development", "bash")
         {
-            Arguments = ["--", "bash", "-c", "echo hello"],
-            ArgumentsContainOptionTerminator = true,
+            Args = ["-c", "echo hello"],
         });
 
         await Assert.That(commandLine.ToString())

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -532,23 +532,7 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Rejects_Manual_Values_For_Missing_Late_Operands()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        await Assert.That(() => builder.Build(
-                new TestTerminatedPassthroughOptions(default!, default!)
-                {
-                    Arguments = ["--", "--force", "source", "destination"],
-                    ArgumentsContainOptionTerminator = true,
-                    ArgumentsContainToolOptions = true,
-                }))
-            .Throws<ArgumentException>()
-            .And.HasMessageContaining("TestTerminatedPassthroughOptions.Source");
-    }
-
-    [Test]
-    public async Task Build_Rejects_Manual_Arguments_For_New_Required_Operand()
+    public async Task Build_Rejects_Manual_Arguments_For_Missing_Required_Operand()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
@@ -556,16 +540,6 @@ public class CommandLineBuilderTests : TestBase
         {
             Arguments = ["legacy-operand"],
         }))
-            .Throws<ArgumentException>()
-            .And.HasMessageContaining("TestRequiredOperandCompatibilityOptions.Operand");
-    }
-
-    [Test]
-    public async Task Build_Still_Rejects_Missing_Required_Operand_Without_Manual_Arguments()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        await Assert.That(() => builder.Build(new TestRequiredOperandCompatibilityOptions()))
             .Throws<ArgumentException>()
             .And.HasMessageContaining("TestRequiredOperandCompatibilityOptions.Operand");
     }
@@ -2120,9 +2094,6 @@ public class CommandLineBuilderTests : TestBase
             : this(default(string)!)
         {
         }
-
-        [CliFlag("--yes")]
-        public bool? Yes { get; init; }
     }
 
     [CliTool("test")]

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -532,72 +532,32 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Reserves_Trailing_Manual_Values_For_Late_Operands()
+    public async Task Build_Rejects_Manual_Values_For_Missing_Late_Operands()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        var result = builder.Build(new TestTerminatedPassthroughOptions(default!, default!)
-        {
-            Arguments = ["--", "--force", "source", "destination"],
-            ArgumentsContainOptionTerminator = true,
-            ArgumentsContainToolOptions = true,
-        });
-
-        await Assert.That(result.ToString())
-            .IsEqualTo("tool copy -- --force source destination");
+        await Assert.That(() => builder.Build(
+                new TestTerminatedPassthroughOptions(default!, default!)
+                {
+                    Arguments = ["--", "--force", "source", "destination"],
+                    ArgumentsContainOptionTerminator = true,
+                    ArgumentsContainToolOptions = true,
+                }))
+            .Throws<ArgumentException>()
+            .And.HasMessageContaining("TestTerminatedPassthroughOptions.Source");
     }
 
     [Test]
-    public async Task Build_Allows_Manual_Arguments_To_Supply_New_Required_Operand()
+    public async Task Build_Rejects_Manual_Arguments_For_New_Required_Operand()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        var result = builder.Build(new TestRequiredOperandCompatibilityOptions
+        await Assert.That(() => builder.Build(new TestRequiredOperandCompatibilityOptions
         {
             Arguments = ["legacy-operand"],
-        });
-
-        await Assert.That(result.ToString()).IsEqualTo("tool run legacy-operand");
-    }
-
-    [Test]
-    public async Task Build_Classifies_Manual_Option_And_Required_Operand_Separately()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        var result = builder.Build(new TestRequiredOperandCompatibilityOptions
-        {
-            Arguments = ["legacy-operand", "--yes"],
-            ArgumentsContainToolOptions = true,
-        });
-
-        await Assert.That(result.ToString()).IsEqualTo("tool run legacy-operand --yes");
-    }
-
-    [Test]
-    public async Task Build_Inserts_Manual_Operand_At_Its_Structured_Position()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        var result = builder.Build(new TestTwoRequiredOperandCompatibilityOptions(default!, "id")
-        {
-            Arguments = ["address"],
-        });
-
-        await Assert.That(result.ToString()).IsEqualTo("tool import address id");
-    }
-
-    [Test]
-    public async Task Build_Rejects_One_Manual_Value_For_Two_Required_Operands()
-    {
-        var builder = await GetService<ICommandLineBuilder>();
-
-        await Assert.That(() => builder.Build(new TestTwoRequiredOperandCompatibilityOptions
-        {
-            Arguments = ["address"],
         }))
             .Throws<ArgumentException>()
-            .And.HasMessageContaining("TestTwoRequiredOperandCompatibilityOptions.Id");
+            .And.HasMessageContaining("TestRequiredOperandCompatibilityOptions.Operand");
     }
 
     [Test]
@@ -988,13 +948,13 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Validates_Mapped_Early_Operand_Terminator()
+    public async Task Build_Validates_Required_Early_Operand_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
         CommandLine Build() => builder.Build(new TestRequiredEarlyOperandOptions
         {
-            Arguments = ["-input"],
+            Operand = "-input",
             Force = true,
         });
 
@@ -2163,19 +2123,6 @@ public class CommandLineBuilderTests : TestBase
 
         [CliFlag("--yes")]
         public bool? Yes { get; init; }
-    }
-
-    [CliTool("tool")]
-    [CliSubCommand("import")]
-    private sealed record TestTwoRequiredOperandCompatibilityOptions(
-        [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Address,
-        [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Id)
-        : CommandLineToolOptions
-    {
-        public TestTwoRequiredOperandCompatibilityOptions()
-            : this(default(string)!, default(string)!)
-        {
-        }
     }
 
     [CliTool("test")]


### PR DESCRIPTION
Closes #4312

## Summary
- remove the raw `Arguments` fallback that could satisfy missing required structured operands
- simplify command argument rendering now that generated metadata is authoritative
- cover bare/default Chocolatey actions and explicit optional operands
- update Pulumi coverage to use the current structured command model

## Validation
- `CommandLineBuilderTests`: 98/98
- `ChocolateyOptionsTests`: 6/6
- `ChocolateyCliScraperTests`: 20/20
- `PulumiOptionsTests`: 5/5
- `ModularPipelines.Tests.slnf` Release build: 0 errors
- Chocolatey solution Release build: 0 warnings, 0 errors
- Pulumi solution Release build: 0 warnings, 0 errors
- scoped whitespace formatting and `git diff --check`: passed

All local .NET commands ran through `scripts/Invoke-AgentDotNet.ps1`. The guard's `-SingleNode` expansion is malformed on this host, so release builds used `/maxcpucount:1` through the guard.