### PR TITLE
[Automated] Update terraform CLI Options

### DIFF
--- a/src/ModularPipelines.Terraform/Generated/Terraform.CommandCoverage.json
+++ b/src/ModularPipelines.Terraform/Generated/Terraform.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "terraform",
-  "toolVersion": "Terraform v1.16.0 on linux_amd64",
+  "toolVersion": "Terraform v1.16.1 on linux_amd64",
   "commandCount": 68,
   "commandTreeSha256": "68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7",
   "commands": [


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **terraform** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- terraform (Terraform v1.16.1 on linux_amd64): 68 commands, tree 68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator