### PR TITLE
[Automated] Update skopeo CLI Options

### DIFF
--- a/src/ModularPipelines.Skopeo/Options/SkopeoStandaloneSignOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoStandaloneSignOptions.Generated.cs
@@ -19,7 +19,6 @@ namespace ModularPipelines.Skopeo.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("standalone-sign")]
 public record SkopeoStandaloneSignOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Signature,
     [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Manifest,
     [property: CliArgument(2, Phase = CommandLinePhase.EarlyOperand, Required = true)] string DockerReference,
     [property: CliArgument(3, Phase = CommandLinePhase.EarlyOperand, Required = true)] string KeyFingerprint


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **skopeo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- skopeo (skopeo version 1.13.3): 11 commands, tree 71df545926b8f3395c60d1ed9e037569395c16b401bff0417eacdfb16d3d7908

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator