### PR TITLE
Refresh eksctl CLI options from current output

### DIFF
--- a/src/ModularPipelines.Eksctl/Enums/EksctlCreateCapabilityType.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlCreateCapabilityType.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Eksctl.Enums;
 public enum EksctlCreateCapabilityType
 {
     [EnumValue("ACK")]
-    Ack = 0,
+    Ack,
 
     [EnumValue("KRO")]
-    Kro = 1,
+    Kro,
 
     [EnumValue("ARGOCD")]
-    Argocd = 2
+    Argocd
 }

--- a/src/ModularPipelines.Eksctl/Enums/EksctlUpdateCapabilityType.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlUpdateCapabilityType.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Eksctl.Enums;
 public enum EksctlUpdateCapabilityType
 {
     [EnumValue("ACK")]
-    Ack = 0,
+    Ack,
 
     [EnumValue("KRO")]
-    Kro = 1,
+    Kro,
 
     [EnumValue("ARGOCD")]
-    Argocd = 2
+    Argocd
 }

--- a/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingDisableTypes.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingDisableTypes.Generated.cs
@@ -17,23 +17,23 @@ namespace ModularPipelines.Eksctl.Enums;
 public enum EksctlUtilsUpdateClusterLoggingDisableTypes
 {
     [EnumValue("all")]
-    All = 0,
+    All,
 
     [EnumValue("none")]
-    None = 1,
+    None,
 
     [EnumValue("api")]
-    Api = 2,
+    Api,
 
     [EnumValue("audit")]
-    Audit = 3,
+    Audit,
 
     [EnumValue("authenticator")]
-    Authenticator = 4,
+    Authenticator,
 
     [EnumValue("controllerManager")]
-    Controllermanager = 5,
+    ControllerManager,
 
     [EnumValue("scheduler")]
-    Scheduler = 6
+    Scheduler
 }

--- a/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingEnableTypes.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingEnableTypes.Generated.cs
@@ -17,23 +17,23 @@ namespace ModularPipelines.Eksctl.Enums;
 public enum EksctlUtilsUpdateClusterLoggingEnableTypes
 {
     [EnumValue("all")]
-    All = 0,
+    All,
 
     [EnumValue("none")]
-    None = 1,
+    None,
 
     [EnumValue("api")]
-    Api = 2,
+    Api,
 
     [EnumValue("audit")]
-    Audit = 3,
+    Audit,
 
     [EnumValue("authenticator")]
-    Authenticator = 4,
+    Authenticator,
 
     [EnumValue("controllerManager")]
-    Controllermanager = 5,
+    ControllerManager,
 
     [EnumValue("scheduler")]
-    Scheduler = 6
+    Scheduler
 }

--- a/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Extensions/EksctlExtensions.Generated.cs
@@ -9,7 +9,6 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
-using ModularPipelines.Context;
 using ModularPipelines.Eksctl.Services;
 
 namespace ModularPipelines.Eksctl.Extensions;

--- a/src/ModularPipelines.Eksctl/Options/EksctlSetOptions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Options/EksctlSetOptions.Generated.cs
@@ -12,9 +12,6 @@ using ModularPipelines.Eksctl.Options;
 
 namespace ModularPipelines.Eksctl.Options;
 
-/// <summary>
-/// eksctl set labels                          Create or overwrite labels for managed nodegroups
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("set")]

--- a/src/ModularPipelines.Eksctl/Services/EksctlSet.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/EksctlSet.Generated.cs
@@ -33,7 +33,7 @@ public class EksctlSet : IEksctlSet
     #region Commands
 
     /// <summary>
-    /// eksctl set labels                          Create or overwrite labels for managed nodegroups
+    /// Executes the parent command directly.
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Eksctl/Services/EksctlUtils.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/EksctlUtils.Generated.cs
@@ -392,14 +392,5 @@ public class EksctlUtils : IEksctlUtils
         return await _command.ExecuteCommandLineToolAsync(options ?? new EksctlUtilsWriteKubeconfigOptions(), executionOptions, cancellationToken);
     }
 
-    [Obsolete("Use WriteKubeConfigAsync instead.")]
-    public virtual async Task<CommandResult> WriteKubeconfigAsync(
-        EksctlUtilsWriteKubeconfigOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await WriteKubeConfigAsync(options, executionOptions, cancellationToken);
-    }
-
     #endregion
 }

--- a/src/ModularPipelines.Eksctl/Services/IEksctlSet.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/IEksctlSet.Generated.cs
@@ -21,13 +21,6 @@ namespace ModularPipelines.Eksctl.Services;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IEksctlSet
 {
-    /// <summary>
-    /// eksctl set labels                          Create or overwrite labels for managed nodegroups
-    /// </summary>
-    /// <param name="options">The command options.</param>
-    /// <param name="executionOptions">The execution configuration options.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The command result.</returns>
     public Task<CommandResult> ExecuteAsync(EksctlSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 

--- a/src/ModularPipelines.Eksctl/Services/IEksctlUtils.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/IEksctlUtils.Generated.cs
@@ -258,13 +258,7 @@ public interface IEksctlUtils
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    #pragma warning disable CS0618
     public Task<CommandResult> WriteKubeConfigAsync(EksctlUtilsWriteKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
-        => WriteKubeconfigAsync(options, executionOptions, cancellationToken);
-    #pragma warning restore CS0618
-
-    [Obsolete("Use WriteKubeConfigAsync instead.")]
-    public Task<CommandResult> WriteKubeconfigAsync(EksctlUtilsWriteKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/test/ModularPipelines.Eksctl.UnitTests/Attributes/EksctlOptionsTests.cs
+++ b/test/ModularPipelines.Eksctl.UnitTests/Attributes/EksctlOptionsTests.cs
@@ -82,7 +82,7 @@ public class EksctlOptionsTests
             EnableTypes =
             [
                 EksctlUtilsUpdateClusterLoggingEnableTypes.Api,
-                EksctlUtilsUpdateClusterLoggingEnableTypes.Controllermanager,
+                EksctlUtilsUpdateClusterLoggingEnableTypes.ControllerManager,
             ],
         });
 


### PR DESCRIPTION
Part of #4331.

## Summary
- regenerate eksctl options from current eksctl v0.230.0 output
- remove compatibility members no longer present in the CLI
- update the enum rendering test for the generated `ControllerManager` member

## Validation
- eksctl solution build: 0 warnings, 0 errors
- eksctl tests: 7/7 passed
- `git diff --check`
- scoped formatter reports only the repository's pre-existing baseline findings