### PR TITLE
Avoid generated validation member collisions

### DIFF
--- a/src/ModularPipelines.Kubernetes/Options/KubernetesApplyOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KubernetesApplyOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Kubernetes.Options;
+using System.ComponentModel.DataAnnotations;
 using ModularPipelines.Kubernetes.Enums;
 
 namespace ModularPipelines.Kubernetes.Options;
@@ -19,7 +20,7 @@ namespace ModularPipelines.Kubernetes.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("apply")]
-public record KubernetesApplyOptions : KubernetesOptions
+public record KubernetesApplyOptions : KubernetesOptions, IValidatableObject
 {
     /// <summary>
     /// Select all resources in the namespace of the specified resource types.
@@ -164,5 +165,14 @@ public record KubernetesApplyOptions : KubernetesOptions
     /// </summary>
     [CliFlag("--wait")]
     public bool? Wait { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(Filename?.Any() == true || !string.IsNullOrWhiteSpace(Kustomize)))
+        {
+            yield return new ValidationResult("At least one of Filename or Kustomize must be specified.", [nameof(Filename), nameof(Kustomize)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Kubernetes/Services/IKubernetesApply.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKubernetesApply.Generated.cs
@@ -28,7 +28,7 @@ public interface IKubernetesApply
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ExecuteAsync(KubernetesApplyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecuteAsync(KubernetesApplyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Kubernetes/Services/KubernetesApply.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/KubernetesApply.Generated.cs
@@ -40,11 +40,11 @@ public class KubernetesApply : IKubernetesApply
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ExecuteAsync(
-        KubernetesApplyOptions? options = null,
+        KubernetesApplyOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new KubernetesApplyOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
+++ b/test/ModularPipelines.Kubernetes.UnitTests/KubernetesCommandRenderingTests.cs
@@ -13,11 +13,12 @@ public class KubernetesCommandRenderingTests : TestBase
     {
         var result = await GetResult(new KubernetesApplyOptions
         {
+            Filename = ["manifest.yaml"],
             Validate = "warn",
         });
 
         await Assert.That(result.CommandInput)
-            .IsEqualTo("kubectl apply --validate=warn");
+            .IsEqualTo("kubectl apply --filename=manifest.yaml --validate=warn");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -509,6 +509,12 @@ public class GeneratorHardeningTests
                     PropertyName = "Git",
                     CSharpType = "string?",
                 },
+                new CliOptionDefinition
+                {
+                    SwitchName = "--validate",
+                    PropertyName = "Validate",
+                    CSharpType = "string?",
+                },
             ],
             PositionalArguments =
             [
@@ -545,6 +551,8 @@ public class GeneratorHardeningTests
         using (Assert.Multiple())
         {
             await Assert.That(options).Contains("public record ToolAddOptions : ToolOptions, IValidatableObject");
+            await Assert.That(options).Contains(
+                "IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)");
             await Assert.That(options).Contains("DepId?.Any() == true");
             await Assert.That(options).Contains("!string.IsNullOrWhiteSpace(Path)");
             await Assert.That(options).Contains("!string.IsNullOrWhiteSpace(Git)");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -211,7 +211,7 @@ public class OptionsClassGenerator : ICodeGenerator
         }
 
         sb.AppendLine("    /// <inheritdoc />");
-        sb.AppendLine("    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)");
+        sb.AppendLine("    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)");
         sb.AppendLine("    {");
         foreach (var group in command.RequiredAlternativeGroups)
         {


### PR DESCRIPTION
Part of #4331.

Refreshes the Kubernetes integration from current kubectl v1.37.0 output and fixes a generator member collision exposed by `kubectl apply --validate`.

Changes:
- emits required-alternative validation through explicit `IValidatableObject.Validate` implementation
- adds regression coverage for a CLI option named `Validate`
- regenerates `KubernetesApplyOptions` and its service signatures from kubectl v1.37.0
- updates the rendering fixture to satisfy the current filename-or-kustomize requirement

Validation:
- generator regression test: passed
- Kubernetes solution build: 0 warnings, 0 errors
- Kubernetes unit tests: 11 passed
- `git diff --check` clean