### PR TITLE
Synchronize generated PublicAPI baselines

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Test exact generated-file staging
         shell: pwsh
         run: tools/ModularPipelines.OptionsGenerator/scripts/Test-StageGeneratedChanges.ps1
+      - name: Test public API baseline synchronization
+        shell: pwsh
+        run: |
+          tools/ModularPipelines.OptionsGenerator/scripts/Test-WritePublicApiSnapshotFromSarif.ps1
+          tools/ModularPipelines.OptionsGenerator/scripts/Test-MergePublicApiBaselineSnapshot.ps1
       - name: Reject stale generated enum attributes
         shell: pwsh
         run: tools/ModularPipelines.OptionsGenerator/scripts/Test-GeneratedEnumAttributes.ps1
@@ -596,6 +601,49 @@ jobs:
             echo "$coverage_delimiter"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Synchronize generated public API baselines
+        if: steps.should-run.outputs.run == 'true'
+        shell: pwsh
+        env:
+          PublicApiAnalyzerProject: ${{ matrix.package }}
+        run: |
+          $packageDirectory = "src/${{ steps.package.outputs.package }}"
+          $shipped = Join-Path $packageDirectory 'PublicAPI.Shipped.txt'
+          $unshipped = Join-Path $packageDirectory 'PublicAPI.Unshipped.txt'
+          $originalShipped = Join-Path $env:RUNNER_TEMP 'PublicAPI.Shipped.original.txt'
+          $originalUnshipped = Join-Path $env:RUNNER_TEMP 'PublicAPI.Unshipped.original.txt'
+          Copy-Item -LiteralPath $shipped -Destination $originalShipped
+          Copy-Item -LiteralPath $unshipped -Destination $originalUnshipped
+          foreach ($baseline in $shipped, $unshipped) {
+            $headers = @(Get-Content -LiteralPath $baseline | Where-Object { $_.StartsWith('#') })
+            [System.IO.File]::WriteAllLines($baseline, $headers, [System.Text.UTF8Encoding]::new($false))
+          }
+
+          $errorLog = Join-Path $env:RUNNER_TEMP 'PublicAPI.current.sarif'
+          $buildLog = Join-Path $env:RUNNER_TEMP 'PublicAPI.snapshot-build.log'
+          dotnet build "${packageDirectory}/${{ steps.package.outputs.package }}.csproj" `
+            -c Release `
+            --no-incremental `
+            -p:TreatWarningsAsErrors=false `
+            -p:WarningsAsErrors= `
+            "-p:ErrorLog=$errorLog" *> $buildLog
+          if ($LASTEXITCODE -ne 0) {
+            Get-Content -LiteralPath $buildLog
+            throw 'Failed to create the current public API snapshot.'
+          }
+
+          tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiSnapshotFromSarif.ps1 `
+            -ErrorLogPath $errorLog `
+            -SnapshotPath $unshipped `
+            -RequireEntries
+
+          tools/ModularPipelines.OptionsGenerator/scripts/Merge-PublicApiBaselineSnapshot.ps1 `
+            -OriginalShippedPath $originalShipped `
+            -OriginalUnshippedPath $originalUnshipped `
+            -CurrentApiSnapshotPath $unshipped `
+            -ShippedOutputPath $shipped `
+            -UnshippedOutputPath $unshipped
+
       - name: Check for changes
         if: steps.should-run.outputs.run == 'true'
         id: changes
@@ -605,6 +653,10 @@ jobs:
             -RepositoryRoot "$env:GITHUB_WORKSPACE" `
             -ManifestPath "$env:RUNNER_TEMP/generated-paths.txt" `
             -AllowedPathFile "$env:RUNNER_TEMP/legacy-generated-paths.txt" `
+            -AllowedPath @(
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Shipped.txt"
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Unshipped.txt"
+            ) `
             -MaximumFileSizeBytes 5242880
 
           # Check for actual content changes (ignore whitespace-only changes)
@@ -632,6 +684,8 @@ jobs:
 
       - name: Build solution to verify changes
         if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true'
+        env:
+          PublicApiAnalyzerProject: ${{ matrix.package }}
         run: |
           BUILD_ARGS=()
           # Gcloud generates enough source for parallel MSBuild nodes to exhaust the hosted runner.
@@ -649,6 +703,10 @@ jobs:
             -RepositoryRoot "$env:GITHUB_WORKSPACE" `
             -ManifestPath "$env:RUNNER_TEMP/generated-paths.txt" `
             -AllowedPathFile "$env:RUNNER_TEMP/legacy-generated-paths.txt" `
+            -AllowedPath @(
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Shipped.txt"
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Unshipped.txt"
+            ) `
             -MaximumFileSizeBytes 5242880
 
       - name: Create Pull Request for ${{ matrix.tool }}
@@ -867,6 +925,49 @@ jobs:
           }
           $coverageDelimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Synchronize generated public API baselines
+        if: steps.should-run.outputs.run == 'true'
+        shell: pwsh
+        env:
+          PublicApiAnalyzerProject: ${{ matrix.package }}
+        run: |
+          $packageDirectory = "src/${{ steps.package.outputs.package }}"
+          $shipped = Join-Path $packageDirectory 'PublicAPI.Shipped.txt'
+          $unshipped = Join-Path $packageDirectory 'PublicAPI.Unshipped.txt'
+          $originalShipped = Join-Path $env:RUNNER_TEMP 'PublicAPI.Shipped.original.txt'
+          $originalUnshipped = Join-Path $env:RUNNER_TEMP 'PublicAPI.Unshipped.original.txt'
+          Copy-Item -LiteralPath $shipped -Destination $originalShipped
+          Copy-Item -LiteralPath $unshipped -Destination $originalUnshipped
+          foreach ($baseline in $shipped, $unshipped) {
+            $headers = @(Get-Content -LiteralPath $baseline | Where-Object { $_.StartsWith('#') })
+            [System.IO.File]::WriteAllLines($baseline, $headers, [System.Text.UTF8Encoding]::new($false))
+          }
+
+          $errorLog = Join-Path $env:RUNNER_TEMP 'PublicAPI.current.sarif'
+          $buildLog = Join-Path $env:RUNNER_TEMP 'PublicAPI.snapshot-build.log'
+          dotnet build "${packageDirectory}/${{ steps.package.outputs.package }}.csproj" `
+            -c Release `
+            --no-incremental `
+            -p:TreatWarningsAsErrors=false `
+            -p:WarningsAsErrors= `
+            "-p:ErrorLog=$errorLog" *> $buildLog
+          if ($LASTEXITCODE -ne 0) {
+            Get-Content -LiteralPath $buildLog
+            throw 'Failed to create the current public API snapshot.'
+          }
+
+          tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiSnapshotFromSarif.ps1 `
+            -ErrorLogPath $errorLog `
+            -SnapshotPath $unshipped `
+            -RequireEntries
+
+          tools/ModularPipelines.OptionsGenerator/scripts/Merge-PublicApiBaselineSnapshot.ps1 `
+            -OriginalShippedPath $originalShipped `
+            -OriginalUnshippedPath $originalUnshipped `
+            -CurrentApiSnapshotPath $unshipped `
+            -ShippedOutputPath $shipped `
+            -UnshippedOutputPath $unshipped
+
       - name: Check for changes
         if: steps.should-run.outputs.run == 'true'
         id: changes
@@ -876,6 +977,10 @@ jobs:
             -RepositoryRoot "$env:GITHUB_WORKSPACE" `
             -ManifestPath "$env:RUNNER_TEMP/generated-paths.txt" `
             -AllowedPathFile "$env:RUNNER_TEMP/legacy-generated-paths.txt" `
+            -AllowedPath @(
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Shipped.txt"
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Unshipped.txt"
+            ) `
             -MaximumFileSizeBytes 5242880
 
           # Check for actual content changes (ignore whitespace-only changes)
@@ -893,6 +998,8 @@ jobs:
 
       - name: Build solution to verify changes
         if: steps.should-run.outputs.run == 'true' && steps.changes.outputs.has_changes == 'true'
+        env:
+          PublicApiAnalyzerProject: ${{ matrix.package }}
         run: >-
           dotnet build
           "src/${{ steps.package.outputs.package }}/${{ steps.package.outputs.package }}.slnx"
@@ -906,6 +1013,10 @@ jobs:
             -RepositoryRoot "$env:GITHUB_WORKSPACE" `
             -ManifestPath "$env:RUNNER_TEMP/generated-paths.txt" `
             -AllowedPathFile "$env:RUNNER_TEMP/legacy-generated-paths.txt" `
+            -AllowedPath @(
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Shipped.txt"
+              "src/${{ steps.package.outputs.package }}/PublicAPI.Unshipped.txt"
+            ) `
             -MaximumFileSizeBytes 5242880
 
       - name: Create Pull Request for ${{ matrix.tool }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,12 +40,12 @@
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="$(MSBuildProjectFile.Contains('Test')) == false and ('$(GITHUB_ACTIONS)' != 'true' or '$(EnableCiAnalyzers)' == 'true')" />
   </ItemGroup>
 
-  <!-- Generated integrations do not follow semantic versioning; enforce API baselines only for the core library. -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' == 'ModularPipelines' and ('$(GITHUB_ACTIONS)' == 'true' or '$(EnableCiAnalyzers)' == 'true')">
+  <!-- Generated integrations opt into baseline synchronization during their generation job. -->
+  <ItemGroup Condition="('$(MSBuildProjectName)' == 'ModularPipelines' and ('$(GITHUB_ACTIONS)' == 'true' or '$(EnableCiAnalyzers)' == 'true')) or '$(PublicApiAnalyzerProject)' == '$(MSBuildProjectName)'">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ModularPipelines' and ('$(GITHUB_ACTIONS)' == 'true' or '$(EnableCiAnalyzers)' == 'true')">
+  <PropertyGroup Condition="('$(MSBuildProjectName)' == 'ModularPipelines' and ('$(GITHUB_ACTIONS)' == 'true' or '$(EnableCiAnalyzers)' == 'true')) or '$(PublicApiAnalyzerProject)' == '$(MSBuildProjectName)'">
     <!-- Keep the core public API baseline enforced in ordinary CI builds. -->
     <EnableNETAnalyzers Condition="'$(GITHUB_ACTIONS)' == 'true' and '$(EnableCiAnalyzers)' != 'true'">false</EnableNETAnalyzers>
     <RunAnalyzers Condition="'$(GITHUB_ACTIONS)' == 'true'">true</RunAnalyzers>

--- a/tools/ModularPipelines.OptionsGenerator/scripts/Merge-PublicApiBaselineSnapshot.ps1
+++ b/tools/ModularPipelines.OptionsGenerator/scripts/Merge-PublicApiBaselineSnapshot.ps1
@@ -1,0 +1,102 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $OriginalShippedPath,
+    [Parameter(Mandatory)][string] $OriginalUnshippedPath,
+    [Parameter(Mandatory)][string] $CurrentApiSnapshotPath,
+    [Parameter(Mandatory)][string] $ShippedOutputPath,
+    [Parameter(Mandatory)][string] $UnshippedOutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+$removedPrefix = '*REMOVED*'
+$comparer = [System.StringComparer]::Ordinal
+
+function Read-Baseline([string] $Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Public API baseline does not exist: $Path"
+    }
+
+    return @(Get-Content -LiteralPath $Path | Where-Object {
+        -not [string]::IsNullOrWhiteSpace($_)
+    })
+}
+
+function Get-Headers([string[]] $Lines) {
+    return @($Lines | Where-Object { $_.StartsWith('#', [System.StringComparison]::Ordinal) })
+}
+
+function Get-ApiEntries([string[]] $Lines) {
+    return @($Lines | Where-Object { -not $_.StartsWith('#', [System.StringComparison]::Ordinal) })
+}
+
+function Write-Baseline([string] $Path, [string[]] $Headers, [string[]] $Entries) {
+    $uniqueEntries = [System.Collections.Generic.HashSet[string]]::new($Entries, $comparer)
+    $sortedEntries = [string[]] @($uniqueEntries)
+    [Array]::Sort($sortedEntries, $comparer)
+    $lines = @($Headers) + $sortedEntries
+    $existing = @(if (Test-Path -LiteralPath $Path -PathType Leaf) {
+        Get-Content -LiteralPath $Path
+    })
+
+    if ([System.Linq.Enumerable]::SequenceEqual([string[]] $existing, [string[]] $lines, $comparer)) {
+        return
+    }
+
+    [System.IO.File]::WriteAllLines(
+        $Path,
+        [string[]] $lines,
+        [System.Text.UTF8Encoding]::new($false))
+}
+
+$originalShipped = Read-Baseline $OriginalShippedPath
+$originalUnshipped = Read-Baseline $OriginalUnshippedPath
+$currentSnapshot = Read-Baseline $CurrentApiSnapshotPath
+
+$currentApis = [System.Collections.Generic.HashSet[string]]::new($comparer)
+foreach ($entry in Get-ApiEntries $currentSnapshot) {
+    if (-not $entry.StartsWith($removedPrefix, [System.StringComparison]::Ordinal)) {
+        $null = $currentApis.Add($entry)
+    }
+}
+
+$shippedApis = [System.Collections.Generic.HashSet[string]]::new($comparer)
+foreach ($entry in Get-ApiEntries $originalShipped) {
+    if ($currentApis.Contains($entry)) {
+        $null = $shippedApis.Add($entry)
+    }
+}
+
+$unshippedApis = [System.Collections.Generic.HashSet[string]]::new($comparer)
+foreach ($entry in $currentApis) {
+    if (-not $shippedApis.Contains($entry)) {
+        $null = $unshippedApis.Add($entry)
+    }
+}
+
+foreach ($entry in Get-ApiEntries $originalShipped) {
+    if (-not $currentApis.Contains($entry)) {
+        $null = $unshippedApis.Add("$removedPrefix$entry")
+    }
+}
+
+foreach ($entry in Get-ApiEntries $originalUnshipped) {
+    if (-not $entry.StartsWith($removedPrefix, [System.StringComparison]::Ordinal)) {
+        continue
+    }
+
+    $removedApi = $entry.Substring($removedPrefix.Length)
+    if (-not $currentApis.Contains($removedApi)) {
+        $null = $unshippedApis.Add($entry)
+    }
+}
+
+Write-Baseline `
+    -Path $ShippedOutputPath `
+    -Headers (Get-Headers $originalShipped) `
+    -Entries @($shippedApis)
+Write-Baseline `
+    -Path $UnshippedOutputPath `
+    -Headers (Get-Headers $originalUnshipped) `
+    -Entries @($unshippedApis)
+
+Write-Output "Synchronized $($currentApis.Count) current public API entries."

--- a/tools/ModularPipelines.OptionsGenerator/scripts/Test-MergePublicApiBaselineSnapshot.ps1
+++ b/tools/ModularPipelines.OptionsGenerator/scripts/Test-MergePublicApiBaselineSnapshot.ps1
@@ -1,0 +1,108 @@
+$ErrorActionPreference = 'Stop'
+
+$mergeScript = Join-Path $PSScriptRoot 'Merge-PublicApiBaselineSnapshot.ps1'
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "merge-public-api-baseline-{0}" -f [guid]::NewGuid())
+$resolvedTempRoot = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::GetTempPath())
+$resolvedTestRoot = [System.IO.Path]::GetFullPath($testRoot)
+if (-not $resolvedTestRoot.StartsWith(
+        $resolvedTempRoot,
+        [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to use test directory outside temp root: $resolvedTestRoot"
+}
+
+New-Item -ItemType Directory -Path $testRoot | Out-Null
+
+function Assert-Lines([string] $Path, [string[]] $Expected) {
+    $actual = @(Get-Content -LiteralPath $Path)
+    if (-not [System.Linq.Enumerable]::SequenceEqual(
+            [string[]] $actual,
+            [string[]] $Expected,
+            [System.StringComparer]::Ordinal)) {
+        throw @"
+Unexpected contents in $Path.
+Expected:
+$($Expected -join [Environment]::NewLine)
+Actual:
+$($actual -join [Environment]::NewLine)
+"@
+    }
+}
+
+try {
+    $originalShipped = Join-Path $testRoot 'PublicAPI.Shipped.original.txt'
+    $originalUnshipped = Join-Path $testRoot 'PublicAPI.Unshipped.original.txt'
+    $currentSnapshot = Join-Path $testRoot 'PublicAPI.Current.txt'
+    $shippedOutput = Join-Path $testRoot 'PublicAPI.Shipped.txt'
+    $unshippedOutput = Join-Path $testRoot 'PublicAPI.Unshipped.txt'
+
+    @(
+        '#nullable enable'
+        'Api.Changed(string)'
+        'Api.Existing'
+        'Api.Removed()'
+    ) | Set-Content -LiteralPath $originalShipped
+    @(
+        '#nullable enable'
+        '*REMOVED*Api.Historical'
+        '*REMOVED*Api.Reintroduced'
+        'Api.Pending'
+        'Api.Stale'
+    ) | Set-Content -LiteralPath $originalUnshipped
+    @(
+        '#nullable enable'
+        'Api.Added'
+        'Api.Added.ApiAdded() -> void'
+        'Api.Added.Name.get -> string!'
+        'Api.Changed(int)'
+        'Api.Existing'
+        'Api.Pending'
+        'Api.Reintroduced'
+    ) | Set-Content -LiteralPath $currentSnapshot
+
+    & $mergeScript `
+        -OriginalShippedPath $originalShipped `
+        -OriginalUnshippedPath $originalUnshipped `
+        -CurrentApiSnapshotPath $currentSnapshot `
+        -ShippedOutputPath $shippedOutput `
+        -UnshippedOutputPath $unshippedOutput
+
+    Assert-Lines $shippedOutput @(
+        '#nullable enable'
+        'Api.Existing'
+    )
+    Assert-Lines $unshippedOutput @(
+        '#nullable enable'
+        '*REMOVED*Api.Changed(string)'
+        '*REMOVED*Api.Historical'
+        '*REMOVED*Api.Removed()'
+        'Api.Added'
+        'Api.Added.ApiAdded() -> void'
+        'Api.Added.Name.get -> string!'
+        'Api.Changed(int)'
+        'Api.Pending'
+        'Api.Reintroduced'
+    )
+
+    $shippedHash = (Get-FileHash -LiteralPath $shippedOutput).Hash
+    $unshippedHash = (Get-FileHash -LiteralPath $unshippedOutput).Hash
+    & $mergeScript `
+        -OriginalShippedPath $shippedOutput `
+        -OriginalUnshippedPath $unshippedOutput `
+        -CurrentApiSnapshotPath $currentSnapshot `
+        -ShippedOutputPath $shippedOutput `
+        -UnshippedOutputPath $unshippedOutput
+
+    if ($shippedHash -ne (Get-FileHash -LiteralPath $shippedOutput).Hash -or
+        $unshippedHash -ne (Get-FileHash -LiteralPath $unshippedOutput).Hash) {
+        throw 'Repeated baseline synchronization was not idempotent.'
+    }
+
+    Write-Output 'OK public API additions, removals, signature changes, and idempotency passed.'
+}
+finally {
+    if (Test-Path -LiteralPath $resolvedTestRoot) {
+        Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/scripts/Test-WritePublicApiSnapshotFromSarif.ps1
+++ b/tools/ModularPipelines.OptionsGenerator/scripts/Test-WritePublicApiSnapshotFromSarif.ps1
@@ -1,0 +1,81 @@
+$ErrorActionPreference = 'Stop'
+
+$snapshotScript = Join-Path $PSScriptRoot 'Write-PublicApiSnapshotFromSarif.ps1'
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) (
+    "write-public-api-snapshot-{0}" -f [guid]::NewGuid())
+$resolvedTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$resolvedTestRoot = [IO.Path]::GetFullPath($testRoot)
+if (-not $resolvedTestRoot.StartsWith(
+        $resolvedTempRoot,
+        [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to use test directory outside temp root: $resolvedTestRoot"
+}
+
+New-Item -ItemType Directory -Path $resolvedTestRoot | Out-Null
+
+function Write-Sarif([string] $Path, [object[]] $Results) {
+    @{
+        version = '2.1.0'
+        runs = @(@{ results = $Results })
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path
+}
+
+try {
+    $errorLog = Join-Path $resolvedTestRoot 'compiler.sarif'
+    $snapshot = Join-Path $resolvedTestRoot 'PublicAPI.Unshipped.txt'
+    @('#nullable enable', 'stale') | Set-Content -LiteralPath $snapshot
+    Write-Sarif $errorLog @(
+        @{ ruleId = 'CS1591'; message = "Missing XML comment" }
+        @{ ruleId = 'RS0016'; message = "Symbol 'api.Lower' is not part of the declared public API" }
+        @{ ruleId = 'RS0016'; message = "Symbol 'Api.Upper' is not part of the declared public API" }
+        @{ ruleId = 'RS0016'; message = "Symbol 'Api.Upper' is not part of the declared public API" }
+    )
+
+    & $snapshotScript `
+        -ErrorLogPath $errorLog `
+        -SnapshotPath $snapshot `
+        -RequireEntries
+
+    $actual = @(Get-Content -LiteralPath $snapshot)
+    $expected = @('#nullable enable', 'Api.Upper', 'api.Lower')
+    if (-not [Linq.Enumerable]::SequenceEqual(
+            [string[]] $actual,
+            [string[]] $expected,
+            [StringComparer]::Ordinal)) {
+        throw "Unexpected snapshot contents: $($actual -join ', ')"
+    }
+
+    Write-Sarif $errorLog @(
+        @{ ruleId = 'RS0016'; message = 'Unexpected message shape' }
+    )
+    try {
+        & $snapshotScript -ErrorLogPath $errorLog -SnapshotPath $snapshot
+        throw 'Malformed RS0016 diagnostic should have failed.'
+    }
+    catch {
+        if ($_.Exception.Message -eq 'Malformed RS0016 diagnostic should have failed.') {
+            throw
+        }
+    }
+
+    Write-Sarif $errorLog @()
+    try {
+        & $snapshotScript `
+            -ErrorLogPath $errorLog `
+            -SnapshotPath $snapshot `
+            -RequireEntries
+        throw 'Empty required snapshot should have failed.'
+    }
+    catch {
+        if ($_.Exception.Message -eq 'Empty required snapshot should have failed.') {
+            throw
+        }
+    }
+
+    Write-Output 'OK SARIF extraction, deduplication, ordering, and fail-closed checks passed.'
+}
+finally {
+    if (Test-Path -LiteralPath $resolvedTestRoot) {
+        Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiSnapshotFromSarif.ps1
+++ b/tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiSnapshotFromSarif.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $ErrorLogPath,
+    [Parameter(Mandatory)][string] $SnapshotPath,
+    [switch] $RequireEntries
+)
+
+$ErrorActionPreference = 'Stop'
+$messagePrefix = "Symbol '"
+$messageSuffix = "' is not part of the declared public API"
+$comparer = [System.StringComparer]::Ordinal
+
+if (-not (Test-Path -LiteralPath $ErrorLogPath -PathType Leaf)) {
+    throw "Compiler error log does not exist: $ErrorLogPath"
+}
+
+if (-not (Test-Path -LiteralPath $SnapshotPath -PathType Leaf)) {
+    throw "Public API snapshot does not exist: $SnapshotPath"
+}
+
+$sarif = Get-Content -LiteralPath $ErrorLogPath -Raw | ConvertFrom-Json
+$results = @($sarif.runs | ForEach-Object { @($_.results) })
+$apis = [System.Collections.Generic.HashSet[string]]::new($comparer)
+
+foreach ($result in $results | Where-Object { $_.ruleId -eq 'RS0016' }) {
+    $message = if ($result.message -is [string]) {
+        [string] $result.message
+    }
+    elseif ($null -ne $result.message.text) {
+        [string] $result.message.text
+    }
+    else {
+        throw 'RS0016 diagnostic does not contain a supported message.'
+    }
+
+    if (-not $message.StartsWith($messagePrefix, [StringComparison]::Ordinal) -or
+        -not $message.EndsWith($messageSuffix, [StringComparison]::Ordinal)) {
+        throw "Unexpected RS0016 diagnostic message: $message"
+    }
+
+    $apiLength = $message.Length - $messagePrefix.Length - $messageSuffix.Length
+    if ($apiLength -le 0) {
+        throw "RS0016 diagnostic contains an empty symbol: $message"
+    }
+
+    $null = $apis.Add($message.Substring($messagePrefix.Length, $apiLength))
+}
+
+if ($RequireEntries -and $apis.Count -eq 0) {
+    throw 'Compiler error log contains no RS0016 public API entries.'
+}
+
+$headers = @(Get-Content -LiteralPath $SnapshotPath | Where-Object {
+    $_.StartsWith('#', [StringComparison]::Ordinal)
+})
+$sortedApis = [string[]] @($apis)
+[Array]::Sort($sortedApis, $comparer)
+[IO.File]::WriteAllLines(
+    $SnapshotPath,
+    [string[]] (@($headers) + $sortedApis),
+    [Text.UTF8Encoding]::new($false))
+
+Write-Output "Wrote $($apis.Count) public API entries from compiler diagnostics."


### PR DESCRIPTION
## Summary
- enable `Microsoft.CodeAnalysis.PublicApiAnalyzers` only for the integration being regenerated
- compile generated code into SARIF and extract exact RS0016 symbols, including generated sources skipped by `dotnet format`
- merge additions, shipped removals, and signature changes into deterministic PublicAPI baselines
- stage the two baseline files and enforce them in the affected integration solution build
- add fail-closed SARIF extraction and baseline merge regression scripts

Follow-up to #4409.

Fixes #4447

## Validation
- `Test-WritePublicApiSnapshotFromSarif.ps1`
- `Test-MergePublicApiBaselineSnapshot.ps1`
- `Test-StageGeneratedChanges.ps1`
- OptionsGenerator Release build: 0 warnings, 0 errors
- core `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- real Syft snapshot: 315 APIs extracted; analyzer-enforced Syft solution build: 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated synchronization of public API baseline files during generation workflows.
  * Added tooling to create API snapshots from compiler diagnostics and merge current API changes into shipped and unshipped baselines.

* **Bug Fixes**
  * Improved handling of API additions, removals, signature changes, ordering, and duplicate entries.

* **Tests**
  * Added integration coverage for snapshot generation, baseline merging, malformed diagnostics, idempotency, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->