### PR TITLE
Remove obsolete Terraform context workaround

### DIFF
--- a/src/ModularPipelines.Terraform/GlobalUsings.cs
+++ b/src/ModularPipelines.Terraform/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using ModularPipelines.Context;


### PR DESCRIPTION
Closes #4332

## Summary
- remove the temporary Terraform package-wide context import left by the stale generated snapshot workaround
- rely on regenerated service files, which now carry their own ModularPipelines.Context imports
- completes the final cleanup acceptance item after #4445 landed refresh provenance and stale-snapshot detection

## Validation
- Terraform solution Release build: passed, 0 warnings/errors
- ModularPipelines.Terraform.UnitTests: 1 passed
- Test-GeneratedOptionsProvenance.ps1: passed
- Test-ResolveGeneratedIntegrationValidation.ps1: passed