### PR TITLE
[Automated] Update brew CLI Options

### DIFF
--- a/src/ModularPipelines.Homebrew/Generated/Brew.Generation.json
+++ b/src/ModularPipelines.Homebrew/Generated/Brew.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "brew",
+  "toolVersion": "Homebrew 6.0.18",
+  "commandTreeSha256": "7530c4cc1b396a84294528123676a40aa6d25f4164ae56b4e949a2eaf3c56888",
+  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+}

--- a/src/ModularPipelines.Homebrew/Options/BrewServicesInfoOptions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Options/BrewServicesInfoOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Homebrew.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Homebrew.Options;
 
@@ -18,7 +19,7 @@ namespace ModularPipelines.Homebrew.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("services", "info")]
-public record BrewServicesInfoOptions : BrewOptions
+public record BrewServicesInfoOptions : BrewOptions, IValidatableObject
 {
     /// <summary>
     /// Display any debugging information.
@@ -67,5 +68,14 @@ public record BrewServicesInfoOptions : BrewOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Formula { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(!string.IsNullOrWhiteSpace(Formula) || All == true))
+        {
+            yield return new ValidationResult("At least one of Formula or All must be specified.", [nameof(Formula), nameof(All)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Homebrew/Options/BrewServicesKillOptions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Options/BrewServicesKillOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Homebrew.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Homebrew.Options;
 
@@ -18,7 +19,7 @@ namespace ModularPipelines.Homebrew.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("services", "kill")]
-public record BrewServicesKillOptions : BrewOptions
+public record BrewServicesKillOptions : BrewOptions, IValidatableObject
 {
     /// <summary>
     /// Display any debugging information.
@@ -61,5 +62,14 @@ public record BrewServicesKillOptions : BrewOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Formula { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(!string.IsNullOrWhiteSpace(Formula) || All == true))
+        {
+            yield return new ValidationResult("At least one of Formula or All must be specified.", [nameof(Formula), nameof(All)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Homebrew/Options/BrewServicesRestartOptions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Options/BrewServicesRestartOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Homebrew.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Homebrew.Options;
 
@@ -18,7 +19,7 @@ namespace ModularPipelines.Homebrew.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("services", "restart")]
-public record BrewServicesRestartOptions : BrewOptions
+public record BrewServicesRestartOptions : BrewOptions, IValidatableObject
 {
     /// <summary>
     /// Display any debugging information.
@@ -67,5 +68,14 @@ public record BrewServicesRestartOptions : BrewOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Formula { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(!string.IsNullOrWhiteSpace(Formula) || All == true))
+        {
+            yield return new ValidationResult("At least one of Formula or All must be specified.", [nameof(Formula), nameof(All)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Homebrew/Options/BrewServicesRunOptions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Options/BrewServicesRunOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Homebrew.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Homebrew.Options;
 
@@ -18,7 +19,7 @@ namespace ModularPipelines.Homebrew.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("services", "run")]
-public record BrewServicesRunOptions : BrewOptions
+public record BrewServicesRunOptions : BrewOptions, IValidatableObject
 {
     /// <summary>
     /// Display any debugging information.
@@ -67,5 +68,14 @@ public record BrewServicesRunOptions : BrewOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Formula { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(!string.IsNullOrWhiteSpace(Formula) || All == true))
+        {
+            yield return new ValidationResult("At least one of Formula or All must be specified.", [nameof(Formula), nameof(All)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Homebrew/Options/BrewServicesStartOptions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Options/BrewServicesStartOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Homebrew.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Homebrew.Options;
 
@@ -18,7 +19,7 @@ namespace ModularPipelines.Homebrew.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("services", "start")]
-public record BrewServicesStartOptions : BrewOptions
+public record BrewServicesStartOptions : BrewOptions, IValidatableObject
 {
     /// <summary>
     /// Display any debugging information.
@@ -67,5 +68,14 @@ public record BrewServicesStartOptions : BrewOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Formula { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(!string.IsNullOrWhiteSpace(Formula) || All == true))
+        {
+            yield return new ValidationResult("At least one of Formula or All must be specified.", [nameof(Formula), nameof(All)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Homebrew/Options/BrewServicesStopOptions.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Options/BrewServicesStopOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Homebrew.Options;
+using System.ComponentModel.DataAnnotations;
 
 namespace ModularPipelines.Homebrew.Options;
 
@@ -18,7 +19,7 @@ namespace ModularPipelines.Homebrew.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("services", "stop")]
-public record BrewServicesStopOptions : BrewOptions
+public record BrewServicesStopOptions : BrewOptions, IValidatableObject
 {
     /// <summary>
     /// Display any debugging information.
@@ -79,5 +80,14 @@ public record BrewServicesStopOptions : BrewOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public string? Formula { get; set; }
+
+    /// <inheritdoc />
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (!(!string.IsNullOrWhiteSpace(Formula) || All == true))
+        {
+            yield return new ValidationResult("At least one of Formula or All must be specified.", [nameof(Formula), nameof(All)]);
+        }
+    }
 
 }

--- a/src/ModularPipelines.Homebrew/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Homebrew/PublicAPI.Shipped.txt
@@ -35,10 +35,7 @@ ModularPipelines.Homebrew.Options.BrewAsConsoleUserOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewAsConsoleUserOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAsConsoleUserOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Arch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Arch.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ArchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ArchValue.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.AuditDebug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.AuditDebug.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.BrewAuditOptions() -> void
@@ -51,16 +48,8 @@ ModularPipelines.Homebrew.Options.BrewAuditOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.DisplayFilename.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.DisplayFilename.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.EvalAll.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Except.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Except.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCops.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCops.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCopsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCopsValue.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptValue.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Fix.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Fix.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Formula.get -> bool?
@@ -77,30 +66,16 @@ ModularPipelines.Homebrew.Options.BrewAuditOptions.New.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.New.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Online.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Online.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Only.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Only.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCops.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCops.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCopsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCopsValue.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyValue.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Os.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Os.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.OsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Signing.get -> bool?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Signing.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.SkipStyle.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.SkipStyle.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Strict.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Strict.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.Tap.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewAuditOptions.TapValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewAuditOptions.TapValue.set -> void
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAuditOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewAutoremoveOptions
@@ -117,11 +92,8 @@ ModularPipelines.Homebrew.Options.BrewAutoremoveOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewAutoremoveOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewAutoremoveOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions
-ModularPipelines.Homebrew.Options.BrewBottleOptions.BrewBottleOptions() -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.BrewBottleOptions(ModularPipelines.Homebrew.Options.BrewBottleOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.BrewBottleOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
-ModularPipelines.Homebrew.Options.BrewBottleOptions.Committer.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBottleOptions.Committer.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
@@ -147,14 +119,8 @@ ModularPipelines.Homebrew.Options.BrewBottleOptions.OnlyJsonTab.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.OnlyJsonTab.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrl.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrl.set -> void
-ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsing.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsing.set -> void
-ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsingValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsingValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.SkipRelocation.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.SkipRelocation.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Verbose.get -> bool?
@@ -162,7 +128,6 @@ ModularPipelines.Homebrew.Options.BrewBottleOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Write.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBottleOptions.Write.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.BrewBumpCaskPrOptions() -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.BrewBumpCaskPrOptions(ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.BrewBumpCaskPrOptions(string! Cask) -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Cask.get -> string!
@@ -174,16 +139,10 @@ ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Deconstruct(out string! Cask) -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.DryRun.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.DryRun.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrg.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrg.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrgValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrgValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Message.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Message.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.MessageValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.MessageValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.NoAudit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.NoAudit.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.NoBrowse.get -> bool?
@@ -194,28 +153,13 @@ ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.NoStyle.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.NoStyle.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256Value.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256Value.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Url.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Url.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.UrlValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.UrlValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Version.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Version.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArm.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArm.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArmValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArmValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntel.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntel.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntelValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntelValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.WriteOnly.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.WriteOnly.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpCompatibilityVersionOptions
@@ -249,24 +193,15 @@ ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.DryRun.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.DryRun.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Force.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Force.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrg.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrg.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrgValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrgValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Formula.get -> string?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.InstallDependencies.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.InstallDependencies.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Message.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Message.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MessageValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MessageValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Mirror.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Mirror.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MirrorValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MirrorValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.NoAudit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.NoAudit.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.NoBrowse.get -> bool?
@@ -275,44 +210,20 @@ ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.NoFork.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.NoFork.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Online.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Online.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackages.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackages.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackagesValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackagesValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackages.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackages.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackagesValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackagesValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageName.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageName.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageNameValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageNameValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Revision.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Revision.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.RevisionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.RevisionValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256Value.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256Value.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Strict.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Strict.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Tag.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Tag.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.TagValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.TagValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Url.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Url.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.UrlValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.UrlValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Version.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Version.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.VersionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.VersionValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.WriteOnly.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.WriteOnly.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpOptions
@@ -324,8 +235,6 @@ ModularPipelines.Homebrew.Options.BrewBumpOptions.Cask.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Cask.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBumpOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Formula.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpOptions.FormulaOperand.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -348,18 +257,11 @@ ModularPipelines.Homebrew.Options.BrewBumpOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Repology.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Repology.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWith.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWith.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWithValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWithValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpOptions.Tap.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpOptions.TapValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpOptions.TapValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions
-ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.BrewBumpRevisionOptions() -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.BrewBumpRevisionOptions(ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.BrewBumpRevisionOptions(System.Collections.Generic.IEnumerable<string!>! Formula) -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Debug.get -> bool?
@@ -371,10 +273,7 @@ ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Formula.get -> System.
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Formula.init -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Message.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Message.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.MessageValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.MessageValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.RemoveBottleBlock.get -> bool?
@@ -384,7 +283,6 @@ ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.WriteOnly.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.WriteOnly.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.BrewBumpUnversionedCasksOptions() -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.BrewBumpUnversionedCasksOptions(ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.BrewBumpUnversionedCasksOptions(System.Collections.Generic.IEnumerable<string!>! Cask) -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Cask.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -396,16 +294,10 @@ ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.DryRun.get -> 
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.DryRun.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Limit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Limit.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.LimitValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.LimitValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFile.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFile.set -> void
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFileValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFileValue.set -> void
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleAddOptions
@@ -800,74 +692,19 @@ ModularPipelines.Homebrew.Options.BrewBundleListOptions.Vscode.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleListOptions.Winget.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleListOptions.Winget.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions
-ModularPipelines.Homebrew.Options.BrewBundleOptions.All.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.All.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.BrewBundleOptions() -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.BrewBundleOptions(ModularPipelines.Homebrew.Options.BrewBundleOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Cargo.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Cargo.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Cask.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Cask.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Check.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Check.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Cleanup.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Cleanup.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Describe.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Describe.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.File.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleOptions.File.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.FileValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.FileValue.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Flatpak.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Flatpak.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Force.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Force.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Formula.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Global.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Global.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Go.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Go.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Install.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Install.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Mas.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Mas.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoCargo.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoCargo.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoFlatpak.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoFlatpak.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoGo.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoGo.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoRestart.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoRestart.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoSecrets.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoSecrets.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoUpgrade.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoUpgrade.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoVscode.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.NoVscode.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Overwrite.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Overwrite.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Services.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Services.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Tap.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Upgrade.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Upgrade.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.UpgradeFormulae.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.UpgradeFormulae.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Vscode.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Vscode.set -> void
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Zap.get -> bool?
-ModularPipelines.Homebrew.Options.BrewBundleOptions.Zap.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions
 ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions.BrewBundleRemoveOptions(ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions.BrewBundleRemoveOptions(string! Name) -> void
@@ -935,11 +772,7 @@ ModularPipelines.Homebrew.Options.BrewBundleShOptions.Services.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleShOptions.Services.set -> void
 ModularPipelines.Homebrew.Options.BrewBundleShOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewBundleShOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewCasksOptions
-ModularPipelines.Homebrew.Options.BrewCasksOptions.BrewCasksOptions() -> void
-ModularPipelines.Homebrew.Options.BrewCasksOptions.BrewCasksOptions(ModularPipelines.Homebrew.Options.BrewCasksOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewCatOptions
-ModularPipelines.Homebrew.Options.BrewCatOptions.BrewCatOptions() -> void
 ModularPipelines.Homebrew.Options.BrewCatOptions.BrewCatOptions(ModularPipelines.Homebrew.Options.BrewCatOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewCatOptions.BrewCatOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewCatOptions.Cask.get -> bool?
@@ -968,21 +801,15 @@ ModularPipelines.Homebrew.Options.BrewCleanupOptions.Formula.get -> System.Colle
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewCleanupOptions.Prune.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Prune.set -> void
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.PrunePrefix.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.PrunePrefix.set -> void
-ModularPipelines.Homebrew.Options.BrewCleanupOptions.PruneValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewCleanupOptions.PruneValue.set -> void
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Scrub.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Scrub.set -> void
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCleanupOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewCommandCommandOptions
-ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.BrewCommandCommandOptions() -> void
-ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.BrewCommandCommandOptions(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions
 ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.BrewCommandNotFoundInitOptions() -> void
 ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.BrewCommandNotFoundInitOptions(ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions! original) -> void
@@ -1070,46 +897,24 @@ ModularPipelines.Homebrew.Options.BrewContributionsOptions.Csv.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Csv.set -> void
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.From.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.From.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.FromValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.FromValue.set -> void
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.MaintainerReportCsv.get -> string?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.MaintainerReportCsv.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.Organisation.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Organisation.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.OrganisationValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.OrganisationValue.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.Quarter.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Quarter.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.QuarterValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.QuarterValue.set -> void
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.Repositories.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Repositories.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.RepositoriesValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.RepositoriesValue.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.Team.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Team.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.TeamValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.TeamValue.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.To.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.To.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.ToValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.ToValue.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.User.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.User.set -> void
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.UserValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewContributionsOptions.UserValue.set -> void
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewContributionsOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Autotools.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Autotools.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.BrewCreateOptions() -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.BrewCreateOptions(ModularPipelines.Homebrew.Options.BrewCreateOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.BrewCreateOptions(string! Url) -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Cabal.get -> bool?
@@ -1147,22 +952,10 @@ ModularPipelines.Homebrew.Options.BrewCreateOptions.Ruby.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Ruby.set -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Rust.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Rust.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicense.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicense.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicenseValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicenseValue.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetName.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.SetName.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetNameValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetNameValue.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersion.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersion.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersionValue.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.Tap.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewCreateOptions.TapValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewCreateOptions.TapValue.set -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Url.get -> string!
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Url.init -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Verbose.get -> bool?
@@ -1170,7 +963,6 @@ ModularPipelines.Homebrew.Options.BrewCreateOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Zig.get -> bool?
 ModularPipelines.Homebrew.Options.BrewCreateOptions.Zig.set -> void
 ModularPipelines.Homebrew.Options.BrewDebuggerOptions
-ModularPipelines.Homebrew.Options.BrewDebuggerOptions.BrewDebuggerOptions() -> void
 ModularPipelines.Homebrew.Options.BrewDebuggerOptions.BrewDebuggerOptions(ModularPipelines.Homebrew.Options.BrewDebuggerOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewDebuggerOptions.BrewDebuggerOptions(System.Collections.Generic.IEnumerable<string!>! Command) -> void
 ModularPipelines.Homebrew.Options.BrewDebuggerOptions.Command.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -1189,10 +981,7 @@ ModularPipelines.Homebrew.Options.BrewDebuggerOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Annotate.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Annotate.set -> void
-ModularPipelines.Homebrew.Options.BrewDepsOptions.Arch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Arch.set -> void
-ModularPipelines.Homebrew.Options.BrewDepsOptions.ArchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewDepsOptions.ArchValue.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.BrewDepsOptions() -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.BrewDepsOptions(ModularPipelines.Homebrew.Options.BrewDepsOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Brewfile.get -> string?
@@ -1205,8 +994,6 @@ ModularPipelines.Homebrew.Options.BrewDepsOptions.Direct.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Direct.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Dot.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Dot.set -> void
-ModularPipelines.Homebrew.Options.BrewDepsOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDepsOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.ForEach.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.ForEach.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Formula.get -> bool?
@@ -1235,10 +1022,7 @@ ModularPipelines.Homebrew.Options.BrewDepsOptions.Installed.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Installed.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Missing.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Missing.set -> void
-ModularPipelines.Homebrew.Options.BrewDepsOptions.Os.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Os.set -> void
-ModularPipelines.Homebrew.Options.BrewDepsOptions.OsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewDepsOptions.OsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Prune.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Prune.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Quiet.get -> bool?
@@ -1254,7 +1038,6 @@ ModularPipelines.Homebrew.Options.BrewDepsOptions.Union.set -> void
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDepsOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions
-ModularPipelines.Homebrew.Options.BrewDescOptions.BrewDescOptions() -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.BrewDescOptions(ModularPipelines.Homebrew.Options.BrewDescOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.BrewDescOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.Cask.get -> bool?
@@ -1264,8 +1047,6 @@ ModularPipelines.Homebrew.Options.BrewDescOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.Description.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDescOptions.Description.set -> void
-ModularPipelines.Homebrew.Options.BrewDescOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDescOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.Formula.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDescOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewDescOptions.FormulaOperand.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -1324,29 +1105,6 @@ ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.BrewDispatchBuildBottleOptions() -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.BrewDispatchBuildBottleOptions(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Issue.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Issue.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Linux.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Linux.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxArm64.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxArm64.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxSelfHosted.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxSelfHosted.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxWheezy.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxWheezy.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Macos.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Macos.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Tap.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Timeout.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Timeout.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Upload.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Upload.set -> void
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Workflow.get -> bool?
-ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Workflow.set -> void
 ModularPipelines.Homebrew.Options.BrewDocsOptions
 ModularPipelines.Homebrew.Options.BrewDocsOptions.BrewDocsOptions() -> void
 ModularPipelines.Homebrew.Options.BrewDocsOptions.BrewDocsOptions(ModularPipelines.Homebrew.Options.BrewDocsOptions! original) -> void
@@ -1417,7 +1175,6 @@ ModularPipelines.Homebrew.Options.BrewExecOptions.Sandbox.set -> void
 ModularPipelines.Homebrew.Options.BrewExecOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewExecOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions
-ModularPipelines.Homebrew.Options.BrewExtractOptions.BrewExtractOptions() -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.BrewExtractOptions(ModularPipelines.Homebrew.Options.BrewExtractOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.BrewExtractOptions(string! Formula, string! Tap) -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Debug.get -> bool?
@@ -1427,10 +1184,7 @@ ModularPipelines.Homebrew.Options.BrewExtractOptions.Force.get -> bool?
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Force.set -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Formula.get -> string!
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Formula.init -> void
-ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevision.get -> bool?
 ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevision.set -> void
-ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevisionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevisionValue.set -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Quiet.get -> bool?
@@ -1439,22 +1193,12 @@ ModularPipelines.Homebrew.Options.BrewExtractOptions.Tap.get -> string!
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Tap.init -> void
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewExtractOptions.Version.get -> bool?
 ModularPipelines.Homebrew.Options.BrewExtractOptions.Version.set -> void
-ModularPipelines.Homebrew.Options.BrewExtractOptions.VersionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewExtractOptions.VersionValue.set -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions
 ModularPipelines.Homebrew.Options.BrewFetchOptions.AllPlatforms.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.AllPlatforms.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.Arch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Arch.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.ArchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewFetchOptions.ArchValue.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTag.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTag.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTagValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTagValue.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.BrewFetchOptions() -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.BrewFetchOptions(ModularPipelines.Homebrew.Options.BrewFetchOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.BrewFetchOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.BuildBottle.get -> bool?
@@ -1480,54 +1224,13 @@ ModularPipelines.Homebrew.Options.BrewFetchOptions.Head.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Head.set -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.Os.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Os.set -> void
-ModularPipelines.Homebrew.Options.BrewFetchOptions.OsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewFetchOptions.OsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Retry.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Retry.set -> void
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFetchOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.AllCoreFormulaeJson.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.AllCoreFormulaeJson.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRun.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRun.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRunOptions.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRunOptions.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewFormulaAnalyticsOptions() -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewFormulaAnalyticsOptions(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewTestBotTest.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewTestBotTest.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BuildError.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BuildError.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.CaskInstall.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.CaskInstall.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.DaysAgo.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.DaysAgo.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewDevcmdrunDeveloper.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewDevcmdrunDeveloper.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewOsArchCi.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewOsArchCi.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewPrefixes.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewPrefixes.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewVersions.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewVersions.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Install.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Install.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.InstallOnRequest.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.InstallOnRequest.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Json.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Json.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.OsVersion.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.OsVersion.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Setup.get -> bool?
-ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Setup.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions
-ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.BrewFormulaFormulaOptions() -> void
-ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.BrewFormulaFormulaOptions(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewFormulaOptions
 ModularPipelines.Homebrew.Options.BrewFormulaOptions.BrewFormulaOptions(ModularPipelines.Homebrew.Options.BrewFormulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewFormulaOptions.BrewFormulaOptions(System.Collections.Generic.IEnumerable<string!>! Formula) -> void
@@ -1542,22 +1245,6 @@ ModularPipelines.Homebrew.Options.BrewFormulaOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFormulaOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewFormulaOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewFormulaOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewFormulaeOptions
-ModularPipelines.Homebrew.Options.BrewFormulaeOptions.BrewFormulaeOptions() -> void
-ModularPipelines.Homebrew.Options.BrewFormulaeOptions.BrewFormulaeOptions(ModularPipelines.Homebrew.Options.BrewFormulaeOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions
-ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.BrewGenerateAnalyticsApiOptions() -> void
-ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.BrewGenerateAnalyticsApiOptions(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions
-ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.BrewGenerateCaskApiOptions() -> void
-ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.BrewGenerateCaskApiOptions(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.DryRun.get -> bool?
-ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.DryRun.set -> void
-ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions
-ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.BrewGenerateFormulaApiOptions() -> void
-ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.BrewGenerateFormulaApiOptions(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.DryRun.get -> bool?
-ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.DryRun.set -> void
 ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions
 ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.BrewGenerateManCompletionsOptions() -> void
 ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.BrewGenerateManCompletionsOptions(ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions! original) -> void
@@ -1588,7 +1275,6 @@ ModularPipelines.Homebrew.Options.BrewGenerateZapOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewGenerateZapOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewGenerateZapOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions
-ModularPipelines.Homebrew.Options.BrewGistLogsOptions.BrewGistLogsOptions() -> void
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions.BrewGistLogsOptions(ModularPipelines.Homebrew.Options.BrewGistLogsOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions.BrewGistLogsOptions(string! Formula) -> void
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Debug.get -> bool?
@@ -1606,8 +1292,6 @@ ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewGistLogsOptions.WithHostname.get -> bool?
-ModularPipelines.Homebrew.Options.BrewGistLogsOptions.WithHostname.set -> void
 ModularPipelines.Homebrew.Options.BrewHomeOptions
 ModularPipelines.Homebrew.Options.BrewHomeOptions.BrewHomeOptions() -> void
 ModularPipelines.Homebrew.Options.BrewHomeOptions.BrewHomeOptions(ModularPipelines.Homebrew.Options.BrewHomeOptions! original) -> void
@@ -1659,27 +1343,18 @@ ModularPipelines.Homebrew.Options.BrewInfoOptions.Variations.set -> void
 ModularPipelines.Homebrew.Options.BrewInfoOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInfoOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions
-ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroups.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroups.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroupsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroupsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.BrewInstallBundlerGemsOptions() -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.BrewInstallBundlerGemsOptions(ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Groups.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Groups.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.GroupsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.GroupsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions
-ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.BrewInstallFormulaOptions() -> void
-ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.BrewInstallFormulaOptions(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Adopt.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Adopt.set -> void
@@ -1689,17 +1364,11 @@ ModularPipelines.Homebrew.Options.BrewInstallOptions.Appimagedir.get -> string?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Appimagedir.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.AsDependency.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.AsDependency.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallOptions.Ask.get -> bool?
-ModularPipelines.Homebrew.Options.BrewInstallOptions.Ask.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.AudioUnitPlugindir.get -> string?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.AudioUnitPlugindir.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Binaries.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Binaries.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArch.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArchValue.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallOptions.BrewInstallOptions() -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.BrewInstallOptions(ModularPipelines.Homebrew.Options.BrewInstallOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.BrewInstallOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.BuildBottle.get -> bool?
@@ -1708,10 +1377,7 @@ ModularPipelines.Homebrew.Options.BrewInstallOptions.BuildFromSource.get -> bool
 ModularPipelines.Homebrew.Options.BrewInstallOptions.BuildFromSource.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Cask.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Cask.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallOptions.Cc.get -> bool?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Cc.set -> void
-ModularPipelines.Homebrew.Options.BrewInstallOptions.CcValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewInstallOptions.CcValue.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Colorpickerdir.get -> string?
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Colorpickerdir.set -> void
 ModularPipelines.Homebrew.Options.BrewInstallOptions.Debug.get -> bool?
@@ -1802,8 +1468,6 @@ ModularPipelines.Homebrew.Options.BrewIrbOptions.Examples.get -> bool?
 ModularPipelines.Homebrew.Options.BrewIrbOptions.Examples.set -> void
 ModularPipelines.Homebrew.Options.BrewIrbOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewIrbOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewIrbOptions.Pry.get -> bool?
-ModularPipelines.Homebrew.Options.BrewIrbOptions.Pry.set -> void
 ModularPipelines.Homebrew.Options.BrewIrbOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewIrbOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewIrbOptions.Verbose.get -> bool?
@@ -1960,27 +1624,16 @@ ModularPipelines.Homebrew.Options.BrewLogOptions.FormulaOperand.get -> string?
 ModularPipelines.Homebrew.Options.BrewLogOptions.FormulaOperand.set -> void
 ModularPipelines.Homebrew.Options.BrewLogOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewLogOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCount.get -> bool?
 ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCount.set -> void
-ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCountValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCountValue.set -> void
 ModularPipelines.Homebrew.Options.BrewLogOptions.Oneline.get -> bool?
 ModularPipelines.Homebrew.Options.BrewLogOptions.Oneline.set -> void
-ModularPipelines.Homebrew.Options.BrewLogOptions.Patch.get -> bool?
-ModularPipelines.Homebrew.Options.BrewLogOptions.Patch.set -> void
 ModularPipelines.Homebrew.Options.BrewLogOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewLogOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewLogOptions.Stat.get -> bool?
 ModularPipelines.Homebrew.Options.BrewLogOptions.Stat.set -> void
 ModularPipelines.Homebrew.Options.BrewLogOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewLogOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewMcpServerOptions
-ModularPipelines.Homebrew.Options.BrewMcpServerOptions.BrewMcpServerOptions() -> void
-ModularPipelines.Homebrew.Options.BrewMcpServerOptions.BrewMcpServerOptions(ModularPipelines.Homebrew.Options.BrewMcpServerOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Debug.get -> bool?
-ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewMigrateOptions
-ModularPipelines.Homebrew.Options.BrewMigrateOptions.BrewMigrateOptions() -> void
 ModularPipelines.Homebrew.Options.BrewMigrateOptions.BrewMigrateOptions(ModularPipelines.Homebrew.Options.BrewMigrateOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewMigrateOptions.BrewMigrateOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
 ModularPipelines.Homebrew.Options.BrewMigrateOptions.Cask.get -> bool?
@@ -2011,10 +1664,7 @@ ModularPipelines.Homebrew.Options.BrewMissingOptions.Formula.get -> System.Colle
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewMissingOptions.Hide.get -> bool?
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Hide.set -> void
-ModularPipelines.Homebrew.Options.BrewMissingOptions.HideValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewMissingOptions.HideValue.set -> void
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewMissingOptions.Verbose.get -> bool?
@@ -2036,14 +1686,10 @@ ModularPipelines.Homebrew.Options.BrewOptions.BrewOptions(ModularPipelines.Homeb
 ModularPipelines.Homebrew.Options.BrewOptionsOptions
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.BrewOptionsOptions() -> void
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.BrewOptionsOptions(ModularPipelines.Homebrew.Options.BrewOptionsOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewOptionsOptions.Command.get -> bool?
-ModularPipelines.Homebrew.Options.BrewOptionsOptions.Command.set -> void
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Compact.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Compact.set -> void
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewOptionsOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewOptionsOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewOptionsOptions.Installed.get -> bool?
@@ -2073,19 +1719,13 @@ ModularPipelines.Homebrew.Options.BrewOutdatedOptions.GreedyLatest.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.GreedyLatest.set -> void
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Json.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Json.set -> void
-ModularPipelines.Homebrew.Options.BrewOutdatedOptions.JsonValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewOutdatedOptions.JsonValue.set -> void
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.MinimumVersion.get -> string?
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.MinimumVersion.set -> void
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions
-ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.BrewPinInstalled_formulaOptions() -> void
-ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.BrewPinInstalled_formulaOptions(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewPinOptions
 ModularPipelines.Homebrew.Options.BrewPinOptions.BrewPinOptions(ModularPipelines.Homebrew.Options.BrewPinOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewPinOptions.BrewPinOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
@@ -2118,102 +1758,7 @@ ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Autosquash.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Autosquash.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.BrewPrAutomergeOptions() -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.BrewPrAutomergeOptions(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.IgnoreFailures.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.IgnoreFailures.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Publish.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Publish.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Tap.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithLabel.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithLabel.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutApproval.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutApproval.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutLabels.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutLabels.set -> void
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Workflow.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Workflow.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Autosquash.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Autosquash.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Branch.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Branch.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.BrewPrPublishOptions() -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.BrewPrPublishOptions(ModularPipelines.Homebrew.Options.BrewPrPublishOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.LargeRunner.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.LargeRunner.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Message.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Message.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Tap.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Workflow.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Workflow.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.ArtifactPattern.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.ArtifactPattern.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Autosquash.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Autosquash.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.BranchOkay.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.BranchOkay.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.BrewPrPullOptions() -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.BrewPrPullOptions(ModularPipelines.Homebrew.Options.BrewPrPullOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Clean.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Clean.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Committer.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Committer.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.DryRun.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.DryRun.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.IgnoreMissingArtifacts.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.IgnoreMissingArtifacts.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.KeepOld.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.KeepOld.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Message.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Message.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCherryPick.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCherryPick.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCommit.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCommit.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoUpload.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoUpload.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Resolve.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Resolve.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.RetainBottleDir.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.RetainBottleDir.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrl.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrl.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrlUsing.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrlUsing.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Tap.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.WarnOnUploadFailure.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.WarnOnUploadFailure.set -> void
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Workflows.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrPullOptions.Workflows.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.BrewPrUploadOptions() -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.BrewPrUploadOptions(ModularPipelines.Homebrew.Options.BrewPrUploadOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Committer.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Committer.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.DryRun.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.DryRun.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.KeepOld.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.KeepOld.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.NoCommit.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.NoCommit.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrl.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrl.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrlUsing.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrlUsing.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.UploadOnly.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.UploadOnly.set -> void
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.WarnOnUploadFailure.get -> bool?
-ModularPipelines.Homebrew.Options.BrewPrUploadOptions.WarnOnUploadFailure.set -> void
 ModularPipelines.Homebrew.Options.BrewProfOptions
-ModularPipelines.Homebrew.Options.BrewProfOptions.BrewProfOptions() -> void
 ModularPipelines.Homebrew.Options.BrewProfOptions.BrewProfOptions(ModularPipelines.Homebrew.Options.BrewProfOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewProfOptions.BrewProfOptions(System.Collections.Generic.IEnumerable<string!>! Command) -> void
 ModularPipelines.Homebrew.Options.BrewProfOptions.Command.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -2258,24 +1803,16 @@ ModularPipelines.Homebrew.Options.BrewRbenvSyncOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Aliases.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Aliases.set -> void
-ModularPipelines.Homebrew.Options.BrewReadallOptions.Arch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Arch.set -> void
-ModularPipelines.Homebrew.Options.BrewReadallOptions.ArchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewReadallOptions.ArchValue.set -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.BrewReadallOptions() -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.BrewReadallOptions(ModularPipelines.Homebrew.Options.BrewReadallOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewReadallOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewReadallOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.NoSimulate.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.NoSimulate.set -> void
-ModularPipelines.Homebrew.Options.BrewReadallOptions.Os.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Os.set -> void
-ModularPipelines.Homebrew.Options.BrewReadallOptions.OsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewReadallOptions.OsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewReadallOptions.Syntax.get -> bool?
@@ -2291,13 +1828,10 @@ ModularPipelines.Homebrew.Options.BrewReinstallOptions.Appdir.get -> string?
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Appdir.set -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Appimagedir.get -> string?
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Appimagedir.set -> void
-ModularPipelines.Homebrew.Options.BrewReinstallOptions.Ask.get -> bool?
-ModularPipelines.Homebrew.Options.BrewReinstallOptions.Ask.set -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.AudioUnitPlugindir.get -> string?
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.AudioUnitPlugindir.set -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Binaries.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Binaries.set -> void
-ModularPipelines.Homebrew.Options.BrewReinstallOptions.BrewReinstallOptions() -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.BrewReinstallOptions(ModularPipelines.Homebrew.Options.BrewReinstallOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.BrewReinstallOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.BuildFromSource.get -> bool?
@@ -2367,18 +1901,6 @@ ModularPipelines.Homebrew.Options.BrewReinstallOptions.VstPlugindir.get -> strin
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.VstPlugindir.set -> void
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Zap.get -> bool?
 ModularPipelines.Homebrew.Options.BrewReinstallOptions.Zap.set -> void
-ModularPipelines.Homebrew.Options.BrewReleaseOptions
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.BrewReleaseOptions() -> void
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.BrewReleaseOptions(ModularPipelines.Homebrew.Options.BrewReleaseOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.Force.get -> bool?
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.Force.set -> void
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.Major.get -> bool?
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.Major.set -> void
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.Minor.get -> bool?
-ModularPipelines.Homebrew.Options.BrewReleaseOptions.Minor.set -> void
-ModularPipelines.Homebrew.Options.BrewRubocopOptions
-ModularPipelines.Homebrew.Options.BrewRubocopOptions.BrewRubocopOptions() -> void
-ModularPipelines.Homebrew.Options.BrewRubocopOptions.BrewRubocopOptions(ModularPipelines.Homebrew.Options.BrewRubocopOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewRubyOptions
 ModularPipelines.Homebrew.Options.BrewRubyOptions.BrewRubyOptions() -> void
 ModularPipelines.Homebrew.Options.BrewRubyOptions.BrewRubyOptions(ModularPipelines.Homebrew.Options.BrewRubyOptions! original) -> void
@@ -2426,7 +1948,6 @@ ModularPipelines.Homebrew.Options.BrewSearchOptions.Alpine.get -> bool?
 ModularPipelines.Homebrew.Options.BrewSearchOptions.Alpine.set -> void
 ModularPipelines.Homebrew.Options.BrewSearchOptions.Archlinux.get -> bool?
 ModularPipelines.Homebrew.Options.BrewSearchOptions.Archlinux.set -> void
-ModularPipelines.Homebrew.Options.BrewSearchOptions.BrewSearchOptions() -> void
 ModularPipelines.Homebrew.Options.BrewSearchOptions.BrewSearchOptions(ModularPipelines.Homebrew.Options.BrewSearchOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewSearchOptions.BrewSearchOptions(System.Collections.Generic.IEnumerable<string!>! Text) -> void
 ModularPipelines.Homebrew.Options.BrewSearchOptions.Cask.get -> bool?
@@ -2533,38 +2054,22 @@ ModularPipelines.Homebrew.Options.BrewServicesListOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Across.get -> string!
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Across.init -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.All.get -> bool?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.All.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.And.get -> string!
 ModularPipelines.Homebrew.Options.BrewServicesOptions.And.init -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.BrewServicesOptions() -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.BrewServicesOptions(ModularPipelines.Homebrew.Options.BrewServicesOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.BrewServicesOptions(string! Restart, string! And, string! Persist, string! Across, string! Upgrades) -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Deconstruct(out string! Restart, out string! And, out string! Persist, out string! Across, out string! Upgrades) -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.File.get -> string?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.File.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.Json.get -> bool?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.Json.set -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.Keep.get -> bool?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.Keep.set -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.MaxWait.get -> string?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.MaxWait.set -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.NoWait.get -> bool?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.NoWait.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Persist.get -> string!
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Persist.init -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Restart.get -> string!
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Restart.init -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUser.get -> bool?
 ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUser.set -> void
-ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUserValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUserValue.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Upgrades.get -> string!
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Upgrades.init -> void
 ModularPipelines.Homebrew.Options.BrewServicesOptions.Verbose.get -> bool?
@@ -2649,22 +2154,13 @@ ModularPipelines.Homebrew.Options.BrewServicesStopOptions.SudoServiceUser.get ->
 ModularPipelines.Homebrew.Options.BrewServicesStopOptions.SudoServiceUser.set -> void
 ModularPipelines.Homebrew.Options.BrewServicesStopOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewServicesStopOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewSetupRubyOptions
-ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.BrewSetupRubyOptions() -> void
-ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.BrewSetupRubyOptions(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewShOptions
 ModularPipelines.Homebrew.Options.BrewShOptions.BrewShOptions() -> void
 ModularPipelines.Homebrew.Options.BrewShOptions.BrewShOptions(ModularPipelines.Homebrew.Options.BrewShOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewShOptions.Cmd.get -> bool?
 ModularPipelines.Homebrew.Options.BrewShOptions.Cmd.set -> void
-ModularPipelines.Homebrew.Options.BrewShOptions.CmdValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewShOptions.CmdValue.set -> void
 ModularPipelines.Homebrew.Options.BrewShOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewShOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewShOptions.Env.get -> bool?
 ModularPipelines.Homebrew.Options.BrewShOptions.Env.set -> void
-ModularPipelines.Homebrew.Options.BrewShOptions.EnvValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewShOptions.EnvValue.set -> void
 ModularPipelines.Homebrew.Options.BrewShOptions.File.get -> string?
 ModularPipelines.Homebrew.Options.BrewShOptions.File.set -> void
 ModularPipelines.Homebrew.Options.BrewShOptions.Help.get -> bool?
@@ -2697,10 +2193,7 @@ ModularPipelines.Homebrew.Options.BrewStyleOptions.Changed.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Changed.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCops.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCops.set -> void
-ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCopsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCopsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.File.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.File.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Fix.get -> bool?
@@ -2709,10 +2202,7 @@ ModularPipelines.Homebrew.Options.BrewStyleOptions.Formula.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCops.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCops.set -> void
-ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCopsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCopsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.ResetCache.get -> bool?
@@ -2722,7 +2212,6 @@ ModularPipelines.Homebrew.Options.BrewStyleOptions.Todo.set -> void
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewStyleOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewTabOptions
-ModularPipelines.Homebrew.Options.BrewTabOptions.BrewTabOptions() -> void
 ModularPipelines.Homebrew.Options.BrewTabOptions.BrewTabOptions(ModularPipelines.Homebrew.Options.BrewTabOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewTabOptions.BrewTabOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
 ModularPipelines.Homebrew.Options.BrewTabOptions.Cask.get -> bool?
@@ -2753,20 +2242,13 @@ ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Installed.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Installed.set -> void
-ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Json.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Json.set -> void
-ModularPipelines.Homebrew.Options.BrewTapInfoOptions.JsonValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTapInfoOptions.JsonValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions
-ModularPipelines.Homebrew.Options.BrewTapNewOptions.Branch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.Branch.set -> void
-ModularPipelines.Homebrew.Options.BrewTapNewOptions.BranchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTapNewOptions.BranchValue.set -> void
-ModularPipelines.Homebrew.Options.BrewTapNewOptions.BrewTapNewOptions() -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.BrewTapNewOptions(ModularPipelines.Homebrew.Options.BrewTapNewOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.BrewTapNewOptions(string! UserOrRepo) -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.Debug.get -> bool?
@@ -2778,8 +2260,6 @@ ModularPipelines.Homebrew.Options.BrewTapNewOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.NoGit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.NoGit.set -> void
-ModularPipelines.Homebrew.Options.BrewTapNewOptions.PullLabel.get -> bool?
-ModularPipelines.Homebrew.Options.BrewTapNewOptions.PullLabel.set -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewTapNewOptions.UserOrRepo.get -> string!
@@ -2793,8 +2273,6 @@ ModularPipelines.Homebrew.Options.BrewTapOptions.CustomRemote.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapOptions.CustomRemote.set -> void
 ModularPipelines.Homebrew.Options.BrewTapOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewTapOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewTapOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewTapOptions.Force.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapOptions.Force.set -> void
 ModularPipelines.Homebrew.Options.BrewTapOptions.Help.get -> bool?
@@ -2810,10 +2288,7 @@ ModularPipelines.Homebrew.Options.BrewTapOptions.UserOrRepo.set -> void
 ModularPipelines.Homebrew.Options.BrewTapOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTapOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulae.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulae.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulaeValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulaeValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.BrewTestBotOptions() -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.BrewTestBotOptions(ModularPipelines.Homebrew.Options.BrewTestBotOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.BuildDependentsFromSource.get -> bool?
@@ -2824,24 +2299,15 @@ ModularPipelines.Homebrew.Options.BrewTestBotOptions.Cleanup.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Cleanup.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Debug.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulae.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulae.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulaeValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulaeValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.DryRun.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.DryRun.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.FailFast.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.FailFast.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Formula.get -> string?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Formula.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmail.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmail.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmailValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmailValue.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitName.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitName.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitNameValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitNameValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Junit.get -> bool?
@@ -2850,10 +2316,6 @@ ModularPipelines.Homebrew.Options.BrewTestBotOptions.KeepOld.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.KeepOld.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Local.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Local.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.New.get -> bool?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.New.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.Online.get -> bool?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.Online.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.OnlyBottlesFetch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.OnlyBottlesFetch.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.OnlyCleanupAfter.get -> bool?
@@ -2876,10 +2338,7 @@ ModularPipelines.Homebrew.Options.BrewTestBotOptions.Publish.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Publish.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrl.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrl.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrlValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrlValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipChecksumOnlyAudit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipChecksumOnlyAudit.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipDependents.get -> bool?
@@ -2902,30 +2361,16 @@ ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipSetup.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipSetup.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipStableVersionAudit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkipStableVersionAudit.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkippedOrFailedFormulae.get -> bool?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkippedOrFailedFormulae.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Stable.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Stable.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.Strict.get -> bool?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.Strict.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.Tap.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Tap.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TapValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TapValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestDefaultFormula.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestDefaultFormula.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulae.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulae.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulaeValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulaeValue.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulae.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulae.set -> void
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulaeValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulaeValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestBotOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewTestOptions
-ModularPipelines.Homebrew.Options.BrewTestOptions.BrewTestOptions() -> void
 ModularPipelines.Homebrew.Options.BrewTestOptions.BrewTestOptions(ModularPipelines.Homebrew.Options.BrewTestOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewTestOptions.BrewTestOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
 ModularPipelines.Homebrew.Options.BrewTestOptions.Debug.get -> bool?
@@ -2966,22 +2411,13 @@ ModularPipelines.Homebrew.Options.BrewTestsOptions.NoParallel.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.NoParallel.set -> void
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Online.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Online.set -> void
-ModularPipelines.Homebrew.Options.BrewTestsOptions.Only.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Only.set -> void
-ModularPipelines.Homebrew.Options.BrewTestsOptions.OnlyValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestsOptions.OnlyValue.set -> void
-ModularPipelines.Homebrew.Options.BrewTestsOptions.Profile.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Profile.set -> void
-ModularPipelines.Homebrew.Options.BrewTestsOptions.ProfileValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestsOptions.ProfileValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewTestsOptions.RubyProf.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.RubyProf.set -> void
-ModularPipelines.Homebrew.Options.BrewTestsOptions.Seed.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Seed.set -> void
-ModularPipelines.Homebrew.Options.BrewTestsOptions.SeedValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewTestsOptions.SeedValue.set -> void
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Stackprof.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Stackprof.set -> void
 ModularPipelines.Homebrew.Options.BrewTestsOptions.Verbose.get -> bool?
@@ -3040,9 +2476,6 @@ ModularPipelines.Homebrew.Options.BrewTypecheckOptions.UpdateAll.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTypecheckOptions.UpdateAll.set -> void
 ModularPipelines.Homebrew.Options.BrewTypecheckOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewTypecheckOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions
-ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.BrewUnaliasAliasOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.BrewUnaliasAliasOptions(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUnaliasOptions
 ModularPipelines.Homebrew.Options.BrewUnaliasOptions.Alias.get -> System.Collections.Generic.IEnumerable<string!>!
 ModularPipelines.Homebrew.Options.BrewUnaliasOptions.Alias.init -> void
@@ -3064,8 +2497,6 @@ ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Dependents.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Dependents.set -> void
-ModularPipelines.Homebrew.Options.BrewUnbottledOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewUnbottledOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Formula.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Help.get -> bool?
@@ -3074,17 +2505,11 @@ ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Lost.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Lost.set -> void
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Tag.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Tag.set -> void
-ModularPipelines.Homebrew.Options.BrewUnbottledOptions.TagValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUnbottledOptions.TagValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Total.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Total.set -> void
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions
-ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.BrewUninstallFormulaOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.BrewUninstallFormulaOptions(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUninstallOptions
 ModularPipelines.Homebrew.Options.BrewUninstallOptions.BrewUninstallOptions(ModularPipelines.Homebrew.Options.BrewUninstallOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUninstallOptions.BrewUninstallOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
@@ -3110,7 +2535,6 @@ ModularPipelines.Homebrew.Options.BrewUninstallOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewUninstallOptions.Zap.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUninstallOptions.Zap.set -> void
 ModularPipelines.Homebrew.Options.BrewUnlinkOptions
-ModularPipelines.Homebrew.Options.BrewUnlinkOptions.BrewUnlinkOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUnlinkOptions.BrewUnlinkOptions(ModularPipelines.Homebrew.Options.BrewUnlinkOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUnlinkOptions.BrewUnlinkOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
 ModularPipelines.Homebrew.Options.BrewUnlinkOptions.Debug.get -> bool?
@@ -3127,7 +2551,6 @@ ModularPipelines.Homebrew.Options.BrewUnlinkOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewUnlinkOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnlinkOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions
-ModularPipelines.Homebrew.Options.BrewUnpackOptions.BrewUnpackOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.BrewUnpackOptions(ModularPipelines.Homebrew.Options.BrewUnpackOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.BrewUnpackOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Cask.get -> bool?
@@ -3135,10 +2558,7 @@ ModularPipelines.Homebrew.Options.BrewUnpackOptions.Cask.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
-ModularPipelines.Homebrew.Options.BrewUnpackOptions.Destdir.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Destdir.set -> void
-ModularPipelines.Homebrew.Options.BrewUnpackOptions.DestdirValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUnpackOptions.DestdirValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Force.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Force.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Formula.get -> bool?
@@ -3155,9 +2575,6 @@ ModularPipelines.Homebrew.Options.BrewUnpackOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnpackOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions
-ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.BrewUnpinInstalled_formulaOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.BrewUnpinInstalled_formulaOptions(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUnpinOptions
 ModularPipelines.Homebrew.Options.BrewUnpinOptions.BrewUnpinOptions(ModularPipelines.Homebrew.Options.BrewUnpinOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUnpinOptions.BrewUnpinOptions(System.Collections.Generic.IEnumerable<string!>! InstalledFormula) -> void
@@ -3177,7 +2594,6 @@ ModularPipelines.Homebrew.Options.BrewUnpinOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewUnpinOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUnpinOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewUntapOptions
-ModularPipelines.Homebrew.Options.BrewUntapOptions.BrewUntapOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUntapOptions.BrewUntapOptions(ModularPipelines.Homebrew.Options.BrewUntapOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUntapOptions.BrewUntapOptions(System.Collections.Generic.IEnumerable<string!>! Tap) -> void
 ModularPipelines.Homebrew.Options.BrewUntapOptions.Debug.get -> bool?
@@ -3214,15 +2630,6 @@ ModularPipelines.Homebrew.Options.BrewUntrustOptions.Target.get -> System.Collec
 ModularPipelines.Homebrew.Options.BrewUntrustOptions.Target.set -> void
 ModularPipelines.Homebrew.Options.BrewUntrustOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUntrustOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions
-ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.BrewUpdateIfNeededOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.BrewUpdateIfNeededOptions(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions
-ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.BrewUpdateLicenseDataOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.BrewUpdateLicenseDataOptions(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions
-ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.BrewUpdateMaintainersOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.BrewUpdateMaintainersOptions(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUpdateOptions
 ModularPipelines.Homebrew.Options.BrewUpdateOptions.AutoUpdate.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdateOptions.AutoUpdate.set -> void
@@ -3239,7 +2646,6 @@ ModularPipelines.Homebrew.Options.BrewUpdateOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdateOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdateOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions
-ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.BrewUpdatePerlResourcesOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.BrewUpdatePerlResourcesOptions(ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.BrewUpdatePerlResourcesOptions(System.Collections.Generic.IEnumerable<string!>! Formula) -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Debug.get -> bool?
@@ -3255,25 +2661,16 @@ ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.PrintOnly.get -
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.PrintOnly.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Silent.get -> bool?
-ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Silent.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.BrewUpdatePythonResourcesOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.BrewUpdatePythonResourcesOptions(ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.BrewUpdatePythonResourcesOptions(System.Collections.Generic.IEnumerable<string!>! Formula) -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! Formula) -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackages.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackages.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackagesValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackagesValue.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackages.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackages.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackagesValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackagesValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Formula.get -> System.Collections.Generic.IEnumerable<string!>!
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Formula.init -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Help.get -> bool?
@@ -3286,22 +2683,14 @@ ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.IgnoreNonPypi
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.IgnoreNonPypiPackages.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.InstallDependencies.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.InstallDependencies.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageName.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageName.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageNameValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageNameValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PrintOnly.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PrintOnly.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Silent.get -> bool?
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Silent.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Version.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Version.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.VersionValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.VersionValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdateResetOptions
 ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.BrewUpdateResetOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.BrewUpdateResetOptions(ModularPipelines.Homebrew.Options.BrewUpdateResetOptions! original) -> void
@@ -3315,20 +2704,11 @@ ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Repository.get -> Syste
 ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Repository.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Verbose.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions
-ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.BrewUpdateSponsorsOptions() -> void
-ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.BrewUpdateSponsorsOptions(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions
-ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Before.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Before.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.BeforeValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.BeforeValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.BrewUpdateTestOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.BrewUpdateTestOptions(ModularPipelines.Homebrew.Options.BrewUpdateTestOptions! original) -> void
-ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Commit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Commit.set -> void
-ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.CommitValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.CommitValue.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Help.get -> bool?
@@ -3346,8 +2726,6 @@ ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Appdir.get -> string?
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Appdir.set -> void
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Appimagedir.get -> string?
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Appimagedir.set -> void
-ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Ask.get -> bool?
-ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Ask.set -> void
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.AudioUnitPlugindir.get -> string?
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.AudioUnitPlugindir.set -> void
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Binaries.get -> bool?
@@ -3433,7 +2811,6 @@ ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Vst3Plugindir.set -> void
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.VstPlugindir.get -> string?
 ModularPipelines.Homebrew.Options.BrewUpgradeOptions.VstPlugindir.set -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions
-ModularPipelines.Homebrew.Options.BrewUsesOptions.BrewUsesOptions() -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.BrewUsesOptions(ModularPipelines.Homebrew.Options.BrewUsesOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.BrewUsesOptions(System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.Cask.get -> bool?
@@ -3441,8 +2818,6 @@ ModularPipelines.Homebrew.Options.BrewUsesOptions.Cask.set -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUsesOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! FormulaOperand) -> void
-ModularPipelines.Homebrew.Options.BrewUsesOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewUsesOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.Formula.get -> bool?
 ModularPipelines.Homebrew.Options.BrewUsesOptions.Formula.set -> void
 ModularPipelines.Homebrew.Options.BrewUsesOptions.FormulaOperand.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -3480,22 +2855,12 @@ ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.NoCommit.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.NoCommit.set -> void
 ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Update.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Update.set -> void
-ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.UpdateValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.UpdateValue.set -> void
 ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.Arch.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Arch.set -> void
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.ArchValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.ArchValue.set -> void
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTag.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTag.set -> void
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTagValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTagValue.set -> void
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.BrewVerifyOptions() -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.BrewVerifyOptions(ModularPipelines.Homebrew.Options.BrewVerifyOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.BrewVerifyOptions(System.Collections.Generic.IEnumerable<string!>! Formula) -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Debug.get -> bool?
@@ -3511,10 +2876,7 @@ ModularPipelines.Homebrew.Options.BrewVerifyOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Json.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Json.set -> void
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.Os.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Os.set -> void
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.OsValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewVerifyOptions.OsValue.set -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Quiet.set -> void
 ModularPipelines.Homebrew.Options.BrewVerifyOptions.Verbose.get -> bool?
@@ -3565,7 +2927,6 @@ ModularPipelines.Homebrew.Options.BrewVulnsOptions.Severity.set -> void
 ModularPipelines.Homebrew.Options.BrewVulnsOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewVulnsOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions
-ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.BrewWhichFormulaOptions() -> void
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.BrewWhichFormulaOptions(ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.BrewWhichFormulaOptions(System.Collections.Generic.IEnumerable<string!>! Command) -> void
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Command.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -3579,31 +2940,20 @@ ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Help.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Quiet.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Quiet.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.SkipUpdate.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.SkipUpdate.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.BottleJsonDir.get -> string?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.BottleJsonDir.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.BrewWhichUpdateOptions() -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.BrewWhichUpdateOptions(ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions! original) -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.BrewWhichUpdateOptions(string! Database) -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Commit.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Commit.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Database.get -> string!
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Database.init -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Debug.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Debug.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Deconstruct(out string! Database) -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.EvalAll.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.EvalAll.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Help.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Help.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.InstallMissing.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.InstallMissing.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.MaxDownloads.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.MaxDownloads.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.PullRequest.get -> string?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.PullRequest.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Quiet.get -> bool?
@@ -3612,14 +2962,7 @@ ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.RemovedFormulaeFile.get
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.RemovedFormulaeFile.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Repository.get -> string?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Repository.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Stats.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Stats.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFile.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFile.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFileValue.get -> string?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFileValue.set -> void
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.UpdateExisting.get -> bool?
-ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.UpdateExisting.set -> void
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Verbose.get -> bool?
 ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Verbose.set -> void
 ModularPipelines.Homebrew.Services.IBrew
@@ -3761,12 +3104,6 @@ override ModularPipelines.Homebrew.Options.BrewBundleShOptions.Equals(object? ob
 override ModularPipelines.Homebrew.Options.BrewBundleShOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewBundleShOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewBundleShOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewCasksOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewCasksOptions!
-override ModularPipelines.Homebrew.Options.BrewCasksOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewCasksOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewCasksOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewCasksOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewCasksOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewCatOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewCatOptions!
 override ModularPipelines.Homebrew.Options.BrewCatOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewCatOptions.Equals(object? obj) -> bool
@@ -3779,12 +3116,6 @@ override ModularPipelines.Homebrew.Options.BrewCleanupOptions.Equals(object? obj
 override ModularPipelines.Homebrew.Options.BrewCleanupOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewCleanupOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewCleanupOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewCommandCommandOptions!
-override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions!
 override ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.Equals(object? obj) -> bool
@@ -3881,12 +3212,6 @@ override ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Equals(obje
 override ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions!
-override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewDocsOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewDocsOptions!
 override ModularPipelines.Homebrew.Options.BrewDocsOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewDocsOptions.Equals(object? obj) -> bool
@@ -3923,48 +3248,12 @@ override ModularPipelines.Homebrew.Options.BrewFetchOptions.Equals(object? obj) 
 override ModularPipelines.Homebrew.Options.BrewFetchOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewFetchOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewFetchOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions!
-override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions!
-override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaOptions!
 override ModularPipelines.Homebrew.Options.BrewFormulaOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewFormulaOptions.Equals(object? obj) -> bool
 override ModularPipelines.Homebrew.Options.BrewFormulaOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewFormulaOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaeOptions!
-override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions!
-override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions!
-override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions!
-override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions!
 override ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.Equals(object? obj) -> bool
@@ -4001,12 +3290,6 @@ override ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Equals(
 override ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions!
-override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewInstallOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewInstallOptions!
 override ModularPipelines.Homebrew.Options.BrewInstallOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewInstallOptions.Equals(object? obj) -> bool
@@ -4061,12 +3344,6 @@ override ModularPipelines.Homebrew.Options.BrewLogOptions.Equals(object? obj) ->
 override ModularPipelines.Homebrew.Options.BrewLogOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewLogOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewLogOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewMcpServerOptions!
-override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewMigrateOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewMigrateOptions!
 override ModularPipelines.Homebrew.Options.BrewMigrateOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewMigrateOptions.Equals(object? obj) -> bool
@@ -4102,12 +3379,6 @@ override ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Equals(object? ob
 override ModularPipelines.Homebrew.Options.BrewOutdatedOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewOutdatedOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewOutdatedOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions!
-override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewPinOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPinOptions!
 override ModularPipelines.Homebrew.Options.BrewPinOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewPinOptions.Equals(object? obj) -> bool
@@ -4120,30 +3391,6 @@ override ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Equals(object?
 override ModularPipelines.Homebrew.Options.BrewPostinstallOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewPostinstallOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewPostinstallOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions!
-override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrPublishOptions!
-override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewPrPullOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrPullOptions!
-override ModularPipelines.Homebrew.Options.BrewPrPullOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewPrPullOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrPullOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewPrPullOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrPullOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrUploadOptions!
-override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewProfOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewProfOptions!
 override ModularPipelines.Homebrew.Options.BrewProfOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewProfOptions.Equals(object? obj) -> bool
@@ -4174,18 +3421,6 @@ override ModularPipelines.Homebrew.Options.BrewReinstallOptions.Equals(object? o
 override ModularPipelines.Homebrew.Options.BrewReinstallOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewReinstallOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewReinstallOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewReleaseOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewReleaseOptions!
-override ModularPipelines.Homebrew.Options.BrewReleaseOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewReleaseOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewReleaseOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewReleaseOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewReleaseOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewRubocopOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewRubocopOptions!
-override ModularPipelines.Homebrew.Options.BrewRubocopOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewRubocopOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewRubocopOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewRubocopOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewRubocopOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewRubyOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewRubyOptions!
 override ModularPipelines.Homebrew.Options.BrewRubyOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewRubyOptions.Equals(object? obj) -> bool
@@ -4264,12 +3499,6 @@ override ModularPipelines.Homebrew.Options.BrewServicesStopOptions.Equals(object
 override ModularPipelines.Homebrew.Options.BrewServicesStopOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewServicesStopOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewServicesStopOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewSetupRubyOptions!
-override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewShOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewShOptions!
 override ModularPipelines.Homebrew.Options.BrewShOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewShOptions.Equals(object? obj) -> bool
@@ -4342,12 +3571,6 @@ override ModularPipelines.Homebrew.Options.BrewTypecheckOptions.Equals(object? o
 override ModularPipelines.Homebrew.Options.BrewTypecheckOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewTypecheckOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewTypecheckOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions!
-override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewUnaliasOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUnaliasOptions!
 override ModularPipelines.Homebrew.Options.BrewUnaliasOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewUnaliasOptions.Equals(object? obj) -> bool
@@ -4360,12 +3583,6 @@ override ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Equals(object? o
 override ModularPipelines.Homebrew.Options.BrewUnbottledOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewUnbottledOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewUnbottledOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions!
-override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewUninstallOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUninstallOptions!
 override ModularPipelines.Homebrew.Options.BrewUninstallOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewUninstallOptions.Equals(object? obj) -> bool
@@ -4384,12 +3601,6 @@ override ModularPipelines.Homebrew.Options.BrewUnpackOptions.Equals(object? obj)
 override ModularPipelines.Homebrew.Options.BrewUnpackOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewUnpackOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewUnpackOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions!
-override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewUnpinOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUnpinOptions!
 override ModularPipelines.Homebrew.Options.BrewUnpinOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewUnpinOptions.Equals(object? obj) -> bool
@@ -4408,24 +3619,6 @@ override ModularPipelines.Homebrew.Options.BrewUntrustOptions.Equals(object? obj
 override ModularPipelines.Homebrew.Options.BrewUntrustOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewUntrustOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewUntrustOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions!
-override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions!
-override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions!
-override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewUpdateOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateOptions!
 override ModularPipelines.Homebrew.Options.BrewUpdateOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewUpdateOptions.Equals(object? obj) -> bool
@@ -4450,12 +3643,6 @@ override ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Equals(object?
 override ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.GetHashCode() -> int
 override ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.ToString() -> string!
-override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions!
-override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.Equals(object? obj) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.GetHashCode() -> int
-override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.ToString() -> string!
 override ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateTestOptions!
 override ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Equals(object? obj) -> bool
@@ -4534,10 +3721,8 @@ override sealed ModularPipelines.Homebrew.Options.BrewBundleListOptions.Equals(M
 override sealed ModularPipelines.Homebrew.Options.BrewBundleOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewBundleShOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewCasksOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewCatOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewCleanupOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewCommandOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewCompletionsLinkOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
@@ -4554,27 +3739,19 @@ override sealed ModularPipelines.Homebrew.Options.BrewDeveloperOffOptions.Equals
 override sealed ModularPipelines.Homebrew.Options.BrewDeveloperOnOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewDeveloperOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewDocsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewDoctorOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewEditOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewExecOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewExtractOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewFetchOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewFormulaeOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewGenerateZapOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewHomeOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewInfoOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewInstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewIrbOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewLeavesOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
@@ -4584,27 +3761,19 @@ override sealed ModularPipelines.Homebrew.Options.BrewLinkageOptions.Equals(Modu
 override sealed ModularPipelines.Homebrew.Options.BrewListOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewLivecheckOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewLogOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewMigrateOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewMissingOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewNodenvSyncOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewOptions.Equals(ModularPipelines.Options.CommandLineToolOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewOptionsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewPinOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewPrPullOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewProfOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewRbenvSyncOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewReadallOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewReinstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewReleaseOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewRubocopOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewRubyOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewRubydocOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewSandboxExecOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
@@ -4618,7 +3787,6 @@ override sealed ModularPipelines.Homebrew.Options.BrewServicesRestartOptions.Equ
 override sealed ModularPipelines.Homebrew.Options.BrewServicesRunOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewServicesStartOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewServicesStopOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewShOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewSourceOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewStyleOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
@@ -4631,25 +3799,18 @@ override sealed ModularPipelines.Homebrew.Options.BrewTestOptions.Equals(Modular
 override sealed ModularPipelines.Homebrew.Options.BrewTestsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewTrustOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewTypecheckOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUnaliasOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUninstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUnlinkOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUnpackOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUnpinOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUntapOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUntrustOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUpdateOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
-override sealed ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 override sealed ModularPipelines.Homebrew.Options.BrewUsesOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
@@ -4707,14 +3868,10 @@ static ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions.operator !=(Mod
 static ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions.operator ==(ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions? left, ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewBundleShOptions.operator !=(ModularPipelines.Homebrew.Options.BrewBundleShOptions? left, ModularPipelines.Homebrew.Options.BrewBundleShOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewBundleShOptions.operator ==(ModularPipelines.Homebrew.Options.BrewBundleShOptions? left, ModularPipelines.Homebrew.Options.BrewBundleShOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewCasksOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCasksOptions? left, ModularPipelines.Homebrew.Options.BrewCasksOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewCasksOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCasksOptions? left, ModularPipelines.Homebrew.Options.BrewCasksOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCatOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCatOptions? left, ModularPipelines.Homebrew.Options.BrewCatOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCatOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCatOptions? left, ModularPipelines.Homebrew.Options.BrewCatOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCleanupOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCleanupOptions? left, ModularPipelines.Homebrew.Options.BrewCleanupOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCleanupOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCleanupOptions? left, ModularPipelines.Homebrew.Options.BrewCleanupOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? left, ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? left, ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions? left, ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions? left, ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewCommandOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCommandOptions? left, ModularPipelines.Homebrew.Options.BrewCommandOptions? right) -> bool
@@ -4747,8 +3904,6 @@ static ModularPipelines.Homebrew.Options.BrewDeveloperOptions.operator !=(Modula
 static ModularPipelines.Homebrew.Options.BrewDeveloperOptions.operator ==(ModularPipelines.Homebrew.Options.BrewDeveloperOptions? left, ModularPipelines.Homebrew.Options.BrewDeveloperOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.operator !=(ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions? left, ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.operator ==(ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions? left, ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.operator !=(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? left, ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.operator ==(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? left, ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewDocsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewDocsOptions? left, ModularPipelines.Homebrew.Options.BrewDocsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewDocsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewDocsOptions? left, ModularPipelines.Homebrew.Options.BrewDocsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewDoctorOptions.operator !=(ModularPipelines.Homebrew.Options.BrewDoctorOptions? left, ModularPipelines.Homebrew.Options.BrewDoctorOptions? right) -> bool
@@ -4761,20 +3916,8 @@ static ModularPipelines.Homebrew.Options.BrewExtractOptions.operator !=(ModularP
 static ModularPipelines.Homebrew.Options.BrewExtractOptions.operator ==(ModularPipelines.Homebrew.Options.BrewExtractOptions? left, ModularPipelines.Homebrew.Options.BrewExtractOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewFetchOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFetchOptions? left, ModularPipelines.Homebrew.Options.BrewFetchOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewFetchOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFetchOptions? left, ModularPipelines.Homebrew.Options.BrewFetchOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewFormulaeOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaeOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewFormulaeOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaeOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewGenerateZapOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateZapOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateZapOptions? right) -> bool
@@ -4787,8 +3930,6 @@ static ModularPipelines.Homebrew.Options.BrewInfoOptions.operator !=(ModularPipe
 static ModularPipelines.Homebrew.Options.BrewInfoOptions.operator ==(ModularPipelines.Homebrew.Options.BrewInfoOptions? left, ModularPipelines.Homebrew.Options.BrewInfoOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions? left, ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions? left, ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewInstallOptions.operator !=(ModularPipelines.Homebrew.Options.BrewInstallOptions? left, ModularPipelines.Homebrew.Options.BrewInstallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewInstallOptions.operator ==(ModularPipelines.Homebrew.Options.BrewInstallOptions? left, ModularPipelines.Homebrew.Options.BrewInstallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewIrbOptions.operator !=(ModularPipelines.Homebrew.Options.BrewIrbOptions? left, ModularPipelines.Homebrew.Options.BrewIrbOptions? right) -> bool
@@ -4807,8 +3948,6 @@ static ModularPipelines.Homebrew.Options.BrewLivecheckOptions.operator !=(Modula
 static ModularPipelines.Homebrew.Options.BrewLivecheckOptions.operator ==(ModularPipelines.Homebrew.Options.BrewLivecheckOptions? left, ModularPipelines.Homebrew.Options.BrewLivecheckOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewLogOptions.operator !=(ModularPipelines.Homebrew.Options.BrewLogOptions? left, ModularPipelines.Homebrew.Options.BrewLogOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewLogOptions.operator ==(ModularPipelines.Homebrew.Options.BrewLogOptions? left, ModularPipelines.Homebrew.Options.BrewLogOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewMcpServerOptions.operator !=(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? left, ModularPipelines.Homebrew.Options.BrewMcpServerOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewMcpServerOptions.operator ==(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? left, ModularPipelines.Homebrew.Options.BrewMcpServerOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewMigrateOptions.operator !=(ModularPipelines.Homebrew.Options.BrewMigrateOptions? left, ModularPipelines.Homebrew.Options.BrewMigrateOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewMigrateOptions.operator ==(ModularPipelines.Homebrew.Options.BrewMigrateOptions? left, ModularPipelines.Homebrew.Options.BrewMigrateOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewMissingOptions.operator !=(ModularPipelines.Homebrew.Options.BrewMissingOptions? left, ModularPipelines.Homebrew.Options.BrewMissingOptions? right) -> bool
@@ -4821,20 +3960,10 @@ static ModularPipelines.Homebrew.Options.BrewOptionsOptions.operator !=(ModularP
 static ModularPipelines.Homebrew.Options.BrewOptionsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewOptionsOptions? left, ModularPipelines.Homebrew.Options.BrewOptionsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewOutdatedOptions.operator !=(ModularPipelines.Homebrew.Options.BrewOutdatedOptions? left, ModularPipelines.Homebrew.Options.BrewOutdatedOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewOutdatedOptions.operator ==(ModularPipelines.Homebrew.Options.BrewOutdatedOptions? left, ModularPipelines.Homebrew.Options.BrewOutdatedOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewPinOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPinOptions? left, ModularPipelines.Homebrew.Options.BrewPinOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewPinOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPinOptions? left, ModularPipelines.Homebrew.Options.BrewPinOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewPostinstallOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPostinstallOptions? left, ModularPipelines.Homebrew.Options.BrewPostinstallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewPostinstallOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPostinstallOptions? left, ModularPipelines.Homebrew.Options.BrewPostinstallOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? left, ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? left, ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrPublishOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? left, ModularPipelines.Homebrew.Options.BrewPrPublishOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrPublishOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? left, ModularPipelines.Homebrew.Options.BrewPrPublishOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrPullOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrPullOptions? left, ModularPipelines.Homebrew.Options.BrewPrPullOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrPullOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrPullOptions? left, ModularPipelines.Homebrew.Options.BrewPrPullOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrUploadOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? left, ModularPipelines.Homebrew.Options.BrewPrUploadOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewPrUploadOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? left, ModularPipelines.Homebrew.Options.BrewPrUploadOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewProfOptions.operator !=(ModularPipelines.Homebrew.Options.BrewProfOptions? left, ModularPipelines.Homebrew.Options.BrewProfOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewProfOptions.operator ==(ModularPipelines.Homebrew.Options.BrewProfOptions? left, ModularPipelines.Homebrew.Options.BrewProfOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions? left, ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions? right) -> bool
@@ -4845,10 +3974,6 @@ static ModularPipelines.Homebrew.Options.BrewReadallOptions.operator !=(ModularP
 static ModularPipelines.Homebrew.Options.BrewReadallOptions.operator ==(ModularPipelines.Homebrew.Options.BrewReadallOptions? left, ModularPipelines.Homebrew.Options.BrewReadallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewReinstallOptions.operator !=(ModularPipelines.Homebrew.Options.BrewReinstallOptions? left, ModularPipelines.Homebrew.Options.BrewReinstallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewReinstallOptions.operator ==(ModularPipelines.Homebrew.Options.BrewReinstallOptions? left, ModularPipelines.Homebrew.Options.BrewReinstallOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewReleaseOptions.operator !=(ModularPipelines.Homebrew.Options.BrewReleaseOptions? left, ModularPipelines.Homebrew.Options.BrewReleaseOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewReleaseOptions.operator ==(ModularPipelines.Homebrew.Options.BrewReleaseOptions? left, ModularPipelines.Homebrew.Options.BrewReleaseOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewRubocopOptions.operator !=(ModularPipelines.Homebrew.Options.BrewRubocopOptions? left, ModularPipelines.Homebrew.Options.BrewRubocopOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewRubocopOptions.operator ==(ModularPipelines.Homebrew.Options.BrewRubocopOptions? left, ModularPipelines.Homebrew.Options.BrewRubocopOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewRubyOptions.operator !=(ModularPipelines.Homebrew.Options.BrewRubyOptions? left, ModularPipelines.Homebrew.Options.BrewRubyOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewRubyOptions.operator ==(ModularPipelines.Homebrew.Options.BrewRubyOptions? left, ModularPipelines.Homebrew.Options.BrewRubyOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewRubydocOptions.operator !=(ModularPipelines.Homebrew.Options.BrewRubydocOptions? left, ModularPipelines.Homebrew.Options.BrewRubydocOptions? right) -> bool
@@ -4875,8 +4000,6 @@ static ModularPipelines.Homebrew.Options.BrewServicesStartOptions.operator !=(Mo
 static ModularPipelines.Homebrew.Options.BrewServicesStartOptions.operator ==(ModularPipelines.Homebrew.Options.BrewServicesStartOptions? left, ModularPipelines.Homebrew.Options.BrewServicesStartOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewServicesStopOptions.operator !=(ModularPipelines.Homebrew.Options.BrewServicesStopOptions? left, ModularPipelines.Homebrew.Options.BrewServicesStopOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewServicesStopOptions.operator ==(ModularPipelines.Homebrew.Options.BrewServicesStopOptions? left, ModularPipelines.Homebrew.Options.BrewServicesStopOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.operator !=(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? left, ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.operator ==(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? left, ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewShOptions.operator !=(ModularPipelines.Homebrew.Options.BrewShOptions? left, ModularPipelines.Homebrew.Options.BrewShOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewShOptions.operator ==(ModularPipelines.Homebrew.Options.BrewShOptions? left, ModularPipelines.Homebrew.Options.BrewShOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewSourceOptions.operator !=(ModularPipelines.Homebrew.Options.BrewSourceOptions? left, ModularPipelines.Homebrew.Options.BrewSourceOptions? right) -> bool
@@ -4901,34 +4024,22 @@ static ModularPipelines.Homebrew.Options.BrewTrustOptions.operator !=(ModularPip
 static ModularPipelines.Homebrew.Options.BrewTrustOptions.operator ==(ModularPipelines.Homebrew.Options.BrewTrustOptions? left, ModularPipelines.Homebrew.Options.BrewTrustOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewTypecheckOptions.operator !=(ModularPipelines.Homebrew.Options.BrewTypecheckOptions? left, ModularPipelines.Homebrew.Options.BrewTypecheckOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewTypecheckOptions.operator ==(ModularPipelines.Homebrew.Options.BrewTypecheckOptions? left, ModularPipelines.Homebrew.Options.BrewTypecheckOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? left, ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? left, ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnaliasOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnaliasOptions? left, ModularPipelines.Homebrew.Options.BrewUnaliasOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnaliasOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnaliasOptions? left, ModularPipelines.Homebrew.Options.BrewUnaliasOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnbottledOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnbottledOptions? left, ModularPipelines.Homebrew.Options.BrewUnbottledOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnbottledOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnbottledOptions? left, ModularPipelines.Homebrew.Options.BrewUnbottledOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUninstallOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUninstallOptions? left, ModularPipelines.Homebrew.Options.BrewUninstallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUninstallOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUninstallOptions? left, ModularPipelines.Homebrew.Options.BrewUninstallOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnlinkOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnlinkOptions? left, ModularPipelines.Homebrew.Options.BrewUnlinkOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnlinkOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnlinkOptions? left, ModularPipelines.Homebrew.Options.BrewUnlinkOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnpackOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnpackOptions? left, ModularPipelines.Homebrew.Options.BrewUnpackOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnpackOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnpackOptions? left, ModularPipelines.Homebrew.Options.BrewUnpackOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnpinOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnpinOptions? left, ModularPipelines.Homebrew.Options.BrewUnpinOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUnpinOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnpinOptions? left, ModularPipelines.Homebrew.Options.BrewUnpinOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUntapOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUntapOptions? left, ModularPipelines.Homebrew.Options.BrewUntapOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUntapOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUntapOptions? left, ModularPipelines.Homebrew.Options.BrewUntapOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUntrustOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUntrustOptions? left, ModularPipelines.Homebrew.Options.BrewUntrustOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUntrustOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUntrustOptions? left, ModularPipelines.Homebrew.Options.BrewUntrustOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdateOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdateOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions? left, ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions? right) -> bool
@@ -4937,8 +4048,6 @@ static ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.operat
 static ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions? left, ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateResetOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateResetOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateResetOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateResetOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? right) -> bool
-static ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateTestOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateTestOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateTestOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateTestOptions? right) -> bool
 static ModularPipelines.Homebrew.Options.BrewUpgradeOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpgradeOptions? left, ModularPipelines.Homebrew.Options.BrewUpgradeOptions? right) -> bool
@@ -4980,10 +4089,8 @@ virtual ModularPipelines.Homebrew.Options.BrewBundleListOptions.Equals(ModularPi
 virtual ModularPipelines.Homebrew.Options.BrewBundleOptions.Equals(ModularPipelines.Homebrew.Options.BrewBundleOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions.Equals(ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewBundleShOptions.Equals(ModularPipelines.Homebrew.Options.BrewBundleShOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewCasksOptions.Equals(ModularPipelines.Homebrew.Options.BrewCasksOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewCatOptions.Equals(ModularPipelines.Homebrew.Options.BrewCatOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewCleanupOptions.Equals(ModularPipelines.Homebrew.Options.BrewCleanupOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.Equals(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions.Equals(ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewCommandOptions.Equals(ModularPipelines.Homebrew.Options.BrewCommandOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewCompletionsLinkOptions.Equals(ModularPipelines.Homebrew.Options.BrewCompletionsLinkOptions? other) -> bool
@@ -5000,27 +4107,19 @@ virtual ModularPipelines.Homebrew.Options.BrewDeveloperOffOptions.Equals(Modular
 virtual ModularPipelines.Homebrew.Options.BrewDeveloperOnOptions.Equals(ModularPipelines.Homebrew.Options.BrewDeveloperOnOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewDeveloperOptions.Equals(ModularPipelines.Homebrew.Options.BrewDeveloperOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions.Equals(ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Equals(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewDocsOptions.Equals(ModularPipelines.Homebrew.Options.BrewDocsOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewDoctorOptions.Equals(ModularPipelines.Homebrew.Options.BrewDoctorOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewEditOptions.Equals(ModularPipelines.Homebrew.Options.BrewEditOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewExecOptions.Equals(ModularPipelines.Homebrew.Options.BrewExecOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewExtractOptions.Equals(ModularPipelines.Homebrew.Options.BrewExtractOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewFetchOptions.Equals(ModularPipelines.Homebrew.Options.BrewFetchOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewFormulaeOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewGenerateZapOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateZapOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewGistLogsOptions.Equals(ModularPipelines.Homebrew.Options.BrewGistLogsOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewHomeOptions.Equals(ModularPipelines.Homebrew.Options.BrewHomeOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewInfoOptions.Equals(ModularPipelines.Homebrew.Options.BrewInfoOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Equals(ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewInstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewInstallOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewIrbOptions.Equals(ModularPipelines.Homebrew.Options.BrewIrbOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewLeavesOptions.Equals(ModularPipelines.Homebrew.Options.BrewLeavesOptions? other) -> bool
@@ -5030,27 +4129,19 @@ virtual ModularPipelines.Homebrew.Options.BrewLinkageOptions.Equals(ModularPipel
 virtual ModularPipelines.Homebrew.Options.BrewListOptions.Equals(ModularPipelines.Homebrew.Options.BrewListOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewLivecheckOptions.Equals(ModularPipelines.Homebrew.Options.BrewLivecheckOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewLogOptions.Equals(ModularPipelines.Homebrew.Options.BrewLogOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Equals(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewMigrateOptions.Equals(ModularPipelines.Homebrew.Options.BrewMigrateOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewMissingOptions.Equals(ModularPipelines.Homebrew.Options.BrewMissingOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewNodenvSyncOptions.Equals(ModularPipelines.Homebrew.Options.BrewNodenvSyncOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewOptionsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptionsOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Equals(ModularPipelines.Homebrew.Options.BrewOutdatedOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewPinOptions.Equals(ModularPipelines.Homebrew.Options.BrewPinOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewPostinstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewPostinstallOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewPrPullOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrPullOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewProfOptions.Equals(ModularPipelines.Homebrew.Options.BrewProfOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions.Equals(ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewRbenvSyncOptions.Equals(ModularPipelines.Homebrew.Options.BrewRbenvSyncOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewReadallOptions.Equals(ModularPipelines.Homebrew.Options.BrewReadallOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewReinstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewReinstallOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewReleaseOptions.Equals(ModularPipelines.Homebrew.Options.BrewReleaseOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewRubocopOptions.Equals(ModularPipelines.Homebrew.Options.BrewRubocopOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewRubyOptions.Equals(ModularPipelines.Homebrew.Options.BrewRubyOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewRubydocOptions.Equals(ModularPipelines.Homebrew.Options.BrewRubydocOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewSandboxExecOptions.Equals(ModularPipelines.Homebrew.Options.BrewSandboxExecOptions? other) -> bool
@@ -5064,7 +4155,6 @@ virtual ModularPipelines.Homebrew.Options.BrewServicesRestartOptions.Equals(Modu
 virtual ModularPipelines.Homebrew.Options.BrewServicesRunOptions.Equals(ModularPipelines.Homebrew.Options.BrewServicesRunOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewServicesStartOptions.Equals(ModularPipelines.Homebrew.Options.BrewServicesStartOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewServicesStopOptions.Equals(ModularPipelines.Homebrew.Options.BrewServicesStopOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.Equals(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewShOptions.Equals(ModularPipelines.Homebrew.Options.BrewShOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewSourceOptions.Equals(ModularPipelines.Homebrew.Options.BrewSourceOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewStyleOptions.Equals(ModularPipelines.Homebrew.Options.BrewStyleOptions? other) -> bool
@@ -5077,25 +4167,18 @@ virtual ModularPipelines.Homebrew.Options.BrewTestOptions.Equals(ModularPipeline
 virtual ModularPipelines.Homebrew.Options.BrewTestsOptions.Equals(ModularPipelines.Homebrew.Options.BrewTestsOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewTrustOptions.Equals(ModularPipelines.Homebrew.Options.BrewTrustOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewTypecheckOptions.Equals(ModularPipelines.Homebrew.Options.BrewTypecheckOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUnaliasOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnaliasOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnbottledOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUninstallOptions.Equals(ModularPipelines.Homebrew.Options.BrewUninstallOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUnlinkOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnlinkOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUnpackOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnpackOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUnpinOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnpinOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUntapOptions.Equals(ModularPipelines.Homebrew.Options.BrewUntapOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUntrustOptions.Equals(ModularPipelines.Homebrew.Options.BrewUntrustOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUpdateOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUpdateResetOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateResetOptions? other) -> bool
-virtual ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateTestOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpgradeOptions? other) -> bool
 virtual ModularPipelines.Homebrew.Options.BrewUsesOptions.Equals(ModularPipelines.Homebrew.Options.BrewUsesOptions? other) -> bool

--- a/src/ModularPipelines.Homebrew/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Homebrew/PublicAPI.Unshipped.txt
@@ -1,4 +1,661 @@
 #nullable enable
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Arch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ArchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ArchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Except.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCops.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCopsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCopsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Only.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCops.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCopsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCopsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Os.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.OsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Signing.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Signing.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.TapValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewAuditOptions.TapValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.BrewBottleOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.Committer.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.Committer.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrl.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsing.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsingValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsingValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.BrewBumpCaskPrOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrg.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrgValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrgValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Message.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.MessageValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.MessageValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256Value.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256Value.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Url.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.UrlValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.UrlValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Version.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArm.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArmValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArmValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntel.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntelValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntelValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrg.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrgValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrgValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Message.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MessageValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MessageValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Mirror.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MirrorValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.MirrorValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackages.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackagesValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackagesValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackages.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackagesValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackagesValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageName.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageNameValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageNameValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Revision.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.RevisionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.RevisionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256Value.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256Value.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Tag.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.TagValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.TagValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Url.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.UrlValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.UrlValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Version.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.VersionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.VersionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWith.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWithValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWithValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.TapValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpOptions.TapValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.BrewBumpRevisionOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Message.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.MessageValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.MessageValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.BrewBumpUnversionedCasksOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Limit.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.LimitValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.LimitValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFile.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFileValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFileValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.All.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.All.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Cargo.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Cargo.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Cask.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Cask.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Check.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Check.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Cleanup.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Cleanup.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Describe.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Describe.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.File.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.FileValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.FileValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Flatpak.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Flatpak.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Force.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Force.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Formula.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Formula.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Go.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Go.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Install.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Install.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Mas.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Mas.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoCargo.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoCargo.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoFlatpak.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoFlatpak.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoGo.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoGo.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoRestart.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoRestart.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoSecrets.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoSecrets.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoUpgrade.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoUpgrade.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoVscode.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.NoVscode.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Overwrite.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Overwrite.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Services.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Services.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Tap.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Upgrade.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Upgrade.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.UpgradeFormulae.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.UpgradeFormulae.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Vscode.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Vscode.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Zap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewBundleOptions.Zap.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCasksOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCasksOptions.BrewCasksOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCasksOptions.BrewCasksOptions(ModularPipelines.Homebrew.Options.BrewCasksOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCatOptions.BrewCatOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCleanupOptions.Prune.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCleanupOptions.PruneValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCleanupOptions.PruneValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCommandCommandOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.BrewCommandCommandOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.BrewCommandCommandOptions(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.From.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.FromValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.FromValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.Organisation.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.OrganisationValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.OrganisationValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.Quarter.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.QuarterValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.QuarterValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.Repositories.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.RepositoriesValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.RepositoriesValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.Team.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.TeamValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.TeamValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.To.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.ToValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.ToValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.User.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.UserValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewContributionsOptions.UserValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.BrewCreateOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicense.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicenseValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicenseValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetName.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetNameValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetNameValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersion.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.TapValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewCreateOptions.TapValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDebuggerOptions.BrewDebuggerOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.Arch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.ArchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.ArchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.Os.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.OsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDepsOptions.OsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDescOptions.BrewDescOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDescOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDescOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.BrewDispatchBuildBottleOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.BrewDispatchBuildBottleOptions(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Issue.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Issue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Linux.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Linux.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxArm64.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxArm64.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxSelfHosted.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxSelfHosted.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxWheezy.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.LinuxWheezy.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Macos.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Macos.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Tap.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Timeout.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Timeout.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Upload.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Upload.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Workflow.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Workflow.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.BrewExtractOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevision.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevisionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevisionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.Version.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.VersionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewExtractOptions.VersionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.Arch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.ArchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.ArchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTag.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTagValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTagValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.BrewFetchOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.Os.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.OsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFetchOptions.OsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.AllCoreFormulaeJson.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.AllCoreFormulaeJson.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRun.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRun.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRunOptions.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewCommandRunOptions.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewFormulaAnalyticsOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewFormulaAnalyticsOptions(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewTestBotTest.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BrewTestBotTest.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BuildError.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.BuildError.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.CaskInstall.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.CaskInstall.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.DaysAgo.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.DaysAgo.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewDevcmdrunDeveloper.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewDevcmdrunDeveloper.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewOsArchCi.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewOsArchCi.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewPrefixes.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewPrefixes.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewVersions.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.HomebrewVersions.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Install.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Install.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.InstallOnRequest.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.InstallOnRequest.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Json.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Json.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.OsVersion.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.OsVersion.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Setup.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Setup.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.BrewFormulaFormulaOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.BrewFormulaFormulaOptions(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaeOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaeOptions.BrewFormulaeOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewFormulaeOptions.BrewFormulaeOptions(ModularPipelines.Homebrew.Options.BrewFormulaeOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.BrewGenerateAnalyticsApiOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.BrewGenerateAnalyticsApiOptions(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.BrewGenerateCaskApiOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.BrewGenerateCaskApiOptions(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.DryRun.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.DryRun.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.BrewGenerateFormulaApiOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.BrewGenerateFormulaApiOptions(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.DryRun.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.DryRun.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGistLogsOptions.BrewGistLogsOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGistLogsOptions.WithHostname.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewGistLogsOptions.WithHostname.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroups.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroupsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroupsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Groups.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.GroupsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.GroupsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.BrewInstallFormulaOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.BrewInstallFormulaOptions(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.Ask.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.Ask.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.BrewInstallOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.Cc.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.CcValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewInstallOptions.CcValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewIrbOptions.Pry.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewIrbOptions.Pry.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCount.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCountValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCountValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewLogOptions.Patch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewLogOptions.Patch.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMcpServerOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMcpServerOptions.BrewMcpServerOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMcpServerOptions.BrewMcpServerOptions(ModularPipelines.Homebrew.Options.BrewMcpServerOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Debug.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Debug.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMigrateOptions.BrewMigrateOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMissingOptions.Hide.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMissingOptions.HideValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewMissingOptions.HideValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOptionsOptions.Command.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOptionsOptions.Command.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOptionsOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOptionsOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Json.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOutdatedOptions.JsonValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewOutdatedOptions.JsonValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.BrewPinInstalled_formulaOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.BrewPinInstalled_formulaOptions(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Autosquash.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Autosquash.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.BrewPrAutomergeOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.BrewPrAutomergeOptions(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.IgnoreFailures.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.IgnoreFailures.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Publish.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Publish.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Tap.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithLabel.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithLabel.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutApproval.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutApproval.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutLabels.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.WithoutLabels.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Workflow.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Workflow.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Autosquash.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Autosquash.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Branch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Branch.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.BrewPrPublishOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.BrewPrPublishOptions(ModularPipelines.Homebrew.Options.BrewPrPublishOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.LargeRunner.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.LargeRunner.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Message.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Message.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Tap.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Workflow.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Workflow.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.ArtifactPattern.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.ArtifactPattern.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Autosquash.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Autosquash.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.BranchOkay.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.BranchOkay.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.BrewPrPullOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.BrewPrPullOptions(ModularPipelines.Homebrew.Options.BrewPrPullOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Clean.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Clean.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Committer.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Committer.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.DryRun.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.DryRun.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.IgnoreMissingArtifacts.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.IgnoreMissingArtifacts.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.KeepOld.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.KeepOld.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Message.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Message.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCherryPick.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCherryPick.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCommit.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoCommit.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoUpload.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.NoUpload.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Resolve.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Resolve.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.RetainBottleDir.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.RetainBottleDir.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrl.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrl.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrlUsing.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.RootUrlUsing.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Tap.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.WarnOnUploadFailure.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.WarnOnUploadFailure.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Workflows.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrPullOptions.Workflows.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.BrewPrUploadOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.BrewPrUploadOptions(ModularPipelines.Homebrew.Options.BrewPrUploadOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Committer.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Committer.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.DryRun.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.DryRun.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.KeepOld.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.KeepOld.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.NoCommit.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.NoCommit.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrl.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrl.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrlUsing.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.RootUrlUsing.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.UploadOnly.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.UploadOnly.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.WarnOnUploadFailure.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewPrUploadOptions.WarnOnUploadFailure.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewProfOptions.BrewProfOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.Arch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.ArchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.ArchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.Os.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.OsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReadallOptions.OsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReinstallOptions.Ask.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReinstallOptions.Ask.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReinstallOptions.BrewReinstallOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.BrewReleaseOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.BrewReleaseOptions(ModularPipelines.Homebrew.Options.BrewReleaseOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.Force.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.Force.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.Major.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.Major.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.Minor.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewReleaseOptions.Minor.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewRubocopOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewRubocopOptions.BrewRubocopOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewRubocopOptions.BrewRubocopOptions(ModularPipelines.Homebrew.Options.BrewRubocopOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewSearchOptions.BrewSearchOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.All.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.All.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.BrewServicesOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.File.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.File.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.Json.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.Json.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.Keep.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.Keep.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.MaxWait.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.MaxWait.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.NoWait.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.NoWait.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUser.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUserValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUserValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewSetupRubyOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.BrewSetupRubyOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.BrewSetupRubyOptions(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewShOptions.Cmd.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewShOptions.CmdValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewShOptions.CmdValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewShOptions.Env.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewShOptions.EnvValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewShOptions.EnvValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCops.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCopsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCopsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCops.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCopsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCopsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTabOptions.BrewTabOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Json.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapInfoOptions.JsonValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapInfoOptions.JsonValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapNewOptions.Branch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapNewOptions.BranchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapNewOptions.BranchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapNewOptions.BrewTapNewOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapNewOptions.PullLabel.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapNewOptions.PullLabel.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTapOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulae.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulaeValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulaeValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulae.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulaeValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulaeValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmail.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmailValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmailValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitName.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitNameValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitNameValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.New.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.New.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.Online.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.Online.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrl.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrlValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrlValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkippedOrFailedFormulae.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.SkippedOrFailedFormulae.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.Strict.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.Strict.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.Tap.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TapValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TapValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulae.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulaeValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulaeValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulae.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulaeValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulaeValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestOptions.BrewTestOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.Only.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.OnlyValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.OnlyValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.Profile.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.ProfileValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.ProfileValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.Seed.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.SeedValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewTestsOptions.SeedValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.BrewUnaliasAliasOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.BrewUnaliasAliasOptions(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnbottledOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnbottledOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Tag.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnbottledOptions.TagValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnbottledOptions.TagValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.BrewUninstallFormulaOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.BrewUninstallFormulaOptions(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnlinkOptions.BrewUnlinkOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpackOptions.BrewUnpackOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpackOptions.Destdir.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpackOptions.DestdirValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpackOptions.DestdirValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.BrewUnpinInstalled_formulaOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.BrewUnpinInstalled_formulaOptions(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUntapOptions.BrewUntapOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.BrewUpdateIfNeededOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.BrewUpdateIfNeededOptions(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.BrewUpdateLicenseDataOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.BrewUpdateLicenseDataOptions(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.BrewUpdateMaintainersOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.BrewUpdateMaintainersOptions(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.BrewUpdatePerlResourcesOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Silent.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions.Silent.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.BrewUpdatePythonResourcesOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackages.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackagesValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackagesValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackages.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackagesValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackagesValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageName.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageNameValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageNameValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Silent.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Silent.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Version.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.VersionValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.VersionValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.BrewUpdateSponsorsOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.BrewUpdateSponsorsOptions(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions! original) -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Before.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.BeforeValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.BeforeValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Commit.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.CommitValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.CommitValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Ask.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUpgradeOptions.Ask.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUsesOptions.BrewUsesOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUsesOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewUsesOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Update.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.UpdateValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.UpdateValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.Arch.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.ArchValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.ArchValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTag.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTagValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTagValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.BrewVerifyOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.Os.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.OsValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewVerifyOptions.OsValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.BrewWhichFormulaOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.SkipUpdate.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions.SkipUpdate.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.BrewWhichUpdateOptions() -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Commit.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Commit.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.EvalAll.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.EvalAll.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.InstallMissing.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.InstallMissing.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.MaxDownloads.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.MaxDownloads.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Stats.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.Stats.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFile.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFileValue.get -> string?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFileValue.set -> void
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.UpdateExisting.get -> bool?
+*REMOVED*ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.UpdateExisting.set -> void
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.AliasAsync(ModularPipelines.Homebrew.Options.BrewAliasOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.AsConsoleUserAsync(ModularPipelines.Homebrew.Options.BrewAsConsoleUserOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.AuditAsync(ModularPipelines.Homebrew.Options.BrewAuditOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -51,8 +708,8 @@
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.FetchAsync(ModularPipelines.Homebrew.Options.BrewFetchOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.FormulaAnalyticsAsync(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.FormulaAsync(ModularPipelines.Homebrew.Options.BrewFormulaOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Homebrew.Services.IBrew.FormulaeAsync(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.FormulaFormulaAsync(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Homebrew.Services.IBrew.FormulaeAsync(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.GenerateAnalyticsApiAsync(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.GenerateCaskApiAsync(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.GenerateFormulaApiAsync(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -67,8 +724,8 @@
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.IrbAsync(ModularPipelines.Homebrew.Options.BrewIrbOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.LeavesAsync(ModularPipelines.Homebrew.Options.BrewLeavesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.LgtmAsync(ModularPipelines.Homebrew.Options.BrewLgtmOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Homebrew.Services.IBrew.LinkageAsync(ModularPipelines.Homebrew.Options.BrewLinkageOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.LinkAsync(ModularPipelines.Homebrew.Options.BrewLinkOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Homebrew.Services.IBrew.LinkageAsync(ModularPipelines.Homebrew.Options.BrewLinkageOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.ListAsync(ModularPipelines.Homebrew.Options.BrewListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.LivecheckAsync(ModularPipelines.Homebrew.Options.BrewLivecheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.LogAsync(ModularPipelines.Homebrew.Options.BrewLogOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -79,14 +736,14 @@
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.OptionsAsync(ModularPipelines.Homebrew.Options.BrewOptionsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.OutdatedAsync(ModularPipelines.Homebrew.Options.BrewOutdatedOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PinAsync(ModularPipelines.Homebrew.Options.BrewPinOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Homebrew.Services.IBrew.PinInstalled_formulaAsync(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PinInstalledFormulaAsync(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Homebrew.Services.IBrew.PinInstalled_formulaAsync(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PostinstallAsync(ModularPipelines.Homebrew.Options.BrewPostinstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PrAutomergeAsync(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Homebrew.Services.IBrew.ProfAsync(ModularPipelines.Homebrew.Options.BrewProfOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PrPublishAsync(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PrPullAsync(ModularPipelines.Homebrew.Options.BrewPrPullOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PrUploadAsync(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Homebrew.Services.IBrew.ProfAsync(ModularPipelines.Homebrew.Options.BrewProfOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.PyenvSyncAsync(ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.RbenvSyncAsync(ModularPipelines.Homebrew.Options.BrewRbenvSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.ReadallAsync(ModularPipelines.Homebrew.Options.BrewReadallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -127,8 +784,8 @@
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UnlinkAsync(ModularPipelines.Homebrew.Options.BrewUnlinkOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UnpackAsync(ModularPipelines.Homebrew.Options.BrewUnpackOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UnpinAsync(ModularPipelines.Homebrew.Options.BrewUnpinOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Homebrew.Services.IBrew.UnpinInstalled_formulaAsync(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UnpinInstalledFormulaAsync(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Homebrew.Services.IBrew.UnpinInstalled_formulaAsync(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UntapAsync(ModularPipelines.Homebrew.Options.BrewUntapOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UntrustAsync(ModularPipelines.Homebrew.Options.BrewUntrustOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.UpdateAsync(ModularPipelines.Homebrew.Options.BrewUpdateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -148,18 +805,370 @@
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.VulnsAsync(ModularPipelines.Homebrew.Options.BrewVulnsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.WhichFormulaAsync(ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Homebrew.Services.IBrew.WhichUpdateAsync(ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCasksOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewCasksOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCasksOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCasksOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCasksOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCasksOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCasksOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewCommandCommandOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewFormulaeOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewFormulaeOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewMcpServerOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewMcpServerOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrPublishOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPublishOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPullOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrPullOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPullOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPullOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPullOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPullOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrPullOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewPrUploadOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewPrUploadOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewReleaseOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewReleaseOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewReleaseOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewReleaseOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewReleaseOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewReleaseOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewReleaseOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewRubocopOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewRubocopOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewRubocopOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewRubocopOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewRubocopOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewRubocopOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewRubocopOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewSetupRubyOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.<Clone>$() -> ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.ToString() -> string!
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewCasksOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewFormulaeOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewPrPullOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewReleaseOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewRubocopOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.Equals(ModularPipelines.Homebrew.Options.BrewOptions? other) -> bool
 *REMOVED*static ModularPipelines.Homebrew.Extensions.BrewExtensions.Brew(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Homebrew.Services.IBrew!
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewCasksOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCasksOptions? left, ModularPipelines.Homebrew.Options.BrewCasksOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewCasksOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCasksOptions? left, ModularPipelines.Homebrew.Options.BrewCasksOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.operator !=(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? left, ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.operator ==(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? left, ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.operator !=(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? left, ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.operator ==(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? left, ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewFormulaeOptions.operator !=(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaeOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewFormulaeOptions.operator ==(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? left, ModularPipelines.Homebrew.Options.BrewFormulaeOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.operator !=(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.operator ==(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? left, ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewMcpServerOptions.operator !=(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? left, ModularPipelines.Homebrew.Options.BrewMcpServerOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewMcpServerOptions.operator ==(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? left, ModularPipelines.Homebrew.Options.BrewMcpServerOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? left, ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? left, ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrPublishOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? left, ModularPipelines.Homebrew.Options.BrewPrPublishOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrPublishOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? left, ModularPipelines.Homebrew.Options.BrewPrPublishOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrPullOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrPullOptions? left, ModularPipelines.Homebrew.Options.BrewPrPullOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrPullOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrPullOptions? left, ModularPipelines.Homebrew.Options.BrewPrPullOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrUploadOptions.operator !=(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? left, ModularPipelines.Homebrew.Options.BrewPrUploadOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewPrUploadOptions.operator ==(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? left, ModularPipelines.Homebrew.Options.BrewPrUploadOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewReleaseOptions.operator !=(ModularPipelines.Homebrew.Options.BrewReleaseOptions? left, ModularPipelines.Homebrew.Options.BrewReleaseOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewReleaseOptions.operator ==(ModularPipelines.Homebrew.Options.BrewReleaseOptions? left, ModularPipelines.Homebrew.Options.BrewReleaseOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewRubocopOptions.operator !=(ModularPipelines.Homebrew.Options.BrewRubocopOptions? left, ModularPipelines.Homebrew.Options.BrewRubocopOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewRubocopOptions.operator ==(ModularPipelines.Homebrew.Options.BrewRubocopOptions? left, ModularPipelines.Homebrew.Options.BrewRubocopOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.operator !=(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? left, ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.operator ==(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? left, ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? left, ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? left, ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? left, ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? left, ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.operator !=(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? right) -> bool
+*REMOVED*static ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.operator ==(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? left, ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? right) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewCasksOptions.Equals(ModularPipelines.Homebrew.Options.BrewCasksOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewCommandCommandOptions.Equals(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions.Equals(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewFormulaeOptions.Equals(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions.Equals(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewMcpServerOptions.Equals(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewPrPublishOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewPrPullOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrPullOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewPrUploadOptions.Equals(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewReleaseOptions.Equals(ModularPipelines.Homebrew.Options.BrewReleaseOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewRubocopOptions.Equals(ModularPipelines.Homebrew.Options.BrewRubocopOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewSetupRubyOptions.Equals(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions.Equals(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions.Equals(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? other) -> bool
+ModularPipelines.Homebrew.Options.BrewAuditOptions.Arch.get -> string?
+ModularPipelines.Homebrew.Options.BrewAuditOptions.Except.get -> string?
+ModularPipelines.Homebrew.Options.BrewAuditOptions.ExceptCops.get -> string?
+ModularPipelines.Homebrew.Options.BrewAuditOptions.Only.get -> string?
+ModularPipelines.Homebrew.Options.BrewAuditOptions.OnlyCops.get -> string?
+ModularPipelines.Homebrew.Options.BrewAuditOptions.Os.get -> string?
+ModularPipelines.Homebrew.Options.BrewAuditOptions.Tap.get -> string?
+ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrl.get -> string?
+ModularPipelines.Homebrew.Options.BrewBottleOptions.RootUrlUsing.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.ForkOrg.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Message.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Sha256.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Url.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.Version.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionArm.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions.VersionIntel.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.ForkOrg.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Message.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Mirror.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExcludePackages.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonExtraPackages.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.PythonPackageName.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Revision.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Sha256.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Tag.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Url.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions.Version.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpOptions.StartWith.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpOptions.Tap.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions.Message.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.Limit.get -> string?
+ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions.StateFile.get -> string?
+ModularPipelines.Homebrew.Options.BrewBundleOptions.File.get -> string?
+ModularPipelines.Homebrew.Options.BrewCleanupOptions.Prune.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.From.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.Organisation.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.Quarter.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.Repositories.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.Team.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.To.get -> string?
+ModularPipelines.Homebrew.Options.BrewContributionsOptions.User.get -> string?
+ModularPipelines.Homebrew.Options.BrewCreateOptions.SetLicense.get -> string?
+ModularPipelines.Homebrew.Options.BrewCreateOptions.SetName.get -> string?
+ModularPipelines.Homebrew.Options.BrewCreateOptions.SetVersion.get -> string?
+ModularPipelines.Homebrew.Options.BrewCreateOptions.Tap.get -> string?
+ModularPipelines.Homebrew.Options.BrewDepsOptions.Arch.get -> string?
+ModularPipelines.Homebrew.Options.BrewDepsOptions.Os.get -> string?
+ModularPipelines.Homebrew.Options.BrewExtractOptions.GitRevision.get -> string?
+ModularPipelines.Homebrew.Options.BrewExtractOptions.Version.get -> string?
+ModularPipelines.Homebrew.Options.BrewFetchOptions.Arch.get -> string?
+ModularPipelines.Homebrew.Options.BrewFetchOptions.BottleTag.get -> string?
+ModularPipelines.Homebrew.Options.BrewFetchOptions.Os.get -> string?
+ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.AddGroups.get -> string?
+ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions.Groups.get -> string?
+ModularPipelines.Homebrew.Options.BrewInstallOptions.BottleArch.get -> string?
+ModularPipelines.Homebrew.Options.BrewInstallOptions.Cc.get -> string?
+ModularPipelines.Homebrew.Options.BrewLogOptions.MaxCount.get -> string?
+ModularPipelines.Homebrew.Options.BrewMissingOptions.Hide.get -> string?
+ModularPipelines.Homebrew.Options.BrewOutdatedOptions.Json.get -> string?
+ModularPipelines.Homebrew.Options.BrewReadallOptions.Arch.get -> string?
+ModularPipelines.Homebrew.Options.BrewReadallOptions.Os.get -> string?
+ModularPipelines.Homebrew.Options.BrewServicesOptions.SudoServiceUser.get -> string?
+ModularPipelines.Homebrew.Options.BrewShOptions.Cmd.get -> string?
+ModularPipelines.Homebrew.Options.BrewShOptions.Env.get -> string?
+ModularPipelines.Homebrew.Options.BrewStyleOptions.ExceptCops.get -> string?
+ModularPipelines.Homebrew.Options.BrewStyleOptions.OnlyCops.get -> string?
+ModularPipelines.Homebrew.Options.BrewTapInfoOptions.Json.get -> string?
+ModularPipelines.Homebrew.Options.BrewTapNewOptions.Branch.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.AddedFormulae.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.DeletedFormulae.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitEmail.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.GitName.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.RootUrl.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.Tap.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestedFormulae.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestBotOptions.TestingFormulae.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestsOptions.Only.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestsOptions.Profile.get -> string?
+ModularPipelines.Homebrew.Options.BrewTestsOptions.Seed.get -> string?
+ModularPipelines.Homebrew.Options.BrewUnbottledOptions.Tag.get -> string?
+ModularPipelines.Homebrew.Options.BrewUnpackOptions.Destdir.get -> string?
+ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExcludePackages.get -> string?
+ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.ExtraPackages.get -> string?
+ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.PackageName.get -> string?
+ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions.Version.get -> string?
+ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Before.get -> string?
+ModularPipelines.Homebrew.Options.BrewUpdateTestOptions.Commit.get -> string?
+ModularPipelines.Homebrew.Options.BrewVendorGemsOptions.Update.get -> string?
+ModularPipelines.Homebrew.Options.BrewVerifyOptions.Arch.get -> string?
+ModularPipelines.Homebrew.Options.BrewVerifyOptions.BottleTag.get -> string?
+ModularPipelines.Homebrew.Options.BrewVerifyOptions.Os.get -> string?
+ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions.SummaryFile.get -> string?
 ModularPipelines.Homebrew.Services.IBrew.AliasAsync(ModularPipelines.Homebrew.Options.BrewAliasOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.AsConsoleUserAsync(ModularPipelines.Homebrew.Options.BrewAsConsoleUserOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.AuditAsync(ModularPipelines.Homebrew.Options.BrewAuditOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.AutoremoveAsync(ModularPipelines.Homebrew.Options.BrewAutoremoveOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.BottleAsync(ModularPipelines.Homebrew.Options.BrewBottleOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.BottleAsync(ModularPipelines.Homebrew.Options.BrewBottleOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BumpAsync(ModularPipelines.Homebrew.Options.BrewBumpOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.BumpCaskPrAsync(ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.BumpCaskPrAsync(ModularPipelines.Homebrew.Options.BrewBumpCaskPrOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BumpCompatibilityVersionAsync(ModularPipelines.Homebrew.Options.BrewBumpCompatibilityVersionOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BumpFormulaPrAsync(ModularPipelines.Homebrew.Options.BrewBumpFormulaPrOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.BumpRevisionAsync(ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.BumpUnversionedCasksAsync(ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.BumpRevisionAsync(ModularPipelines.Homebrew.Options.BrewBumpRevisionOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.BumpUnversionedCasksAsync(ModularPipelines.Homebrew.Options.BrewBumpUnversionedCasksOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BundleAddAsync(ModularPipelines.Homebrew.Options.BrewBundleAddOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BundleAsync(ModularPipelines.Homebrew.Options.BrewBundleOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BundleCheckAsync(ModularPipelines.Homebrew.Options.BrewBundleCheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -172,11 +1181,9 @@ ModularPipelines.Homebrew.Services.IBrew.BundleInstallAsync(ModularPipelines.Hom
 ModularPipelines.Homebrew.Services.IBrew.BundleListAsync(ModularPipelines.Homebrew.Options.BrewBundleListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BundleRemoveAsync(ModularPipelines.Homebrew.Options.BrewBundleRemoveOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.BundleShAsync(ModularPipelines.Homebrew.Options.BrewBundleShOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.CasksAsync(ModularPipelines.Homebrew.Options.BrewCasksOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.CatAsync(ModularPipelines.Homebrew.Options.BrewCatOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.CatAsync(ModularPipelines.Homebrew.Options.BrewCatOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.CleanupAsync(ModularPipelines.Homebrew.Options.BrewCleanupOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.CommandAsync(ModularPipelines.Homebrew.Options.BrewCommandOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.CommandCommandAsync(ModularPipelines.Homebrew.Options.BrewCommandCommandOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.CommandNotFoundInitAsync(ModularPipelines.Homebrew.Options.BrewCommandNotFoundInitOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.CompletionsAsync(ModularPipelines.Homebrew.Options.BrewCompletionsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.CompletionsLinkAsync(ModularPipelines.Homebrew.Options.BrewCompletionsLinkOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -184,118 +1191,91 @@ ModularPipelines.Homebrew.Services.IBrew.CompletionsStateAsync(ModularPipelines.
 ModularPipelines.Homebrew.Services.IBrew.CompletionsUnlinkAsync(ModularPipelines.Homebrew.Options.BrewCompletionsUnlinkOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ConfigAsync(ModularPipelines.Homebrew.Options.BrewConfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ContributionsAsync(ModularPipelines.Homebrew.Options.BrewContributionsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.CreateAsync(ModularPipelines.Homebrew.Options.BrewCreateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.DebuggerAsync(ModularPipelines.Homebrew.Options.BrewDebuggerOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.CreateAsync(ModularPipelines.Homebrew.Options.BrewCreateOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.DebuggerAsync(ModularPipelines.Homebrew.Options.BrewDebuggerOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DepsAsync(ModularPipelines.Homebrew.Options.BrewDepsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.DescAsync(ModularPipelines.Homebrew.Options.BrewDescOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.DescAsync(ModularPipelines.Homebrew.Options.BrewDescOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DeveloperAsync(ModularPipelines.Homebrew.Options.BrewDeveloperOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DeveloperOffAsync(ModularPipelines.Homebrew.Options.BrewDeveloperOffOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DeveloperOnAsync(ModularPipelines.Homebrew.Options.BrewDeveloperOnOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DeveloperStateAsync(ModularPipelines.Homebrew.Options.BrewDeveloperStateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.DispatchBuildBottleAsync(ModularPipelines.Homebrew.Options.BrewDispatchBuildBottleOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DocsAsync(ModularPipelines.Homebrew.Options.BrewDocsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.DoctorAsync(ModularPipelines.Homebrew.Options.BrewDoctorOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.EditAsync(ModularPipelines.Homebrew.Options.BrewEditOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ExecAsync(ModularPipelines.Homebrew.Options.BrewExecOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ExtractAsync(ModularPipelines.Homebrew.Options.BrewExtractOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.FetchAsync(ModularPipelines.Homebrew.Options.BrewFetchOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.FormulaAnalyticsAsync(ModularPipelines.Homebrew.Options.BrewFormulaAnalyticsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ExtractAsync(ModularPipelines.Homebrew.Options.BrewExtractOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.FetchAsync(ModularPipelines.Homebrew.Options.BrewFetchOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.FormulaAsync(ModularPipelines.Homebrew.Options.BrewFormulaOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.FormulaeAsync(ModularPipelines.Homebrew.Options.BrewFormulaeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.FormulaFormulaAsync(ModularPipelines.Homebrew.Options.BrewFormulaFormulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.GenerateAnalyticsApiAsync(ModularPipelines.Homebrew.Options.BrewGenerateAnalyticsApiOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.GenerateCaskApiAsync(ModularPipelines.Homebrew.Options.BrewGenerateCaskApiOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.GenerateFormulaApiAsync(ModularPipelines.Homebrew.Options.BrewGenerateFormulaApiOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.GenerateManCompletionsAsync(ModularPipelines.Homebrew.Options.BrewGenerateManCompletionsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.GenerateZapAsync(ModularPipelines.Homebrew.Options.BrewGenerateZapOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.GistLogsAsync(ModularPipelines.Homebrew.Options.BrewGistLogsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.GistLogsAsync(ModularPipelines.Homebrew.Options.BrewGistLogsOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.HomeAsync(ModularPipelines.Homebrew.Options.BrewHomeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.InfoAsync(ModularPipelines.Homebrew.Options.BrewInfoOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.InstallAsync(ModularPipelines.Homebrew.Options.BrewInstallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.InstallAsync(ModularPipelines.Homebrew.Options.BrewInstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.InstallBundlerGemsAsync(ModularPipelines.Homebrew.Options.BrewInstallBundlerGemsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.InstallFormulaAsync(ModularPipelines.Homebrew.Options.BrewInstallFormulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.IrbAsync(ModularPipelines.Homebrew.Options.BrewIrbOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.LeavesAsync(ModularPipelines.Homebrew.Options.BrewLeavesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.LgtmAsync(ModularPipelines.Homebrew.Options.BrewLgtmOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.LinkageAsync(ModularPipelines.Homebrew.Options.BrewLinkageOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.LinkAsync(ModularPipelines.Homebrew.Options.BrewLinkOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.LinkageAsync(ModularPipelines.Homebrew.Options.BrewLinkageOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ListAsync(ModularPipelines.Homebrew.Options.BrewListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.LivecheckAsync(ModularPipelines.Homebrew.Options.BrewLivecheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.LogAsync(ModularPipelines.Homebrew.Options.BrewLogOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.McpServerAsync(ModularPipelines.Homebrew.Options.BrewMcpServerOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.MigrateAsync(ModularPipelines.Homebrew.Options.BrewMigrateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.MigrateAsync(ModularPipelines.Homebrew.Options.BrewMigrateOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.MissingAsync(ModularPipelines.Homebrew.Options.BrewMissingOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.NodenvSyncAsync(ModularPipelines.Homebrew.Options.BrewNodenvSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.OptionsAsync(ModularPipelines.Homebrew.Options.BrewOptionsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.OutdatedAsync(ModularPipelines.Homebrew.Options.BrewOutdatedOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.PinAsync(ModularPipelines.Homebrew.Options.BrewPinOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.PinInstalled_formulaAsync(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.PinInstalledFormulaAsync(ModularPipelines.Homebrew.Options.BrewPinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.PostinstallAsync(ModularPipelines.Homebrew.Options.BrewPostinstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.PrAutomergeAsync(ModularPipelines.Homebrew.Options.BrewPrAutomergeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ProfAsync(ModularPipelines.Homebrew.Options.BrewProfOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.PrPublishAsync(ModularPipelines.Homebrew.Options.BrewPrPublishOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.PrPullAsync(ModularPipelines.Homebrew.Options.BrewPrPullOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.PrUploadAsync(ModularPipelines.Homebrew.Options.BrewPrUploadOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ProfAsync(ModularPipelines.Homebrew.Options.BrewProfOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.PyenvSyncAsync(ModularPipelines.Homebrew.Options.BrewPyenvSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.RbenvSyncAsync(ModularPipelines.Homebrew.Options.BrewRbenvSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ReadallAsync(ModularPipelines.Homebrew.Options.BrewReadallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ReinstallAsync(ModularPipelines.Homebrew.Options.BrewReinstallOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ReleaseAsync(ModularPipelines.Homebrew.Options.BrewReleaseOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.RubocopAsync(ModularPipelines.Homebrew.Options.BrewRubocopOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ReinstallAsync(ModularPipelines.Homebrew.Options.BrewReinstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.RubyAsync(ModularPipelines.Homebrew.Options.BrewRubyOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.RubydocAsync(ModularPipelines.Homebrew.Options.BrewRubydocOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.SandboxExecAsync(ModularPipelines.Homebrew.Options.BrewSandboxExecOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.SearchAsync(ModularPipelines.Homebrew.Options.BrewSearchOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesAsync(ModularPipelines.Homebrew.Options.BrewServicesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.SearchAsync(ModularPipelines.Homebrew.Options.BrewSearchOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesAsync(ModularPipelines.Homebrew.Options.BrewServicesOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ServicesCleanupAsync(ModularPipelines.Homebrew.Options.BrewServicesCleanupOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesInfoAsync(ModularPipelines.Homebrew.Options.BrewServicesInfoOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesKillAsync(ModularPipelines.Homebrew.Options.BrewServicesKillOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesInfoAsync(ModularPipelines.Homebrew.Options.BrewServicesInfoOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesKillAsync(ModularPipelines.Homebrew.Options.BrewServicesKillOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ServicesListAsync(ModularPipelines.Homebrew.Options.BrewServicesListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesRestartAsync(ModularPipelines.Homebrew.Options.BrewServicesRestartOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesRunAsync(ModularPipelines.Homebrew.Options.BrewServicesRunOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesStartAsync(ModularPipelines.Homebrew.Options.BrewServicesStartOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.ServicesStopAsync(ModularPipelines.Homebrew.Options.BrewServicesStopOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.SetupRubyAsync(ModularPipelines.Homebrew.Options.BrewSetupRubyOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesRestartAsync(ModularPipelines.Homebrew.Options.BrewServicesRestartOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesRunAsync(ModularPipelines.Homebrew.Options.BrewServicesRunOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesStartAsync(ModularPipelines.Homebrew.Options.BrewServicesStartOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.ServicesStopAsync(ModularPipelines.Homebrew.Options.BrewServicesStopOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.ShAsync(ModularPipelines.Homebrew.Options.BrewShOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.SourceAsync(ModularPipelines.Homebrew.Options.BrewSourceOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.StyleAsync(ModularPipelines.Homebrew.Options.BrewStyleOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.TabAsync(ModularPipelines.Homebrew.Options.BrewTabOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.TabAsync(ModularPipelines.Homebrew.Options.BrewTabOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.TapAsync(ModularPipelines.Homebrew.Options.BrewTapOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.TapInfoAsync(ModularPipelines.Homebrew.Options.BrewTapInfoOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.TapNewAsync(ModularPipelines.Homebrew.Options.BrewTapNewOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.TestAsync(ModularPipelines.Homebrew.Options.BrewTestOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.TapNewAsync(ModularPipelines.Homebrew.Options.BrewTapNewOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.TestAsync(ModularPipelines.Homebrew.Options.BrewTestOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.TestBotAsync(ModularPipelines.Homebrew.Options.BrewTestBotOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.TestsAsync(ModularPipelines.Homebrew.Options.BrewTestsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.TrustAsync(ModularPipelines.Homebrew.Options.BrewTrustOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.TypecheckAsync(ModularPipelines.Homebrew.Options.BrewTypecheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UnaliasAliasAsync(ModularPipelines.Homebrew.Options.BrewUnaliasAliasOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UnaliasAsync(ModularPipelines.Homebrew.Options.BrewUnaliasOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UnbottledAsync(ModularPipelines.Homebrew.Options.BrewUnbottledOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UninstallAsync(ModularPipelines.Homebrew.Options.BrewUninstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UninstallFormulaAsync(ModularPipelines.Homebrew.Options.BrewUninstallFormulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UnlinkAsync(ModularPipelines.Homebrew.Options.BrewUnlinkOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UnpackAsync(ModularPipelines.Homebrew.Options.BrewUnpackOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.UnlinkAsync(ModularPipelines.Homebrew.Options.BrewUnlinkOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.UnpackAsync(ModularPipelines.Homebrew.Options.BrewUnpackOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UnpinAsync(ModularPipelines.Homebrew.Options.BrewUnpinOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UnpinInstalled_formulaAsync(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UnpinInstalledFormulaAsync(ModularPipelines.Homebrew.Options.BrewUnpinInstalled_formulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UntapAsync(ModularPipelines.Homebrew.Options.BrewUntapOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.UntapAsync(ModularPipelines.Homebrew.Options.BrewUntapOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UntrustAsync(ModularPipelines.Homebrew.Options.BrewUntrustOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UpdateAsync(ModularPipelines.Homebrew.Options.BrewUpdateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UpdateIfNeededAsync(ModularPipelines.Homebrew.Options.BrewUpdateIfNeededOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UpdateLicenseDataAsync(ModularPipelines.Homebrew.Options.BrewUpdateLicenseDataOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UpdateMaintainersAsync(ModularPipelines.Homebrew.Options.BrewUpdateMaintainersOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UpdatePerlResourcesAsync(ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UpdatePythonResourcesAsync(ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.UpdatePerlResourcesAsync(ModularPipelines.Homebrew.Options.BrewUpdatePerlResourcesOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.UpdatePythonResourcesAsync(ModularPipelines.Homebrew.Options.BrewUpdatePythonResourcesOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UpdateResetAsync(ModularPipelines.Homebrew.Options.BrewUpdateResetOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UpdateSponsorsAsync(ModularPipelines.Homebrew.Options.BrewUpdateSponsorsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UpdateTestAsync(ModularPipelines.Homebrew.Options.BrewUpdateTestOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.UpgradeAsync(ModularPipelines.Homebrew.Options.BrewUpgradeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.UsesAsync(ModularPipelines.Homebrew.Options.BrewUsesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.UsesAsync(ModularPipelines.Homebrew.Options.BrewUsesOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.VendorGemsAsync(ModularPipelines.Homebrew.Options.BrewVendorGemsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.VerifyAsync(ModularPipelines.Homebrew.Options.BrewVerifyOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.VerifyAsync(ModularPipelines.Homebrew.Options.BrewVerifyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.VersionInstallAsync(ModularPipelines.Homebrew.Options.BrewVersionInstallOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Homebrew.Services.IBrew.VulnsAsync(ModularPipelines.Homebrew.Options.BrewVulnsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.WhichFormulaAsync(ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Homebrew.Services.IBrew.WhichUpdateAsync(ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-static ModularPipelines.Homebrew.Extensions.BrewExtensions.Brew(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Homebrew.Services.IBrew!
+ModularPipelines.Homebrew.Services.IBrew.WhichFormulaAsync(ModularPipelines.Homebrew.Options.BrewWhichFormulaOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Homebrew.Services.IBrew.WhichUpdateAsync(ModularPipelines.Homebrew.Options.BrewWhichUpdateOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!

--- a/src/ModularPipelines.Homebrew/Services/Brew.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Services/Brew.Generated.cs
@@ -754,20 +754,20 @@ internal partial class Brew : IBrew
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ServicesInfoAsync(
-        BrewServicesInfoOptions? options = null,
+        BrewServicesInfoOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new BrewServicesInfoOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ServicesKillAsync(
-        BrewServicesKillOptions? options = null,
+        BrewServicesKillOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new BrewServicesKillOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -790,38 +790,38 @@ internal partial class Brew : IBrew
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ServicesRestartAsync(
-        BrewServicesRestartOptions? options = null,
+        BrewServicesRestartOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new BrewServicesRestartOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ServicesRunAsync(
-        BrewServicesRunOptions? options = null,
+        BrewServicesRunOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new BrewServicesRunOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ServicesStartAsync(
-        BrewServicesStartOptions? options = null,
+        BrewServicesStartOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new BrewServicesStartOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ServicesStopAsync(
-        BrewServicesStopOptions? options = null,
+        BrewServicesStopOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new BrewServicesStopOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.Homebrew/Services/IBrew.Generated.cs
+++ b/src/ModularPipelines.Homebrew/Services/IBrew.Generated.cs
@@ -813,7 +813,7 @@ public partial interface IBrew
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ServicesInfoAsync(BrewServicesInfoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ServicesInfoAsync(BrewServicesInfoOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -823,7 +823,7 @@ public partial interface IBrew
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ServicesKillAsync(BrewServicesKillOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ServicesKillAsync(BrewServicesKillOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -846,7 +846,7 @@ public partial interface IBrew
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ServicesRestartAsync(BrewServicesRestartOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ServicesRestartAsync(BrewServicesRestartOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -856,7 +856,7 @@ public partial interface IBrew
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ServicesRunAsync(BrewServicesRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ServicesRunAsync(BrewServicesRunOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -866,7 +866,7 @@ public partial interface IBrew
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ServicesStartAsync(BrewServicesStartOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ServicesStartAsync(BrewServicesStartOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -876,7 +876,7 @@ public partial interface IBrew
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> ServicesStopAsync(BrewServicesStopOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ServicesStopAsync(BrewServicesStopOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **brew** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- brew (Homebrew 6.0.18): 121 commands, tree 7530c4cc1b396a84294528123676a40aa6d25f4164ae56b4e949a2eaf3c56888
  - Baseline comparison: 121 commands at Homebrew 6.0.18 -> 121 commands at Homebrew 6.0.18

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator