### PR TITLE
Keep distributed retries node-local

### DIFF
--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -62,7 +62,6 @@ internal class DistributedWorkPublisher(
 
         var dependencyResults = GatherDependencyResults(module);
 
-        // Distributed workers do not yet consume portable retry configuration.
         return new ModuleAssignment(
             ModuleTypeName: moduleType.FullName!,
             ResultTypeName: resultTypeName,
@@ -70,7 +69,6 @@ internal class DistributedWorkPublisher(
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfiguration(
                 TimeoutSeconds: config.Timeout is not null ? (int?) config.Timeout.Value.TotalSeconds : null,
-                RetryCount: 0,
                 AlwaysRun: config.AlwaysRun
             ),
             DependencyResults: dependencyResults)

--- a/src/ModularPipelines/Distributed/ModuleAssignmentConfiguration.cs
+++ b/src/ModularPipelines/Distributed/ModuleAssignmentConfiguration.cs
@@ -1,6 +1,13 @@
 namespace ModularPipelines.Distributed;
 
+/// <summary>
+/// Contains the portable module settings used by distributed coordination.
+/// </summary>
+/// <remarks>
+/// Retry policies are resolved on the executing node from the module's configuration and
+/// <see cref="Options.PipelineOptions.DefaultRetryCount"/>. This preserves declarative retries and
+/// node-local resilience shield factories without attempting to serialize delegates.
+/// </remarks>
 public record ModuleAssignmentConfiguration(
     double? TimeoutSeconds,
-    int RetryCount,
     bool AlwaysRun);

--- a/src/ModularPipelines/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines/PublicAPI.Unshipped.txt
@@ -1482,11 +1482,9 @@ ModularPipelines.Distributed.ModuleAssignment.SatisfiedConditionGroups.init -> v
 ModularPipelines.Distributed.ModuleAssignmentConfiguration
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.AlwaysRun.get -> bool
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.AlwaysRun.init -> void
-ModularPipelines.Distributed.ModuleAssignmentConfiguration.Deconstruct(out double? TimeoutSeconds, out int RetryCount, out bool AlwaysRun) -> void
-ModularPipelines.Distributed.ModuleAssignmentConfiguration.ModuleAssignmentConfiguration(double? TimeoutSeconds, int RetryCount, bool AlwaysRun) -> void
+ModularPipelines.Distributed.ModuleAssignmentConfiguration.Deconstruct(out double? TimeoutSeconds, out bool AlwaysRun) -> void
+ModularPipelines.Distributed.ModuleAssignmentConfiguration.ModuleAssignmentConfiguration(double? TimeoutSeconds, bool AlwaysRun) -> void
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.ModuleAssignmentConfiguration(ModularPipelines.Distributed.ModuleAssignmentConfiguration! original) -> void
-ModularPipelines.Distributed.ModuleAssignmentConfiguration.RetryCount.get -> int
-ModularPipelines.Distributed.ModuleAssignmentConfiguration.RetryCount.init -> void
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.TimeoutSeconds.get -> double?
 ModularPipelines.Distributed.ModuleAssignmentConfiguration.TimeoutSeconds.init -> void
 ModularPipelines.Distributed.WorkerRegistration.RunIdentifier.get -> string?

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorTests.cs
@@ -227,7 +227,7 @@ public class RedisDistributedCoordinatorTests
             ResultTypeName: "System.String",
             RequiredCapabilities: requiredCapabilities ?? new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
     }
 
     private static SerializedModuleResult CreateResult(string moduleTypeName)

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/DistributedPipelineHubTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/DistributedPipelineHubTests.cs
@@ -56,7 +56,7 @@ public class DistributedPipelineHubTests
             "System.String",
             FrozenSet<Capability>.Empty,
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false));
+            new ModuleAssignmentConfiguration(null, false));
     }
 
     private static SerializedModuleResult CreateResult(string moduleTypeName)

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRIntegrationTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRIntegrationTests.cs
@@ -158,7 +158,7 @@ public class SignalRIntegrationTests
                 ResultTypeName: "System.Int32",
                 RequiredCapabilities: new HashSet<Capability>(),
                 AssignedAt: DateTimeOffset.UtcNow,
-                Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+                Configuration: new ModuleAssignmentConfiguration(null, false));
 
             masterState.PendingAssignments.Enqueue(moduleAssignment);
 
@@ -247,19 +247,19 @@ public class SignalRIntegrationTests
                 "WindowsBuildModule", "System.String",
                 new HashSet<Capability> { "windows" },
                 DateTimeOffset.UtcNow,
-                new ModuleAssignmentConfiguration(null, 0, false));
+                new ModuleAssignmentConfiguration(null, false));
 
             var dockerModule = new ModuleAssignment(
                 "DockerBuildModule", "System.String",
                 new HashSet<Capability> { "linux", "docker" },
                 DateTimeOffset.UtcNow,
-                new ModuleAssignmentConfiguration(null, 0, false));
+                new ModuleAssignmentConfiguration(null, false));
 
             var genericModule = new ModuleAssignment(
                 "GenericModule", "System.String",
                 new HashSet<Capability>(),
                 DateTimeOffset.UtcNow,
-                new ModuleAssignmentConfiguration(null, 0, false));
+                new ModuleAssignmentConfiguration(null, false));
 
             masterState.PendingAssignments.Enqueue(windowsModule);
             masterState.PendingAssignments.Enqueue(dockerModule);
@@ -409,7 +409,7 @@ public class SignalRIntegrationTests
 
                 masterState.PendingAssignments.Enqueue(new ModuleAssignment(
                     moduleName, "System.String", new HashSet<Capability>(),
-                    DateTimeOffset.UtcNow, new ModuleAssignmentConfiguration(null, 0, false)));
+                    DateTimeOffset.UtcNow, new ModuleAssignmentConfiguration(null, false)));
             }
 
             // Worker requests work — will get first assignment, then re-request after each publish

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
@@ -217,7 +217,7 @@ public class SignalRMasterCoordinatorTests
             "LinuxModule", "System.String",
             new HashSet<Capability> { "linux" },
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false));
+            new ModuleAssignmentConfiguration(null, false));
 
         await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
 
@@ -320,7 +320,7 @@ public class SignalRMasterCoordinatorTests
             "LinuxModule", "System.String",
             new HashSet<Capability> { "linux" },
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false));
+            new ModuleAssignmentConfiguration(null, false));
 
         await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
 
@@ -334,7 +334,7 @@ public class SignalRMasterCoordinatorTests
             moduleTypeName, "System.String",
             new HashSet<Capability>(),
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false));
+            new ModuleAssignmentConfiguration(null, false));
     }
 
     private static SerializedModuleResult CreateResult(string moduleTypeName)

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -66,7 +66,7 @@ public class SignalRMasterStateTests
             state.Registrations[i] = new WorkerRegistration(i, FrozenSet<Capability>.Empty, DateTimeOffset.UtcNow);
             state.PendingAssignments.Enqueue(new ModuleAssignment(
                 $"Module{i}", "System.String", FrozenSet<Capability>.Empty,
-                DateTimeOffset.UtcNow, new ModuleAssignmentConfiguration(null, 0, false)));
+                DateTimeOffset.UtcNow, new ModuleAssignmentConfiguration(null, false)));
             state.ResultWaiters[$"Module{i}"] = new TaskCompletionSource<SerializedModuleResult>();
         }));
 
@@ -98,7 +98,7 @@ public class SignalRMasterStateTests
                 "System.String",
                 FrozenSet<Capability>.Empty,
                 DateTimeOffset.UtcNow,
-                new ModuleAssignmentConfiguration(null, 0, false)));
+                new ModuleAssignmentConfiguration(null, false)));
 
         await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
 
@@ -386,7 +386,7 @@ public class SignalRMasterStateTests
             "System.String",
             FrozenSet<Capability>.Empty,
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false));
+            new ModuleAssignmentConfiguration(null, false));
     }
 
     private static SerializedModuleResult CreateResult()

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRWorkerCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRWorkerCoordinatorTests.cs
@@ -23,7 +23,7 @@ public class SignalRWorkerCoordinatorTests
             "System.String",
             FrozenSet<Capability>.Empty,
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false));
+            new ModuleAssignmentConfiguration(null, false));
 
         await Assert.That(() => coordinator.EnqueueModuleAsync(assignment, CancellationToken.None))
             .Throws<NotSupportedException>();

--- a/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityMatcherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Capabilities/CapabilityMatcherTests.cs
@@ -12,7 +12,7 @@ public class CapabilityMatcherTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
@@ -32,7 +32,7 @@ public class CapabilityMatcherTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "docker", "linux" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
@@ -52,7 +52,7 @@ public class CapabilityMatcherTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,
@@ -72,7 +72,7 @@ public class CapabilityMatcherTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "Docker" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         var worker = new WorkerRegistration(
             WorkerIndex: 1,

--- a/test/ModularPipelines.Distributed.UnitTests/Coordination/InMemoryDistributedCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Coordination/InMemoryDistributedCoordinatorTests.cs
@@ -54,7 +54,7 @@ public class InMemoryDistributedCoordinatorTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         await coordinator.EnqueueModuleAsync(dockerAssignment, CancellationToken.None);
 

--- a/test/ModularPipelines.Distributed.UnitTests/DependencyResultPropagationTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/DependencyResultPropagationTests.cs
@@ -76,7 +76,7 @@ public class DependencyResultPropagationTests
             ResultTypeName: typeof(string).FullName!,
             RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false),
+            Configuration: new ModuleAssignmentConfiguration(null, false),
             DependencyResults: [serializedDep]);
 
         // Create module instances
@@ -120,7 +120,7 @@ public class DependencyResultPropagationTests
             ResultTypeName: typeof(int).FullName!,
             RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false),
+            Configuration: new ModuleAssignmentConfiguration(null, false),
             DependencyResults: null);
 
         // Act & Assert — should not throw
@@ -136,7 +136,7 @@ public class DependencyResultPropagationTests
             ResultTypeName: typeof(int).FullName!,
             RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false),
+            Configuration: new ModuleAssignmentConfiguration(null, false),
             DependencyResults: []);
 
         // Act & Assert — check guard condition

--- a/test/ModularPipelines.Distributed.UnitTests/Integration/CapabilityRoutingIntegrationTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Integration/CapabilityRoutingIntegrationTests.cs
@@ -15,7 +15,7 @@ public class CapabilityRoutingIntegrationTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
 
@@ -37,7 +37,7 @@ public class CapabilityRoutingIntegrationTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
 
@@ -67,14 +67,14 @@ public class CapabilityRoutingIntegrationTests
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability> { "docker" },
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         var plainAssignment = new ModuleAssignment(
             ModuleTypeName: "Plain.Module",
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
 
         // Docker worker can execute both
         await Assert.That(CapabilityMatcher.CanExecute(dockerAssignment, dockerWorker)).IsTrue();

--- a/test/ModularPipelines.Distributed.UnitTests/Serialization/ReadOnlySetJsonConverterTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Serialization/ReadOnlySetJsonConverterTests.cs
@@ -31,7 +31,7 @@ public class ReadOnlySetJsonConverterTests
             "System.String",
             new HashSet<Capability> { "Docker" },
             DateTimeOffset.UtcNow,
-            new ModuleAssignmentConfiguration(null, 0, false))
+            new ModuleAssignmentConfiguration(null, false))
         {
             SatisfiedConditionGroups = ["Conditions.CrossPlatform"],
         };

--- a/test/ModularPipelines.Distributed.UnitTests/WorkerModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/WorkerModuleExecutorTests.cs
@@ -1,0 +1,121 @@
+using Kevlar;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Distributed.Coordination;
+using ModularPipelines.Distributed.Serialization;
+using ModularPipelines.Distributed.Worker;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace ModularPipelines.Distributed.UnitTests;
+
+public class WorkerModuleExecutorTests
+{
+    private abstract class RetryingModule : Module<int>
+    {
+        public int AttemptCount { get; private set; }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            if (++AttemptCount < 3)
+            {
+                throw new InvalidOperationException("Retry this attempt.");
+            }
+
+            return Task.FromResult(AttemptCount);
+        }
+    }
+
+    private sealed class DeclarativeRetryModule : RetryingModule
+    {
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithRetry(2, TimeSpan.Zero);
+    }
+
+    private sealed class ShieldFactoryRetryModule : RetryingModule
+    {
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithShield(_ => Shield.Retry(2));
+    }
+
+    private sealed class DefaultRetryModule : RetryingModule;
+
+    [Test]
+    public Task Worker_Uses_Module_Retry_Configuration(CancellationToken cancellationToken) =>
+        AssertWorkerRetriesAsync<DeclarativeRetryModule>(null, cancellationToken);
+
+    [Test]
+    public Task Worker_Uses_Module_Shield_Factory(CancellationToken cancellationToken) =>
+        AssertWorkerRetriesAsync<ShieldFactoryRetryModule>(null, cancellationToken);
+
+    [Test]
+    public Task Worker_Uses_Default_Retry_Configuration(CancellationToken cancellationToken) =>
+        AssertWorkerRetriesAsync<DefaultRetryModule>(
+            builder => builder.ConfigureOptions(options => options with { DefaultRetryCount = 2 }),
+            cancellationToken);
+
+    private static async Task AssertWorkerRetriesAsync<TModule>(
+        Action<PipelineBuilder>? configureBuilder,
+        CancellationToken cancellationToken)
+        where TModule : RetryingModule
+    {
+        var builder = TestPipelineBuilder.Create();
+        configureBuilder?.Invoke(builder);
+        builder.AddModule<TModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var module = pipeline.Services.GetServices<IModule>()
+            .OfType<TModule>()
+            .Single();
+        var coordinator = new InMemoryDistributedCoordinator();
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(TModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var assignment = new ModuleAssignment(
+            typeof(TModule).FullName!,
+            typeof(int).FullName!,
+            new HashSet<Capability>(),
+            DateTimeOffset.UtcNow,
+            new ModuleAssignmentConfiguration(null, false));
+        await coordinator.EnqueueModuleAsync(assignment, cancellationToken);
+        var executor = new WorkerModuleExecutor(
+            pipeline.Services.GetRequiredService<IHostApplicationLifetime>(),
+            coordinator,
+            [module],
+            typeRegistry,
+            serializer,
+            pipeline.Services.GetRequiredService<IModuleRunner>(),
+            pipeline.Services.GetRequiredService<IModuleResultRegistry>(),
+            pipeline.Services.GetRequiredService<IModuleDependencyRegistry>(),
+            pipeline.Services.GetRequiredService<IModuleMetadataRegistry>(),
+            MsOptions.Create(new DistributedOptions
+            {
+                InstanceIndex = 1,
+                AutoDetectOsCapability = false,
+            }),
+            pipeline.Services.GetRequiredService<IServiceScopeFactory>(),
+            null,
+            NullLogger<WorkerModuleExecutor>.Instance);
+
+        var executionTask = executor.ExecuteAsync([module]);
+        var serializedResult = await coordinator.WaitForResultAsync(
+            typeof(TModule).FullName!,
+            cancellationToken).WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        await coordinator.SignalCompletionAsync(cancellationToken);
+        await executionTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        var result = serializer.Deserialize(serializedResult);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.AttemptCount).IsEqualTo(3);
+            await Assert.That(result?.ExceptionOrDefault).IsNull();
+            await Assert.That(result?.ValueOrDefault).IsEqualTo(3);
+        }
+    }
+}

--- a/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
+++ b/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
@@ -63,7 +63,7 @@ public static class DistributedCoordinatorContract
             ResultTypeName: "System.String",
             RequiredCapabilities: new HashSet<Capability>(),
             AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfiguration(null, 0, false));
+            Configuration: new ModuleAssignmentConfiguration(null, false));
     }
 
     private static SerializedModuleResult CreateResult(string moduleTypeName)


### PR DESCRIPTION
## Summary
- remove unused `RetryCount` from the unshipped distributed assignment configuration
- document retry policy resolution on the executing node
- verify workers apply module `WithRetry`, custom `Shield` factories, and `PipelineOptions.DefaultRetryCount`
- update coordinator test fixtures and the unshipped API baseline

The wire field was never consumed. Keeping retry policy node-local preserves complete behavior, including predicates and delegate-based shields, instead of transmitting a misleading integer subset.

## Validation
- `ModularPipelines.Distributed.UnitTests` Release: 122 passed with coverage
- focused worker retry tests: 3 passed with coverage
- `ModularPipelines.slnx` Release: 0 warnings, 0 errors
- Distributed Redis solution Release: 0 warnings, 0 errors
- Distributed SignalR solution Release: 0 errors; one existing warning in untouched `MasterServerHost.cs:108`
- scoped whitespace verification: passed

Closes #4382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Distributed workers now resolve retry policies locally from module settings or the pipeline’s default retry configuration.
  * Retry behavior supports module-defined policies, resilience shield factories, and default retry settings.

* **Breaking Changes**
  * Removed the `RetryCount` property and constructor parameter from distributed module assignment configuration.

* **Tests**
  * Added coverage validating retry behavior across module, shield-factory, and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->