### PR TITLE
[Automated] Update pulumi CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/pulumi.md
+++ b/docs/docs/mp-packages/cli/pulumi.md
@@ -100,6 +100,10 @@ var pulumi = context.Tools.Pulumi;
 | `pulumi env settings` | `PulumiEnvSettingsOptions` |
 | `pulumi env settings get` | `PulumiEnvSettingsGetOptions` |
 | `pulumi env settings set` | `PulumiEnvSettingsSetOptions` |
+| `pulumi env setup` | `PulumiEnvSetupOptions` |
+| `pulumi env setup aws` | `PulumiEnvSetupAwsOptions` |
+| `pulumi env setup azure` | `PulumiEnvSetupAzureOptions` |
+| `pulumi env setup gcp` | `PulumiEnvSetupGcpOptions` |
 | `pulumi env tag` | `PulumiEnvTagOptions` |
 | `pulumi env tag get` | `PulumiEnvTagGetOptions` |
 | `pulumi env tag list` | `PulumiEnvTagListOptions` |

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAwsLoginStaticOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAwsLoginStaticOptions.Generated.cs
@@ -22,7 +22,7 @@ namespace ModularPipelines.Pulumi.Options;
 [CliSubCommand("env", "provider", "aws-login", "static")]
 public record PulumiEnvProviderAwsLoginStaticOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string EnvironmentName,
-    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string AccessKeyId,
+    [property: SecretValue, CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string AccessKeyId,
     [property: SecretValue, CliArgument(2, Phase = CommandLinePhase.EarlyOperand, Required = true)] string SecretAccessKey
 ) : PulumiOptions
 {


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pulumi** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pulumi (v3.261.0): 233 commands, tree 26a5eadd276eea43631e4ac3298884c71fca0ef0efa6ed2e1270e406b45179b8
  - Baseline comparison: 233 commands at v3.261.0 -> 233 commands at v3.261.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator