### PR TITLE
[Automated] Update pnpm CLI Options

### DIFF
--- a/src/ModularPipelines.Node/Generated/Pnpm.CommandCoverage.json
+++ b/src/ModularPipelines.Node/Generated/Pnpm.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pnpm",
-  "toolVersion": "11.24.0",
+  "toolVersion": "11.25.0",
   "commandCount": 17,
   "commandTreeSha256": "18696e1b021b815b55d2466263ab6d8af87d0d9de99a4f2adf93ef61a3961e51",
   "commands": [

--- a/src/ModularPipelines.Node/Generated/Pnpm.Generation.json
+++ b/src/ModularPipelines.Node/Generated/Pnpm.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "pnpm",
+  "toolVersion": "11.25.0",
+  "commandTreeSha256": "18696e1b021b815b55d2466263ab6d8af87d0d9de99a4f2adf93ef61a3961e51",
+  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+}

--- a/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("add")]
-public record PnpmAddOptions : PnpmOptions
+public record PnpmAddOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Name
+) : PnpmOptions
 {
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
@@ -199,11 +201,5 @@ public record PnpmAddOptions : PnpmOptions
     /// </summary>
     [CliOption("--test-pattern")]
     public string? TestPattern { get; set; }
-
-    /// <summary>
-    /// The name operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public string? Name { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmCreateOptions.Generated.cs
@@ -18,18 +18,14 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("create")]
-public record PnpmCreateOptions : PnpmOptions
+public record PnpmCreateOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Name
+) : PnpmOptions
 {
     /// <summary>
     /// A list of package names that are allowed to run postinstall scripts during installation
     /// </summary>
     [CliOption("--allow-build")]
     public string? AllowBuild { get; set; }
-
-    /// <summary>
-    /// The name operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public string? Name { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PnpmInitOptions : PnpmOptions
     public string? Bare { get; set; }
 
     /// <summary>
-    /// Pin the pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing
+    /// Pin the latest pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing
     /// </summary>
     [CliFlag("--init-package-manager")]
     public bool? InitPackageManager { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
@@ -35,6 +35,12 @@ public record PnpmRunOptions(
     public string? Dir { get; set; }
 
     /// <summary>
+    /// Print the task graph a recursive run would execute, without running anything. With "--json", prints the tasks and their resolved dependency edges as JSON
+    /// </summary>
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
+
+    /// <summary>
     /// Output usage information
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]

--- a/src/ModularPipelines.Node/Options/PnpmStageApproveOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageApproveOptions.Generated.cs
@@ -19,9 +19,7 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stage", "approve")]
-public record PnpmStageApproveOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string StageId
-) : PnpmOptions
+public record PnpmStageApproveOptions : PnpmOptions
 {
     /// <summary>
     /// Tells the registry whether the staged package should be public or restricted.
@@ -42,7 +40,7 @@ public record PnpmStageApproveOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]
@@ -95,5 +93,11 @@ public record PnpmStageApproveOptions(
     /// </summary>
     [CliOption("--test-pattern")]
     public string? TestPattern { get; set; }
+
+    /// <summary>
+    /// The &lt;stage-id&gt; operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? StageId { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmStageDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageDownloadOptions.Generated.cs
@@ -42,7 +42,7 @@ public record PnpmStageDownloadOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageListOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageListOptions.Generated.cs
@@ -40,7 +40,7 @@ public record PnpmStageListOptions : PnpmOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
@@ -40,7 +40,7 @@ public record PnpmStageOptions : PnpmOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStagePublishOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStagePublishOptions.Generated.cs
@@ -40,7 +40,7 @@ public record PnpmStagePublishOptions : PnpmOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageRejectOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageRejectOptions.Generated.cs
@@ -42,7 +42,7 @@ public record PnpmStageRejectOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/Options/PnpmStageViewOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageViewOptions.Generated.cs
@@ -42,7 +42,7 @@ public record PnpmStageViewOptions(
     public bool? Json { get; set; }
 
     /// <summary>
-    /// One-time password for approve and reject.
+    /// One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.
     /// </summary>
     [SecretValue]
     [CliOption("--otp")]

--- a/src/ModularPipelines.Node/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Node/PublicAPI.Shipped.txt
@@ -436,17 +436,14 @@ ModularPipelines.Node.Models.NpxOptions
 ModularPipelines.Node.Models.NpxOptions.NpxOptions() -> void
 ModularPipelines.Node.Models.NpxOptions.NpxOptions(ModularPipelines.Node.Models.NpxOptions! original) -> void
 ModularPipelines.Node.Options.PnpmAddOptions
-ModularPipelines.Node.Options.PnpmAddOptions.AggregateOutput.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.AggregateOutput.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.AllowBuild.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.AllowBuild.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.ChangedFilesIgnorePattern.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.ChangedFilesIgnorePattern.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.Config.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Config.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.Dir.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Dir.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.FailIfNoMatch.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.FailIfNoMatch.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.Filter.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Filter.set -> void
@@ -456,7 +453,6 @@ ModularPipelines.Node.Options.PnpmAddOptions.Global.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.Global.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.GlobalDir.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.GlobalDir.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.Help.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Help.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.IgnoreScripts.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.IgnoreScripts.set -> void
@@ -464,7 +460,6 @@ ModularPipelines.Node.Options.PnpmAddOptions.Loglevel.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Loglevel.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.Offline.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.Offline.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.PnpmAddOptions() -> void
 ModularPipelines.Node.Options.PnpmAddOptions.PnpmAddOptions(ModularPipelines.Node.Options.PnpmAddOptions! original) -> void
 ModularPipelines.Node.Options.PnpmAddOptions.PreferOffline.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.PreferOffline.set -> void
@@ -472,7 +467,6 @@ ModularPipelines.Node.Options.PnpmAddOptions.Recursive.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.Recursive.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.Registry.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Registry.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.SaveCatalog.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.SaveCatalog.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.SaveDev.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.SaveDev.set -> void
@@ -480,65 +474,49 @@ ModularPipelines.Node.Options.PnpmAddOptions.SaveOptional.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.SaveOptional.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.SavePeer.get -> bool?
 ModularPipelines.Node.Options.PnpmAddOptions.SavePeer.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.SaveProd.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.SaveProd.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.StoreDir.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.StoreDir.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.Stream.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Stream.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.TestPattern.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.TestPattern.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.UseStderr.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.UseStderr.set -> void
 ModularPipelines.Node.Options.PnpmAddOptions.VirtualStoreDir.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.VirtualStoreDir.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.Workspace.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Workspace.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.WorkspaceRoot.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.WorkspaceRoot.set -> void
-ModularPipelines.Node.Options.PnpmAddOptions.Yes.get -> string?
 ModularPipelines.Node.Options.PnpmAddOptions.Yes.set -> void
 ModularPipelines.Node.Options.PnpmAuditOptions
 ModularPipelines.Node.Options.PnpmAuditOptions.AuditLevel.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.AuditLevel.set -> void
-ModularPipelines.Node.Options.PnpmAuditOptions.Dev.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.Dev.set -> void
 ModularPipelines.Node.Options.PnpmAuditOptions.Fix.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.Fix.set -> void
 ModularPipelines.Node.Options.PnpmAuditOptions.Ignore.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.Ignore.set -> void
-ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreRegistryErrors.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreRegistryErrors.set -> void
-ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreUnfixable.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreUnfixable.set -> void
-ModularPipelines.Node.Options.PnpmAuditOptions.Interactive.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.Interactive.set -> void
-ModularPipelines.Node.Options.PnpmAuditOptions.Json.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.Json.set -> void
 ModularPipelines.Node.Options.PnpmAuditOptions.NoOptional.get -> bool?
 ModularPipelines.Node.Options.PnpmAuditOptions.NoOptional.set -> void
 ModularPipelines.Node.Options.PnpmAuditOptions.PnpmAuditOptions() -> void
 ModularPipelines.Node.Options.PnpmAuditOptions.PnpmAuditOptions(ModularPipelines.Node.Options.PnpmAuditOptions! original) -> void
-ModularPipelines.Node.Options.PnpmAuditOptions.Prod.get -> string?
 ModularPipelines.Node.Options.PnpmAuditOptions.Prod.set -> void
 ModularPipelines.Node.Options.PnpmCreateOptions
 ModularPipelines.Node.Options.PnpmCreateOptions.AllowBuild.get -> string?
 ModularPipelines.Node.Options.PnpmCreateOptions.AllowBuild.set -> void
-ModularPipelines.Node.Options.PnpmCreateOptions.PnpmCreateOptions() -> void
 ModularPipelines.Node.Options.PnpmCreateOptions.PnpmCreateOptions(ModularPipelines.Node.Options.PnpmCreateOptions! original) -> void
 ModularPipelines.Node.Options.PnpmDlxOptions
 ModularPipelines.Node.Options.PnpmDlxOptions.AllowBuild.get -> string?
 ModularPipelines.Node.Options.PnpmDlxOptions.AllowBuild.set -> void
 ModularPipelines.Node.Options.PnpmDlxOptions.Package.get -> string?
 ModularPipelines.Node.Options.PnpmDlxOptions.Package.set -> void
-ModularPipelines.Node.Options.PnpmDlxOptions.PnpmDlxOptions() -> void
 ModularPipelines.Node.Options.PnpmDlxOptions.PnpmDlxOptions(ModularPipelines.Node.Options.PnpmDlxOptions! original) -> void
-ModularPipelines.Node.Options.PnpmDlxOptions.ShellMode.get -> string?
 ModularPipelines.Node.Options.PnpmDlxOptions.ShellMode.set -> void
 ModularPipelines.Node.Options.PnpmInitOptions
 ModularPipelines.Node.Options.PnpmInitOptions.Bare.get -> string?
 ModularPipelines.Node.Options.PnpmInitOptions.Bare.set -> void
-ModularPipelines.Node.Options.PnpmInitOptions.InitPackageManager.get -> string?
 ModularPipelines.Node.Options.PnpmInitOptions.InitPackageManager.set -> void
 ModularPipelines.Node.Options.PnpmInitOptions.InitType.get -> string?
 ModularPipelines.Node.Options.PnpmInitOptions.InitType.set -> void
@@ -550,23 +528,18 @@ ModularPipelines.Node.Options.PnpmOptions.PnpmOptions(ModularPipelines.Node.Opti
 ModularPipelines.Node.Options.PnpmPublishOptions
 ModularPipelines.Node.Options.PnpmPublishOptions.Access.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.Access.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.Batch.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.Batch.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.ChangedFilesIgnorePattern.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.ChangedFilesIgnorePattern.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.DryRun.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.DryRun.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.FailIfNoMatch.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.FailIfNoMatch.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.Filter.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.Filter.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.FilterProd.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.FilterProd.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.Force.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.Force.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.IgnoreScripts.get -> bool?
 ModularPipelines.Node.Options.PnpmPublishOptions.IgnoreScripts.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.Json.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.Json.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.NoGitChecks.get -> bool?
 ModularPipelines.Node.Options.PnpmPublishOptions.NoGitChecks.set -> void
@@ -578,73 +551,55 @@ ModularPipelines.Node.Options.PnpmPublishOptions.PublishBranch.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.PublishBranch.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.Recursive.get -> bool?
 ModularPipelines.Node.Options.PnpmPublishOptions.Recursive.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.ReportSummary.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.ReportSummary.set -> void
-ModularPipelines.Node.Options.PnpmPublishOptions.SkipManifestObfuscation.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.SkipManifestObfuscation.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.Tag.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.Tag.set -> void
 ModularPipelines.Node.Options.PnpmPublishOptions.TestPattern.get -> string?
 ModularPipelines.Node.Options.PnpmPublishOptions.TestPattern.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions
-ModularPipelines.Node.Options.PnpmRunOptions.AggregateOutput.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.AggregateOutput.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.ChangedFilesIgnorePattern.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.ChangedFilesIgnorePattern.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.Dir.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Dir.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.FailIfNoMatch.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.FailIfNoMatch.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.Filter.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Filter.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.FilterProd.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.FilterProd.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.Help.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Help.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.IfPresent.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.IfPresent.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.Loglevel.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Loglevel.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.NoBail.get -> bool?
 ModularPipelines.Node.Options.PnpmRunOptions.NoBail.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.Parallel.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Parallel.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.PnpmRunOptions() -> void
 ModularPipelines.Node.Options.PnpmRunOptions.PnpmRunOptions(ModularPipelines.Node.Options.PnpmRunOptions! original) -> void
 ModularPipelines.Node.Options.PnpmRunOptions.Recursive.get -> bool?
 ModularPipelines.Node.Options.PnpmRunOptions.Recursive.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.ReporterHidePrefix.get -> string?
-ModularPipelines.Node.Options.PnpmRunOptions.ReporterHidePrefix.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.ReportSummary.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.ReportSummary.set -> void
+ModularPipelines.Node.Options.PnpmRunOptions.ReporterHidePrefix.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.ResumeFrom.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.ResumeFrom.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.Sequential.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Sequential.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.Stream.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Stream.set -> void
 ModularPipelines.Node.Options.PnpmRunOptions.TestPattern.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.TestPattern.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.UseStderr.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.UseStderr.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.WorkspaceRoot.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.WorkspaceRoot.set -> void
-ModularPipelines.Node.Options.PnpmRunOptions.Yes.get -> string?
 ModularPipelines.Node.Options.PnpmRunOptions.Yes.set -> void
 ModularPipelines.Node.Options.PnpmStageOptions
 ModularPipelines.Node.Options.PnpmStageOptions.Access.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.Access.set -> void
 ModularPipelines.Node.Options.PnpmStageOptions.ChangedFilesIgnorePattern.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.ChangedFilesIgnorePattern.set -> void
-ModularPipelines.Node.Options.PnpmStageOptions.DryRun.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.DryRun.set -> void
-ModularPipelines.Node.Options.PnpmStageOptions.FailIfNoMatch.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.FailIfNoMatch.set -> void
 ModularPipelines.Node.Options.PnpmStageOptions.Filter.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.Filter.set -> void
 ModularPipelines.Node.Options.PnpmStageOptions.FilterProd.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.FilterProd.set -> void
-ModularPipelines.Node.Options.PnpmStageOptions.Json.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.Json.set -> void
 ModularPipelines.Node.Options.PnpmStageOptions.Otp.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.Otp.set -> void
@@ -659,11 +614,9 @@ ModularPipelines.Node.Options.PnpmStageOptions.Tag.set -> void
 ModularPipelines.Node.Options.PnpmStageOptions.TestPattern.get -> string?
 ModularPipelines.Node.Options.PnpmStageOptions.TestPattern.set -> void
 ModularPipelines.Node.Options.PnpmUnlinkOptions
-ModularPipelines.Node.Options.PnpmUnlinkOptions.AggregateOutput.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.AggregateOutput.set -> void
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Dir.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Dir.set -> void
-ModularPipelines.Node.Options.PnpmUnlinkOptions.Help.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Help.set -> void
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Loglevel.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Loglevel.set -> void
@@ -671,28 +624,20 @@ ModularPipelines.Node.Options.PnpmUnlinkOptions.PnpmUnlinkOptions() -> void
 ModularPipelines.Node.Options.PnpmUnlinkOptions.PnpmUnlinkOptions(ModularPipelines.Node.Options.PnpmUnlinkOptions! original) -> void
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Recursive.get -> bool?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Recursive.set -> void
-ModularPipelines.Node.Options.PnpmUnlinkOptions.Stream.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Stream.set -> void
-ModularPipelines.Node.Options.PnpmUnlinkOptions.UseStderr.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.UseStderr.set -> void
-ModularPipelines.Node.Options.PnpmUnlinkOptions.WorkspaceRoot.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.WorkspaceRoot.set -> void
-ModularPipelines.Node.Options.PnpmUnlinkOptions.Yes.get -> string?
 ModularPipelines.Node.Options.PnpmUnlinkOptions.Yes.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions
-ModularPipelines.Node.Options.PnpmWhyOptions.AggregateOutput.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.AggregateOutput.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.ChangedFilesIgnorePattern.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.ChangedFilesIgnorePattern.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.Depth.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Depth.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Dev.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Dev.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.Dir.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Dir.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.ExcludePeers.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.ExcludePeers.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.FailIfNoMatch.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.FailIfNoMatch.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.Filter.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Filter.set -> void
@@ -702,36 +647,25 @@ ModularPipelines.Node.Options.PnpmWhyOptions.Global.get -> bool?
 ModularPipelines.Node.Options.PnpmWhyOptions.Global.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.GlobalDir.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.GlobalDir.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Help.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Help.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Json.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Json.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.Loglevel.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Loglevel.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Long.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Long.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.NoOptional.get -> bool?
 ModularPipelines.Node.Options.PnpmWhyOptions.NoOptional.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Parseable.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Parseable.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.PnpmWhyOptions() -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.PnpmWhyOptions(ModularPipelines.Node.Options.PnpmWhyOptions! original) -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Prod.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Prod.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.Recursive.get -> bool?
 ModularPipelines.Node.Options.PnpmWhyOptions.Recursive.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Stream.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Stream.set -> void
 ModularPipelines.Node.Options.PnpmWhyOptions.TestPattern.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.TestPattern.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.UseStderr.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.UseStderr.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.WorkspaceRoot.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.WorkspaceRoot.set -> void
-ModularPipelines.Node.Options.PnpmWhyOptions.Yes.get -> string?
 ModularPipelines.Node.Options.PnpmWhyOptions.Yes.set -> void
 ModularPipelines.Node.Services.IPnpm
-override abstract ModularPipelines.Node.Options.PnpmOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmOptions!
 override ModularPipelines.Node.Models.NpmAccessGetStatusOptions.<Clone>$() -> ModularPipelines.Node.Models.NpmAccessGetStatusOptions!
 override ModularPipelines.Node.Models.NpmAccessGetStatusOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Node.Models.NpmAccessGetStatusOptions.Equals(object? obj) -> bool
@@ -1373,6 +1307,7 @@ override ModularPipelines.Node.Options.PnpmWhyOptions.Equals(object? obj) -> boo
 override ModularPipelines.Node.Options.PnpmWhyOptions.GetHashCode() -> int
 override ModularPipelines.Node.Options.PnpmWhyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Node.Options.PnpmWhyOptions.ToString() -> string!
+override abstract ModularPipelines.Node.Options.PnpmOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmOptions!
 override sealed ModularPipelines.Node.Models.NpmAccessGetStatusOptions.Equals(ModularPipelines.Node.Models.NpmOptions? other) -> bool
 override sealed ModularPipelines.Node.Models.NpmAccessGrantOptions.Equals(ModularPipelines.Node.Models.NpmOptions? other) -> bool
 override sealed ModularPipelines.Node.Models.NpmAccessListCollaboratorsOptions.Equals(ModularPipelines.Node.Models.NpmOptions? other) -> bool

--- a/src/ModularPipelines.Node/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Node/PublicAPI.Unshipped.txt
@@ -100,6 +100,71 @@
 *REMOVED*ModularPipelines.Node.INvm.UseAsync(string! version, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Node.INvm.VersionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Node.INvm.WhichAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.AggregateOutput.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.Config.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.FailIfNoMatch.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.Help.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.PnpmAddOptions() -> void
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.SaveCatalog.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.SaveProd.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.Stream.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.UseStderr.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.Workspace.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.WorkspaceRoot.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAddOptions.Yes.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAuditOptions.Dev.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreRegistryErrors.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreUnfixable.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAuditOptions.Interactive.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAuditOptions.Json.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmAuditOptions.Prod.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmCreateOptions.PnpmCreateOptions() -> void
+*REMOVED*ModularPipelines.Node.Options.PnpmDlxOptions.PnpmDlxOptions() -> void
+*REMOVED*ModularPipelines.Node.Options.PnpmDlxOptions.ShellMode.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmInitOptions.InitPackageManager.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.Batch.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.DryRun.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.FailIfNoMatch.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.Force.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.Json.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.ReportSummary.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmPublishOptions.SkipManifestObfuscation.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.AggregateOutput.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.FailIfNoMatch.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.Help.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.IfPresent.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.Parallel.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.PnpmRunOptions() -> void
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.ReportSummary.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.ReporterHidePrefix.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.Sequential.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.Stream.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.UseStderr.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.WorkspaceRoot.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmRunOptions.Yes.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmStageOptions.DryRun.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmStageOptions.FailIfNoMatch.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmStageOptions.Json.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmUnlinkOptions.AggregateOutput.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmUnlinkOptions.Help.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmUnlinkOptions.Stream.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmUnlinkOptions.UseStderr.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmUnlinkOptions.WorkspaceRoot.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmUnlinkOptions.Yes.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.AggregateOutput.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Dev.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.ExcludePeers.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.FailIfNoMatch.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Help.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Json.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Long.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Parseable.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.PnpmWhyOptions() -> void
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Prod.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Stream.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.UseStderr.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.WorkspaceRoot.get -> string?
+*REMOVED*ModularPipelines.Node.Options.PnpmWhyOptions.Yes.get -> string?
 *REMOVED*ModularPipelines.Node.Services.IPnpm.AddAsync(ModularPipelines.Node.Options.PnpmAddOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Node.Services.IPnpm.AuditAsync(ModularPipelines.Node.Options.PnpmAuditOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Node.Services.IPnpm.CreateAsync(ModularPipelines.Node.Options.PnpmCreateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -213,15 +278,380 @@ ModularPipelines.Node.INvm.InstallAsync(string! version, System.Threading.Cancel
 ModularPipelines.Node.INvm.UseAsync(string! version, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.INvm.VersionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.INvm.WhichAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Node.Services.IPnpm.AddAsync(ModularPipelines.Node.Options.PnpmAddOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Options.PnpmAddOptions.AggregateOutput.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Config.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Deconstruct(out string! Name) -> void
+ModularPipelines.Node.Options.PnpmAddOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Help.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Name.get -> string!
+ModularPipelines.Node.Options.PnpmAddOptions.Name.init -> void
+ModularPipelines.Node.Options.PnpmAddOptions.PnpmAddOptions(string! Name) -> void
+ModularPipelines.Node.Options.PnpmAddOptions.SaveCatalog.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.SaveProd.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Stream.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.UseStderr.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Workspace.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.WorkspaceRoot.get -> bool?
+ModularPipelines.Node.Options.PnpmAddOptions.Yes.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditOptions.Dev.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreRegistryErrors.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditOptions.IgnoreUnfixable.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditOptions.Interactive.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditOptions.Prod.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.AuditLevel.get -> string?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.AuditLevel.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Dev.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Dev.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Fix.get -> string?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Fix.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Ignore.get -> string?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Ignore.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.IgnoreRegistryErrors.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.IgnoreRegistryErrors.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.IgnoreUnfixable.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.IgnoreUnfixable.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Interactive.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Interactive.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.NoOptional.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.NoOptional.set -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.PnpmAuditSignaturesOptions() -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.PnpmAuditSignaturesOptions(ModularPipelines.Node.Options.PnpmAuditSignaturesOptions! original) -> void
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Prod.get -> bool?
+ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Prod.set -> void
+ModularPipelines.Node.Options.PnpmCreateOptions.Deconstruct(out string! Name) -> void
+ModularPipelines.Node.Options.PnpmCreateOptions.Name.get -> string!
+ModularPipelines.Node.Options.PnpmCreateOptions.Name.init -> void
+ModularPipelines.Node.Options.PnpmCreateOptions.PnpmCreateOptions(string! Name) -> void
+ModularPipelines.Node.Options.PnpmDlxOptions.Args.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Node.Options.PnpmDlxOptions.Args.set -> void
+ModularPipelines.Node.Options.PnpmDlxOptions.Command.get -> string!
+ModularPipelines.Node.Options.PnpmDlxOptions.Command.init -> void
+ModularPipelines.Node.Options.PnpmDlxOptions.Deconstruct(out string! Command) -> void
+ModularPipelines.Node.Options.PnpmDlxOptions.PnpmDlxOptions(string! Command) -> void
+ModularPipelines.Node.Options.PnpmDlxOptions.ShellMode.get -> bool?
+ModularPipelines.Node.Options.PnpmInitOptions.InitPackageManager.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.Batch.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.Force.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.ReportSummary.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.SkipManifestObfuscation.get -> bool?
+ModularPipelines.Node.Options.PnpmPublishOptions.Tarball.get -> string?
+ModularPipelines.Node.Options.PnpmPublishOptions.Tarball.set -> void
+ModularPipelines.Node.Options.PnpmRunOptions.AggregateOutput.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.Args.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Node.Options.PnpmRunOptions.Args.set -> void
+ModularPipelines.Node.Options.PnpmRunOptions.Command.get -> string!
+ModularPipelines.Node.Options.PnpmRunOptions.Command.init -> void
+ModularPipelines.Node.Options.PnpmRunOptions.Deconstruct(out string! Command) -> void
+ModularPipelines.Node.Options.PnpmRunOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmRunOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.Help.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.IfPresent.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.Parallel.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.PnpmRunOptions(string! Command) -> void
+ModularPipelines.Node.Options.PnpmRunOptions.ReportSummary.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.ReporterHidePrefix.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.Sequential.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.Stream.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.UseStderr.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.WorkspaceRoot.get -> bool?
+ModularPipelines.Node.Options.PnpmRunOptions.Yes.get -> bool?
+ModularPipelines.Node.Options.PnpmStageApproveOptions
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Access.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Access.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.ChangedFilesIgnorePattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.ChangedFilesIgnorePattern.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.FailIfNoMatch.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Filter.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Filter.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.FilterProd.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.FilterProd.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Otp.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Otp.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.PnpmStageApproveOptions() -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.PnpmStageApproveOptions(ModularPipelines.Node.Options.PnpmStageApproveOptions! original) -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Recursive.get -> bool?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Recursive.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Registry.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Registry.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.StageId.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.StageId.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Tag.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.Tag.set -> void
+ModularPipelines.Node.Options.PnpmStageApproveOptions.TestPattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageApproveOptions.TestPattern.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Access.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Access.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.ChangedFilesIgnorePattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.ChangedFilesIgnorePattern.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Deconstruct(out string! StageId) -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.FailIfNoMatch.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Filter.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Filter.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.FilterProd.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.FilterProd.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Otp.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Otp.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.PnpmStageDownloadOptions(ModularPipelines.Node.Options.PnpmStageDownloadOptions! original) -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.PnpmStageDownloadOptions(string! StageId) -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Recursive.get -> bool?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Recursive.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Registry.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Registry.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.StageId.get -> string!
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.StageId.init -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Tag.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.Tag.set -> void
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.TestPattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageDownloadOptions.TestPattern.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions
+ModularPipelines.Node.Options.PnpmStageListOptions.Access.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.Access.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.ChangedFilesIgnorePattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.ChangedFilesIgnorePattern.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStageListOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStageListOptions.FailIfNoMatch.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.Filter.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.Filter.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.FilterProd.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.FilterProd.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStageListOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.Otp.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.Otp.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.PackageSpec.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.PackageSpec.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.PnpmStageListOptions() -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.PnpmStageListOptions(ModularPipelines.Node.Options.PnpmStageListOptions! original) -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.Recursive.get -> bool?
+ModularPipelines.Node.Options.PnpmStageListOptions.Recursive.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.Registry.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.Registry.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.Tag.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.Tag.set -> void
+ModularPipelines.Node.Options.PnpmStageListOptions.TestPattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageListOptions.TestPattern.set -> void
+ModularPipelines.Node.Options.PnpmStageOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStageOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStageOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStagePublishOptions
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Access.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Access.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.ChangedFilesIgnorePattern.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.ChangedFilesIgnorePattern.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.FailIfNoMatch.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Filter.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Filter.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.FilterProd.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.FilterProd.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Otp.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Otp.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.PnpmStagePublishOptions() -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.PnpmStagePublishOptions(ModularPipelines.Node.Options.PnpmStagePublishOptions! original) -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Recursive.get -> bool?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Recursive.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Registry.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Registry.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Tag.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Tag.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Tarball.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.Tarball.set -> void
+ModularPipelines.Node.Options.PnpmStagePublishOptions.TestPattern.get -> string?
+ModularPipelines.Node.Options.PnpmStagePublishOptions.TestPattern.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Access.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Access.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.ChangedFilesIgnorePattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.ChangedFilesIgnorePattern.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Deconstruct(out string! StageId) -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.FailIfNoMatch.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Filter.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Filter.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.FilterProd.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.FilterProd.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Otp.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Otp.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.PnpmStageRejectOptions(ModularPipelines.Node.Options.PnpmStageRejectOptions! original) -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.PnpmStageRejectOptions(string! StageId) -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Recursive.get -> bool?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Recursive.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Registry.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Registry.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.StageId.get -> string!
+ModularPipelines.Node.Options.PnpmStageRejectOptions.StageId.init -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Tag.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.Tag.set -> void
+ModularPipelines.Node.Options.PnpmStageRejectOptions.TestPattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageRejectOptions.TestPattern.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions
+ModularPipelines.Node.Options.PnpmStageViewOptions.Access.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Access.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.ChangedFilesIgnorePattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.ChangedFilesIgnorePattern.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Deconstruct(out string! StageId) -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.DryRun.get -> bool?
+ModularPipelines.Node.Options.PnpmStageViewOptions.DryRun.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmStageViewOptions.FailIfNoMatch.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Filter.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Filter.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.FilterProd.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.FilterProd.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Json.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Otp.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Otp.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.PnpmStageViewOptions(ModularPipelines.Node.Options.PnpmStageViewOptions! original) -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.PnpmStageViewOptions(string! StageId) -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Recursive.get -> bool?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Recursive.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Registry.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Registry.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.StageId.get -> string!
+ModularPipelines.Node.Options.PnpmStageViewOptions.StageId.init -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.Tag.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.Tag.set -> void
+ModularPipelines.Node.Options.PnpmStageViewOptions.TestPattern.get -> string?
+ModularPipelines.Node.Options.PnpmStageViewOptions.TestPattern.set -> void
+ModularPipelines.Node.Options.PnpmUnlinkOptions.AggregateOutput.get -> bool?
+ModularPipelines.Node.Options.PnpmUnlinkOptions.Help.get -> bool?
+ModularPipelines.Node.Options.PnpmUnlinkOptions.Pkg.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Node.Options.PnpmUnlinkOptions.Pkg.set -> void
+ModularPipelines.Node.Options.PnpmUnlinkOptions.Stream.get -> bool?
+ModularPipelines.Node.Options.PnpmUnlinkOptions.UseStderr.get -> bool?
+ModularPipelines.Node.Options.PnpmUnlinkOptions.WorkspaceRoot.get -> bool?
+ModularPipelines.Node.Options.PnpmUnlinkOptions.Yes.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.AggregateOutput.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! Pkg) -> void
+ModularPipelines.Node.Options.PnpmWhyOptions.Dev.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.ExcludePeers.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.FailIfNoMatch.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Help.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Json.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Long.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Parseable.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Pkg.get -> System.Collections.Generic.IEnumerable<string!>!
+ModularPipelines.Node.Options.PnpmWhyOptions.Pkg.init -> void
+ModularPipelines.Node.Options.PnpmWhyOptions.PnpmWhyOptions(System.Collections.Generic.IEnumerable<string!>! Pkg) -> void
+ModularPipelines.Node.Options.PnpmWhyOptions.Prod.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Stream.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.UseStderr.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.WorkspaceRoot.get -> bool?
+ModularPipelines.Node.Options.PnpmWhyOptions.Yes.get -> bool?
+ModularPipelines.Node.Services.IPnpm.AddAsync(ModularPipelines.Node.Options.PnpmAddOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.Services.IPnpm.AuditAsync(ModularPipelines.Node.Options.PnpmAuditOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Node.Services.IPnpm.CreateAsync(ModularPipelines.Node.Options.PnpmCreateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Node.Services.IPnpm.DlxAsync(ModularPipelines.Node.Options.PnpmDlxOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.AuditSignaturesAsync(ModularPipelines.Node.Options.PnpmAuditSignaturesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.CreateAsync(ModularPipelines.Node.Options.PnpmCreateOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.DlxAsync(ModularPipelines.Node.Options.PnpmDlxOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.Services.IPnpm.InitAsync(ModularPipelines.Node.Options.PnpmInitOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.Services.IPnpm.PublishAsync(ModularPipelines.Node.Options.PnpmPublishOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Node.Services.IPnpm.RunAsync(ModularPipelines.Node.Options.PnpmRunOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.RunAsync(ModularPipelines.Node.Options.PnpmRunOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.StageApproveAsync(ModularPipelines.Node.Options.PnpmStageApproveOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.Services.IPnpm.StageAsync(ModularPipelines.Node.Options.PnpmStageOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.StageDownloadAsync(ModularPipelines.Node.Options.PnpmStageDownloadOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.StageListAsync(ModularPipelines.Node.Options.PnpmStageListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.StagePublishAsync(ModularPipelines.Node.Options.PnpmStagePublishOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.StageRejectAsync(ModularPipelines.Node.Options.PnpmStageRejectOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Node.Services.IPnpm.StageViewAsync(ModularPipelines.Node.Options.PnpmStageViewOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Node.Services.IPnpm.UnlinkAsync(ModularPipelines.Node.Options.PnpmUnlinkOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Node.Services.IPnpm.WhyAsync(ModularPipelines.Node.Options.PnpmWhyOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-static ModularPipelines.Node.Extensions.NodeExtensions.Node(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Node.INode!
-static ModularPipelines.Node.Extensions.PnpmExtensions.Pnpm(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Node.Services.IPnpm!
+ModularPipelines.Node.Services.IPnpm.WhyAsync(ModularPipelines.Node.Options.PnpmWhyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+override ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmAuditSignaturesOptions!
+override ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.ToString() -> string!
+override ModularPipelines.Node.Options.PnpmStageApproveOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmStageApproveOptions!
+override ModularPipelines.Node.Options.PnpmStageApproveOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmStageApproveOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmStageApproveOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmStageApproveOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmStageApproveOptions.ToString() -> string!
+override ModularPipelines.Node.Options.PnpmStageDownloadOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmStageDownloadOptions!
+override ModularPipelines.Node.Options.PnpmStageDownloadOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmStageDownloadOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmStageDownloadOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmStageDownloadOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmStageDownloadOptions.ToString() -> string!
+override ModularPipelines.Node.Options.PnpmStageListOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmStageListOptions!
+override ModularPipelines.Node.Options.PnpmStageListOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmStageListOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmStageListOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmStageListOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmStageListOptions.ToString() -> string!
+override ModularPipelines.Node.Options.PnpmStagePublishOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmStagePublishOptions!
+override ModularPipelines.Node.Options.PnpmStagePublishOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmStagePublishOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmStagePublishOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmStagePublishOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmStagePublishOptions.ToString() -> string!
+override ModularPipelines.Node.Options.PnpmStageRejectOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmStageRejectOptions!
+override ModularPipelines.Node.Options.PnpmStageRejectOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmStageRejectOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmStageRejectOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmStageRejectOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmStageRejectOptions.ToString() -> string!
+override ModularPipelines.Node.Options.PnpmStageViewOptions.<Clone>$() -> ModularPipelines.Node.Options.PnpmStageViewOptions!
+override ModularPipelines.Node.Options.PnpmStageViewOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Node.Options.PnpmStageViewOptions.Equals(object? obj) -> bool
+override ModularPipelines.Node.Options.PnpmStageViewOptions.GetHashCode() -> int
+override ModularPipelines.Node.Options.PnpmStageViewOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Node.Options.PnpmStageViewOptions.ToString() -> string!
+override sealed ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+override sealed ModularPipelines.Node.Options.PnpmStageApproveOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+override sealed ModularPipelines.Node.Options.PnpmStageDownloadOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+override sealed ModularPipelines.Node.Options.PnpmStageListOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+override sealed ModularPipelines.Node.Options.PnpmStagePublishOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+override sealed ModularPipelines.Node.Options.PnpmStageRejectOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+override sealed ModularPipelines.Node.Options.PnpmStageViewOptions.Equals(ModularPipelines.Node.Options.PnpmOptions? other) -> bool
+static ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.operator !=(ModularPipelines.Node.Options.PnpmAuditSignaturesOptions? left, ModularPipelines.Node.Options.PnpmAuditSignaturesOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.operator ==(ModularPipelines.Node.Options.PnpmAuditSignaturesOptions? left, ModularPipelines.Node.Options.PnpmAuditSignaturesOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageApproveOptions.operator !=(ModularPipelines.Node.Options.PnpmStageApproveOptions? left, ModularPipelines.Node.Options.PnpmStageApproveOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageApproveOptions.operator ==(ModularPipelines.Node.Options.PnpmStageApproveOptions? left, ModularPipelines.Node.Options.PnpmStageApproveOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageDownloadOptions.operator !=(ModularPipelines.Node.Options.PnpmStageDownloadOptions? left, ModularPipelines.Node.Options.PnpmStageDownloadOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageDownloadOptions.operator ==(ModularPipelines.Node.Options.PnpmStageDownloadOptions? left, ModularPipelines.Node.Options.PnpmStageDownloadOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageListOptions.operator !=(ModularPipelines.Node.Options.PnpmStageListOptions? left, ModularPipelines.Node.Options.PnpmStageListOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageListOptions.operator ==(ModularPipelines.Node.Options.PnpmStageListOptions? left, ModularPipelines.Node.Options.PnpmStageListOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStagePublishOptions.operator !=(ModularPipelines.Node.Options.PnpmStagePublishOptions? left, ModularPipelines.Node.Options.PnpmStagePublishOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStagePublishOptions.operator ==(ModularPipelines.Node.Options.PnpmStagePublishOptions? left, ModularPipelines.Node.Options.PnpmStagePublishOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageRejectOptions.operator !=(ModularPipelines.Node.Options.PnpmStageRejectOptions? left, ModularPipelines.Node.Options.PnpmStageRejectOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageRejectOptions.operator ==(ModularPipelines.Node.Options.PnpmStageRejectOptions? left, ModularPipelines.Node.Options.PnpmStageRejectOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageViewOptions.operator !=(ModularPipelines.Node.Options.PnpmStageViewOptions? left, ModularPipelines.Node.Options.PnpmStageViewOptions? right) -> bool
+static ModularPipelines.Node.Options.PnpmStageViewOptions.operator ==(ModularPipelines.Node.Options.PnpmStageViewOptions? left, ModularPipelines.Node.Options.PnpmStageViewOptions? right) -> bool
+virtual ModularPipelines.Node.Options.PnpmAuditSignaturesOptions.Equals(ModularPipelines.Node.Options.PnpmAuditSignaturesOptions? other) -> bool
+virtual ModularPipelines.Node.Options.PnpmStageApproveOptions.Equals(ModularPipelines.Node.Options.PnpmStageApproveOptions? other) -> bool
+virtual ModularPipelines.Node.Options.PnpmStageDownloadOptions.Equals(ModularPipelines.Node.Options.PnpmStageDownloadOptions? other) -> bool
+virtual ModularPipelines.Node.Options.PnpmStageListOptions.Equals(ModularPipelines.Node.Options.PnpmStageListOptions? other) -> bool
+virtual ModularPipelines.Node.Options.PnpmStagePublishOptions.Equals(ModularPipelines.Node.Options.PnpmStagePublishOptions? other) -> bool
+virtual ModularPipelines.Node.Options.PnpmStageRejectOptions.Equals(ModularPipelines.Node.Options.PnpmStageRejectOptions? other) -> bool
+virtual ModularPipelines.Node.Options.PnpmStageViewOptions.Equals(ModularPipelines.Node.Options.PnpmStageViewOptions? other) -> bool

--- a/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
@@ -27,7 +27,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> AddAsync(PnpmAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AddAsync(PnpmAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -57,7 +57,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> CreateAsync(PnpmCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CreateAsync(PnpmCreateOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -107,7 +107,7 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public Task<CommandResult> StageApproveAsync(PnpmStageApproveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StageApproveAsync(PnpmStageApproveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Node/Services/Pnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/Pnpm.Generated.cs
@@ -34,11 +34,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AddAsync(
-        PnpmAddOptions? options = null,
+        PnpmAddOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmAddOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -61,11 +61,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> CreateAsync(
-        PnpmCreateOptions? options = null,
+        PnpmCreateOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmCreateOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -106,11 +106,11 @@ internal partial class Pnpm : IPnpm
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> StageApproveAsync(
-        PnpmStageApproveOptions options,
+        PnpmStageApproveOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new PnpmStageApproveOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pnpm** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pnpm (11.25.0): 17 commands, tree 18696e1b021b815b55d2466263ab6d8af87d0d9de99a4f2adf93ef61a3961e51
  - Baseline comparison: 17 commands at 11.24.0 -> 17 commands at 11.25.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator