### PR TITLE
[Automated] Update kind CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/kind.md
+++ b/docs/docs/mp-packages/cli/kind.md
@@ -42,11 +42,11 @@ var kind = context.Tools.Kind;
 | `kind delete cluster` | `KindDeleteClusterOptions` |
 | `kind delete clusters` | `KindDeleteClustersOptions` |
 | `kind export` | `KindExportOptions` |
-| `kind export kubeconfig` | `KindExportKubeconfigOptions` |
+| `kind export kubeconfig` | `KindExportKubeConfigOptions` |
 | `kind export logs` | `KindExportLogsOptions` |
 | `kind get` | `KindGetOptions` |
 | `kind get clusters` | `KindGetClustersOptions` |
-| `kind get kubeconfig` | `KindGetKubeconfigOptions` |
+| `kind get kubeconfig` | `KindGetKubeConfigOptions` |
 | `kind get nodes` | `KindGetNodesOptions` |
 | `kind load` | `KindLoadOptions` |
 | `kind load docker-image` | `KindLoadDockerImageOptions` |

--- a/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
+++ b/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
@@ -17,17 +17,17 @@ namespace ModularPipelines.Kind.Enums;
 public enum KindBuildNodeImageType
 {
     [EnumValue("url")]
-    Url = 0,
+    Url,
 
     [EnumValue("file")]
-    File = 1,
+    File,
 
     [EnumValue("release")]
-    Release = 2,
+    Release,
 
     [EnumValue("ci")]
-    Ci = 3,
+    Ci,
 
     [EnumValue("source")]
-    Source = 4
+    Source
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Kind.Services;
 
 namespace ModularPipelines.Kind.Extensions;

--- a/src/ModularPipelines.Kind/Generated/Kind.CommandCoverage.json
+++ b/src/ModularPipelines.Kind/Generated/Kind.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "kind",
-  "toolVersion": "kind version 0.34.0-alpha\u002B440e1abb2bdc24",
+  "toolVersion": "kind version 0.34.0-alpha\u002B6a54ab4800dab5",
   "commandCount": 17,
   "commandTreeSha256": "a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b",
   "commands": [

--- a/src/ModularPipelines.Kind/Options/KindCreateClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindCreateClusterOptions.Generated.cs
@@ -74,11 +74,4 @@ public record KindCreateClusterOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
-    [Obsolete("Use KubeConfig instead.")]
-    public string? Kubeconfig
-    {
-        get => KubeConfig;
-        set => KubeConfig = value;
-    }
-
 }

--- a/src/ModularPipelines.Kind/Options/KindDeleteClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteClusterOptions.Generated.cs
@@ -50,11 +50,4 @@ public record KindDeleteClusterOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
-    [Obsolete("Use KubeConfig instead.")]
-    public string? Kubeconfig
-    {
-        get => KubeConfig;
-        set => KubeConfig = value;
-    }
-
 }

--- a/src/ModularPipelines.Kind/Options/KindDeleteClustersOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteClustersOptions.Generated.cs
@@ -50,11 +50,4 @@ public record KindDeleteClustersOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
-    [Obsolete("Use KubeConfig instead.")]
-    public string? Kubeconfig
-    {
-        get => KubeConfig;
-        set => KubeConfig = value;
-    }
-
 }

--- a/src/ModularPipelines.Kind/Options/KindExportKubeConfigOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportKubeConfigOptions.Generated.cs
@@ -18,7 +18,7 @@ namespace ModularPipelines.Kind.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("export", "kubeconfig")]
-public record KindExportKubeconfigOptions : KindOptions
+public record KindExportKubeConfigOptions : KindOptions
 {
     /// <summary>
     /// help for kubeconfig
@@ -55,12 +55,5 @@ public record KindExportKubeconfigOptions : KindOptions
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
-
-    [Obsolete("Use KubeConfig instead.")]
-    public string? Kubeconfig
-    {
-        get => KubeConfig;
-        set => KubeConfig = value;
-    }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindGetKubeConfigOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindGetKubeConfigOptions.Generated.cs
@@ -18,7 +18,7 @@ namespace ModularPipelines.Kind.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("get", "kubeconfig")]
-public record KindGetKubeconfigOptions : KindOptions
+public record KindGetKubeConfigOptions : KindOptions
 {
     /// <summary>
     /// help for kubeconfig

--- a/src/ModularPipelines.Kind/Services/IKindExport.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindExport.Generated.cs
@@ -38,13 +38,7 @@ public interface IKindExport
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    #pragma warning disable CS0618
-    public Task<CommandResult> KubeConfigAsync(KindExportKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => KubeconfigAsync(options, executionOptions, cancellationToken);
-    #pragma warning restore CS0618
-
-    [Obsolete("Use KubeConfigAsync instead.")]
-    public Task<CommandResult> KubeconfigAsync(KindExportKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> KubeConfigAsync(KindExportKubeConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Kind/Services/IKindGet.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindGet.Generated.cs
@@ -48,13 +48,7 @@ public interface IKindGet
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    #pragma warning disable CS0618
-    public Task<CommandResult> KubeConfigAsync(KindGetKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => KubeconfigAsync(options, executionOptions, cancellationToken);
-    #pragma warning restore CS0618
-
-    [Obsolete("Use KubeConfigAsync instead.")]
-    public Task<CommandResult> KubeconfigAsync(KindGetKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> KubeConfigAsync(KindGetKubeConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Kind/Services/KindExport.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindExport.Generated.cs
@@ -55,20 +55,11 @@ public class KindExport : IKindExport
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> KubeConfigAsync(
-        KindExportKubeconfigOptions? options = null,
+        KindExportKubeConfigOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KindExportKubeconfigOptions(), executionOptions, cancellationToken);
-    }
-
-    [Obsolete("Use KubeConfigAsync instead.")]
-    public virtual async Task<CommandResult> KubeconfigAsync(
-        KindExportKubeconfigOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await KubeConfigAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new KindExportKubeConfigOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Kind/Services/KindGet.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindGet.Generated.cs
@@ -70,20 +70,11 @@ public class KindGet : IKindGet
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> KubeConfigAsync(
-        KindGetKubeconfigOptions? options = null,
+        KindGetKubeConfigOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KindGetKubeconfigOptions(), executionOptions, cancellationToken);
-    }
-
-    [Obsolete("Use KubeConfigAsync instead.")]
-    public virtual async Task<CommandResult> KubeconfigAsync(
-        KindGetKubeconfigOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await KubeConfigAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new KindGetKubeConfigOptions(), executionOptions, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kind** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- kind (kind version 0.34.0-alpha+6a54ab4800dab5): 17 commands, tree a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b
  - Baseline comparison: 17 commands at kind version 0.34.0-alpha+440e1abb2bdc24 -> 17 commands at kind version 0.34.0-alpha+6a54ab4800dab5

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator