### PR TITLE
[Automated] Update grype CLI Options

### DIFF
--- a/src/ModularPipelines.Grype/Generated/Grype.Generation.json
+++ b/src/ModularPipelines.Grype/Generated/Grype.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "grype",
+  "toolVersion": "grype 0.118.0",
+  "commandTreeSha256": "b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c",
+  "generatorSourceSha256": "d9158a695acc19054e4501e243f73451e38058e36153726384f7e577db59b384"
+}

--- a/src/ModularPipelines.Grype/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Grype/PublicAPI.Shipped.txt
@@ -87,8 +87,6 @@ ModularPipelines.Grype.Options.GrypeDbListOptions.Quiet.set -> void
 ModularPipelines.Grype.Options.GrypeDbListOptions.Verbose.get -> int?
 ModularPipelines.Grype.Options.GrypeDbListOptions.Verbose.set -> void
 ModularPipelines.Grype.Options.GrypeDbOptions
-ModularPipelines.Grype.Options.GrypeDbOptions.Command.get -> string?
-ModularPipelines.Grype.Options.GrypeDbOptions.Command.set -> void
 ModularPipelines.Grype.Options.GrypeDbOptions.Config.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Grype.Options.GrypeDbOptions.Config.set -> void
 ModularPipelines.Grype.Options.GrypeDbOptions.GrypeDbOptions() -> void
@@ -119,8 +117,6 @@ ModularPipelines.Grype.Options.GrypeDbProvidersOptions.Verbose.set -> void
 ModularPipelines.Grype.Options.GrypeDbSearchOptions
 ModularPipelines.Grype.Options.GrypeDbSearchOptions.BroadCpeMatching.get -> bool?
 ModularPipelines.Grype.Options.GrypeDbSearchOptions.BroadCpeMatching.set -> void
-ModularPipelines.Grype.Options.GrypeDbSearchOptions.Command.get -> string?
-ModularPipelines.Grype.Options.GrypeDbSearchOptions.Command.set -> void
 ModularPipelines.Grype.Options.GrypeDbSearchOptions.Config.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.Grype.Options.GrypeDbSearchOptions.Config.set -> void
 ModularPipelines.Grype.Options.GrypeDbSearchOptions.Distro.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -224,8 +220,6 @@ ModularPipelines.Grype.Options.GrypeExplainOptions.Quiet.get -> bool?
 ModularPipelines.Grype.Options.GrypeExplainOptions.Quiet.set -> void
 ModularPipelines.Grype.Options.GrypeExplainOptions.Verbose.get -> int?
 ModularPipelines.Grype.Options.GrypeExplainOptions.Verbose.set -> void
-ModularPipelines.Grype.Options.GrypeExplainOptions.VulnerabilityId.get -> string?
-ModularPipelines.Grype.Options.GrypeExplainOptions.VulnerabilityId.set -> void
 ModularPipelines.Grype.Options.GrypeOptions
 ModularPipelines.Grype.Options.GrypeOptions.GrypeOptions() -> void
 ModularPipelines.Grype.Options.GrypeOptions.GrypeOptions(ModularPipelines.Grype.Options.GrypeOptions! original) -> void

--- a/src/ModularPipelines.Grype/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Grype/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 #nullable enable
+*REMOVED*ModularPipelines.Grype.Options.GrypeDbOptions.Command.get -> string?
+*REMOVED*ModularPipelines.Grype.Options.GrypeDbOptions.Command.set -> void
+*REMOVED*ModularPipelines.Grype.Options.GrypeDbSearchOptions.Command.get -> string?
+*REMOVED*ModularPipelines.Grype.Options.GrypeDbSearchOptions.Command.set -> void
+*REMOVED*ModularPipelines.Grype.Options.GrypeExplainOptions.VulnerabilityId.get -> string?
+*REMOVED*ModularPipelines.Grype.Options.GrypeExplainOptions.VulnerabilityId.set -> void
 *REMOVED*ModularPipelines.Grype.Services.GrypeDb.GrypeDb(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.Grype.Services.GrypeDbSearch.GrypeDbSearch(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.Grype.Services.IGrype.ExplainAsync(ModularPipelines.Grype.Options.GrypeExplainOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -35,7 +41,6 @@ ModularPipelines.Grype.Services.IGrypeDb.ListAsync(ModularPipelines.Grype.Option
 ModularPipelines.Grype.Services.IGrypeDb.ProvidersAsync(ModularPipelines.Grype.Options.GrypeDbProvidersOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Grype.Services.IGrypeDb.StatusAsync(ModularPipelines.Grype.Options.GrypeDbStatusOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Grype.Services.IGrypeDb.UpdateAsync(ModularPipelines.Grype.Options.GrypeDbUpdateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-static ModularPipelines.Grype.Extensions.GrypeExtensions.Grype(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Grype.Services.IGrype!
 virtual ModularPipelines.Grype.Services.GrypeDb.CheckAsync(ModularPipelines.Grype.Options.GrypeDbCheckOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Grype.Services.GrypeDb.DeleteAsync(ModularPipelines.Grype.Options.GrypeDbDeleteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Grype.Services.GrypeDb.DiffAsync(ModularPipelines.Grype.Options.GrypeDbDiffOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **grype** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- grype (grype 0.118.0): 12 commands, tree b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c
  - Baseline comparison: 12 commands at grype 0.118.0 -> 12 commands at grype 0.118.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator