### PR TITLE
[Automated] Update minikube CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/minikube.md
+++ b/docs/docs/mp-packages/cli/minikube.md
@@ -65,7 +65,9 @@ var minikube = context.Tools.Minikube;
 | `minikube mount` | `MinikubeMountOptions` |
 | `minikube node` | `MinikubeNodeOptions` |
 | `minikube node add` | `MinikubeNodeAddOptions` |
+| `minikube node delete` | `MinikubeNodeDeleteOptions` |
 | `minikube node start` | `MinikubeNodeStartOptions` |
+| `minikube node stop` | `MinikubeNodeStopOptions` |
 | `minikube pause` | `MinikubePauseOptions` |
 | `minikube podman-env` | `MinikubePodmanEnvOptions` |
 | `minikube profile` | `MinikubeProfileOptions` |

--- a/src/ModularPipelines.Minikube/Generated/Minikube.CommandCoverage.json
+++ b/src/ModularPipelines.Minikube/Generated/Minikube.CommandCoverage.json
@@ -1,9 +1,9 @@
 {
   "formatVersion": 1,
   "toolName": "minikube",
-  "toolVersion": "v1.38.1",
-  "commandCount": 46,
-  "commandTreeSha256": "fe004f502186d3380241c4979ceefbcc1c6f7c2ea8c76bd41efd9b802f971224",
+  "toolVersion": "v1.39.0",
+  "commandCount": 48,
+  "commandTreeSha256": "bf42616787394cb9655a39166d359fda44cf62395db38aa427f98dc1b9f67bd6",
   "commands": [
     "minikube addons",
     "minikube addons configure",
@@ -36,7 +36,9 @@
     "minikube mount",
     "minikube node",
     "minikube node add",
+    "minikube node delete",
     "minikube node start",
+    "minikube node stop",
     "minikube pause",
     "minikube podman-env",
     "minikube profile",

--- a/src/ModularPipelines.Minikube/Options/MinikubeNodeDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Options/MinikubeNodeDeleteOptions.Generated.cs
@@ -13,19 +13,13 @@ using ModularPipelines.Minikube.Options;
 namespace ModularPipelines.Minikube.Options;
 
 /// <summary>
-/// Starts an existing stopped node in a cluster.
+/// Deletes a node from a cluster.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("node", "start")]
-public record MinikubeNodeStartOptions(
+[CliSubCommand("node", "delete")]
+public record MinikubeNodeDeleteOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string NodeName
 ) : MinikubeOptions
 {
-    /// <summary>
-    /// If set, delete the current cluster if start fails and try again. Defaults to false.
-    /// </summary>
-    [CliFlag("--delete-on-failure")]
-    public bool? DeleteOnFailure { get; set; }
-
 }

--- a/src/ModularPipelines.Minikube/Options/MinikubeNodeStopOptions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Options/MinikubeNodeStopOptions.Generated.cs
@@ -13,19 +13,13 @@ using ModularPipelines.Minikube.Options;
 namespace ModularPipelines.Minikube.Options;
 
 /// <summary>
-/// Starts an existing stopped node in a cluster.
+/// Stops a node in a cluster.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("node", "start")]
-public record MinikubeNodeStartOptions(
+[CliSubCommand("node", "stop")]
+public record MinikubeNodeStopOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string NodeName
 ) : MinikubeOptions
 {
-    /// <summary>
-    /// If set, delete the current cluster if start fails and try again. Defaults to false.
-    /// </summary>
-    [CliFlag("--delete-on-failure")]
-    public bool? DeleteOnFailure { get; set; }
-
 }

--- a/src/ModularPipelines.Minikube/Options/MinikubeStartOptions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Options/MinikubeStartOptions.Generated.cs
@@ -64,7 +64,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public bool? AutoUpdateDrivers { get; set; }
 
     /// <summary>
-    /// v0.0.50@sha256:eb4fec00e8ad70adf8e6436f195cc429825ffb85f95afcdb5d8d9deb576f3e93':
+    /// v0.0.51@sha256:4a1c825b61479e6c898851ea66f13c620aaeab6002746e95067fc2c4b38a0b24':
     /// </summary>
     [CliOption("--base-image", Format = OptionFormat.EqualsSeparated)]
     public string? BaseImage { get; set; }
@@ -158,6 +158,12 @@ public record MinikubeStartOptions : MinikubeOptions
     /// </summary>
     [CliFlag("--dns-proxy")]
     public bool? DnsProxy { get; set; }
+
+    /// <summary>
+    /// Static DNS server IP addresses for the VM (VM drivers only)
+    /// </summary>
+    [CliOption("--dns-servers", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? DnsServers { get; set; }
 
     /// <summary>
     /// Environment variables to pass to the Docker daemon. (format: key=value)
@@ -316,7 +322,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public bool? Interactive { get; set; }
 
     /// <summary>
-    /// //storage.googleapis.com/minikube/iso/minikube-v1.38.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.38.0/minikube-v1.38.0-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.38.0-amd64.iso]:
+    /// //storage.googleapis.com/minikube/iso/minikube-v1.39.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.39.0/minikube-v1.39.0-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.39.0-amd64.iso]:
     /// </summary>
     [CliOption("--iso-url", Format = OptionFormat.EqualsSeparated)]
     public string? IsoUrl { get; set; }
@@ -328,7 +334,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public bool? KeepContext { get; set; }
 
     /// <summary>
-    /// The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.35.1, 'latest' for v1.35.1). Defaults to 'stable'.
+    /// The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.37.0, 'latest' for v1.37.0). Defaults to 'stable'.
     /// </summary>
     [CliOption("--kubernetes-version", Format = OptionFormat.EqualsSeparated)]
     public string? KubernetesVersion { get; set; }
@@ -368,6 +374,12 @@ public record MinikubeStartOptions : MinikubeOptions
     /// </summary>
     [CliOption("--listen-address", Format = OptionFormat.EqualsSeparated)]
     public string? ListenAddress { get; set; }
+
+    /// <summary>
+    /// Enable mDNS (.local address resolution) by configuring systemd-resolved inside the node (VM drivers only)
+    /// </summary>
+    [CliFlag("--mdns")]
+    public bool? Mdns { get; set; }
 
     /// <summary>
     /// Amount of RAM to allocate to Kubernetes (format: &lt;number&gt;[&lt;unit&gt;], where unit = b, k, m or g). Use "max" to use the maximum amount of memory. Use "no-limit" to not specify a limit (Docker/Podman only)
@@ -508,7 +520,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public bool? Preload { get; set; }
 
     /// <summary>
-    /// Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try both).
+    /// Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try github first, then gcs as failover).
     /// </summary>
     [CliOption("--preload-source", Format = OptionFormat.EqualsSeparated)]
     public string? PreloadSource { get; set; }
@@ -602,6 +614,12 @@ public record MinikubeStartOptions : MinikubeOptions
     /// </summary>
     [CliFlag("--vm")]
     public bool? Vm { get; set; }
+
+    /// <summary>
+    /// Enable vmnet checksum and TSO offloading. See krunkit driver documentation for known limitations (krunkit driver only)
+    /// </summary>
+    [CliFlag("--vmnet-offloading")]
+    public bool? VmnetOffloading { get; set; }
 
     /// <summary>
     /// comma separated list of Kubernetes components to verify and wait for after starting a cluster. defaults to "apiserver,system_pods", available options: "apiserver,system_pods,default_sa,apps_running,node_ready,kubelet,extra" . other acceptable values are 'all' or 'none', 'true' and 'false'

--- a/src/ModularPipelines.Minikube/Options/MinikubeTunnelOptions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Options/MinikubeTunnelOptions.Generated.cs
@@ -13,7 +13,7 @@ using ModularPipelines.Minikube.Options;
 namespace ModularPipelines.Minikube.Options;
 
 /// <summary>
-/// tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. for a detailed example see https://minikube.sigs.k8s.io/docs/tasks/loadbalancer
+/// tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. For a detailed example see https://minikube.sigs.k8s.io/docs/handbook/accessing
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.Minikube/Services/IMinikube.Generated.cs
+++ b/src/ModularPipelines.Minikube/Services/IMinikube.Generated.cs
@@ -230,7 +230,7 @@ public partial interface IMinikube
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. for a detailed example see https://minikube.sigs.k8s.io/docs/tasks/loadbalancer
+    /// tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. For a detailed example see https://minikube.sigs.k8s.io/docs/handbook/accessing
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Minikube/Services/IMinikubeNode.Generated.cs
+++ b/src/ModularPipelines.Minikube/Services/IMinikubeNode.Generated.cs
@@ -42,13 +42,33 @@ public interface IMinikubeNode
         => throw new System.NotSupportedException();
 
     /// <summary>
+    /// Deletes a node from a cluster.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> DeleteAsync(MinikubeNodeDeleteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
     /// Starts an existing stopped node in a cluster.
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> StartAsync(MinikubeNodeStartOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StartAsync(MinikubeNodeStartOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Stops a node in a cluster.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> StopAsync(MinikubeNodeStopOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Minikube/Services/MinikubeNode.Generated.cs
+++ b/src/ModularPipelines.Minikube/Services/MinikubeNode.Generated.cs
@@ -63,6 +63,21 @@ public class MinikubeNode : IMinikubeNode
     }
 
     /// <summary>
+    /// Deletes a node from a cluster.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> DeleteAsync(
+        MinikubeNodeDeleteOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <summary>
     /// Starts an existing stopped node in a cluster.
     /// </summary>
     /// <param name="options">The command options.</param>
@@ -70,11 +85,26 @@ public class MinikubeNode : IMinikubeNode
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> StartAsync(
-        MinikubeNodeStartOptions? options = null,
+        MinikubeNodeStartOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new MinikubeNodeStartOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Stops a node in a cluster.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> StopAsync(
+        MinikubeNodeStopOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **minikube** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- minikube (v1.39.0): 48 commands, tree bf42616787394cb9655a39166d359fda44cf62395db38aa427f98dc1b9f67bd6
  - Added: minikube node delete, minikube node stop

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator