### PR TITLE
Preserve distributed always-run teardown

### DIFF
--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -20,6 +20,7 @@ internal class DistributedModuleExecutor(
     IHostApplicationLifetime lifetime,
     IModuleSchedulerFactory schedulerFactory,
     IModuleRunner moduleRunner,
+    IAlwaysRunHandler alwaysRunHandler,
     IRegistrationEventExecutor registrationEventExecutor,
     IDistributedMasterCoordinator masterCoordinator,
     IDistributedWorkerCoordinator workerCoordinator,
@@ -39,6 +40,7 @@ internal class DistributedModuleExecutor(
     private readonly IHostApplicationLifetime _lifetime = lifetime;
     private readonly IModuleSchedulerFactory _schedulerFactory = schedulerFactory;
     private readonly IModuleRunner _moduleRunner = moduleRunner;
+    private readonly IAlwaysRunHandler _alwaysRunHandler = alwaysRunHandler;
     private readonly IRegistrationEventExecutor _registrationEventExecutor = registrationEventExecutor;
     private readonly IDistributedMasterCoordinator _masterCoordinator = masterCoordinator;
     private readonly IDistributedWorkerCoordinator _workerCoordinator = workerCoordinator;
@@ -101,6 +103,7 @@ internal class DistributedModuleExecutor(
                 _resultRegistry);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.ApplicationStopping);
+            using var masterWorkerCts = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.ApplicationStopping);
             cts.Token.Register(() => CompleteCancelledModules(scheduler, _resultRegistrar, cts.Token));
 
             var schedulerTask = scheduler.RunSchedulerAsync(cts.Token);
@@ -108,7 +111,7 @@ internal class DistributedModuleExecutor(
 
             // Start the master worker loop — the master participates as a worker,
             // dequeuing and executing modules from the same queue as external workers.
-            var masterWorkerTask = RunMasterWorkerLoopAsync(modules, moduleLookup, cts.Token);
+            var masterWorkerTask = RunMasterWorkerLoopAsync(modules, moduleLookup, masterWorkerCts.Token);
 
             try
             {
@@ -148,7 +151,22 @@ internal class DistributedModuleExecutor(
                 // Expected when a module failure cancels the pipeline
             }
 
-            // All results collected — cancel to stop the master worker loop
+            try
+            {
+                if (cts.IsCancellationRequested && !_lifetime.ApplicationStopping.IsCancellationRequested)
+                {
+                    await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                if (!masterWorkerCts.IsCancellationRequested)
+                {
+                    await masterWorkerCts.CancelAsync();
+                }
+            }
+
+            // All results collected — stop the scheduler after successful execution.
             if (!cts.IsCancellationRequested)
             {
                 await cts.CancelAsync();
@@ -497,8 +515,11 @@ internal class DistributedModuleExecutor(
         CancellationTokenSource cts,
         Action requestFailureCancellation)
     {
-        using var timeoutCts = CreateResultTimeoutSource(module.Configuration.Timeout, cts.Token);
-        var lifecycleToken = timeoutCts?.Token ?? cts.Token;
+        var pipelineToken = module.Configuration.AlwaysRun
+            ? _lifetime.ApplicationStopping
+            : cts.Token;
+        using var timeoutCts = CreateResultTimeoutSource(module.Configuration.Timeout, pipelineToken);
+        var lifecycleToken = timeoutCts?.Token ?? pipelineToken;
 
         try
         {

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -111,7 +111,11 @@ internal class DistributedModuleExecutor(
 
             // Start the master worker loop — the master participates as a worker,
             // dequeuing and executing modules from the same queue as external workers.
-            var masterWorkerTask = RunMasterWorkerLoopAsync(modules, moduleLookup, masterWorkerCts.Token);
+            var masterWorkerTask = RunMasterWorkerLoopAsync(
+                modules,
+                moduleLookup,
+                cts.Token,
+                masterWorkerCts.Token);
 
             try
             {
@@ -151,20 +155,8 @@ internal class DistributedModuleExecutor(
                 // Expected when a module failure cancels the pipeline
             }
 
-            try
-            {
-                if (cts.IsCancellationRequested && !_lifetime.ApplicationStopping.IsCancellationRequested)
-                {
-                    await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                if (!masterWorkerCts.IsCancellationRequested)
-                {
-                    await masterWorkerCts.CancelAsync();
-                }
-            }
+            await CompleteAlwaysRunModulesAsync(scheduler, modules, cts, masterWorkerCts)
+                .ConfigureAwait(false);
 
             // All results collected — stop the scheduler after successful execution.
             if (!cts.IsCancellationRequested)
@@ -262,6 +254,28 @@ internal class DistributedModuleExecutor(
             executionContext);
     }
 
+    private async Task CompleteAlwaysRunModulesAsync(
+        IModuleScheduler scheduler,
+        IReadOnlyList<IModule> modules,
+        CancellationTokenSource pipelineCts,
+        CancellationTokenSource masterWorkerCts)
+    {
+        try
+        {
+            if (pipelineCts.IsCancellationRequested && !_lifetime.ApplicationStopping.IsCancellationRequested)
+            {
+                await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (!masterWorkerCts.IsCancellationRequested)
+            {
+                await masterWorkerCts.CancelAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
     private async Task WaitForWorkersAsync(CancellationToken cancellationToken)
     {
         var expectedWorkers = _options.Value.TotalInstances - 1;
@@ -308,7 +322,11 @@ internal class DistributedModuleExecutor(
         }
     }
 
-    private async Task RunMasterWorkerLoopAsync(IReadOnlyList<IModule> modules, Dictionary<string, IModule> moduleLookup, CancellationToken cancellationToken)
+    private async Task RunMasterWorkerLoopAsync(
+        IReadOnlyList<IModule> modules,
+        Dictionary<string, IModule> moduleLookup,
+        CancellationToken pipelineCancellationToken,
+        CancellationToken workerCancellationToken)
     {
         // Build master's capabilities (same logic as WorkerModuleExecutor)
         var options = _options.Value;
@@ -323,20 +341,38 @@ internal class DistributedModuleExecutor(
 
         using var workerScheduler = new WorkerModuleScheduler();
 
-        while (!cancellationToken.IsCancellationRequested)
+        while (!workerCancellationToken.IsCancellationRequested)
         {
             try
             {
-                var assignment = await _workerCoordinator.DequeueModuleAsync(capabilities, cancellationToken);
+                var assignment = await _workerCoordinator
+                    .DequeueModuleAsync(capabilities, workerCancellationToken)
+                    .ConfigureAwait(false);
                 if (assignment is null)
                 {
                     break;
                 }
 
+                if (pipelineCancellationToken.IsCancellationRequested && !assignment.Configuration.AlwaysRun)
+                {
+                    _logger.LogInformation(
+                        "Master skipping cancelled module {Module}",
+                        assignment.ModuleTypeName);
+                    continue;
+                }
+
                 _logger.LogInformation("Master executing module {Module} locally",
                     assignment.ModuleTypeName);
 
-                await ExecuteAssignmentAsync(assignment, modules, moduleLookup, workerScheduler, cancellationToken);
+                var executionCancellationToken = assignment.Configuration.AlwaysRun
+                    ? workerCancellationToken
+                    : pipelineCancellationToken;
+                await ExecuteAssignmentAsync(
+                    assignment,
+                    modules,
+                    moduleLookup,
+                    workerScheduler,
+                    executionCancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -108,7 +108,6 @@ internal class DistributedModuleExecutor(
             cts.Token.Register(() => CompleteCancelledModules(scheduler, _resultRegistrar, cts.Token));
 
             var schedulerTask = scheduler.RunSchedulerAsync(cts.Token);
-            var resultTasks = new List<Task>();
 
             // Start the master worker loop — the master participates as a worker,
             // dequeuing and executing modules from the same queue as external workers.
@@ -118,89 +117,21 @@ internal class DistributedModuleExecutor(
                 cts.Token,
                 masterWorkerCts.Token);
 
-            try
-            {
-                await foreach (var moduleState in scheduler.ReadyModules.ReadAllAsync(cts.Token))
-                {
-                    var moduleType = moduleState.Module.GetType();
-                    var assignment = await _publisher.CreateAssignmentAsync(
-                            moduleState.Module,
-                            cts.Token)
-                        .ConfigureAwait(false);
-                    if (!scheduler.MarkModuleStarted(moduleType))
-                    {
-                        continue;
-                    }
-
-                    var collectTask = PublishAndCollectDistributedResultAsync(
-                        assignment,
-                        moduleState.Module,
-                        moduleType,
-                        scheduler,
-                        cts,
-                        requestFailureCancellation);
-                    resultTasks.Add(collectTask);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected during shutdown
-            }
-
-            try
-            {
-                await Task.WhenAll(resultTasks).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected when a module failure cancels the pipeline
-            }
-
-            Exception? alwaysRunException = null;
-            try
-            {
-                await CompleteAlwaysRunModulesAsync(
-                        scheduler,
-                        modules,
-                        cts,
-                        masterWorkerCts,
-                        requestFailureCancellation)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                requestFailureCancellation();
-                alwaysRunException = exception;
-            }
-
-            // All results collected — stop the scheduler after successful execution.
-            if (!cts.IsCancellationRequested)
-            {
-                await cts.CancelAsync();
-            }
-
-            try
-            {
-                await masterWorkerTask.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected — master worker loop exits on cancellation
-            }
-
-            try
-            {
-                await schedulerTask.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected
-            }
-
-            if (alwaysRunException is not null)
-            {
-                ExceptionDispatchInfo.Capture(alwaysRunException).Throw();
-            }
+            var resultTasks = await PublishReadyModulesAsync(
+                    scheduler,
+                    cts,
+                    requestFailureCancellation)
+                .ConfigureAwait(false);
+            await IgnoreCancellationAsync(Task.WhenAll(resultTasks)).ConfigureAwait(false);
+            await FinalizeExecutionAsync(
+                    scheduler,
+                    modules,
+                    cts,
+                    masterWorkerCts,
+                    masterWorkerTask,
+                    schedulerTask,
+                    requestFailureCancellation)
+                .ConfigureAwait(false);
         }
         catch
         {
@@ -217,6 +148,95 @@ internal class DistributedModuleExecutor(
         }
 
         return modules;
+    }
+
+    private async Task<IReadOnlyList<Task>> PublishReadyModulesAsync(
+        IModuleScheduler scheduler,
+        CancellationTokenSource pipelineCts,
+        Action requestFailureCancellation)
+    {
+        var resultTasks = new List<Task>();
+        try
+        {
+            await foreach (var moduleState in scheduler.ReadyModules.ReadAllAsync(pipelineCts.Token))
+            {
+                var moduleType = moduleState.Module.GetType();
+                var assignment = await _publisher.CreateAssignmentAsync(
+                        moduleState.Module,
+                        pipelineCts.Token)
+                    .ConfigureAwait(false);
+                if (!scheduler.MarkModuleStarted(moduleType))
+                {
+                    continue;
+                }
+
+                resultTasks.Add(PublishAndCollectDistributedResultAsync(
+                    assignment,
+                    moduleState.Module,
+                    moduleType,
+                    scheduler,
+                    pipelineCts,
+                    requestFailureCancellation));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown.
+        }
+
+        return resultTasks;
+    }
+
+    private async Task FinalizeExecutionAsync(
+        IModuleScheduler scheduler,
+        IReadOnlyList<IModule> modules,
+        CancellationTokenSource pipelineCts,
+        CancellationTokenSource masterWorkerCts,
+        Task masterWorkerTask,
+        Task schedulerTask,
+        Action requestFailureCancellation)
+    {
+        Exception? alwaysRunException = null;
+        try
+        {
+            await CompleteAlwaysRunModulesAsync(
+                    scheduler,
+                    modules,
+                    pipelineCts,
+                    masterWorkerCts,
+                    requestFailureCancellation)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            requestFailureCancellation();
+            alwaysRunException = exception;
+        }
+
+        if (!pipelineCts.IsCancellationRequested)
+        {
+            await pipelineCts.CancelAsync();
+        }
+
+        await IgnoreCancellationAsync(masterWorkerTask).ConfigureAwait(false);
+        await IgnoreCancellationAsync(schedulerTask).ConfigureAwait(false);
+
+        if (alwaysRunException is not null)
+        {
+            ExceptionDispatchInfo.Capture(alwaysRunException).Throw();
+        }
+    }
+
+    private static async Task IgnoreCancellationAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when pipeline or worker shutdown stops background work.
+        }
     }
 
     private async Task SignalWorkerShutdownAsync(bool broadcastCancellation)

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -155,8 +156,22 @@ internal class DistributedModuleExecutor(
                 // Expected when a module failure cancels the pipeline
             }
 
-            await CompleteAlwaysRunModulesAsync(scheduler, modules, cts, masterWorkerCts)
-                .ConfigureAwait(false);
+            Exception? alwaysRunException = null;
+            try
+            {
+                await CompleteAlwaysRunModulesAsync(
+                        scheduler,
+                        modules,
+                        cts,
+                        masterWorkerCts,
+                        requestFailureCancellation)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                requestFailureCancellation();
+                alwaysRunException = exception;
+            }
 
             // All results collected — stop the scheduler after successful execution.
             if (!cts.IsCancellationRequested)
@@ -180,6 +195,11 @@ internal class DistributedModuleExecutor(
             catch (OperationCanceledException)
             {
                 // Expected
+            }
+
+            if (alwaysRunException is not null)
+            {
+                ExceptionDispatchInfo.Capture(alwaysRunException).Throw();
             }
         }
         catch
@@ -258,13 +278,22 @@ internal class DistributedModuleExecutor(
         IModuleScheduler scheduler,
         IReadOnlyList<IModule> modules,
         CancellationTokenSource pipelineCts,
-        CancellationTokenSource masterWorkerCts)
+        CancellationTokenSource masterWorkerCts,
+        Action requestFailureCancellation)
     {
         try
         {
             if (pipelineCts.IsCancellationRequested && !_lifetime.ApplicationStopping.IsCancellationRequested)
             {
-                await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
+                await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(
+                        scheduler,
+                        modules,
+                        moduleState => PublishAndCollectLateAlwaysRunModuleAsync(
+                            moduleState,
+                            scheduler,
+                            pipelineCts,
+                            requestFailureCancellation))
+                    .ConfigureAwait(false);
             }
         }
         finally
@@ -274,6 +303,33 @@ internal class DistributedModuleExecutor(
                 await masterWorkerCts.CancelAsync().ConfigureAwait(false);
             }
         }
+    }
+
+    private async Task PublishAndCollectLateAlwaysRunModuleAsync(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        CancellationTokenSource pipelineCts,
+        Action requestFailureCancellation)
+    {
+        var module = moduleState.Module;
+        var moduleType = moduleState.ModuleType;
+        var assignment = await _publisher.CreateAssignmentAsync(
+                module,
+                _lifetime.ApplicationStopping)
+            .ConfigureAwait(false);
+        if (!scheduler.MarkModuleStarted(moduleType))
+        {
+            return;
+        }
+
+        await PublishAndCollectDistributedResultAsync(
+                assignment,
+                module,
+                moduleType,
+                scheduler,
+                pipelineCts,
+                requestFailureCancellation)
+            .ConfigureAwait(false);
     }
 
     private async Task WaitForWorkersAsync(CancellationToken cancellationToken)
@@ -569,7 +625,9 @@ internal class DistributedModuleExecutor(
                 requestFailureCancellation,
                 lifecycleToken);
         }
-        catch (OperationCanceledException) when (!cts.IsCancellationRequested)
+        catch (OperationCanceledException) when (
+            timeoutCts?.IsCancellationRequested == true
+            && !pipelineToken.IsCancellationRequested)
         {
             // Timeout expired (not pipeline cancellation)
             _logger.LogError("Distributed module {Module} timed out waiting for result — worker may have died", moduleType.Name);

--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -26,7 +26,20 @@ internal class AlwaysRunHandler(
     private readonly TimeProvider _timeProvider = timeProvider;
 
     /// <inheritdoc />
-    public async Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules)
+    public Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules) =>
+        WaitForAlwaysRunModulesAsync(
+            scheduler,
+            modules,
+            moduleState => _moduleRunner.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler,
+                CancellationToken.None));
+
+    /// <inheritdoc />
+    public async Task WaitForAlwaysRunModulesAsync(
+        IModuleScheduler scheduler,
+        IReadOnlyList<IModule> modules,
+        Func<ModuleState, Task> startPendingModuleAsync)
     {
         var alwaysRunModules = modules.Where(x => x.Configuration.AlwaysRun).ToList();
         _logger.LogDebug("Found {Count} AlwaysRun modules", alwaysRunModules.Count);
@@ -46,7 +59,12 @@ internal class AlwaysRunHandler(
                     break;
                 }
 
-                await ProcessAlwaysRunModulesAsync(scheduler, modulesToProcess, exceptions).ConfigureAwait(false);
+                await ProcessAlwaysRunModulesAsync(
+                        scheduler,
+                        modulesToProcess,
+                        exceptions,
+                        startPendingModuleAsync)
+                    .ConfigureAwait(false);
 
                 var deferredModules = modulesToProcess
                     .Where(module =>
@@ -159,7 +177,8 @@ internal class AlwaysRunHandler(
     private async Task ProcessAlwaysRunModulesAsync(
         IModuleScheduler scheduler,
         IReadOnlyCollection<IModule> modules,
-        ConcurrentQueue<Exception> exceptions)
+        ConcurrentQueue<Exception> exceptions,
+        Func<ModuleState, Task> startPendingModuleAsync)
     {
         var parallelOptions = new ParallelOptions
         {
@@ -171,7 +190,11 @@ internal class AlwaysRunHandler(
             parallelOptions,
             async (module, _) =>
             {
-                var exception = await WaitForSingleAlwaysRunModuleAsync(scheduler, module).ConfigureAwait(false);
+                var exception = await WaitForSingleAlwaysRunModuleAsync(
+                        scheduler,
+                        module,
+                        startPendingModuleAsync)
+                    .ConfigureAwait(false);
                 if (exception != null)
                 {
                     exceptions.Enqueue(exception);
@@ -179,7 +202,10 @@ internal class AlwaysRunHandler(
             }).ConfigureAwait(false);
     }
 
-    private async Task<Exception?> WaitForSingleAlwaysRunModuleAsync(IModuleScheduler scheduler, IModule module)
+    private async Task<Exception?> WaitForSingleAlwaysRunModuleAsync(
+        IModuleScheduler scheduler,
+        IModule module,
+        Func<ModuleState, Task> startPendingModuleAsync)
     {
         var moduleType = module.GetType();
         var moduleState = scheduler.GetModuleState(moduleType);
@@ -202,7 +228,7 @@ internal class AlwaysRunHandler(
 
             try
             {
-                await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, scheduler, CancellationToken.None).ConfigureAwait(false);
+                await startPendingModuleAsync(moduleState).ConfigureAwait(false);
 
                 if (CanLateStartAlwaysRunModule(moduleState))
                 {

--- a/src/ModularPipelines/Engine/Execution/IAlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/IAlwaysRunHandler.cs
@@ -13,4 +13,16 @@ internal interface IAlwaysRunHandler
     /// <param name="scheduler">The scheduler managing module execution.</param>
     /// <param name="modules">All modules in the pipeline.</param>
     Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules);
+
+    /// <summary>
+    /// Waits for all AlwaysRun modules to complete, using the supplied callback to start
+    /// pending modules through an executor-specific path.
+    /// </summary>
+    /// <param name="scheduler">The scheduler managing module execution.</param>
+    /// <param name="modules">All modules in the pipeline.</param>
+    /// <param name="startPendingModuleAsync">Starts a pending or queued module.</param>
+    Task WaitForAlwaysRunModulesAsync(
+        IModuleScheduler scheduler,
+        IReadOnlyList<IModule> modules,
+        Func<ModuleState, Task> startPendingModuleAsync);
 }

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -182,12 +182,17 @@ public class DistributedModuleExecutorTests
 
     /// <summary>
     /// Wraps an <see cref="IDistributedMasterCoordinator"/> so that <see cref="DequeueModuleAsync"/>
-    /// returns null immediately. This prevents the master worker loop from competing with
-    /// simulated external workers in tests that verify the distributed collection path.
+    /// returns null immediately by default. Tests can instead gate delegation until their
+    /// simulated external worker has claimed its assignment.
     /// </summary>
-    private class NoDequeueCoordinator(IDistributedMasterCoordinator inner) : IDistributedMasterCoordinator
+    private class ResultTrackingCoordinator(
+        IDistributedMasterCoordinator inner,
+        bool dequeueAfterRelease = false) : IDistributedMasterCoordinator
     {
         private readonly ConcurrentDictionary<string, TaskCompletionSource> _resultWaits = new();
+        private readonly TaskCompletionSource _assignmentDequeued =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _dequeueCount;
 
         public TaskCompletionSource ResultWaitStarted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -200,16 +205,37 @@ public class DistributedModuleExecutorTests
         public TaskCompletionSource CompletionSignaled { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public int DequeueCount => Volatile.Read(ref _dequeueCount);
+
         private TaskCompletionSource WorkerQueryRelease { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void ReleaseWorkerQuery() => WorkerQueryRelease.TrySetResult();
 
+        public Task WaitForAssignmentDequeuedAsync() => _assignmentDequeued.Task;
+
         public Task EnqueueModuleAsync(ModuleAssignment assignment, CancellationToken cancellationToken)
             => inner.EnqueueModuleAsync(assignment, cancellationToken);
 
-        public Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<Capability> workerCapabilities, CancellationToken cancellationToken)
-            => Task.FromResult<ModuleAssignment?>(null);
+        public async Task<ModuleAssignment?> DequeueModuleAsync(
+            IReadOnlySet<Capability> workerCapabilities,
+            CancellationToken cancellationToken)
+        {
+            if (!dequeueAfterRelease)
+            {
+                return null;
+            }
+
+            await WorkerQueryRelease.Task.WaitAsync(cancellationToken);
+            var assignment = await inner.DequeueModuleAsync(workerCapabilities, cancellationToken);
+            if (assignment is not null)
+            {
+                Interlocked.Increment(ref _dequeueCount);
+                _assignmentDequeued.TrySetResult();
+            }
+
+            return assignment;
+        }
 
         public Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
             => inner.PublishResultAsync(result, cancellationToken);
@@ -397,7 +423,7 @@ public class DistributedModuleExecutorTests
         var scheduler = CreateMockScheduler(moduleState);
         var resultRegistry = new ModuleResultRegistry();
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         var serializer = new ModuleResultSerializer(typeRegistry);
@@ -437,7 +463,7 @@ public class DistributedModuleExecutorTests
         var scheduler = CreateMockScheduler(moduleState);
         var resultRegistry = new ModuleResultRegistry();
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         var serializer = new ModuleResultSerializer(typeRegistry);
@@ -574,7 +600,7 @@ public class DistributedModuleExecutorTests
         var moduleState = new ModuleState(module, typeof(DistributedModule));
         var scheduler = CreateMockScheduler(moduleState);
         var resultRegistry = new ModuleResultRegistry();
-        var coordinator = new NoDequeueCoordinator(new InMemoryDistributedCoordinator());
+        var coordinator = new ResultTrackingCoordinator(new InMemoryDistributedCoordinator());
         var options = new DistributedOptions { ModuleResultTimeout = TimeSpan.FromSeconds(1) };
         var executor = CreateExecutor(
             scheduler,
@@ -600,7 +626,7 @@ public class DistributedModuleExecutorTests
         var moduleState = new ModuleState(module, typeof(ShortTimeoutDistributedModule));
         var scheduler = CreateMockScheduler(moduleState);
         var resultRegistry = new ModuleResultRegistry();
-        var coordinator = new NoDequeueCoordinator(new InMemoryDistributedCoordinator());
+        var coordinator = new ResultTrackingCoordinator(new InMemoryDistributedCoordinator());
         var options = new DistributedOptions { ModuleResultTimeout = TimeSpan.FromSeconds(30) };
         var executor = CreateExecutor(
             scheduler,
@@ -624,7 +650,7 @@ public class DistributedModuleExecutorTests
         var scheduler = CreateMockScheduler(moduleState);
         var resultRegistry = new ModuleResultRegistry();
         var innerCoordinator = new InMemoryDistributedCoordinator();
-        var coordinator = new NoDequeueCoordinator(innerCoordinator);
+        var coordinator = new ResultTrackingCoordinator(innerCoordinator);
         var options = new DistributedOptions { ModuleResultTimeout = TimeSpan.Zero };
         var executor = CreateExecutor(
             scheduler,
@@ -669,7 +695,7 @@ public class DistributedModuleExecutorTests
         var scheduler = CreateMockScheduler(stateA, stateB);
         var resultRegistry = new ModuleResultRegistry();
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         typeRegistry.Register(typeof(AnotherDistributedModule));
@@ -735,7 +761,7 @@ public class DistributedModuleExecutorTests
             typeof(int).FullName!,
             workerIndex: 1);
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var releaseAlwaysRun = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var alwaysRunStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
@@ -781,13 +807,19 @@ public class DistributedModuleExecutorTests
     {
         var failedModule = new DistributedModule();
         var queuedModule = new AnotherDistributedModule();
+        var coordinator = new InMemoryDistributedCoordinator();
+        var noDequeue = new ResultTrackingCoordinator(coordinator, dequeueAfterRelease: true);
         var scheduler = CreateMockScheduler(
             new ModuleState(failedModule, typeof(DistributedModule)),
             new ModuleState(queuedModule, typeof(AnotherDistributedModule)));
         var pipelineCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         scheduler
             .Setup(x => x.CancelPendingModules())
-            .Callback(() => pipelineCancelled.TrySetResult())
+            .Callback(() =>
+            {
+                noDequeue.ReleaseWorkerQuery();
+                pipelineCancelled.TrySetResult();
+            })
             .Returns([]);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
@@ -799,28 +831,39 @@ public class DistributedModuleExecutorTests
             typeof(DistributedModule).FullName!,
             typeof(SimpleResult).FullName!,
             workerIndex: 1);
-        var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
         var resultCollector = new DistributedResultCollector(noDequeue, serializer);
         var moduleRunner = new Mock<IModuleRunner>();
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler
+            .Setup(x => x.WaitForAlwaysRunModulesAsync(
+                scheduler.Object,
+                It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(noDequeue.WaitForAssignmentDequeuedAsync());
         var executor = CreateExecutor(
             scheduler,
             moduleRunner,
+            alwaysRunHandler: alwaysRunHandler.Object,
             coordinator: noDequeue,
             resultCollector: resultCollector);
 
         var executionTask = executor.ExecuteAsync([failedModule, queuedModule]);
         await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
         await noDequeue.WaitForResultStartedAsync(typeof(AnotherDistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        var externalWorkerAssignment = await coordinator.DequeueModuleAsync(
+            new HashSet<Capability>(),
+            CancellationToken.None);
+        await Assert.That(externalWorkerAssignment?.ModuleTypeName)
+            .IsEqualTo(typeof(DistributedModule).FullName);
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
         await pipelineCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        noDequeue.ReleaseWorkerQuery();
 
         await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await Assert.That(noDequeue.DequeueCount).IsEqualTo(1);
         moduleRunner.Verify(runner => runner.ExecuteWithoutDependencyWaitAsync(
             It.IsAny<ModuleState>(),
             It.IsAny<IModuleScheduler>(),
             It.IsAny<CancellationToken>()), Times.Never);
+        alwaysRunHandler.VerifyAll();
     }
 
     // =================================================================
@@ -1411,7 +1454,7 @@ public class DistributedModuleExecutorTests
         var moduleState = new ModuleState(module, typeof(DistributedModule));
         var scheduler = CreateMockScheduler(moduleState);
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         var serializer = new ModuleResultSerializer(typeRegistry);
@@ -1478,7 +1521,7 @@ public class DistributedModuleExecutorTests
             .Returns(false)
             .Returns(true);
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         var serializer = new ModuleResultSerializer(typeRegistry);
@@ -1672,7 +1715,7 @@ public class DistributedModuleExecutorTests
         var moduleState = new ModuleState(module, typeof(DistributedModule));
         var scheduler = CreateMockScheduler(moduleState);
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         var serializer = new ModuleResultSerializer(typeRegistry);
@@ -1762,7 +1805,7 @@ public class DistributedModuleExecutorTests
         var moduleState = new ModuleState(module, typeof(DistributedModule));
         var scheduler = CreateMockScheduler(moduleState);
         var coordinator = new InMemoryDistributedCoordinator();
-        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
         var typeRegistry = new ModuleTypeRegistry();
         typeRegistry.Register(typeof(DistributedModule));
         var serializer = new ModuleResultSerializer(typeRegistry);

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -776,6 +776,53 @@ public class DistributedModuleExecutorTests
         alwaysRunHandler.VerifyAll();
     }
 
+    [Test]
+    public async Task FailFast_Skips_Queued_NonAlwaysRun_Master_Assignments()
+    {
+        var failedModule = new DistributedModule();
+        var queuedModule = new AnotherDistributedModule();
+        var scheduler = CreateMockScheduler(
+            new ModuleState(failedModule, typeof(DistributedModule)),
+            new ModuleState(queuedModule, typeof(AnotherDistributedModule)));
+        var pipelineCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler
+            .Setup(x => x.CancelPendingModules())
+            .Callback(() => pipelineCancelled.TrySetResult())
+            .Returns([]);
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        typeRegistry.Register(typeof(AnotherDistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var failureResult = CreateTypedFailureResult(failedModule, new Exception("failed"));
+        var serializedFailure = serializer.Serialize(
+            failureResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 1);
+        var coordinator = new InMemoryDistributedCoordinator();
+        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var resultCollector = new DistributedResultCollector(noDequeue, serializer);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var executor = CreateExecutor(
+            scheduler,
+            moduleRunner,
+            coordinator: noDequeue,
+            resultCollector: resultCollector);
+
+        var executionTask = executor.ExecuteAsync([failedModule, queuedModule]);
+        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WaitForResultStartedAsync(typeof(AnotherDistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
+        await pipelineCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        noDequeue.ReleaseWorkerQuery();
+
+        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+        moduleRunner.Verify(runner => runner.ExecuteWithoutDependencyWaitAsync(
+            It.IsAny<ModuleState>(),
+            It.IsAny<IModuleScheduler>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // =================================================================
     // Master-as-Worker Tests
     // =================================================================

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -18,6 +18,7 @@ using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
+using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -36,6 +37,18 @@ public class DistributedModuleExecutorTests
 
     private static ModuleResultRegistrar NewResultRegistrar(IModuleResultRegistry resultRegistry) =>
         new ModuleResultRegistrar(resultRegistry, NullLogger<ModuleResultRegistrar>.Instance);
+
+    private static AlwaysRunHandler NewAlwaysRunHandler(IModuleRunner moduleRunner)
+    {
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(2);
+        return new AlwaysRunHandler(
+            moduleRunner,
+            parallelLimitProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            NullLogger<AlwaysRunHandler>.Instance,
+            TimeProvider.System);
+    }
 
     // --- Test module types ---
 
@@ -156,6 +169,17 @@ public class DistributedModuleExecutorTests
             CancellationToken cancellationToken) => Task.FromResult(42);
     }
 
+    private sealed class ShortTimeoutAlwaysRunDistributedModule : Module<int>
+    {
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun()
+            .WithTimeout(TimeSpan.FromMilliseconds(100));
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(42);
+    }
+
     [ProducesArtifact("distributed-output", "missing-output.txt")]
     private class ArtifactLoggingModule : Module<SimpleResult>
     {
@@ -190,6 +214,7 @@ public class DistributedModuleExecutorTests
         bool dequeueAfterRelease = false) : IDistributedMasterCoordinator
     {
         private readonly ConcurrentDictionary<string, TaskCompletionSource> _resultWaits = new();
+        private readonly ConcurrentDictionary<string, TaskCompletionSource> _publishedResults = new();
         private readonly TaskCompletionSource _assignmentDequeued =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _dequeueCount;
@@ -237,8 +262,18 @@ public class DistributedModuleExecutorTests
             return assignment;
         }
 
-        public Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
-            => inner.PublishResultAsync(result, cancellationToken);
+        public async Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
+        {
+            await inner.PublishResultAsync(result, cancellationToken);
+            _publishedResults.GetOrAdd(
+                result.ModuleTypeName,
+                _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)).TrySetResult();
+        }
+
+        public Task WaitForResultPublishedAsync(Type moduleType) =>
+            _publishedResults.GetOrAdd(
+                moduleType.FullName!,
+                _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
 
         public Task<SerializedModuleResult> WaitForResultAsync(string moduleTypeName, CancellationToken cancellationToken)
         {
@@ -768,7 +803,8 @@ public class DistributedModuleExecutorTests
         alwaysRunHandler
             .Setup(x => x.WaitForAlwaysRunModulesAsync(
                 scheduler.Object,
-                It.Is<IReadOnlyList<IModule>>(modules => modules.Contains(alwaysRunModule))))
+                It.Is<IReadOnlyList<IModule>>(modules => modules.Contains(alwaysRunModule)),
+                It.IsAny<Func<ModuleState, Task>>()))
             .Callback(() => alwaysRunStarted.TrySetResult())
             .Returns(releaseAlwaysRun.Task);
         var resultCollector = new DistributedResultCollector(noDequeue, serializer);
@@ -799,6 +835,159 @@ public class DistributedModuleExecutorTests
         await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
         await noDequeue.CompletionSignaled.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await Assert.That(resultRegistry.GetResult(typeof(AlwaysRunDistributedModule))?.ExceptionOrDefault).IsNull();
+        alwaysRunHandler.VerifyAll();
+    }
+
+    [Test]
+    public async Task FailFast_Classifies_Subsequent_AlwaysRun_Timeout()
+    {
+        var failedModule = new DistributedModule();
+        var alwaysRunModule = new ShortTimeoutAlwaysRunDistributedModule();
+        var scheduler = CreateMockScheduler(
+            new ModuleState(failedModule, typeof(DistributedModule)),
+            new ModuleState(alwaysRunModule, typeof(ShortTimeoutAlwaysRunDistributedModule)));
+        scheduler.Setup(x => x.CancelPendingModules()).Returns([]);
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        typeRegistry.Register(typeof(ShortTimeoutAlwaysRunDistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var failureResult = CreateTypedFailureResult(failedModule, new Exception("failed"));
+        var serializedFailure = serializer.Serialize(
+            failureResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 1);
+        var coordinator = new InMemoryDistributedCoordinator();
+        var noDequeue = new ResultTrackingCoordinator(coordinator);
+        var resultRegistry = new ModuleResultRegistry();
+        var executor = CreateExecutor(
+            scheduler,
+            alwaysRunHandler: Mock.Of<IAlwaysRunHandler>(),
+            resultRegistry: resultRegistry,
+            coordinator: noDequeue,
+            resultCollector: new DistributedResultCollector(noDequeue, serializer));
+
+        var executionTask = executor.ExecuteAsync([failedModule, alwaysRunModule]);
+        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WaitForResultStartedAsync(typeof(ShortTimeoutAlwaysRunDistributedModule))
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
+        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var result = resultRegistry.GetResult(typeof(ShortTimeoutAlwaysRunDistributedModule));
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Status).IsEqualTo(ModuleStatus.TimedOut);
+        await Assert.That(result.ExceptionOrDefault).IsTypeOf<TimeoutException>();
+    }
+
+    [Test]
+    public async Task FailFast_LateStarts_AlwaysRun_Through_Distributed_Path()
+    {
+        var failedModule = new DistributedModule();
+        var failedState = new ModuleState(failedModule, typeof(DistributedModule));
+        var alwaysRunModule = new AlwaysRunDistributedModule();
+        var alwaysRunState = new ModuleState(alwaysRunModule, typeof(AlwaysRunDistributedModule));
+        var coordinator = new InMemoryDistributedCoordinator();
+        var trackingCoordinator = new ResultTrackingCoordinator(coordinator, dequeueAfterRelease: true);
+        var scheduler = CreateMockScheduler(failedState);
+        scheduler.Setup(x => x.GetModuleState(typeof(AlwaysRunDistributedModule))).Returns(alwaysRunState);
+        scheduler.Setup(x => x.GetModuleCompletionTask(typeof(AlwaysRunDistributedModule)))
+            .Returns(alwaysRunState.CompletionSource.Task);
+        scheduler.Setup(x => x.MarkModuleStarted(typeof(AlwaysRunDistributedModule)))
+            .Callback(() => alwaysRunState.State = ModuleExecutionState.Executing)
+            .Returns(true);
+        scheduler.Setup(x => x.CancelPendingModules())
+            .Callback(trackingCoordinator.ReleaseWorkerQuery)
+            .Returns([]);
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        typeRegistry.Register(typeof(AlwaysRunDistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var failureResult = CreateTypedFailureResult(failedModule, new Exception("failed"));
+        var serializedFailure = serializer.Serialize(
+            failureResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 1);
+        var moduleRunner = new Mock<IModuleRunner>();
+        moduleRunner.Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                It.Is<ModuleState>(state => ReferenceEquals(state.Module, alwaysRunModule)),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                ModuleCompletionSourceApplicator.TryApply(
+                    alwaysRunModule,
+                    CreateSuccessResult(42, nameof(AlwaysRunDistributedModule)));
+                alwaysRunState.State = ModuleExecutionState.Completed;
+                alwaysRunState.CompletionSource.TrySetResult(alwaysRunModule);
+            })
+            .Returns(Task.CompletedTask);
+        var resultRegistry = new ModuleResultRegistry();
+        var executor = CreateExecutor(
+            scheduler,
+            moduleRunner,
+            resultRegistry,
+            trackingCoordinator,
+            new DistributedResultCollector(trackingCoordinator, serializer),
+            alwaysRunHandler: NewAlwaysRunHandler(moduleRunner.Object));
+
+        var executionTask = executor.ExecuteAsync([failedModule, alwaysRunModule]);
+        await trackingCoordinator.WaitForResultStartedAsync(typeof(DistributedModule))
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        var failedAssignment = await coordinator.DequeueModuleAsync(
+            new HashSet<Capability>(),
+            CancellationToken.None);
+        await Assert.That(failedAssignment?.ModuleTypeName).IsEqualTo(typeof(DistributedModule).FullName);
+        await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
+
+        await trackingCoordinator.WaitForResultPublishedAsync(typeof(AlwaysRunDistributedModule))
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await Assert.That(resultRegistry.GetResult(typeof(AlwaysRunDistributedModule))?.Status)
+            .IsEqualTo(ModuleStatus.Succeeded);
+        moduleRunner.VerifyAll();
+    }
+
+    [Test]
+    public async Task AlwaysRun_Handler_Failure_Is_Rethrown_After_Worker_Shutdown()
+    {
+        var failure = new InvalidOperationException("AlwaysRun failed");
+        var module = new DistributedModule();
+        var scheduler = CreateMockScheduler(new ModuleState(module, typeof(DistributedModule)));
+        scheduler.Setup(x => x.CancelPendingModules()).Returns([]);
+        var coordinator = new InMemoryDistributedCoordinator();
+        var trackingCoordinator = new ResultTrackingCoordinator(coordinator);
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var failureResult = CreateTypedFailureResult(module, new Exception("pipeline failed"));
+        var serializedFailure = serializer.Serialize(
+            failureResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 1);
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler.Setup(x => x.WaitForAlwaysRunModulesAsync(
+                scheduler.Object,
+                It.IsAny<IReadOnlyList<IModule>>(),
+                It.IsAny<Func<ModuleState, Task>>()))
+            .ThrowsAsync(failure);
+        var executor = CreateExecutor(
+            scheduler,
+            coordinator: trackingCoordinator,
+            resultCollector: new DistributedResultCollector(trackingCoordinator, serializer),
+            alwaysRunHandler: alwaysRunHandler.Object);
+
+        var executionTask = executor.ExecuteAsync([module]);
+        await trackingCoordinator.WaitForResultStartedAsync(typeof(DistributedModule))
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
+        var exception = await Assert.That(async () => await executionTask)
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception).IsSameReferenceAs(failure);
+        await trackingCoordinator.CompletionSignaled.Task.WaitAsync(TimeSpan.FromSeconds(2));
         alwaysRunHandler.VerifyAll();
     }
 
@@ -837,7 +1026,8 @@ public class DistributedModuleExecutorTests
         alwaysRunHandler
             .Setup(x => x.WaitForAlwaysRunModulesAsync(
                 scheduler.Object,
-                It.IsAny<IReadOnlyList<IModule>>()))
+                It.IsAny<IReadOnlyList<IModule>>(),
+                It.IsAny<Func<ModuleState, Task>>()))
             .Returns(noDequeue.WaitForAssignmentDequeuedAsync());
         var executor = CreateExecutor(
             scheduler,

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -146,6 +147,15 @@ public class DistributedModuleExecutorTests
             => Task.FromResult(42);
     }
 
+    private sealed class AlwaysRunDistributedModule : Module<int>
+    {
+        protected override void Configure(ModuleConfigurationBuilder module) => module.WithAlwaysRun();
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(42);
+    }
+
     [ProducesArtifact("distributed-output", "missing-output.txt")]
     private class ArtifactLoggingModule : Module<SimpleResult>
     {
@@ -177,10 +187,17 @@ public class DistributedModuleExecutorTests
     /// </summary>
     private class NoDequeueCoordinator(IDistributedMasterCoordinator inner) : IDistributedMasterCoordinator
     {
+        private readonly ConcurrentDictionary<string, TaskCompletionSource> _resultWaits = new();
+
         public TaskCompletionSource ResultWaitStarted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public ConcurrentDictionary<string, CancellationToken> ResultWaitTokens { get; } = new();
+
         public TaskCompletionSource WorkerQueryStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource CompletionSignaled { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private TaskCompletionSource WorkerQueryRelease { get; } =
@@ -200,8 +217,17 @@ public class DistributedModuleExecutorTests
         public Task<SerializedModuleResult> WaitForResultAsync(string moduleTypeName, CancellationToken cancellationToken)
         {
             ResultWaitStarted.TrySetResult();
+            ResultWaitTokens[moduleTypeName] = cancellationToken;
+            _resultWaits.GetOrAdd(
+                moduleTypeName,
+                _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)).TrySetResult();
             return inner.WaitForResultAsync(moduleTypeName, cancellationToken);
         }
+
+        public Task WaitForResultStartedAsync(Type moduleType) =>
+            _resultWaits.GetOrAdd(
+                moduleType.FullName!,
+                _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
 
         public Task RegisterWorkerAsync(WorkerRegistration registration, CancellationToken cancellationToken)
             => inner.RegisterWorkerAsync(registration, cancellationToken);
@@ -214,8 +240,11 @@ public class DistributedModuleExecutorTests
             return await inner.GetRegisteredWorkersAsync(cancellationToken);
         }
 
-        public Task SignalCompletionAsync(CancellationToken cancellationToken)
-            => inner.SignalCompletionAsync(cancellationToken);
+        public async Task SignalCompletionAsync(CancellationToken cancellationToken)
+        {
+            await inner.SignalCompletionAsync(cancellationToken);
+            CompletionSignaled.TrySetResult();
+        }
 
         public Task BroadcastCancellationAsync(CancellationToken cancellationToken)
             => inner.BroadcastCancellationAsync(cancellationToken);
@@ -293,9 +322,10 @@ public class DistributedModuleExecutorTests
         DistributedResultCollector? resultCollector = null,
         ArtifactLifecycleManager? artifactManager = null,
         DistributedOptions? distributedOptions = null,
-        CancellationToken applicationStopping = default,
         IInternalModuleLogger? moduleLogger = null,
         ILogger<DistributedModuleExecutor>? executorLogger = null,
+        IAlwaysRunHandler? alwaysRunHandler = null,
+        CancellationToken applicationStopping = default,
         IModuleConditionHandler? conditionHandler = null)
     {
         var lifetime = new Mock<IHostApplicationLifetime>();
@@ -320,11 +350,13 @@ public class DistributedModuleExecutorTests
             conditionHandler: conditionHandler);
         resultCollector ??= new DistributedResultCollector(coordinator, serializer);
         moduleRunner ??= new Mock<IModuleRunner>();
+        alwaysRunHandler ??= Mock.Of<IAlwaysRunHandler>();
 
         return new DistributedModuleExecutor(
             lifetime.Object,
             factory.Object,
             moduleRunner.Object,
+            alwaysRunHandler,
             regEventExecutor.Object,
             coordinator,
             coordinator,
@@ -671,6 +703,77 @@ public class DistributedModuleExecutorTests
         var resultB = resultRegistry.GetResult(typeof(AnotherDistributedModule));
         await Assert.That(resultB).IsNotNull();
         await Assert.That(resultB!.ExceptionOrDefault).IsNotNull();
+    }
+
+    [Test]
+    public async Task FailFast_Does_Not_Cancel_InFlight_AlwaysRun_Result()
+    {
+        var failedModule = new DistributedModule();
+        var alwaysRunModule = new AlwaysRunDistributedModule();
+        var scheduler = CreateMockScheduler(
+            new ModuleState(failedModule, typeof(DistributedModule)),
+            new ModuleState(alwaysRunModule, typeof(AlwaysRunDistributedModule)));
+        var pipelineCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler
+            .Setup(x => x.CancelPendingModules())
+            .Callback(() => pipelineCancelled.TrySetResult())
+            .Returns([]);
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        typeRegistry.Register(typeof(AlwaysRunDistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var failureResult = CreateTypedFailureResult(failedModule, new Exception("failed"));
+        var serializedFailure = serializer.Serialize(
+            failureResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            workerIndex: 1);
+        var alwaysRunResult = CreateSuccessResult(42, nameof(AlwaysRunDistributedModule));
+        var serializedAlwaysRunResult = serializer.Serialize(
+            alwaysRunResult,
+            typeof(AlwaysRunDistributedModule).FullName!,
+            typeof(int).FullName!,
+            workerIndex: 1);
+        var coordinator = new InMemoryDistributedCoordinator();
+        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var releaseAlwaysRun = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var alwaysRunStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler
+            .Setup(x => x.WaitForAlwaysRunModulesAsync(
+                scheduler.Object,
+                It.Is<IReadOnlyList<IModule>>(modules => modules.Contains(alwaysRunModule))))
+            .Callback(() => alwaysRunStarted.TrySetResult())
+            .Returns(releaseAlwaysRun.Task);
+        var resultCollector = new DistributedResultCollector(noDequeue, serializer);
+        var resultRegistry = new ModuleResultRegistry();
+        var executor = CreateExecutor(
+            scheduler,
+            alwaysRunHandler: alwaysRunHandler.Object,
+            resultRegistry: resultRegistry,
+            coordinator: noDequeue,
+            resultCollector: resultCollector);
+
+        var executionTask = executor.ExecuteAsync([failedModule, alwaysRunModule]);
+        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WaitForResultStartedAsync(typeof(AlwaysRunDistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
+        await pipelineCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var alwaysRunWaitToken = noDequeue.ResultWaitTokens[typeof(AlwaysRunDistributedModule).FullName!];
+        await Assert.That(alwaysRunWaitToken.IsCancellationRequested).IsFalse();
+        await Assert.That(executionTask.IsCompleted).IsFalse();
+
+        await coordinator.PublishResultAsync(serializedAlwaysRunResult, CancellationToken.None);
+        await alwaysRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Assert.That(executionTask.IsCompleted).IsFalse();
+        await Assert.That(noDequeue.CompletionSignaled.Task.IsCompleted).IsFalse();
+
+        releaseAlwaysRun.TrySetResult();
+        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.CompletionSignaled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Assert.That(resultRegistry.GetResult(typeof(AlwaysRunDistributedModule))?.ExceptionOrDefault).IsNull();
+        alwaysRunHandler.VerifyAll();
     }
 
     // =================================================================
@@ -1583,7 +1686,7 @@ public class DistributedModuleExecutorTests
         var moduleRunner = new Mock<IModuleRunner>();
 
         var executor = new DistributedModuleExecutor(
-            lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
+            lifetime.Object, factory.Object, moduleRunner.Object, Mock.Of<IAlwaysRunHandler>(), regEventExecutor.Object,
             coordinator.Object, coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
@@ -1632,7 +1735,7 @@ public class DistributedModuleExecutorTests
         var publisher = new DistributedWorkPublisher(noDequeue, typeRegistry, serializer, resultRegistry);
 
         var executor = new DistributedModuleExecutor(
-            lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
+            lifetime.Object, factory.Object, moduleRunner.Object, Mock.Of<IAlwaysRunHandler>(), regEventExecutor.Object,
             noDequeue, noDequeue, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
@@ -1725,7 +1828,7 @@ public class DistributedModuleExecutorTests
         var publisher = new DistributedWorkPublisher(coordinator.Object, typeRegistry, serializer, resultRegistry);
 
         var executor = new DistributedModuleExecutor(
-            lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
+            lifetime.Object, factory.Object, moduleRunner.Object, Mock.Of<IAlwaysRunHandler>(), regEventExecutor.Object,
             coordinator.Object, coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),


### PR DESCRIPTION
## Summary
- keep the master worker and `AlwaysRun` result collection alive after distributed fail-fast
- invoke the shared always-run handler for cleanup modules that were not dispatched
- delay distributed completion signaling until teardown finishes
- cover cancellation-token survival and completion ordering

## Validation
- `ModularPipelines.Distributed.UnitTests` Release: 121 passed with coverage
- focused fail-fast/always-run regression: passed
- scoped whitespace verification: passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors

Closes #4381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always-run distributed modules now complete result processing after fail-fast pipeline cancellation.
  * In-flight always-run results are no longer interrupted unnecessarily.
  * Queued non-always-run modules are skipped after a fail-fast cancellation.
  * The master worker waits for always-run modules to finish before stopping, except during application shutdown.
* **Tests**
  * Added coverage for always-run completion and queued assignment handling during fail-fast cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->