### PR TITLE
Preserve case-only generated renames

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GenerationResultTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GenerationResultTests.cs
@@ -1,0 +1,19 @@
+using ModularPipelines.OptionsGenerator.Generators;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Generators;
+
+public class GenerationResultTests
+{
+    [Test]
+    public async Task ChangedPaths_Preserves_Both_Sides_Of_Case_Only_Renames()
+    {
+        var result = new GenerationResult();
+        result.FilesGenerated.Add("src/Fake/Options/FakeChangeSetOptions.Generated.cs");
+        result.FilesDeleted.Add("src/Fake/Options/FakeChangesetOptions.Generated.cs");
+
+        await Assert.That(result.ChangedPaths).IsEquivalentTo([
+            "src/Fake/Options/FakeChangeSetOptions.Generated.cs",
+            "src/Fake/Options/FakeChangesetOptions.Generated.cs",
+        ]);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -1411,7 +1411,7 @@ public class GenerationResult
     public IEnumerable<string> ChangedPaths => FilesGenerated
         .Concat(FilesDeleted)
         .Select(path => path.Replace('\\', '/'))
-        .Distinct(StringComparer.OrdinalIgnoreCase);
+        .Distinct(StringComparer.Ordinal);
 
     public bool HasErrors => Errors.Count > 0;
 


### PR DESCRIPTION
Fixes #4509

Keeps both spellings of case-only generated renames in change manifests, allowing Linux exact-path staging to authorize the deletion and addition without weakening fail-closed staging.

Validation:
- GenerationResultTests: 1/1 passed
- Test-StageGeneratedChanges.ps1: passed
- OptionsGenerator Release build: succeeded
- scoped whitespace format: clean