### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
+++ b/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "go",
-  "toolVersion": "go version go1.27.0 linux/amd64",
+  "toolVersion": "go version go1.27.1 linux/amd64",
   "commandCount": 32,
   "commandTreeSha256": "548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f",
   "commands": [

--- a/src/ModularPipelines.Go/Options/GoBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoBuildOptions.Generated.cs
@@ -117,7 +117,7 @@ public record GoBuildOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -177,7 +177,7 @@ public record GoBuildOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoCleanOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoCleanOptions.Generated.cs
@@ -129,7 +129,7 @@ public record GoCleanOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -183,7 +183,7 @@ public record GoCleanOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoDocOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoDocOptions.Generated.cs
@@ -30,7 +30,7 @@ public record GoDocOptions : GoOptions
     /// Respect case when matching symbols.
     /// </summary>
     [CliFlag("-c")]
-    public bool? C { get; set; }
+    public bool? LowerC { get; set; }
 
     /// <summary>
     /// Treat a command (package main) like a regular package. Otherwise package main's exported symbols are hidden when showing the package's top-level documentation.
@@ -44,6 +44,9 @@ public record GoDocOptions : GoOptions
     [CliFlag("-ex")]
     public bool? Ex { get; set; }
 
+    /// <summary>
+    /// Serve HTML docs over HTTP.
+    /// </summary>
     [CliFlag("-http")]
     public bool? Http { get; set; }
 
@@ -69,7 +72,7 @@ public record GoDocOptions : GoOptions
     /// Change to dir before running the command. Any files named on the command line are interpreted after changing directories. If used, this flag must be the first one in the command line.
     /// </summary>
     [CliOption("-C", Phase = CommandLinePhase.EarlyOperand)]
-    public string? COption { get; set; }
+    public string? UpperC { get; set; }
 
     /// <summary>
     /// The package operand.

--- a/src/ModularPipelines.Go/Options/GoFixOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoFixOptions.Generated.cs
@@ -26,6 +26,9 @@ public record GoFixOptions : GoOptions
     [CliOption("-fixtool")]
     public string? Fixtool { get; set; }
 
+    /// <summary>
+    /// instead of applying each fix, print the patch as a unified diff; exit with a non-zero status if the diff is not empty
+    /// </summary>
     [CliFlag("-diff")]
     public bool? Diff { get; set; }
 
@@ -102,7 +105,7 @@ public record GoFixOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -162,7 +165,7 @@ public record GoFixOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoGenerateOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGenerateOptions.Generated.cs
@@ -105,7 +105,7 @@ public record GoGenerateOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -159,7 +159,7 @@ public record GoGenerateOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
@@ -112,7 +112,7 @@ public record GoGetOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -166,7 +166,7 @@ public record GoGetOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoInstallOptions.Generated.cs
@@ -111,7 +111,7 @@ public record GoInstallOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -171,7 +171,7 @@ public record GoInstallOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
@@ -130,7 +130,7 @@ public record GoListOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -184,7 +184,7 @@ public record GoListOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoRunOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoRunOptions.Generated.cs
@@ -119,7 +119,7 @@ public record GoRunOptions(
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -179,7 +179,7 @@ public record GoRunOptions(
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
@@ -30,7 +30,7 @@ public record GoTestOptions : GoOptions
     /// Compile the test binary to pkg.test in the current directory but do not run it (where pkg is the last element of the package's import path). The file name or target directory can be changed with the -o flag.
     /// </summary>
     [CliFlag("-c")]
-    public bool? C { get; set; }
+    public bool? LowerC { get; set; }
 
     /// <summary>
     /// Run the test binary using xprog. The behavior is the same as in 'go run'. See 'go help run' for details.
@@ -123,7 +123,7 @@ public record GoTestOptions : GoOptions
     public string? Fuzztime { get; set; }
 
     /// <summary>
-    /// Run enough iterations of the fuzz target during each minimization attempt to take t, as specified as a time.Duration (for example,
+    /// Run enough iterations of the fuzz target during each minimization attempt to take t, as specified as a time.Duration (for example, -fuzzminimizetime 30s). The default is 60s. The special syntax Nx means to run the fuzz target N times (for example, -fuzzminimizetime 100x).
     /// </summary>
     [CliOption("-fuzzminimizetime")]
     public string? Fuzzminimizetime { get; set; }
@@ -252,7 +252,7 @@ public record GoTestOptions : GoOptions
     /// Change to dir before running the command. Any files named on the command line are interpreted after changing directories. If used, this flag must be the first one in the command line.
     /// </summary>
     [CliOption("-C", Phase = CommandLinePhase.EarlyOperand)]
-    public string? COption { get; set; }
+    public string? UpperC { get; set; }
 
     /// <summary>
     /// force rebuilding of packages that are already up-to-date.
@@ -315,7 +315,7 @@ public record GoTestOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -369,7 +369,7 @@ public record GoTestOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }

--- a/src/ModularPipelines.Go/Options/GoVetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoVetOptions.Generated.cs
@@ -26,8 +26,11 @@ public record GoVetOptions : GoOptions
     [CliOption("-vettool")]
     public string? Vettool { get; set; }
 
+    /// <summary>
+    /// display offending line with this many lines of context (default -1)
+    /// </summary>
     [CliOption("-c")]
-    public string? C { get; set; }
+    public string? LowerC { get; set; }
 
     /// <summary>
     /// Emit build output in JSON suitable for automated processing. See 'go help buildjson' for the encoding details.
@@ -35,9 +38,15 @@ public record GoVetOptions : GoOptions
     [CliFlag("-json")]
     public bool? Json { get; set; }
 
+    /// <summary>
+    /// instead of printing each diagnostic, apply its first fix (if any)
+    /// </summary>
     [CliFlag("-fix")]
     public bool? Fix { get; set; }
 
+    /// <summary>
+    /// instead of applying each fix, print the patch as a unified diff; exit with a non-zero status if the diff is not empty
+    /// </summary>
     [CliFlag("-diff")]
     public bool? Diff { get; set; }
 
@@ -45,7 +54,7 @@ public record GoVetOptions : GoOptions
     /// Change to dir before running the command. Any files named on the command line are interpreted after changing directories. If used, this flag must be the first one in the command line.
     /// </summary>
     [CliOption("-C", Phase = CommandLinePhase.EarlyOperand)]
-    public string? COption { get; set; }
+    public string? UpperC { get; set; }
 
     /// <summary>
     /// force rebuilding of packages that are already up-to-date.
@@ -114,7 +123,7 @@ public record GoVetOptions : GoOptions
     public string? Buildmode { get; set; }
 
     /// <summary>
-    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or
+    /// Whether to stamp binaries with version control information ("true", "false", or "auto"). By default ("auto"), version control information is stamped into a binary if the main package, the main module containing it, and the current directory are all in the same repository. Use -buildvcs=false to always omit version control information, or -buildvcs=true to error out if version control information is available but cannot be included due to a missing tool or ambiguous directory structure.
     /// </summary>
     [CliOption("-buildvcs", Format = OptionFormat.EqualsSeparated)]
     public string? Buildvcs { get; set; }
@@ -168,7 +177,7 @@ public record GoVetOptions : GoOptions
     public bool? Modcacherw { get; set; }
 
     /// <summary>
-    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the
+    /// in module aware mode, read (and possibly write) an alternate go.mod file instead of the one in the module root directory. A file named "go.mod" must still be present in order to determine the module root directory, but it is not accessed. When -modfile is specified, an alternate go.sum file is also used: its path is derived from the -modfile flag by trimming the ".mod" extension and appending ".sum".
     /// </summary>
     [CliOption("-modfile")]
     public string? Modfile { get; set; }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- go (go version go1.27.1 linux/amd64): 32 commands, tree 548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f
  - Baseline comparison: 32 commands at go version go1.27.0 linux/amd64 -> 32 commands at go version go1.27.1 linux/amd64

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator