### PR TITLE
[Automated] Update kustomize CLI Options

### DIFF
--- a/src/ModularPipelines.Kubernetes/Generated/Kustomize.Generation.json
+++ b/src/ModularPipelines.Kubernetes/Generated/Kustomize.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "kustomize",
+  "toolVersion": "v5.8.1",
+  "commandTreeSha256": "0ae36cae52a7633cdaf6161528ae7819e41d2855a07443c9b69a53279326fb08",
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+}

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeEditFixOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeEditFixOptions.Generated.cs
@@ -27,7 +27,7 @@ public record KustomizeEditFixOptions : KustomizeOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// If specified, kustomize will attempt to convert vars to replacements.
+    /// If specified, kustomize will attempt to convert vars to replacements. We recommend doing this in a clean git repository where the change is easy to undo.
     /// </summary>
     [CliFlag("--vars")]
     public bool? Vars { get; set; }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kustomize** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- kustomize (v5.8.1): 45 commands, tree 0ae36cae52a7633cdaf6161528ae7819e41d2855a07443c9b69a53279326fb08
  - Baseline comparison: 45 commands at v5.8.1 -> 45 commands at v5.8.1

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator