### PR TITLE
[Automated] Update pip CLI Options

### DIFF
--- a/src/ModularPipelines.Python/Generated/Pip.Generation.json
+++ b/src/ModularPipelines.Python/Generated/Pip.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "pip",
+  "toolVersion": "pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)",
+  "commandTreeSha256": "a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac",
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+}

--- a/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
@@ -105,7 +105,7 @@ public record PipDownloadOptions : PipOptions
     public IEnumerable<string>? Platform { get; set; }
 
     /// <summary>
-    /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
+    /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify --implementation, --platform, and --python- version when using this option.
     /// </summary>
     [CliOption("--abi")]
     public IEnumerable<string>? Abi { get; set; }
@@ -123,7 +123,7 @@ public record PipDownloadOptions : PipOptions
     public string? IndexUrl { get; set; }
 
     /// <summary>
-    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as
+    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url.
     /// </summary>
     [CliOption("--extra-index-url")]
     public string? ExtraIndexUrl { get; set; }
@@ -273,7 +273,7 @@ public record PipDownloadOptions : PipOptions
     public string? UseDeprecated { get; set; }
 
     /// <summary>
-    /// The requirement specifier operand.
+    /// The &lt;requirement specifier&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? RequirementSpecifier { get; set; }

--- a/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PipIndexOptions : PipOptions
     public IEnumerable<string>? Platform { get; set; }
 
     /// <summary>
-    /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
+    /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify --implementation, --platform, and --python- version when using this option.
     /// </summary>
     [CliOption("--abi")]
     public IEnumerable<string>? Abi { get; set; }
@@ -51,7 +51,7 @@ public record PipIndexOptions : PipOptions
     public string? IndexUrl { get; set; }
 
     /// <summary>
-    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as
+    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url.
     /// </summary>
     [CliOption("--extra-index-url")]
     public string? ExtraIndexUrl { get; set; }

--- a/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
@@ -51,7 +51,7 @@ public record PipInstallOptions : PipOptions
     public string? Editable { get; set; }
 
     /// <summary>
-    /// Don't actually install anything, just print what would be. Can be used in combination with
+    /// Don't actually install anything, just print what would be. Can be used in combination with --ignore-installed to 'resolve' the requirements.
     /// </summary>
     [CliOption("--dry-run")]
     public string? DryRun { get; set; }
@@ -69,7 +69,7 @@ public record PipInstallOptions : PipOptions
     public IEnumerable<string>? Platform { get; set; }
 
     /// <summary>
-    /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
+    /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify --implementation, --platform, and --python- version when using this option.
     /// </summary>
     [CliOption("--abi")]
     public IEnumerable<string>? Abi { get; set; }
@@ -189,7 +189,7 @@ public record PipInstallOptions : PipOptions
     public bool? RequireHashes { get; set; }
 
     /// <summary>
-    /// Generate a JSON file describing what pip did to install the provided requirements. Can be used in combination with --dry-run and --ignore- installed to 'resolve' the requirements. When - is used as file name it writes to stdout. When writing to stdout, please combine with the
+    /// Generate a JSON file describing what pip did to install the provided requirements. Can be used in combination with --dry-run and --ignore- installed to 'resolve' the requirements. When - is used as file name it writes to stdout. When writing to stdout, please combine with the --quiet option to avoid mixing pip logging output with JSON output.
     /// </summary>
     [CliOption("--report")]
     public string? Report { get; set; }
@@ -207,7 +207,7 @@ public record PipInstallOptions : PipOptions
     public string? IndexUrl { get; set; }
 
     /// <summary>
-    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as
+    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url.
     /// </summary>
     [CliOption("--extra-index-url")]
     public string? ExtraIndexUrl { get; set; }
@@ -357,7 +357,7 @@ public record PipInstallOptions : PipOptions
     public string? UseDeprecated { get; set; }
 
     /// <summary>
-    /// The requirement specifier operand.
+    /// The &lt;requirement specifier&gt; operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? RequirementSpecifier { get; set; }

--- a/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
@@ -99,7 +99,7 @@ public record PipListOptions : PipOptions
     public string? IndexUrl { get; set; }
 
     /// <summary>
-    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as
+    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url.
     /// </summary>
     [CliOption("--extra-index-url")]
     public string? ExtraIndexUrl { get; set; }

--- a/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Python.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Python.Options;
 
@@ -18,7 +19,9 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("uninstall")]
-public record PipUninstallOptions : PipOptions
+public record PipUninstallOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Package
+) : PipOptions, IValidatableObject
 {
     /// <summary>
     /// Uninstall all the packages listed in the given requirements file.  This option can be used multiple times.
@@ -170,10 +173,13 @@ public record PipUninstallOptions : PipOptions
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
 
-    /// <summary>
-    /// The package operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Package { get; set; }
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(Package?.Any() == true || Requirement?.Any() == true))
+        {
+            yield return new ValidationResult("At least one of Package or Requirement must be specified.", [nameof(Package), nameof(Requirement)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("wheel")]
-public record PipWheelOptions : PipOptions
+public record PipWheelOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> RequirementSpecifier
+) : PipOptions
 {
     /// <summary>
     /// Build wheels into &lt;dir&gt;, where the default is the current working directory.
@@ -129,7 +131,7 @@ public record PipWheelOptions : PipOptions
     public string? IndexUrl { get; set; }
 
     /// <summary>
-    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as
+    /// Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url.
     /// </summary>
     [CliOption("--extra-index-url")]
     public string? ExtraIndexUrl { get; set; }
@@ -277,11 +279,5 @@ public record PipWheelOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
-
-    /// <summary>
-    /// The requirement specifier operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? RequirementSpecifier { get; set; }
 
 }

--- a/src/ModularPipelines.Python/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Python/PublicAPI.Shipped.txt
@@ -155,7 +155,6 @@ ModularPipelines.Python.Options.PipConfigOptions.Verbose.set -> void
 ModularPipelines.Python.Options.PipConfigOptions.Version.get -> string?
 ModularPipelines.Python.Options.PipConfigOptions.Version.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions
-ModularPipelines.Python.Options.PipDownloadOptions.Abi.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Abi.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.CacheDir.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.CacheDir.set -> void
@@ -165,7 +164,6 @@ ModularPipelines.Python.Options.PipDownloadOptions.CheckBuildDependencies.get ->
 ModularPipelines.Python.Options.PipDownloadOptions.CheckBuildDependencies.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.ClientCert.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.ClientCert.set -> void
-ModularPipelines.Python.Options.PipDownloadOptions.Constraint.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Constraint.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.Debug.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Debug.set -> void
@@ -205,7 +203,6 @@ ModularPipelines.Python.Options.PipDownloadOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipDownloadOptions.NoInput.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.PipDownloadOptions() -> void
 ModularPipelines.Python.Options.PipDownloadOptions.PipDownloadOptions(ModularPipelines.Python.Options.PipDownloadOptions! original) -> void
-ModularPipelines.Python.Options.PipDownloadOptions.Platform.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Platform.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.Pre.get -> bool?
 ModularPipelines.Python.Options.PipDownloadOptions.Pre.set -> void
@@ -217,11 +214,9 @@ ModularPipelines.Python.Options.PipDownloadOptions.Python.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Python.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.Quiet.get -> bool?
 ModularPipelines.Python.Options.PipDownloadOptions.Quiet.set -> void
-ModularPipelines.Python.Options.PipDownloadOptions.RequireHashes.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.RequireHashes.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.RequireVirtualenv.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.RequireVirtualenv.set -> void
-ModularPipelines.Python.Options.PipDownloadOptions.Requirement.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Requirement.set -> void
 ModularPipelines.Python.Options.PipDownloadOptions.Retries.get -> string?
 ModularPipelines.Python.Options.PipDownloadOptions.Retries.set -> void
@@ -272,7 +267,6 @@ ModularPipelines.Python.Options.PipFreezeOptions.NoColor.get -> bool?
 ModularPipelines.Python.Options.PipFreezeOptions.NoColor.set -> void
 ModularPipelines.Python.Options.PipFreezeOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipFreezeOptions.NoInput.set -> void
-ModularPipelines.Python.Options.PipFreezeOptions.Path.get -> string?
 ModularPipelines.Python.Options.PipFreezeOptions.Path.set -> void
 ModularPipelines.Python.Options.PipFreezeOptions.PipFreezeOptions() -> void
 ModularPipelines.Python.Options.PipFreezeOptions.PipFreezeOptions(ModularPipelines.Python.Options.PipFreezeOptions! original) -> void
@@ -284,7 +278,6 @@ ModularPipelines.Python.Options.PipFreezeOptions.Quiet.get -> bool?
 ModularPipelines.Python.Options.PipFreezeOptions.Quiet.set -> void
 ModularPipelines.Python.Options.PipFreezeOptions.RequireVirtualenv.get -> string?
 ModularPipelines.Python.Options.PipFreezeOptions.RequireVirtualenv.set -> void
-ModularPipelines.Python.Options.PipFreezeOptions.Requirement.get -> string?
 ModularPipelines.Python.Options.PipFreezeOptions.Requirement.set -> void
 ModularPipelines.Python.Options.PipFreezeOptions.Retries.get -> string?
 ModularPipelines.Python.Options.PipFreezeOptions.Retries.set -> void
@@ -325,7 +318,6 @@ ModularPipelines.Python.Options.PipHashOptions.NoColor.get -> bool?
 ModularPipelines.Python.Options.PipHashOptions.NoColor.set -> void
 ModularPipelines.Python.Options.PipHashOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipHashOptions.NoInput.set -> void
-ModularPipelines.Python.Options.PipHashOptions.PipHashOptions() -> void
 ModularPipelines.Python.Options.PipHashOptions.PipHashOptions(ModularPipelines.Python.Options.PipHashOptions! original) -> void
 ModularPipelines.Python.Options.PipHashOptions.Proxy.get -> string?
 ModularPipelines.Python.Options.PipHashOptions.Proxy.set -> void
@@ -350,7 +342,6 @@ ModularPipelines.Python.Options.PipHashOptions.Verbose.set -> void
 ModularPipelines.Python.Options.PipHashOptions.Version.get -> string?
 ModularPipelines.Python.Options.PipHashOptions.Version.set -> void
 ModularPipelines.Python.Options.PipIndexOptions
-ModularPipelines.Python.Options.PipIndexOptions.Abi.get -> string?
 ModularPipelines.Python.Options.PipIndexOptions.Abi.set -> void
 ModularPipelines.Python.Options.PipIndexOptions.CacheDir.get -> string?
 ModularPipelines.Python.Options.PipIndexOptions.CacheDir.set -> void
@@ -386,7 +377,6 @@ ModularPipelines.Python.Options.PipIndexOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipIndexOptions.NoInput.set -> void
 ModularPipelines.Python.Options.PipIndexOptions.PipIndexOptions() -> void
 ModularPipelines.Python.Options.PipIndexOptions.PipIndexOptions(ModularPipelines.Python.Options.PipIndexOptions! original) -> void
-ModularPipelines.Python.Options.PipIndexOptions.Platform.get -> string?
 ModularPipelines.Python.Options.PipIndexOptions.Platform.set -> void
 ModularPipelines.Python.Options.PipIndexOptions.Pre.get -> bool?
 ModularPipelines.Python.Options.PipIndexOptions.Pre.set -> void
@@ -437,7 +427,6 @@ ModularPipelines.Python.Options.PipInspectOptions.NoColor.get -> bool?
 ModularPipelines.Python.Options.PipInspectOptions.NoColor.set -> void
 ModularPipelines.Python.Options.PipInspectOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipInspectOptions.NoInput.set -> void
-ModularPipelines.Python.Options.PipInspectOptions.Path.get -> string?
 ModularPipelines.Python.Options.PipInspectOptions.Path.set -> void
 ModularPipelines.Python.Options.PipInspectOptions.PipInspectOptions() -> void
 ModularPipelines.Python.Options.PipInspectOptions.PipInspectOptions(ModularPipelines.Python.Options.PipInspectOptions! original) -> void
@@ -466,7 +455,6 @@ ModularPipelines.Python.Options.PipInspectOptions.Verbose.set -> void
 ModularPipelines.Python.Options.PipInspectOptions.Version.get -> string?
 ModularPipelines.Python.Options.PipInspectOptions.Version.set -> void
 ModularPipelines.Python.Options.PipInstallOptions
-ModularPipelines.Python.Options.PipInstallOptions.Abi.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Abi.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.BreakSystemPackages.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.BreakSystemPackages.set -> void
@@ -480,7 +468,6 @@ ModularPipelines.Python.Options.PipInstallOptions.ClientCert.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.ClientCert.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.Compile.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Compile.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.Constraint.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Constraint.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.Debug.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Debug.set -> void
@@ -532,7 +519,6 @@ ModularPipelines.Python.Options.PipInstallOptions.NoWarnScriptLocation.get -> bo
 ModularPipelines.Python.Options.PipInstallOptions.NoWarnScriptLocation.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.PipInstallOptions() -> void
 ModularPipelines.Python.Options.PipInstallOptions.PipInstallOptions(ModularPipelines.Python.Options.PipInstallOptions! original) -> void
-ModularPipelines.Python.Options.PipInstallOptions.Platform.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Platform.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.Pre.get -> bool?
 ModularPipelines.Python.Options.PipInstallOptions.Pre.set -> void
@@ -548,11 +534,9 @@ ModularPipelines.Python.Options.PipInstallOptions.Quiet.get -> bool?
 ModularPipelines.Python.Options.PipInstallOptions.Quiet.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.Report.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Report.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.RequireHashes.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.RequireHashes.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.RequireVirtualenv.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.RequireVirtualenv.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.Requirement.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Requirement.set -> void
 ModularPipelines.Python.Options.PipInstallOptions.Retries.get -> string?
 ModularPipelines.Python.Options.PipInstallOptions.Retries.set -> void
@@ -627,7 +611,6 @@ ModularPipelines.Python.Options.PipListOptions.NotRequired.get -> string?
 ModularPipelines.Python.Options.PipListOptions.NotRequired.set -> void
 ModularPipelines.Python.Options.PipListOptions.Outdated.get -> string?
 ModularPipelines.Python.Options.PipListOptions.Outdated.set -> void
-ModularPipelines.Python.Options.PipListOptions.Path.get -> string?
 ModularPipelines.Python.Options.PipListOptions.Path.set -> void
 ModularPipelines.Python.Options.PipListOptions.PipListOptions() -> void
 ModularPipelines.Python.Options.PipListOptions.PipListOptions(ModularPipelines.Python.Options.PipListOptions! original) -> void
@@ -687,7 +670,6 @@ ModularPipelines.Python.Options.PipSearchOptions.NoColor.get -> bool?
 ModularPipelines.Python.Options.PipSearchOptions.NoColor.set -> void
 ModularPipelines.Python.Options.PipSearchOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipSearchOptions.NoInput.set -> void
-ModularPipelines.Python.Options.PipSearchOptions.PipSearchOptions() -> void
 ModularPipelines.Python.Options.PipSearchOptions.PipSearchOptions(ModularPipelines.Python.Options.PipSearchOptions! original) -> void
 ModularPipelines.Python.Options.PipSearchOptions.Proxy.get -> string?
 ModularPipelines.Python.Options.PipSearchOptions.Proxy.set -> void
@@ -736,7 +718,6 @@ ModularPipelines.Python.Options.PipShowOptions.NoColor.get -> bool?
 ModularPipelines.Python.Options.PipShowOptions.NoColor.set -> void
 ModularPipelines.Python.Options.PipShowOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipShowOptions.NoInput.set -> void
-ModularPipelines.Python.Options.PipShowOptions.PipShowOptions() -> void
 ModularPipelines.Python.Options.PipShowOptions.PipShowOptions(ModularPipelines.Python.Options.PipShowOptions! original) -> void
 ModularPipelines.Python.Options.PipShowOptions.Proxy.get -> string?
 ModularPipelines.Python.Options.PipShowOptions.Proxy.set -> void
@@ -785,7 +766,6 @@ ModularPipelines.Python.Options.PipUninstallOptions.NoColor.get -> bool?
 ModularPipelines.Python.Options.PipUninstallOptions.NoColor.set -> void
 ModularPipelines.Python.Options.PipUninstallOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipUninstallOptions.NoInput.set -> void
-ModularPipelines.Python.Options.PipUninstallOptions.PipUninstallOptions() -> void
 ModularPipelines.Python.Options.PipUninstallOptions.PipUninstallOptions(ModularPipelines.Python.Options.PipUninstallOptions! original) -> void
 ModularPipelines.Python.Options.PipUninstallOptions.Proxy.get -> string?
 ModularPipelines.Python.Options.PipUninstallOptions.Proxy.set -> void
@@ -795,7 +775,6 @@ ModularPipelines.Python.Options.PipUninstallOptions.Quiet.get -> bool?
 ModularPipelines.Python.Options.PipUninstallOptions.Quiet.set -> void
 ModularPipelines.Python.Options.PipUninstallOptions.RequireVirtualenv.get -> string?
 ModularPipelines.Python.Options.PipUninstallOptions.RequireVirtualenv.set -> void
-ModularPipelines.Python.Options.PipUninstallOptions.Requirement.get -> string?
 ModularPipelines.Python.Options.PipUninstallOptions.Requirement.set -> void
 ModularPipelines.Python.Options.PipUninstallOptions.Retries.get -> string?
 ModularPipelines.Python.Options.PipUninstallOptions.Retries.set -> void
@@ -824,7 +803,6 @@ ModularPipelines.Python.Options.PipWheelOptions.CheckBuildDependencies.get -> st
 ModularPipelines.Python.Options.PipWheelOptions.CheckBuildDependencies.set -> void
 ModularPipelines.Python.Options.PipWheelOptions.ClientCert.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.ClientCert.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.Constraint.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.Constraint.set -> void
 ModularPipelines.Python.Options.PipWheelOptions.Debug.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.Debug.set -> void
@@ -864,7 +842,6 @@ ModularPipelines.Python.Options.PipWheelOptions.NoInput.get -> bool?
 ModularPipelines.Python.Options.PipWheelOptions.NoInput.set -> void
 ModularPipelines.Python.Options.PipWheelOptions.NoVerify.get -> bool?
 ModularPipelines.Python.Options.PipWheelOptions.NoVerify.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.PipWheelOptions() -> void
 ModularPipelines.Python.Options.PipWheelOptions.PipWheelOptions(ModularPipelines.Python.Options.PipWheelOptions! original) -> void
 ModularPipelines.Python.Options.PipWheelOptions.Pre.get -> bool?
 ModularPipelines.Python.Options.PipWheelOptions.Pre.set -> void
@@ -876,11 +853,9 @@ ModularPipelines.Python.Options.PipWheelOptions.Python.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.Python.set -> void
 ModularPipelines.Python.Options.PipWheelOptions.Quiet.get -> bool?
 ModularPipelines.Python.Options.PipWheelOptions.Quiet.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.RequireHashes.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.RequireHashes.set -> void
 ModularPipelines.Python.Options.PipWheelOptions.RequireVirtualenv.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.RequireVirtualenv.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.Requirement.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.Requirement.set -> void
 ModularPipelines.Python.Options.PipWheelOptions.Retries.get -> string?
 ModularPipelines.Python.Options.PipWheelOptions.Retries.set -> void

--- a/src/ModularPipelines.Python/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Python/PublicAPI.Unshipped.txt
@@ -1,4 +1,29 @@
 #nullable enable
+*REMOVED*ModularPipelines.Python.Options.PipDownloadOptions.Abi.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipDownloadOptions.Constraint.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipDownloadOptions.Platform.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipDownloadOptions.RequireHashes.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipDownloadOptions.Requirement.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipFreezeOptions.Path.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipFreezeOptions.Requirement.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipHashOptions.PipHashOptions() -> void
+*REMOVED*ModularPipelines.Python.Options.PipIndexOptions.Abi.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipIndexOptions.Platform.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipInspectOptions.Path.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipInstallOptions.Abi.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipInstallOptions.Constraint.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipInstallOptions.Platform.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipInstallOptions.RequireHashes.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipInstallOptions.Requirement.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipListOptions.Path.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipSearchOptions.PipSearchOptions() -> void
+*REMOVED*ModularPipelines.Python.Options.PipShowOptions.PipShowOptions() -> void
+*REMOVED*ModularPipelines.Python.Options.PipUninstallOptions.PipUninstallOptions() -> void
+*REMOVED*ModularPipelines.Python.Options.PipUninstallOptions.Requirement.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipWheelOptions.Constraint.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipWheelOptions.PipWheelOptions() -> void
+*REMOVED*ModularPipelines.Python.Options.PipWheelOptions.RequireHashes.get -> string?
+*REMOVED*ModularPipelines.Python.Options.PipWheelOptions.Requirement.get -> string?
 *REMOVED*ModularPipelines.Python.Services.IPip.CacheAsync(ModularPipelines.Python.Options.PipCacheOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Python.Services.IPip.CheckAsync(ModularPipelines.Python.Options.PipCheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Python.Services.IPip.ConfigAsync(ModularPipelines.Python.Options.PipConfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -14,42 +39,30 @@
 *REMOVED*ModularPipelines.Python.Services.IPip.UninstallAsync(ModularPipelines.Python.Options.PipUninstallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Python.Services.IPip.WheelAsync(ModularPipelines.Python.Options.PipWheelOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Python.Extensions.PipExtensions.Pip(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Python.Services.IPip!
-ModularPipelines.Python.Options.PipDownloadOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipDownloadOptions.AbiValues.set -> void
-ModularPipelines.Python.Options.PipDownloadOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipDownloadOptions.ConstraintValues.set -> void
-ModularPipelines.Python.Options.PipDownloadOptions.PlatformValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipDownloadOptions.PlatformValues.set -> void
+ModularPipelines.Python.Options.PipDownloadOptions.Abi.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.Constraint.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.Platform.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipDownloadOptions.RequireHashes.get -> bool?
+ModularPipelines.Python.Options.PipDownloadOptions.Requirement.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Python.Options.PipDownloadOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Python.Options.PipDownloadOptions.RequirementSpecifier.set -> void
-ModularPipelines.Python.Options.PipDownloadOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipDownloadOptions.RequirementValues.set -> void
-ModularPipelines.Python.Options.PipFreezeOptions.PathValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipFreezeOptions.PathValues.set -> void
-ModularPipelines.Python.Options.PipFreezeOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipFreezeOptions.RequirementValues.set -> void
+ModularPipelines.Python.Options.PipFreezeOptions.Path.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipFreezeOptions.Requirement.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Python.Options.PipHashOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! File) -> void
 ModularPipelines.Python.Options.PipHashOptions.File.get -> System.Collections.Generic.IEnumerable<string!>!
 ModularPipelines.Python.Options.PipHashOptions.File.init -> void
 ModularPipelines.Python.Options.PipHashOptions.PipHashOptions(System.Collections.Generic.IEnumerable<string!>! File) -> void
-ModularPipelines.Python.Options.PipIndexOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipIndexOptions.AbiValues.set -> void
-ModularPipelines.Python.Options.PipIndexOptions.PlatformValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipIndexOptions.PlatformValues.set -> void
-ModularPipelines.Python.Options.PipInspectOptions.PathValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipInspectOptions.PathValues.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipInstallOptions.AbiValues.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipInstallOptions.ConstraintValues.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.PlatformValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipInstallOptions.PlatformValues.set -> void
+ModularPipelines.Python.Options.PipIndexOptions.Abi.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipIndexOptions.Platform.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInspectOptions.Path.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.Abi.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.Constraint.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.Platform.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipInstallOptions.RequireHashes.get -> bool?
+ModularPipelines.Python.Options.PipInstallOptions.Requirement.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Python.Options.PipInstallOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Python.Options.PipInstallOptions.RequirementSpecifier.set -> void
-ModularPipelines.Python.Options.PipInstallOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipInstallOptions.RequirementValues.set -> void
-ModularPipelines.Python.Options.PipListOptions.PathValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipListOptions.PathValues.set -> void
+ModularPipelines.Python.Options.PipListOptions.Path.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Python.Options.PipSearchOptions.Deconstruct(out string! Query) -> void
 ModularPipelines.Python.Options.PipSearchOptions.PipSearchOptions(string! Query) -> void
 ModularPipelines.Python.Options.PipSearchOptions.Query.get -> string!
@@ -58,28 +71,29 @@ ModularPipelines.Python.Options.PipShowOptions.Deconstruct(out System.Collection
 ModularPipelines.Python.Options.PipShowOptions.Package.get -> System.Collections.Generic.IEnumerable<string!>!
 ModularPipelines.Python.Options.PipShowOptions.Package.init -> void
 ModularPipelines.Python.Options.PipShowOptions.PipShowOptions(System.Collections.Generic.IEnumerable<string!>! Package) -> void
-ModularPipelines.Python.Options.PipUninstallOptions.Package.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipUninstallOptions.Package.set -> void
-ModularPipelines.Python.Options.PipUninstallOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipUninstallOptions.RequirementValues.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipWheelOptions.ConstraintValues.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipWheelOptions.RequirementSpecifier.set -> void
-ModularPipelines.Python.Options.PipWheelOptions.RequirementValues.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.Python.Options.PipWheelOptions.RequirementValues.set -> void
+ModularPipelines.Python.Options.PipUninstallOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! Package) -> void
+ModularPipelines.Python.Options.PipUninstallOptions.Package.get -> System.Collections.Generic.IEnumerable<string!>!
+ModularPipelines.Python.Options.PipUninstallOptions.Package.init -> void
+ModularPipelines.Python.Options.PipUninstallOptions.PipUninstallOptions(System.Collections.Generic.IEnumerable<string!>! Package) -> void
+ModularPipelines.Python.Options.PipUninstallOptions.Requirement.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipWheelOptions.Constraint.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipWheelOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! RequirementSpecifier) -> void
+ModularPipelines.Python.Options.PipWheelOptions.PipWheelOptions(System.Collections.Generic.IEnumerable<string!>! RequirementSpecifier) -> void
+ModularPipelines.Python.Options.PipWheelOptions.RequireHashes.get -> bool?
+ModularPipelines.Python.Options.PipWheelOptions.Requirement.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Python.Options.PipWheelOptions.RequirementSpecifier.get -> System.Collections.Generic.IEnumerable<string!>!
+ModularPipelines.Python.Options.PipWheelOptions.RequirementSpecifier.init -> void
 ModularPipelines.Python.Services.IPip.CacheAsync(ModularPipelines.Python.Options.PipCacheOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.CheckAsync(ModularPipelines.Python.Options.PipCheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.ConfigAsync(ModularPipelines.Python.Options.PipConfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.DownloadAsync(ModularPipelines.Python.Options.PipDownloadOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.FreezeAsync(ModularPipelines.Python.Options.PipFreezeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Python.Services.IPip.HashAsync(ModularPipelines.Python.Options.PipHashOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Python.Services.IPip.HashAsync(ModularPipelines.Python.Options.PipHashOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.IndexAsync(ModularPipelines.Python.Options.PipIndexOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.InspectAsync(ModularPipelines.Python.Options.PipInspectOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.InstallAsync(ModularPipelines.Python.Options.PipInstallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Python.Services.IPip.ListAsync(ModularPipelines.Python.Options.PipListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Python.Services.IPip.SearchAsync(ModularPipelines.Python.Options.PipSearchOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Python.Services.IPip.ShowAsync(ModularPipelines.Python.Options.PipShowOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Python.Services.IPip.UninstallAsync(ModularPipelines.Python.Options.PipUninstallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Python.Services.IPip.WheelAsync(ModularPipelines.Python.Options.PipWheelOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-static ModularPipelines.Python.Extensions.PipExtensions.Pip(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Python.Services.IPip!
+ModularPipelines.Python.Services.IPip.SearchAsync(ModularPipelines.Python.Options.PipSearchOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Python.Services.IPip.ShowAsync(ModularPipelines.Python.Options.PipShowOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Python.Services.IPip.UninstallAsync(ModularPipelines.Python.Options.PipUninstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Python.Services.IPip.WheelAsync(ModularPipelines.Python.Options.PipWheelOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!

--- a/src/ModularPipelines.Python/Services/IPip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/IPip.Generated.cs
@@ -147,7 +147,7 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> UninstallAsync(PipUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UninstallAsync(PipUninstallOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -157,7 +157,7 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> WheelAsync(PipWheelOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WheelAsync(PipWheelOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion

--- a/src/ModularPipelines.Python/Services/Pip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/Pip.Generated.cs
@@ -142,20 +142,20 @@ internal partial class Pip : IPip
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> UninstallAsync(
-        PipUninstallOptions? options = null,
+        PipUninstallOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipUninstallOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> WheelAsync(
-        PipWheelOptions? options = null,
+        PipWheelOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipWheelOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pip** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Assembly/common`, `Pip`.

- Added APIs: 33
- Removed or changed APIs: 69
- Members with matching names but changed signatures: 29

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Python.Options.PipDownloadOptions.Abi.get -> string?`
- `ModularPipelines.Python.Options.PipDownloadOptions.AbiValues.get -> System.Collections.Generic.IEnumerable<string!>?`
- `ModularPipelines.Python.Options.PipDownloadOptions.AbiValues.set -> void`
- `ModularPipelines.Python.Options.PipDownloadOptions.Constraint.get -> string?`
- `ModularPipelines.Python.Options.PipDownloadOptions.ConstraintValues.get -> System.Collections.Generic.IEnumerable<string!>?`

Representative added members:
- `ModularPipelines.Python.Options.PipDownloadOptions.Abi.get -> System.Collections.Generic.IEnumerable<string!>?`
- `ModularPipelines.Python.Options.PipDownloadOptions.Constraint.get -> System.Collections.Generic.IEnumerable<string!>?`
- `ModularPipelines.Python.Options.PipDownloadOptions.Platform.get -> System.Collections.Generic.IEnumerable<string!>?`
- `ModularPipelines.Python.Options.PipDownloadOptions.RequireHashes.get -> bool?`
- `ModularPipelines.Python.Options.PipDownloadOptions.Requirement.get -> System.Collections.Generic.IEnumerable<string!>?`

## Command coverage
Command coverage report:
- pip (pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)): 14 commands, tree a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac
  - Baseline comparison: 14 commands at pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12) -> 14 commands at pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator