### PR TITLE
Stabilize always-run dependency ordering test

### DIFF
--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -277,7 +277,17 @@ public class AlwaysRunHandlerTests
     }
 
     [Test]
-    public async Task WaitForAlwaysRunModulesAsync_PreservesAlwaysRunDependencyOrder()
+    [Timeout(30_000)]
+    public async Task WaitForAlwaysRunModulesAsync_PreservesAlwaysRunDependencyOrder(
+        CancellationToken cancellationToken)
+    {
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            await AssertAlwaysRunDependencyOrderAsync(cancellationToken);
+        }
+    }
+
+    private static async Task AssertAlwaysRunDependencyOrderAsync(CancellationToken cancellationToken)
     {
         var prerequisite = new FirstAlwaysRunModule();
         var dependent = new SecondAlwaysRunModule();
@@ -322,10 +332,10 @@ public class AlwaysRunHandlerTests
             scheduler.Object,
             [prerequisite, dependent]);
 
-        await prerequisiteStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await prerequisiteStarted.Task.WaitAsync(cancellationToken);
         releasePrerequisite.TrySetResult();
-        await dependentStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        await handlerTask;
+        await dependentStarted.Task.WaitAsync(cancellationToken);
+        await handlerTask.WaitAsync(cancellationToken);
 
         await Assert.That(prerequisiteStateWhenDependentStarted)
             .IsEqualTo(ModuleExecutionState.Completed);


### PR DESCRIPTION
## Summary
- replace independent two-second scheduling waits with the TUnit timeout cancellation token
- run the dependency-order scenario 25 times to stress the ordering contract
- keep the assertion that the dependent starts only after the prerequisite reaches `Completed`

## Root cause
The CI failure occurred before the mocked prerequisite execution started. The product ordering path is correct; the test imposed a short wall-clock scheduling deadline that becomes unreliable under loaded Linux CI.

## Validation
- focused dependency-order test: passed (25 internal scenarios)
- all `AlwaysRunHandlerTests`: 8/8 passed
- scoped whitespace verification: passed
- `git diff --check`: passed

Closes #4517