### PR TITLE
Report assembly-wide generated API changes

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -65,6 +65,7 @@ jobs:
           tools/ModularPipelines.OptionsGenerator/scripts/Test-WriteRemovedPublicApiSnapshotFromSarif.ps1
           tools/ModularPipelines.OptionsGenerator/scripts/Test-MergePublicApiBaselineSnapshot.ps1
           tools/ModularPipelines.OptionsGenerator/scripts/Test-SyncPublicApiBaselines.ps1
+          tools/ModularPipelines.OptionsGenerator/scripts/Test-WritePublicApiChangeSummary.ps1
       - name: Reject stale generated enum attributes
         shell: pwsh
         run: tools/ModularPipelines.OptionsGenerator/scripts/Test-GeneratedEnumAttributes.ps1
@@ -674,6 +675,26 @@ jobs:
             -TemporaryDirectory $env:RUNNER_TEMP `
             -ExtraBuildArguments $buildArguments
 
+      - name: Summarize assembly public API changes
+        id: api-summary
+        if: steps.should-run.outputs.run == 'true'
+        shell: pwsh
+        run: |
+          $packageDirectory = "src/${{ steps.package.outputs.package }}"
+          $summaryPath = Join-Path $env:RUNNER_TEMP 'public-api-summary.md'
+          tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiChangeSummary.ps1 `
+            -OriginalShippedPath (Join-Path $env:RUNNER_TEMP 'PublicAPI.Shipped.original.txt') `
+            -OriginalUnshippedPath (Join-Path $env:RUNNER_TEMP 'PublicAPI.Unshipped.original.txt') `
+            -CurrentShippedPath (Join-Path $packageDirectory 'PublicAPI.Shipped.txt') `
+            -CurrentUnshippedPath (Join-Path $packageDirectory 'PublicAPI.Unshipped.txt') `
+            -PackageDirectory $packageDirectory `
+            -OutputPath $summaryPath
+
+          $delimiter = "api_summary_$([guid]::NewGuid().ToString('N'))"
+          "markdown<<$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Get-Content -LiteralPath $summaryPath | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $delimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Check for changes
         if: steps.should-run.outputs.run == 'true'
         id: changes
@@ -759,6 +780,8 @@ jobs:
             - Updated options classes to reflect latest CLI documentation
             - Added new commands if any were detected
             - Updated option types and descriptions
+
+            ${{ steps.api-summary.outputs.markdown }}
 
             ## Command coverage
             ${{ steps.generator.outputs.coverage-report }}
@@ -1018,6 +1041,26 @@ jobs:
             -ProjectPath "${packageDirectory}/${{ steps.package.outputs.package }}.csproj" `
             -TemporaryDirectory $env:RUNNER_TEMP
 
+      - name: Summarize assembly public API changes
+        id: api-summary
+        if: steps.should-run.outputs.run == 'true'
+        shell: pwsh
+        run: |
+          $packageDirectory = "src/${{ steps.package.outputs.package }}"
+          $summaryPath = Join-Path $env:RUNNER_TEMP 'public-api-summary.md'
+          tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiChangeSummary.ps1 `
+            -OriginalShippedPath (Join-Path $env:RUNNER_TEMP 'PublicAPI.Shipped.original.txt') `
+            -OriginalUnshippedPath (Join-Path $env:RUNNER_TEMP 'PublicAPI.Unshipped.original.txt') `
+            -CurrentShippedPath (Join-Path $packageDirectory 'PublicAPI.Shipped.txt') `
+            -CurrentUnshippedPath (Join-Path $packageDirectory 'PublicAPI.Unshipped.txt') `
+            -PackageDirectory $packageDirectory `
+            -OutputPath $summaryPath
+
+          $delimiter = "api_summary_$([guid]::NewGuid().ToString('N'))"
+          "markdown<<$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Get-Content -LiteralPath $summaryPath | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $delimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Check for changes
         if: steps.should-run.outputs.run == 'true'
         id: changes
@@ -1089,6 +1132,8 @@ jobs:
             - Updated options classes to reflect latest CLI documentation
             - Added new commands if any were detected
             - Updated option types and descriptions
+
+            ${{ steps.api-summary.outputs.markdown }}
 
             ## Command coverage
             ${{ steps.generator.outputs.coverage-report }}

--- a/tools/ModularPipelines.OptionsGenerator/scripts/Test-WritePublicApiChangeSummary.ps1
+++ b/tools/ModularPipelines.OptionsGenerator/scripts/Test-WritePublicApiChangeSummary.ps1
@@ -1,0 +1,58 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$temporaryDirectory = Join-Path ([IO.Path]::GetTempPath()) "public-api-summary-$([guid]::NewGuid().ToString('N'))"
+$packageDirectory = Join-Path $temporaryDirectory 'src/ModularPipelines.Kubernetes'
+$generatedDirectory = Join-Path $packageDirectory 'Generated'
+[IO.Directory]::CreateDirectory($generatedDirectory) | Out-Null
+
+try {
+    $originalShipped = Join-Path $temporaryDirectory 'PublicAPI.Shipped.original.txt'
+    $originalUnshipped = Join-Path $temporaryDirectory 'PublicAPI.Unshipped.original.txt'
+    $currentShipped = Join-Path $packageDirectory 'PublicAPI.Shipped.txt'
+    $currentUnshipped = Join-Path $packageDirectory 'PublicAPI.Unshipped.txt'
+    $summaryPath = Join-Path $temporaryDirectory 'summary.md'
+
+    [IO.File]::WriteAllLines($originalShipped, @(
+        '#nullable enable',
+        'ModularPipelines.Kubernetes.Options.KubernetesApplyOptions.DryRun.get -> string?',
+        'ModularPipelines.Kubernetes.Services.IKubernetesApply.ApplyAsync(ModularPipelines.Kubernetes.Options.KubernetesApplyOptions? options = null) -> System.Threading.Tasks.Task!'
+    ))
+    [IO.File]::WriteAllLines($originalUnshipped, @())
+    [IO.File]::WriteAllLines($currentShipped, @('#nullable enable'))
+    [IO.File]::WriteAllLines($currentUnshipped, @(
+        '*REMOVED*ModularPipelines.Kubernetes.Options.KubernetesApplyOptions.DryRun.get -> string?',
+        '*REMOVED*ModularPipelines.Kubernetes.Services.IKubernetesApply.ApplyAsync(ModularPipelines.Kubernetes.Options.KubernetesApplyOptions? options = null) -> System.Threading.Tasks.Task!',
+        'ModularPipelines.Kubernetes.Options.KubernetesApplyOptions.DryRun.get -> ModularPipelines.Kubernetes.Enums.KubernetesApplyDryRun?',
+        'ModularPipelines.Kubernetes.Options.KustomizeBuildOptions.EnableAlphaPlugins.get -> bool?'
+    ))
+    [IO.File]::WriteAllText((Join-Path $generatedDirectory 'Kubernetes.CommandCoverage.json'), '{"toolName":"kubectl"}')
+    [IO.File]::WriteAllText((Join-Path $generatedDirectory 'Kustomize.CommandCoverage.json'), '{"toolName":"kustomize"}')
+
+    & (Join-Path $PSScriptRoot 'Write-PublicApiChangeSummary.ps1') `
+        -OriginalShippedPath $originalShipped `
+        -OriginalUnshippedPath $originalUnshipped `
+        -CurrentShippedPath $currentShipped `
+        -CurrentUnshippedPath $currentUnshipped `
+        -PackageDirectory $packageDirectory `
+        -OutputPath $summaryPath
+
+    $summary = Get-Content -LiteralPath $summaryPath -Raw
+    foreach ($expected in @(
+        'Affected API families: `Kubernetes (kubectl)`, `Kustomize`.',
+        'Breaking changes are present.',
+        'Members with matching names but changed signatures: 1',
+        'KubernetesApplyOptions.DryRun.get -> string?',
+        'KustomizeBuildOptions.EnableAlphaPlugins.get -> bool?')) {
+        if (-not $summary.Contains($expected, [StringComparison]::Ordinal)) {
+            throw "Summary did not contain expected text: $expected`n$summary"
+        }
+    }
+
+    Write-Output 'OK public API change summary reports cross-tool assembly impact.'
+}
+finally {
+    if (Test-Path -LiteralPath $temporaryDirectory) {
+        Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiChangeSummary.ps1
+++ b/tools/ModularPipelines.OptionsGenerator/scripts/Write-PublicApiChangeSummary.ps1
@@ -1,0 +1,146 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $OriginalShippedPath,
+    [Parameter(Mandatory)][string] $OriginalUnshippedPath,
+    [Parameter(Mandatory)][string] $CurrentShippedPath,
+    [Parameter(Mandatory)][string] $CurrentUnshippedPath,
+    [Parameter(Mandatory)][string] $PackageDirectory,
+    [Parameter(Mandatory)][string] $OutputPath,
+    [ValidateRange(1, 20)][int] $MaximumExamples = 5
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+foreach ($path in @(
+    $OriginalShippedPath,
+    $OriginalUnshippedPath,
+    $CurrentShippedPath,
+    $CurrentUnshippedPath)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Public API baseline does not exist: $path"
+    }
+}
+
+if (-not (Test-Path -LiteralPath $PackageDirectory -PathType Container)) {
+    throw "Package directory does not exist: $PackageDirectory"
+}
+
+function Read-ActiveApi([string[]] $Paths) {
+    $entries = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($path in $Paths) {
+        foreach ($line in Get-Content -LiteralPath $path) {
+            $entry = $line.Trim()
+            if (($entry.Length -gt 0) -and
+                (-not $entry.StartsWith('#', [StringComparison]::Ordinal)) -and
+                (-not $entry.StartsWith('*REMOVED*', [StringComparison]::Ordinal))) {
+                [void] $entries.Add($entry)
+            }
+        }
+    }
+
+    return ,$entries
+}
+
+function Get-ApiFamily([string] $Api, [string[]] $Prefixes) {
+    $match = [regex]::Match(
+        $Api,
+        '^ModularPipelines\.[^.]+\.(?:Enums|Extensions|Models|Options|Services)\.(?<type>[A-Za-z_][A-Za-z0-9_]*)')
+    if (-not $match.Success) {
+        return 'Assembly/common'
+    }
+
+    $typeName = $match.Groups['type'].Value
+    foreach ($prefix in $Prefixes) {
+        if ($typeName.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase) -or
+            ($typeName.StartsWith('I', [StringComparison]::Ordinal) -and
+                $typeName.Substring(1).StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase))) {
+            return $prefix
+        }
+    }
+
+    return 'Assembly/common'
+}
+
+function Get-MemberKey([string] $Api) {
+    $arrowIndex = $Api.IndexOf(' -> ', [StringComparison]::Ordinal)
+    $declaration = if ($arrowIndex -ge 0) { $Api.Substring(0, $arrowIndex) } else { $Api }
+    $parameterIndex = $declaration.IndexOf('(', [StringComparison]::Ordinal)
+    if ($parameterIndex -ge 0) {
+        return $declaration.Substring(0, $parameterIndex)
+    }
+
+    return $declaration
+}
+
+$oldApi = Read-ActiveApi @($OriginalShippedPath, $OriginalUnshippedPath)
+$currentApi = Read-ActiveApi @($CurrentShippedPath, $CurrentUnshippedPath)
+$added = @($currentApi.Where({ -not $oldApi.Contains($_) }) | Sort-Object)
+$removed = @($oldApi.Where({ -not $currentApi.Contains($_) }) | Sort-Object)
+
+$coverageDirectory = Join-Path $PackageDirectory 'Generated'
+$prefixLabels = @{}
+if (Test-Path -LiteralPath $coverageDirectory -PathType Container) {
+    foreach ($coverageFile in Get-ChildItem -LiteralPath $coverageDirectory -Filter '*.CommandCoverage.json' -File) {
+        $prefix = $coverageFile.BaseName -replace '\.CommandCoverage$', ''
+        $metadata = Get-Content -LiteralPath $coverageFile.FullName -Raw | ConvertFrom-Json
+        $toolName = [string] $metadata.toolName
+        $prefixLabels[$prefix] = if ($toolName -and -not $prefix.Equals($toolName, [StringComparison]::OrdinalIgnoreCase)) {
+            "$prefix ($toolName)"
+        } else {
+            $prefix
+        }
+    }
+}
+$prefixes = @($prefixLabels.Keys |
+    Sort-Object -Property @{ Expression = { $_.Length }; Descending = $true }, @{ Expression = { $_ } })
+
+$families = @($added + $removed |
+    ForEach-Object { Get-ApiFamily $_ $prefixes } |
+    Sort-Object -Unique)
+$removedKeys = [Collections.Generic.HashSet[string]]::new(
+    [string[]] @($removed | ForEach-Object { Get-MemberKey $_ }),
+    [StringComparer]::Ordinal)
+$changedSignatureCount = @($added | Where-Object { $removedKeys.Contains((Get-MemberKey $_)) }).Count
+
+$lines = [Collections.Generic.List[string]]::new()
+$lines.Add('## Assembly-wide public API impact')
+$lines.Add('')
+if ($added.Count -eq 0 -and $removed.Count -eq 0) {
+    $lines.Add('No active public API changes were detected in this assembly.')
+} else {
+    $familyList = ($families | ForEach-Object {
+        $label = if ($prefixLabels.ContainsKey($_)) { $prefixLabels[$_] } else { $_ }
+        "``$label``"
+    }) -join ', '
+    $lines.Add("Affected API families: $familyList.")
+    $lines.Add('')
+    $lines.Add("- Added APIs: $($added.Count)")
+    $lines.Add("- Removed or changed APIs: $($removed.Count)")
+    $lines.Add("- Members with matching names but changed signatures: $changedSignatureCount")
+
+    if ($removed.Count -gt 0) {
+        $lines.Add('')
+        $lines.Add('Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.')
+        $lines.Add('')
+        $lines.Add('Representative removed or changed members:')
+        foreach ($api in $removed | Select-Object -First $MaximumExamples) {
+            $lines.Add("- ``$api``")
+        }
+    }
+
+    if ($added.Count -gt 0) {
+        $lines.Add('')
+        $lines.Add('Representative added members:')
+        foreach ($api in $added | Select-Object -First $MaximumExamples) {
+            $lines.Add("- ``$api``")
+        }
+    }
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+if ($outputDirectory) {
+    [IO.Directory]::CreateDirectory($outputDirectory) | Out-Null
+}
+[IO.File]::WriteAllLines($OutputPath, $lines, [Text.UTF8Encoding]::new($false))
+Write-Output "Wrote public API change summary to $OutputPath"


### PR DESCRIPTION
Closes #4576.

## Summary
- compare active pre/post assembly public API baselines during CLI generation
- name every affected API family, including sibling tools in shared assemblies
- highlight removals/signature changes with representative members and consumer migration impact
- include the generated summary in Linux and Windows automated PR bodies

## Validation
- public API snapshot/removal/merge/sync script tests passed
- cross-tool Kubernetes/kustomize summary test passed
- exact staging and generated enum safety tests passed
- workflow YAML parsed successfully