### PR TITLE
[Automated] Update argocd CLI Options

### DIFF
--- a/src/ModularPipelines.ArgoCd/Generated/ArgoCd.Generation.json
+++ b/src/ModularPipelines.ArgoCd/Generated/ArgoCd.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "argocd",
+  "toolVersion": "argocd: v3.5.2+e258ee2   BuildDate: 2026-08-27T09:34:36Z   GitCommit: e258ee23c3e52266d407572f4bcdfe7d9ed36cb5   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64",
+  "commandTreeSha256": "f12af4288e7a39a4ac683d429edf0cf75b10df027963bc60b408a2f2ea0df4b2",
+  "generatorSourceSha256": "3a0f1b60d1f3d47891ce37485ca0b428775eedd54571e4e1e4e72d9257f5e919"
+}

--- a/src/ModularPipelines.ArgoCd/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.ArgoCd/PublicAPI.Shipped.txt
@@ -186,17 +186,6 @@ ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterGenerateSpecOutput.Yaml = 1 -> M
 ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterGenerateSpecRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterGenerateSpecRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterGenerateSpecRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterGenerateSpecRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterGenerateSpecRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterLogformat
@@ -771,89 +760,6 @@ ModularPipelines.ArgoCd.Enums.ArgoCdAppHistoryOutput.Wide = 0 -> ModularPipeline
 ModularPipelines.ArgoCd.Enums.ArgoCdAppHistoryRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAppHistoryRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAppHistoryRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAppHistoryRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAppHistoryRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Json = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Name = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Wide = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Yaml = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat
@@ -1019,6 +925,89 @@ ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitLoglevel.Warn = 2 -> ModularPipelines
 ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetCreateRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetDeleteRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGenerateRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetGetRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Json = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Name = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Wide = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput.Yaml = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetListRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdApplicationSetRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdCertAddSshLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdCertAddSshLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdCertAddSshLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdCertAddSshLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdCertAddSshLogformat
@@ -1311,17 +1300,6 @@ ModularPipelines.ArgoCd.Enums.ArgoCdProjAddOrphanedIgnoreLoglevel.Warn = 2 -> Mo
 ModularPipelines.ArgoCd.Enums.ArgoCdProjAddOrphanedIgnoreRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdProjAddOrphanedIgnoreRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddOrphanedIgnoreRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdProjAddOrphanedIgnoreRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddOrphanedIgnoreRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSourceLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSourceLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSourceLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSourceLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSourceLogformat
@@ -1496,17 +1474,6 @@ ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveOrphanedIgnoreLoglevel.Warn = 2 ->
 ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveOrphanedIgnoreRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveOrphanedIgnoreRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveOrphanedIgnoreRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveOrphanedIgnoreRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveOrphanedIgnoreRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSourceLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSourceLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSourceLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSourceLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSourceLogformat
@@ -1887,55 +1854,6 @@ ModularPipelines.ArgoCd.Enums.ArgoCdRepoAddLoglevel.Warn = 2 -> ModularPipelines
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoAddRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoAddRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoAddRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoAddRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoAddRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Url = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress
-ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat
@@ -1985,6 +1903,55 @@ ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmLoglevel.Warn = 2 -> ModularPipelines.
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress
 ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsAddRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Url = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Wide = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput.Yaml = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListOutput
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsListRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsRmRedisCompress
 ModularPipelines.ArgoCd.Extensions.ArgoCdExtensions
 ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions
 ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.ArgoCdAccountBcryptOptions() -> void
@@ -2418,24 +2385,12 @@ ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ArgoCdAccountOptions() -> v
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ArgoCdAccountOptions(ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ArgocdContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsUid.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Config.get -> string?
@@ -2446,8 +2401,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ControllerName.get -> strin
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.GrpcWebRootPath.get -> string?
@@ -2500,8 +2453,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.User.get -> string?
@@ -2960,8 +2911,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Insecur
 ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.L.get -> string?
@@ -3183,105 +3134,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Shard.get 
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Shard.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.SystemNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.SystemNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgoCdAdminClusterKubeconfigOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgoCdAdminClusterKubeconfigOptions(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsUid.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCertificate.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Cluster.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Cluster.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClusterUrl.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClusterUrl.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Context.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Context.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.DisableCompression.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.InsecureSkipTlsVerify.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Namespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Namespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.OutputPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.OutputPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Password.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Password.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ProxyUrl.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ProxyUrl.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RequestTimeout.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RequestTimeout.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.TlsServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Token.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Token.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.User.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.User.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Username.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions(string! Pattern) -> void
@@ -3334,7 +3186,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedMod
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.KubeContext.set -> void
@@ -3436,8 +3288,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedMode
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterNamespacesEnableNamespacedModeLogformat?
@@ -3535,7 +3387,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Insecure.get
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.KubeContext.set -> void
@@ -3691,8 +3543,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Insecure.get -> 
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterShardsLogformat?
@@ -3725,8 +3577,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisClientKey.g
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterShardsRedisCompress?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Redisdb.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Redisdb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisHaproxyName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisHaproxyName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisInsecureSkipTlsVerify.get -> bool?
@@ -3735,6 +3585,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisName.get ->
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisUseTls.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RedisUseTls.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Redisdb.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Redisdb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Replicas.get -> int?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Replicas.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.RepoServerName.get -> string?
@@ -3850,8 +3702,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisClientKey.ge
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterStatsRedisCompress?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Redisdb.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Redisdb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisHaproxyName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisHaproxyName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisInsecureSkipTlsVerify.get -> bool?
@@ -3860,6 +3710,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisName.get -> 
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisUseTls.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RedisUseTls.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Redisdb.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Redisdb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Replicas.get -> int?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Replicas.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.RepoServerName.get -> string?
@@ -4040,7 +3892,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.Insecure.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.KubeContext.set -> void
@@ -4146,7 +3998,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.Insecure.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.KubeContext.set -> void
@@ -4253,8 +4105,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Insecure.get -
 ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminInitialPasswordLogformat?
@@ -4308,8 +4160,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServer
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -4357,7 +4207,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.Insecure.set -> 
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminNotificationsLogformat?
@@ -4419,8 +4269,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Argoc
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -4467,8 +4315,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Insec
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminNotificationsTemplateGetLogformat?
@@ -4526,8 +4374,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.Ar
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -4575,7 +4421,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.In
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.KubeContext.set -> void
@@ -4638,8 +4484,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRe
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -4686,7 +4530,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.Insecure
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.KubeContext.set -> void
@@ -4743,8 +4587,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Argocd
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -4791,7 +4633,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Insecu
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.KubeContext.set -> void
@@ -4850,8 +4692,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRep
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -4898,8 +4738,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Insecure.
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminNotificationsTriggerLogformat?
@@ -4955,8 +4795,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Argocd
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServer.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServerPlaintext.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServerPlaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServerStrictTls.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServerStrictTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.As.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.As.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -5004,8 +4842,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Insecu
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminNotificationsTriggerRunLogformat?
@@ -5523,7 +5361,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.Insecure.
 ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.KubeContext.set -> void
@@ -5800,7 +5638,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.LoadClusterSettings.get -> bool?
@@ -5905,8 +5743,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.Insecure.get -
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.LoadClusterSettings.get -> bool?
@@ -6021,7 +5859,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.Insecure.set -> v
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.LoadClusterSettings.get -> bool?
@@ -6122,7 +5960,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.Insecure.
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.LoadClusterSettings.get -> bool?
@@ -6225,7 +6063,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOption
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.KubeContext.set -> void
@@ -6435,8 +6273,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResour
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.LoadClusterSettings.get -> bool?
@@ -6540,7 +6378,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsO
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.LoadClusterSettings.get -> bool?
@@ -6642,8 +6480,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.Inse
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.LoadClusterSettings.get -> bool?
@@ -6746,7 +6584,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOpt
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.KubeContext.set -> void
@@ -6853,8 +6691,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Insecure.get 
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.LoadClusterSettings.get -> bool?
@@ -6902,10 +6740,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.User.set -> v
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ArgoCdAppActionsListOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ArgoCdAppActionsListOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsListOptions.ArgocdContext.get -> string?
@@ -7035,10 +6873,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.Action.get -> string!
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.Action.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.All.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.All.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ArgoCdAppActionsRunOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ArgoCdAppActionsRunOptions(string! ApplicationName, string! Action) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ArgocdContext.get -> string?
@@ -7107,10 +6945,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppActionsRunOptions.ServerName.set -> voi
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.AllowEmpty.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.AllowEmpty.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ArgoCdAppAddSourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ArgoCdAppAddSourceOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ArgocdContext.get -> string?
@@ -7309,10 +7147,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.Values.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ValuesLiteralFile.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppAddSourceOptions.ValuesLiteralFile.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ArgoCdAppConfirmDeletionOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ArgoCdAppConfirmDeletionOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppConfirmDeletionOptions.ArgocdContext.get -> string?
@@ -7375,10 +7213,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.AllowEmpty.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.AllowEmpty.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.Annotations.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.Annotations.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ArgoCdAppCreateOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ArgoCdAppCreateOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ArgocdContext.get -> string?
@@ -7587,10 +7425,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.Values.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ValuesLiteralFile.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppCreateOptions.ValuesLiteralFile.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ApplicationNames.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ApplicationNames.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ApplicationNames.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ApplicationNames.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ArgoCdAppDeleteOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ArgoCdAppDeleteOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.ArgocdContext.get -> string?
@@ -7660,10 +7498,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteOptions.Yes.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.All.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.All.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ArgoCdAppDeleteResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ArgoCdAppDeleteResourceOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ArgocdContext.get -> string?
@@ -7736,10 +7574,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ServerCrt.set -> 
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppDeleteResourceOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ArgoCdAppDiffOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ArgoCdAppDiffOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.ArgocdContext.get -> string?
@@ -7830,10 +7668,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.SourceNames.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.SourcePositions.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdAppDiffOptions.SourcePositions.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ArgoCdAppEditOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ArgoCdAppEditOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ArgocdContext.get -> string?
@@ -7892,10 +7730,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ArgoCdAppGetOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ArgoCdAppGetOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.ArgocdContext.get -> string?
@@ -7970,10 +7808,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.SourcePosition.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.Timeout.get -> int?
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.Timeout.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ArgoCdAppGetResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ArgoCdAppGetResourceOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ArgocdContext.get -> string?
@@ -8046,10 +7884,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ServerName.set -> vo
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ShowManagedFields.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.ShowManagedFields.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.AppNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ApplicationName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ArgoCdAppHistoryOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ArgoCdAppHistoryOptions(string! ApplicationName) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ArgocdContext.get -> string?
@@ -8109,6 +7947,1234 @@ ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgoCdAppListOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgoCdAppListOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Cluster.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Cluster.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Output.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListOutput?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Path.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Path.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Project.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Repo.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Repo.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Selector.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Selector.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgoCdAppLogsOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgoCdAppLogsOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Container.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Container.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Filter.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Filter.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Follow.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Follow.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Group.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Group.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Kind.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Kind.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogsLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogsLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.MatchCase.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.MatchCase.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Name.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Name.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Namespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Namespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Previous.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Previous.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogsRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.SinceSeconds.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.SinceSeconds.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Tail.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Tail.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.UntilTime.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.UntilTime.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgoCdAppManifestsOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgoCdAppManifestsOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Local.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Local.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.LocalRepoRoot.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.LocalRepoRoot.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revision.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revision.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revisions.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revisions.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Source.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsSource?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Source.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourceNames.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourceNames.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourcePositions.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourcePositions.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgoCdAppOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgoCdAppOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Cluster.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Cluster.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Context.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Context.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.InsecureSkipTlsVerify.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.InsecureSkipTlsVerify.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeConfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Namespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Namespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Password.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Password.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ProxyUrl.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ProxyUrl.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RequestTimeout.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RequestTimeout.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Token.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Token.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.User.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.User.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Username.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Username.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgoCdAppPatchOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgoCdAppPatchOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Patch.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Patch.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Type.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Type.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.All.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.All.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgoCdAppPatchResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgoCdAppPatchResourceOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Group.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Group.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Kind.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Kind.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchResourceLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchResourceLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Namespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Namespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Patch.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Patch.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PatchType.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PatchType.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Project.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchResourceRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ResourceName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ResourceName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgoCdAppRemoveSourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgoCdAppRemoveSourceOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRemoveSourceLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRemoveSourceLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRemoveSourceRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourceName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourceName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourcePosition.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourcePosition.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgoCdAppResourcesOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgoCdAppResourcesOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppResourcesLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppResourcesLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Orphaned.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Orphaned.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Output.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Project.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppResourcesRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgoCdAppRollbackOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgoCdAppRollbackOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Id.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Id.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRollbackLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRollbackLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Output.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Prune.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Prune.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRollbackRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Timeout.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Timeout.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AllowEmpty.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AllowEmpty.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgoCdAppSetOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgoCdAppSetOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AutoPrune.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AutoPrune.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ConfigManagementPlugin.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ConfigManagementPlugin.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestServer.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestServer.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryExclude.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryExclude.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryInclude.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryInclude.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryRecurse.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryRecurse.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourcePath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourcePath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRepo.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRepo.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRevision.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRevision.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Env.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Env.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmApiVersions.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmApiVersions.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmChart.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmChart.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmKubeVersion.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmKubeVersion.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmPassCredentials.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmPassCredentials.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSet.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSet.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetFile.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetFile.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetString.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetString.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipCrds.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipCrds.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipSchemaValidation.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipSchemaValidation.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipTests.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipTests.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmVersion.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmVersion.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HydrateToBranch.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HydrateToBranch.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingComponents.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingComponents.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingValueFiles.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingValueFiles.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarCode.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarCode.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarStr.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarStr.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetLibs.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetLibs.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaCode.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaCode.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaStr.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaStr.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeApiVersions.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeApiVersions.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonAnnotation.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonAnnotation.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonLabel.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonLabel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonAnnotation.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonAnnotation.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonLabel.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonLabel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeImage.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeImage.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeKubeVersion.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeKubeVersion.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelIncludeTemplates.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelIncludeTemplates.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelWithoutSelector.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelWithoutSelector.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeReplica.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeReplica.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeVersion.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeVersion.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSetLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSetLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Nameprefix.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Nameprefix.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Namesuffix.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Namesuffix.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Parameter.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Parameter.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Path.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Path.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PluginEnv.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PluginEnv.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Project.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSetRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Ref.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Ref.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ReleaseName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ReleaseName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Repo.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Repo.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Revision.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Revision.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RevisionHistoryLimit.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RevisionHistoryLimit.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SelfHeal.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SelfHeal.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourceName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourceName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourcePosition.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourcePosition.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncOption.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncOption.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncPolicy.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncPolicy.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffDuration.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffDuration.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffFactor.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffFactor.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffMaxDuration.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffMaxDuration.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryLimit.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryLimit.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryRefresh.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryRefresh.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourceBranch.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourceBranch.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourcePath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourcePath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.TagPrefix.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.TagPrefix.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Validate.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Validate.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Values.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Values.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ValuesLiteralFile.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ValuesLiteralFile.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplicationNames.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplicationNames.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplyOutOfSyncOnly.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplyOutOfSyncOnly.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgoCdAppSyncOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgoCdAppSyncOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AssumeYes.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AssumeYes.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Async.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Async.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.DryRun.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.DryRun.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Force.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Force.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.IgnoreNormalizerJqExecutionTimeout.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.IgnoreNormalizerJqExecutionTimeout.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Info.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Info.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Label.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Label.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Local.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Local.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.LocalRepoRoot.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.LocalRepoRoot.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Output.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PreviewChanges.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PreviewChanges.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Project.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Prune.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Prune.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Replace.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Replace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Resource.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Resource.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffDuration.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffDuration.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffFactor.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffFactor.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffMaxDuration.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffMaxDuration.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryLimit.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryLimit.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryRefresh.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryRefresh.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revision.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revision.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revisions.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revisions.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Selector.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Selector.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSide.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSide.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffConcurrency.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffConcurrency.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffMaxBatchKb.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffMaxBatchKb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourceNames.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourceNames.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourcePositions.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourcePositions.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Strategy.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncStrategy?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Strategy.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Timeout.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Timeout.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgoCdAppTerminateOpOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgoCdAppTerminateOpOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppTerminateOpLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppTerminateOpLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppTerminateOpRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ApplicationName.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ApplicationName.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgoCdAppUnsetOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgoCdAppUnsetOptions(string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Deconstruct(out string! ApplicationName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingComponents.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingComponents.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingValueFiles.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingValueFiles.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeImage.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeImage.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeNamespace.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeReplica.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeReplica.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeVersion.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeVersion.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppUnsetLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppUnsetLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Nameprefix.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Nameprefix.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Namesuffix.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Namesuffix.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Parameter.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Parameter.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PassCredentials.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PassCredentials.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PluginEnv.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PluginEnv.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppUnsetRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Ref.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Ref.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourceName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourceName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourcePosition.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourcePosition.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Values.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Values.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ValuesLiteral.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ValuesLiteral.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AppNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AppNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ApplicationNames.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ApplicationNames.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgoCdAppWaitOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgoCdAppWaitOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Degraded.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Degraded.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Delete.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Delete.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Health.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Health.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Hydrated.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Hydrated.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Operation.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Operation.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Output.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Resource.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Resource.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Selector.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Selector.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Suspended.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Suspended.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Sync.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Sync.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Timeout.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Timeout.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.AppsetNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.AppsetNamespace.set -> void
@@ -8445,24 +9511,12 @@ ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ArgoCdApplicationSet
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ArgoCdApplicationSetOptions(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ArgocdContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsUid.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Config.get -> string?
@@ -8473,8 +9527,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ControllerName.get -
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.GrpcWebRootPath.get -> string?
@@ -8527,1258 +9579,12 @@ ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ServerCrt.get -> str
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.User.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.User.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Username.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgoCdAppListOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgoCdAppListOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Cluster.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Cluster.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Output.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListOutput?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Path.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Path.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Project.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppListRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Repo.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Repo.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Selector.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Selector.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgoCdAppLogsOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgoCdAppLogsOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Container.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Container.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Filter.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Filter.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Follow.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Follow.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Group.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Group.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Kind.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Kind.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogsLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogsLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.MatchCase.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.MatchCase.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Name.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Name.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Namespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Namespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Previous.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Previous.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogsRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.SinceSeconds.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.SinceSeconds.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Tail.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Tail.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.UntilTime.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.UntilTime.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgoCdAppManifestsOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgoCdAppManifestsOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Local.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Local.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.LocalRepoRoot.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.LocalRepoRoot.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revision.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revision.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revisions.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Revisions.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Source.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppManifestsSource?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Source.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourceNames.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourceNames.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourcePositions.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.SourcePositions.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgoCdAppOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgoCdAppOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsUid.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCertificate.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Cluster.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Cluster.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Context.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Context.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.DisableCompression.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.InsecureSkipTlsVerify.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Namespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Namespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Password.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Password.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ProxyUrl.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ProxyUrl.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RequestTimeout.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.RequestTimeout.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.TlsServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Token.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Token.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.User.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.User.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Username.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Username.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgoCdAppPatchOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgoCdAppPatchOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Patch.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Patch.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Type.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchOptions.Type.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.All.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.All.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgoCdAppPatchResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgoCdAppPatchResourceOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Group.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Group.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Kind.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Kind.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchResourceLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchResourceLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Namespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Namespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Patch.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Patch.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PatchType.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PatchType.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Project.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppPatchResourceRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ResourceName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ResourceName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppPatchResourceOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgoCdAppRemoveSourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgoCdAppRemoveSourceOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRemoveSourceLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRemoveSourceLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRemoveSourceRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourceName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourceName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourcePosition.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRemoveSourceOptions.SourcePosition.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgoCdAppResourcesOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgoCdAppResourcesOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppResourcesLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppResourcesLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Orphaned.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Orphaned.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Output.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Project.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppResourcesRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppResourcesOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgoCdAppRollbackOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgoCdAppRollbackOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Id.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Id.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRollbackLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRollbackLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Output.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Prune.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Prune.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppRollbackRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Timeout.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppRollbackOptions.Timeout.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AllowEmpty.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AllowEmpty.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgoCdAppSetOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgoCdAppSetOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AutoPrune.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.AutoPrune.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ConfigManagementPlugin.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ConfigManagementPlugin.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestServer.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DestServer.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryExclude.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryExclude.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryInclude.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryInclude.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryRecurse.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DirectoryRecurse.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourcePath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourcePath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRepo.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRepo.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRevision.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.DrySourceRevision.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Env.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Env.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmApiVersions.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmApiVersions.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmChart.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmChart.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmKubeVersion.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmKubeVersion.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmPassCredentials.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmPassCredentials.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSet.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSet.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetFile.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetFile.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetString.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSetString.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipCrds.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipCrds.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipSchemaValidation.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipSchemaValidation.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipTests.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmSkipTests.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmVersion.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HelmVersion.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HydrateToBranch.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.HydrateToBranch.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingComponents.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingComponents.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingValueFiles.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.IgnoreMissingValueFiles.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarCode.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarCode.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarStr.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetExtVarStr.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetLibs.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetLibs.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaCode.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaCode.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaStr.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.JsonnetTlaStr.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeApiVersions.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeApiVersions.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonAnnotation.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonAnnotation.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonLabel.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeCommonLabel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonAnnotation.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonAnnotation.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonLabel.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeForceCommonLabel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeImage.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeImage.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeKubeVersion.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeKubeVersion.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelIncludeTemplates.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelIncludeTemplates.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelWithoutSelector.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeLabelWithoutSelector.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeReplica.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeReplica.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeVersion.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.KustomizeVersion.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSetLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSetLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Nameprefix.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Nameprefix.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Namesuffix.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Namesuffix.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Parameter.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Parameter.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Path.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Path.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PluginEnv.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PluginEnv.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Project.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSetRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Ref.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Ref.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ReleaseName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ReleaseName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Repo.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Repo.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Revision.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Revision.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RevisionHistoryLimit.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.RevisionHistoryLimit.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SelfHeal.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SelfHeal.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourceName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourceName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourcePosition.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SourcePosition.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncOption.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncOption.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncPolicy.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncPolicy.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffDuration.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffDuration.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffFactor.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffFactor.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffMaxDuration.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryBackoffMaxDuration.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryLimit.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryLimit.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryRefresh.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncRetryRefresh.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourceBranch.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourceBranch.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourcePath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.SyncSourcePath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.TagPrefix.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.TagPrefix.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Validate.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Validate.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Values.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.Values.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ValuesLiteralFile.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSetOptions.ValuesLiteralFile.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplicationNames.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplicationNames.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplyOutOfSyncOnly.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ApplyOutOfSyncOnly.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgoCdAppSyncOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgoCdAppSyncOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AssumeYes.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Assumeyes.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Async.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Async.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.DryRun.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.DryRun.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Force.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Force.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.IgnoreNormalizerJqExecutionTimeout.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.IgnoreNormalizerJqExecutionTimeout.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Info.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Info.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Label.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Label.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Local.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Local.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.LocalRepoRoot.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.LocalRepoRoot.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Output.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PreviewChanges.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PreviewChanges.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Project.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Prune.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Prune.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Replace.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Replace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Resource.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Resource.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffDuration.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffDuration.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffFactor.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffFactor.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffMaxDuration.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryBackoffMaxDuration.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryLimit.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryLimit.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryRefresh.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.RetryRefresh.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revision.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revision.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revisions.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Revisions.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Selector.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Selector.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSide.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSide.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffConcurrency.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffConcurrency.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffMaxBatchKb.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.ServerSideDiffMaxBatchKb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourceNames.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourceNames.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourcePositions.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.SourcePositions.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Strategy.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppSyncStrategy?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Strategy.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Timeout.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Timeout.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgoCdAppTerminateOpOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgoCdAppTerminateOpOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppTerminateOpLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppTerminateOpLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppTerminateOpRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ApplicationName.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ApplicationName.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgoCdAppUnsetOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgoCdAppUnsetOptions(string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Deconstruct(out string! ApplicationName) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingComponents.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingComponents.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingValueFiles.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.IgnoreMissingValueFiles.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeImage.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeImage.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeNamespace.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeReplica.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeReplica.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeVersion.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.KustomizeVersion.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppUnsetLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppUnsetLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Nameprefix.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Nameprefix.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Namesuffix.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Namesuffix.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Parameter.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Parameter.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PassCredentials.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PassCredentials.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PluginEnv.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PluginEnv.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppUnsetRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Ref.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Ref.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourceName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourceName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourcePosition.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.SourcePosition.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Values.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Values.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ValuesLiteral.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.ValuesLiteral.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ApplicationNames.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ApplicationNames.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AppNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AppNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgoCdAppWaitOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgoCdAppWaitOptions(ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Degraded.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Degraded.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Delete.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Delete.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Health.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Health.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Hydrated.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Hydrated.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Operation.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Operation.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Output.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAppWaitRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Resource.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Resource.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Selector.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Selector.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Suspended.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Suspended.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Sync.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Sync.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Timeout.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Timeout.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions
 ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.ArgoCdCertAddSshOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.ArgoCdCertAddSshOptions(ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions! original) -> void
@@ -9976,24 +9782,12 @@ ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ArgoCdCertOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ArgoCdCertOptions(ModularPipelines.ArgoCd.Options.ArgoCdCertOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ArgocdContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsUid.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Config.get -> string?
@@ -10004,8 +9798,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ControllerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.GrpcWebRootPath.get -> string?
@@ -10020,7 +9812,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Insecure.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Kubeconfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.KubeConfig.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.KubeContext.set -> void
@@ -10058,8 +9850,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.User.get -> string?
@@ -10189,7 +9979,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.InCluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Insecure.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Label.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -10364,24 +10154,12 @@ ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ArgoCdClusterOptions() -> v
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ArgoCdClusterOptions(ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ArgocdContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsUid.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Config.get -> string?
@@ -10392,8 +10170,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ControllerName.get -> strin
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.GrpcWebRootPath.get -> string?
@@ -10446,8 +10222,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.User.get -> string?
@@ -10649,24 +10423,12 @@ ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ArgoCdConfigureOptions() 
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ArgoCdConfigureOptions(ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ArgocdContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsUid.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Config.get -> string?
@@ -10677,8 +10439,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ControllerName.get -> str
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.GrpcWebRootPath.get -> string?
@@ -10694,7 +10454,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdConfigureLogformat?
@@ -10731,8 +10491,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.User.get -> string?
@@ -10740,10 +10498,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.User.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions
-ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ArgoCdContextOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ArgoCdContextOptions(ModularPipelines.ArgoCd.Options.ArgoCdContextOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ClientCrt.get -> string?
@@ -10801,10 +10559,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdContextOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions
-ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ArgoCdGpgAddOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ArgoCdGpgAddOptions(ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ClientCrt.get -> string?
@@ -10860,10 +10618,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgAddOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ArgoCdGpgGetOptions(ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ArgoCdGpgGetOptions(string! KeyId) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ClientCrt.get -> string?
@@ -10922,10 +10680,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgGetOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ArgoCdGpgListOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ArgoCdGpgListOptions(ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ClientCrt.get -> string?
@@ -10981,28 +10739,16 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgListOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ArgoCdGpgOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ArgoCdGpgOptions(ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsUid.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Config.get -> string?
@@ -11013,8 +10759,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ControllerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.GrpcWebRootPath.get -> string?
@@ -11030,7 +10774,7 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.InsecureSkipTlsVerify.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdGpgLogformat?
@@ -11067,8 +10811,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.User.get -> string?
@@ -11076,10 +10818,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.User.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions
-ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ArgoCdGpgRmOptions(ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ArgoCdGpgRmOptions(string! KeyId) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ClientCrt.get -> string?
@@ -11136,10 +10878,9 @@ ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdGpgRmOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgoCdLoginOptions(ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgocdContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgoCdLoginOptions(ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgoCdLoginOptions(string! Server) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Callback.get -> string?
@@ -11154,7 +10895,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ControllerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Deconstruct(out string! Server) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.GrpcWebRootPath.get -> string?
@@ -11193,14 +10933,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.RedisName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.RedisName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.RepoServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Server.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Server.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerOption.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerOption.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.SkipTestTls.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.SkipTestTls.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Sso.get -> bool?
@@ -11212,10 +10948,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.SsoPort.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions
-ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ArgoCdLogoutOptions(ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ArgoCdLogoutOptions(string! Context) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdLogoutOptions.ClientCrt.get -> string?
@@ -11275,10 +11011,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdOptions
 ModularPipelines.ArgoCd.Options.ArgoCdOptions.ArgoCdOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdOptions.ArgoCdOptions(ModularPipelines.ArgoCd.Options.ArgoCdOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ArgoCdProjAddDestinationOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ArgoCdProjAddDestinationOptions(string! Project, string! ServerOrName, string! Namespace) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ClientCrt.get -> string?
@@ -11341,10 +11077,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ServerName.set -
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ServerOrName.get -> string!
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.ServerOrName.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ArgoCdProjAddDestinationServiceAccountOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ArgoCdProjAddDestinationServiceAccountOptions(string! Project, string! DestinationServer, string! Namespace, string! ServiceAccount) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ClientCrt.get -> string?
@@ -11409,10 +11145,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.Se
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ServiceAccountNamespace.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.ServiceAccountNamespace.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ArgoCdProjAddOrphanedIgnoreOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ArgoCdProjAddOrphanedIgnoreOptions(string! Project, string! Group, string! Kind) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ClientCrt.get -> string?
@@ -11474,73 +11210,11 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ServerCrt.get
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgoCdProjAddSignatureKeyOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgoCdProjAddSignatureKeyOptions(string! Project, string! KeyId) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Deconstruct(out string! Project, out string! KeyId) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KeyId.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KeyId.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Project.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Project.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ArgoCdProjAddSourceNamespaceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ArgoCdProjAddSourceNamespaceOptions(string! Project, string! Namespace) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ClientCrt.get -> string?
@@ -11599,10 +11273,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ServerCrt.se
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ArgoCdProjAddSourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ArgoCdProjAddSourceOptions(string! Project, string! Url) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ClientCrt.get -> string?
@@ -11661,10 +11335,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.ServerName.set -> voi
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.Url.get -> string!
 ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.Url.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ArgoCdProjAllowClusterResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ArgoCdProjAllowClusterResourceOptions(string! Project, string! Group, string! Kind) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ClientCrt.get -> string?
@@ -11729,10 +11403,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ServerCrt.
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ArgoCdProjAllowNamespaceResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ArgoCdProjAllowNamespaceResourceOptions(string! Project, string! Group, string! Kind) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjAllowNamespaceResourceOptions.ClientCrt.get -> string?
@@ -11799,10 +11473,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.AllowClusterResource.get
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.AllowClusterResource.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.AllowNamespacedResource.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.AllowNamespacedResource.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ArgoCdProjCreateOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ArgoCdProjCreateOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.ClientCrt.get -> string?
@@ -11883,10 +11557,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.Src.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.Upsert.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjCreateOptions.Upsert.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ArgoCdProjDeleteOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ArgoCdProjDeleteOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ClientCrt.get -> string?
@@ -11943,10 +11617,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjDeleteOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ArgoCdProjDenyClusterResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ArgoCdProjDenyClusterResourceOptions(string! Project, string! Group, string! Kind) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ClientCrt.get -> string?
@@ -12009,10 +11683,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ServerCrt.s
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyClusterResourceOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ArgoCdProjDenyNamespaceResourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ArgoCdProjDenyNamespaceResourceOptions(string! Project, string! Group, string! Kind) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ClientCrt.get -> string?
@@ -12075,10 +11749,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ServerCrt
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjDenyNamespaceResourceOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ArgoCdProjEditOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ArgoCdProjEditOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ClientCrt.get -> string?
@@ -12135,10 +11809,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjEditOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ArgoCdProjGetOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ArgoCdProjGetOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ClientCrt.get -> string?
@@ -12197,10 +11871,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjGetOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ArgoCdProjListOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ArgoCdProjListOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ClientCrt.get -> string?
@@ -12256,28 +11930,16 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjListOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ArgoCdProjOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ArgoCdProjOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsUid.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Config.get -> string?
@@ -12288,8 +11950,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ControllerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.GrpcWebRootPath.get -> string?
@@ -12342,8 +12002,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.User.get -> string?
@@ -12351,10 +12009,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.User.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ArgoCdProjRemoveDestinationOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ArgoCdProjRemoveDestinationOptions(string! Project, string! DestinationServer, string! Namespace) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ClientCrt.get -> string?
@@ -12415,10 +12073,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ServerCrt.set
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ArgoCdProjRemoveDestinationServiceAccountOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ArgoCdProjRemoveDestinationServiceAccountOptions(string! Project, string! DestinationServer, string! Namespace, string! ServiceAccount) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ClientCrt.get -> string?
@@ -12481,10 +12139,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ServiceAccount.get -> string!
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.ServiceAccount.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ArgoCdProjRemoveOrphanedIgnoreOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ArgoCdProjRemoveOrphanedIgnoreOptions(string! Project, string! Group, string! Kind) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ClientCrt.get -> string?
@@ -12546,73 +12204,11 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ServerCrt.
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgoCdProjRemoveSignatureKeyOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgoCdProjRemoveSignatureKeyOptions(string! Project, string! KeyId) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Deconstruct(out string! Project, out string! KeyId) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KeyId.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KeyId.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Project.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Project.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ArgoCdProjRemoveSourceNamespaceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ArgoCdProjRemoveSourceNamespaceOptions(string! Project, string! Namespace) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ClientCrt.get -> string?
@@ -12671,10 +12267,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ServerCrt
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ArgoCdProjRemoveSourceOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ArgoCdProjRemoveSourceOptions(string! Project, string! Url) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ClientCrt.get -> string?
@@ -12733,10 +12329,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.ServerName.set -> 
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.Url.get -> string!
 ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.Url.init -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ArgoCdProjRoleAddGroupOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ArgoCdProjRoleAddGroupOptions(string! Project, string! RoleName, string! GroupClaim) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ClientCrt.get -> string?
@@ -12799,10 +12395,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.ServerName.set -> 
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.Action.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.Action.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ArgoCdProjRoleAddPolicyOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ArgoCdProjRoleAddPolicyOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ClientCrt.get -> string?
@@ -12867,10 +12463,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ServerCrt.set -> 
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddPolicyOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ArgoCdProjRoleCreateOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ArgoCdProjRoleCreateOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ClientCrt.get -> string?
@@ -12931,10 +12527,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ServerCrt.set -> voi
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ArgoCdProjRoleCreateTokenOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ArgoCdProjRoleCreateTokenOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ClientCrt.get -> string?
@@ -12999,10 +12595,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.ServerName.set 
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.TokenOnly.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleCreateTokenOptions.TokenOnly.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ArgoCdProjRoleDeleteOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ArgoCdProjRoleDeleteOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ClientCrt.get -> string?
@@ -13061,10 +12657,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ServerCrt.set -> voi
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ArgoCdProjRoleDeleteTokenOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ArgoCdProjRoleDeleteTokenOptions(string! Project, string! RoleName, string! IssuedAt) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ClientCrt.get -> string?
@@ -13125,10 +12721,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ServerCrt.set -
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleDeleteTokenOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ArgoCdProjRoleGetOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ArgoCdProjRoleGetOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ClientCrt.get -> string?
@@ -13187,10 +12783,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleGetOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ArgoCdProjRoleListOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ArgoCdProjRoleListOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ClientCrt.get -> string?
@@ -13249,10 +12845,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ArgoCdProjRoleListTokensOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ArgoCdProjRoleListTokensOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ClientCrt.get -> string?
@@ -13313,10 +12909,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.ServerName.set -
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.Unixtime.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleListTokensOptions.Unixtime.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ArgoCdProjRoleOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ArgoCdProjRoleOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ClientCrt.get -> string?
@@ -13370,10 +12966,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ArgoCdProjRoleRemoveGroupOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ArgoCdProjRoleRemoveGroupOptions(string! Project, string! RoleName, string! GroupClaim) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ClientCrt.get -> string?
@@ -13436,10 +13032,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemoveGroupOptions.ServerName.set 
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.Action.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.Action.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ArgoCdProjRoleRemovePolicyOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ArgoCdProjRoleRemovePolicyOptions(string! Project, string! RoleName) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjRoleRemovePolicyOptions.ClientCrt.get -> string?
@@ -13508,10 +13104,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.AllowClusterResource.get ->
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.AllowClusterResource.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.AllowNamespacedResource.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.AllowNamespacedResource.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ArgoCdProjSetOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ArgoCdProjSetOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.ClientCrt.get -> string?
@@ -13588,10 +13184,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.SourceNamespaces.set -> voi
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.Src.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions.Src.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ArgoCdProjSourceIntegrityGitOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ArgoCdProjSourceIntegrityGitOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ClientCrt.get -> string?
@@ -13645,10 +13241,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ServerCrt.se
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ArgoCdProjSourceIntegrityGitPoliciesAddOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ArgoCdProjSourceIntegrityGitPoliciesAddOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ClientCrt.get -> string?
@@ -13711,10 +13307,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.S
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesAddOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions(string! Project, System.Collections.Generic.IEnumerable<string!>! PolicyId) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.ClientCrt.get -> string?
@@ -13775,10 +13371,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOption
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.Yes.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesDeleteOptions.Yes.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ArgoCdProjSourceIntegrityGitPoliciesListOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ArgoCdProjSourceIntegrityGitPoliciesListOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ClientCrt.get -> string?
@@ -13835,10 +13431,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesListOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ArgoCdProjSourceIntegrityGitPoliciesOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ArgoCdProjSourceIntegrityGitPoliciesOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesOptions.ClientCrt.get -> string?
@@ -13896,10 +13492,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOption
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.AddGpgKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.AddRepoUrl.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.AddRepoUrl.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions(string! Project, string! PolicyId) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.ClientCrt.get -> string?
@@ -13970,10 +13566,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOption
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.Yes.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityGitPoliciesUpdateOptions.Yes.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ArgoCdProjSourceIntegrityOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ArgoCdProjSourceIntegrityOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ClientCrt.get -> string?
@@ -14029,10 +13625,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjSourceIntegrityOptions.ServerName.set 
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.Applications.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.Applications.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ArgoCdProjWindowsAddOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ArgoCdProjWindowsAddOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.ClientCrt.get -> string?
@@ -14109,10 +13705,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.TimeZone.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.UseAndOperator.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsAddOptions.UseAndOperator.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ArgoCdProjWindowsDeleteOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ArgoCdProjWindowsDeleteOptions(string! Project, string! Id) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ClientCrt.get -> string?
@@ -14171,10 +13767,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ServerCrt.set -> 
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDeleteOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ArgoCdProjWindowsDisableManualSyncOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ArgoCdProjWindowsDisableManualSyncOptions(string! Project, string! Id) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ClientCrt.get -> string?
@@ -14233,10 +13829,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.Server
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableManualSyncOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ArgoCdProjWindowsDisableSyncOverrunOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ArgoCdProjWindowsDisableSyncOverrunOptions(string! Project, string! Id) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ClientCrt.get -> string?
@@ -14295,10 +13891,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.Serve
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsDisableSyncOverrunOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ArgoCdProjWindowsEnableManualSyncOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ArgoCdProjWindowsEnableManualSyncOptions(string! Project, string! Id) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ClientCrt.get -> string?
@@ -14357,10 +13953,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ServerC
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableManualSyncOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ArgoCdProjWindowsEnableSyncOverrunOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ArgoCdProjWindowsEnableSyncOverrunOptions(string! Project, string! Id) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ClientCrt.get -> string?
@@ -14419,10 +14015,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.Server
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsEnableSyncOverrunOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ArgoCdProjWindowsListOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ArgoCdProjWindowsListOptions(string! Project) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ClientCrt.get -> string?
@@ -14481,10 +14077,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ServerCrt.set -> vo
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsListOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ArgoCdProjWindowsOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ArgoCdProjWindowsOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ClientCrt.get -> string?
@@ -14540,10 +14136,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.Applications.get -> System.Collections.Generic.IEnumerable<string!>?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.Applications.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ArgoCdProjWindowsUpdateOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ArgoCdProjWindowsUpdateOptions(string! Project, string! Id) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ClientCrt.get -> string?
@@ -14614,10 +14210,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.ServerName.set ->
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.TimeZone.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.TimeZone.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions
-ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.ArgoCdReloginOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.ArgoCdReloginOptions(ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.Callback.get -> string?
@@ -14679,10 +14275,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.SsoLaunchBrowser.set -> voi
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.SsoPort.get -> int?
 ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.SsoPort.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ArgoCdRepoAddOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ArgoCdRepoAddOptions(string! RepositoryUrl) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.AzureActiveDirectoryEndpoint.get -> string?
@@ -14798,11 +14394,279 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.WebhookManifestCacheWarmDisabled.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.WebhookManifestCacheWarmDisabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgoCdRepoGetOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgoCdRepoGetOptions(string! Repo) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Deconstruct(out string! Repo) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Output.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetOutput?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Project.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Refresh.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Refresh.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Repo.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Repo.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgoCdRepoListOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgoCdRepoListOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoListLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoListLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Output.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Output.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoListRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Refresh.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Refresh.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgoCdRepoOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgoCdRepoOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Cluster.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Cluster.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Context.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Context.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.InsecureSkipTlsVerify.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.InsecureSkipTlsVerify.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeConfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Namespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Namespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Password.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Password.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ProxyUrl.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ProxyUrl.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RequestTimeout.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RequestTimeout.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Token.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Token.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.User.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.User.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Username.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Username.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgoCdRepoRmOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgoCdRepoRmOptions(System.Collections.Generic.IEnumerable<string!>! Repositories) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! Repositories) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Project.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Project.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Repositories.get -> System.Collections.Generic.IEnumerable<string!>!
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Repositories.init -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ArgoCdRepocredsAddOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ArgoCdRepocredsAddOptions(string! RepositoryUrl) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.AzureActiveDirectoryEndpoint.get -> string?
@@ -14903,10 +14767,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.UseAzureWorkloadIdenti
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ArgoCdRepocredsListOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ArgoCdRepocredsListOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ClientCrt.get -> string?
@@ -14962,28 +14826,16 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ArgoCdRepocredsOptions() -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ArgoCdRepocredsOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsUid.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCertificate.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCrtKey.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientKey.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Cluster.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Cluster.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Config.get -> string?
@@ -14994,8 +14846,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ControllerName.get -> str
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ControllerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Core.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.DisableCompression.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.GrpcWeb.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.GrpcWeb.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.GrpcWebRootPath.get -> string?
@@ -15010,8 +14860,8 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Insecure.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Insecure.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.InsecureSkipTlsVerify.get -> bool?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Kubeconfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.KubeConfig.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.KubeContext.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.KubeContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepocredsLogformat?
@@ -15048,8 +14898,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ServerCrt.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.TlsServerName.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Token.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Token.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.User.get -> string?
@@ -15057,10 +14905,10 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.User.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Username.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Username.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ArgoCdRepocredsRmOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions! original) -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ArgoCdRepocredsRmOptions(string! CredentialsUrl) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ArgocdContext.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.AuthToken.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.AuthToken.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ClientCrt.get -> string?
@@ -15116,290 +14964,6 @@ ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ServerCrt.get -> string
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ServerCrt.set -> void
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ServerName.get -> string?
 ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgoCdRepoGetOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ArgoCdRepoGetOptions(string! Repo) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Deconstruct(out string! Repo) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Output.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetOutput?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Project.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoGetRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Refresh.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Refresh.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Repo.get -> string!
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Repo.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgoCdRepoListOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ArgoCdRepoListOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoListLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoListLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Output.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Output.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoListRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Refresh.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Refresh.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgoCdRepoOptions() -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ArgoCdRepoOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.As.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.As.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsGroup.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsUid.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsUid.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.CertificateAuthority.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.CertificateAuthority.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCertificate.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCertificate.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Cluster.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Cluster.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Context.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Context.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.DisableCompression.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.DisableCompression.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.InsecureSkipTlsVerify.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.InsecureSkipTlsVerify.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Namespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Namespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Password.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Password.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ProxyUrl.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ProxyUrl.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RequestTimeout.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.RequestTimeout.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.TlsServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.TlsServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Token.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Token.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.User.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.User.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Username.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Username.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgocdContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgocdContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgoCdRepoRmOptions(ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions! original) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ArgoCdRepoRmOptions(System.Collections.Generic.IEnumerable<string!>! Repositories) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.AuthToken.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.AuthToken.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrtKey.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ClientCrtKey.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Config.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Config.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ControllerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ControllerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Core.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Core.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Deconstruct(out System.Collections.Generic.IEnumerable<string!>! Repositories) -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWeb.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWeb.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWebRootPath.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GrpcWebRootPath.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Header.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Help.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Help.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.HttpRetryMax.get -> int?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.HttpRetryMax.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Insecure.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Insecure.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.KubeContext.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.KubeContext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmLogformat?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Logformat.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmLoglevel?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Loglevel.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Plaintext.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Plaintext.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForward.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForward.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForwardNamespace.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PortForwardNamespace.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Project.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Project.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PromptsEnabled.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PromptsEnabled.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdRepoRmRedisCompress?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisCompress.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisHaproxyName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisHaproxyName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RedisName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RepoServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.RepoServerName.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Repositories.get -> System.Collections.Generic.IEnumerable<string!>!
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Repositories.init -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Server.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Server.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerCrt.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerCrt.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerName.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ServerName.set -> void
 ModularPipelines.ArgoCd.Services.ArgoCdAccount
 ModularPipelines.ArgoCd.Services.ArgoCdAdmin
 ModularPipelines.ArgoCd.Services.ArgoCdAdmin.App.get -> ModularPipelines.ArgoCd.Services.ArgoCdAdminApp!
@@ -15476,7 +15040,8 @@ ModularPipelines.ArgoCd.Services.IArgoCdProj.Windows.get -> ModularPipelines.Arg
 ModularPipelines.ArgoCd.Services.IArgoCdRepo
 ModularPipelines.ArgoCd.Services.IArgoCdRepocreds
 ModularPipelines.Context.ModularPipelines_ArgoCd_741689711b8e0914ToolsExtensions
-override abstract ModularPipelines.ArgoCd.Options.ArgoCdOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdOptions!
+ModularPipelines.Context.ModularPipelines_ArgoCd_741689711b8e0914ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
+ModularPipelines.Context.ModularPipelines_ArgoCd_741689711b8e0914ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).ArgoCd.get -> ModularPipelines.ArgoCd.Services.IArgoCd!
 override ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.Equals(object? obj) -> bool
@@ -15567,12 +15132,6 @@ override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.E
 override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ToString() -> string!
 override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Equals(object? obj) -> bool
@@ -15867,42 +15426,6 @@ override ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.Equals(object? 
 override ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ToString() -> string!
 override ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Equals(object? obj) -> bool
@@ -15987,6 +15510,42 @@ override ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Equals(object? obj
 override ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ToString() -> string!
 override ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.Equals(object? obj) -> bool
@@ -16136,12 +15695,6 @@ override ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.Equa
 override ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ToString() -> string!
 override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.Equals(object? obj) -> bool
@@ -16232,12 +15785,6 @@ override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.E
 override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ToString() -> string!
 override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.Equals(object? obj) -> bool
@@ -16436,30 +15983,6 @@ override ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.Equals(object? obj
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ToString() -> string!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.Equals(object? obj) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.GetHashCode() -> int
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ToString() -> string!
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions!
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Equals(object? obj) -> bool
@@ -16484,6 +16007,31 @@ override ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Equals(object? obj)
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.GetHashCode() -> int
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ToString() -> string!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.ToString() -> string!
+override abstract ModularPipelines.ArgoCd.Options.ArgoCdOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdOptions!
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAccountCanIOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAccountDeleteTokenOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
@@ -16499,7 +16047,6 @@ override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGenerateSpecOption
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
@@ -16549,12 +16096,6 @@ override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.Equals(Modu
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
@@ -16569,6 +16110,12 @@ override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Equals(Modu
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdCertAddTlsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdCertListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
@@ -16594,7 +16141,6 @@ override sealed ModularPipelines.ArgoCd.Options.ArgoCdOptions.Equals(ModularPipe
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
@@ -16610,7 +16156,6 @@ override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Equals(Modular
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
@@ -16644,14 +16189,14 @@ override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.Equals(
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
-override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 static ModularPipelines.ArgoCd.Extensions.ArgoCdExtensions.RegisterArgoCdContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? right) -> bool
@@ -16683,8 +16228,6 @@ static ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions.operator !=(Modular
 static ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions? right) -> bool
@@ -16783,18 +16326,6 @@ static ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.operator !=(M
 static ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions? right) -> bool
@@ -16823,6 +16354,18 @@ static ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.operator !=(Modular
 static ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdCertAddTlsOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdCertAddTlsOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdCertAddTlsOptions? right) -> bool
@@ -16873,8 +16416,6 @@ static ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOpt
 static ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions? right) -> bool
@@ -16905,8 +16446,6 @@ static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccount
 static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions? right) -> bool
@@ -16973,14 +16512,6 @@ static ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.operator !=(ModularP
 static ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? right) -> bool
-static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions? right) -> bool
@@ -16989,6 +16520,14 @@ static ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.operator !=(ModularPipe
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions? right) -> bool
 static ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? right) -> bool
 static ModularPipelines.Context.ModularPipelines_ArgoCd_741689711b8e0914ToolsExtensions.get_ArgoCd(ModularPipelines.Context.IToolsContext! tools) -> ModularPipelines.ArgoCd.Services.IArgoCd!
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAccountCanIOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAccountCanIOptions? other) -> bool
@@ -17005,7 +16544,6 @@ virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGenerateSpecOptions.Equals
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminAppOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions? other) -> bool
@@ -17055,12 +16593,6 @@ virtual ModularPipelines.ArgoCd.Options.ArgoCdAppEditOptions.Equals(ModularPipel
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppGetOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppGetResourceOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppHistoryOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppListOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppLogsOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppManifestsOptions? other) -> bool
@@ -17075,6 +16607,12 @@ virtual ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Equals(ModularPipel
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppTerminateOpOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppUnsetOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAppWaitOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetCreateOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetDeleteOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGenerateOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetGetOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetListOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdCertAddSshOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdCertAddTlsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdCertAddTlsOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdCertListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdCertListOptions? other) -> bool
@@ -17100,7 +16638,6 @@ virtual ModularPipelines.ArgoCd.Options.ArgoCdOptions.Equals(ModularPipelines.Ar
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions? other) -> bool
@@ -17116,7 +16653,6 @@ virtual ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Equals(ModularPipeline
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRoleAddGroupOptions? other) -> bool
@@ -17150,103 +16686,11 @@ virtual ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsOptions.Equals(ModularP
 virtual ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjWindowsUpdateOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdReloginOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepoAddOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? other) -> bool
-virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepoGetOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepoListOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepoRmOptions? other) -> bool
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminDashboardOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminDashboardOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminProjGenerateAllowListOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminProjGenerateAllowListOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminProjUpdateRolePolicyOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminProjUpdateRolePolicyOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreDifferencesOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreDifferencesOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.AssumeYes.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Assumeyes.get -> bool?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Kubeconfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Kubeconfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.KubeConfig.set -> void
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.KubeConfig.get -> string?
-ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.KubeConfig.set -> void
-ModularPipelines.Context.ModularPipelines_ArgoCd_741689711b8e0914ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
-ModularPipelines.Context.ModularPipelines_ArgoCd_741689711b8e0914ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).ArgoCd.get -> ModularPipelines.ArgoCd.Services.IArgoCd!
+virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsAddOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? other) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions? other) -> bool

--- a/src/ModularPipelines.ArgoCd/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.ArgoCd/PublicAPI.Unshipped.txt
@@ -1,4 +1,530 @@
 #nullable enable
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAccountOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgoCdAdminClusterKubeconfigOptions() -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgoCdAdminClusterKubeconfigOptions(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions! original) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgocdContext.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ArgocdContext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AuthToken.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.AuthToken.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrt.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrt.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrtKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientCrtKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Cluster.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Cluster.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClusterUrl.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ClusterUrl.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Config.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Config.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Context.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Context.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ControllerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ControllerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Core.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Core.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWeb.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWeb.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWebRootPath.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GrpcWebRootPath.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Header.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Help.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Help.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.HttpRetryMax.get -> int?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.HttpRetryMax.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Insecure.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Insecure.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.InsecureSkipTlsVerify.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.InsecureSkipTlsVerify.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeConfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeConfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeContext.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.KubeContext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLogformat?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Logformat.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigLoglevel?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Loglevel.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Namespace.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Namespace.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.OutputPath.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.OutputPath.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Password.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Password.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Plaintext.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Plaintext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForward.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForward.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForwardNamespace.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PortForwardNamespace.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PromptsEnabled.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PromptsEnabled.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ProxyUrl.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ProxyUrl.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeconfigRedisCompress?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisCompress.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisHaproxyName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisHaproxyName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RedisName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RepoServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RepoServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RequestTimeout.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.RequestTimeout.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Server.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Server.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerCrt.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerCrt.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Token.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Token.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.User.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.User.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Username.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Username.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesEnableNamespacedModeOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminDashboardOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminDashboardOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminExportOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminImportOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminInitialPasswordOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateGetOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateNotifyOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTemplateOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerGetOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServerStrictTls.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.ArgocdRepoServerStrictTls.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminNotificationsTriggerRunOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminProjGenerateAllowListOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminProjGenerateAllowListOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminProjUpdateRolePolicyOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminProjUpdateRolePolicyOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminRedisInitialPasswordOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacCanOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsRbacValidateOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesHealthOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreDifferencesOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreDifferencesOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesIgnoreResourceUpdatesOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesListActionsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsResourceOverridesRunActionOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAdminSettingsValidateOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Assumeyes.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdAppSyncOptions.Assumeyes.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdApplicationSetOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdCertOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterAddOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdClusterOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdConfigureOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdGpgOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgoCdLoginOptions(string! Server) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Deconstruct(out string! Server) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Server.get -> string!
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Server.init -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerOption.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerOption.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgoCdProjAddSignatureKeyOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions! original) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgoCdProjAddSignatureKeyOptions(string! Project, string! KeyId) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgocdContext.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ArgocdContext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.AuthToken.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.AuthToken.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrt.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrt.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrtKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ClientCrtKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Config.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Config.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ControllerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ControllerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Core.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Core.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Deconstruct(out string! Project, out string! KeyId) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWeb.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWeb.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWebRootPath.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GrpcWebRootPath.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Header.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Help.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Help.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.HttpRetryMax.get -> int?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.HttpRetryMax.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Insecure.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Insecure.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KeyId.get -> string!
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KeyId.init -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KubeContext.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.KubeContext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLogformat?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Logformat.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyLoglevel?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Loglevel.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Plaintext.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Plaintext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForward.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForward.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForwardNamespace.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PortForwardNamespace.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Project.get -> string!
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Project.init -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PromptsEnabled.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PromptsEnabled.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjAddSignatureKeyRedisCompress?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisCompress.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisHaproxyName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisHaproxyName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RedisName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RepoServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.RepoServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Server.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Server.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerCrt.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerCrt.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgoCdProjRemoveSignatureKeyOptions(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions! original) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgoCdProjRemoveSignatureKeyOptions(string! Project, string! KeyId) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgocdContext.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ArgocdContext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.AuthToken.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.AuthToken.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrt.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrt.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrtKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ClientCrtKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Config.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Config.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ControllerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ControllerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Core.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Core.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Deconstruct(out string! Project, out string! KeyId) -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWeb.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWeb.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWebRootPath.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GrpcWebRootPath.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Header.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Help.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Help.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.HttpRetryMax.get -> int?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.HttpRetryMax.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Insecure.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Insecure.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KeyId.get -> string!
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KeyId.init -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KubeContext.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.KubeContext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLogformat?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Logformat.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyLoglevel?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Loglevel.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Plaintext.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Plaintext.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForward.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForward.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForwardNamespace.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PortForwardNamespace.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Project.get -> string!
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Project.init -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PromptsEnabled.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PromptsEnabled.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdProjRemoveSignatureKeyRedisCompress?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisCompress.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisHaproxyName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisHaproxyName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RedisName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RepoServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.RepoServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Server.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Server.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerCrt.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerCrt.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepoOptions.TlsServerName.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.As.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.As.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsGroup.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsUid.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.AsUid.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.CertificateAuthority.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.CertificateAuthority.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCertificate.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientCertificate.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientKey.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.ClientKey.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.DisableCompression.get -> bool?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.DisableCompression.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Kubeconfig.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.Kubeconfig.set -> void
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.TlsServerName.get -> string?
+*REMOVED*ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions.TlsServerName.set -> void
 *REMOVED*ModularPipelines.ArgoCd.Services.ArgoCdAccount.ArgoCdAccount(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.ArgoCd.Services.ArgoCdAdmin.ArgoCdAdmin(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.ArgoCd.Services.ArgoCdAdminApp.ArgoCdAdminApp(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
@@ -126,7 +652,37 @@
 *REMOVED*ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.ExecuteAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.ListAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.RmAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.ToString() -> string!
+*REMOVED*override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
 *REMOVED*static ModularPipelines.ArgoCd.Extensions.ArgoCdExtensions.ArgoCd(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.ArgoCd.Services.IArgoCd!
+*REMOVED*static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? right) -> bool
+*REMOVED*static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? right) -> bool
+*REMOVED*static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? right) -> bool
+*REMOVED*static ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? right) -> bool
+*REMOVED*static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? right) -> bool
+*REMOVED*static ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? right) -> bool
+*REMOVED*virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions? other) -> bool
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAccount.BcryptAsync(ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAccount.CanIAsync(ModularPipelines.ArgoCd.Options.ArgoCdAccountCanIOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAccount.DeleteTokenAsync(ModularPipelines.ArgoCd.Options.ArgoCdAccountDeleteTokenOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -149,8 +705,8 @@
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminApp.GetReconcileResultsAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.ExecuteAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.GenerateSpecAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.KubeconfigAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.KubeConfigAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.KubeconfigAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.ShardsAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.StatsAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminClusterNamespaces.DisableNamespacedModeAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -290,6 +846,122 @@
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdRepocreds.ExecuteAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdRepocreds.ListAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.ArgoCd.Services.ArgoCdRepocreds.RmAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLogformat.Json = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLogformat.Text = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLogformat
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel.Debug = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel.Error = 3 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel.Info = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel.Warn = 2 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigRedisCompress.Gzip = 0 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigRedisCompress
+ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigRedisCompress.None = 1 -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigRedisCompress
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ArgoCdAdminClusterKubeConfigOptions() -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ArgoCdAdminClusterKubeConfigOptions(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions! original) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ArgocdContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ArgocdContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.As.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.As.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.AsGroup.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.AsGroup.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.AsUid.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.AsUid.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.AuthToken.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.AuthToken.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.CertificateAuthority.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.CertificateAuthority.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientCertificate.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientCertificate.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientCrtKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientCrtKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientKey.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClientKey.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Cluster.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Cluster.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClusterUrl.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ClusterUrl.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Config.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Config.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Context.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Context.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ControllerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ControllerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Core.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Core.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.DisableCompression.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.DisableCompression.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.GrpcWeb.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.GrpcWeb.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.GrpcWebRootPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.GrpcWebRootPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Header.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Header.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Help.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Help.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.HttpRetryMax.get -> int?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.HttpRetryMax.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Insecure.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Insecure.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.InsecureSkipTlsVerify.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.InsecureSkipTlsVerify.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.KubeConfig.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.KubeConfig.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.KubeContext.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.KubeContext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Logformat.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLogformat?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Logformat.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Loglevel.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigLoglevel?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Loglevel.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Namespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Namespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.OutputPath.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.OutputPath.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Password.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Password.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Plaintext.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Plaintext.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PortForward.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PortForward.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PortForwardNamespace.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PortForwardNamespace.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PromptsEnabled.get -> bool?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PromptsEnabled.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ProxyUrl.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ProxyUrl.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RedisCompress.get -> ModularPipelines.ArgoCd.Enums.ArgoCdAdminClusterKubeConfigRedisCompress?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RedisCompress.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RedisHaproxyName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RedisHaproxyName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RedisName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RedisName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RepoServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RepoServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RequestTimeout.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.RequestTimeout.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ServerCrt.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ServerCrt.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.TlsServerName.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.TlsServerName.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Token.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Token.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.User.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.User.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Username.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Username.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ArgoCdLoginOptions(string! ServerArgument) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Deconstruct(out string! ServerArgument) -> void
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Server.get -> string?
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.Server.set -> void
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerArgument.get -> string!
+ModularPipelines.ArgoCd.Options.ArgoCdLoginOptions.ServerArgument.init -> void
 ModularPipelines.ArgoCd.Services.ArgoCdAccount.ArgoCdAccount(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.ArgoCd.Services.ArgoCdAdmin.ArgoCdAdmin(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.ArgoCd.Services.ArgoCdAdminApp.ArgoCdAdminApp(ModularPipelines.Context.ICommandContext! command) -> void
@@ -388,7 +1060,6 @@ ModularPipelines.ArgoCd.Services.IArgoCdGpg.RmAsync(ModularPipelines.ArgoCd.Opti
 ModularPipelines.ArgoCd.Services.IArgoCdProj.AddDestinationAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.AddDestinationServiceAccountAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.AddOrphanedIgnoreAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.ArgoCd.Services.IArgoCdProj.AddSignatureKeyAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.AddSourceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.AddSourceNamespaceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.AllowClusterResourceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -404,7 +1075,6 @@ ModularPipelines.ArgoCd.Services.IArgoCdProj.ListAsync(ModularPipelines.ArgoCd.O
 ModularPipelines.ArgoCd.Services.IArgoCdProj.RemoveDestinationAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.RemoveDestinationServiceAccountAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.RemoveOrphanedIgnoreAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.ArgoCd.Services.IArgoCdProj.RemoveSignatureKeyAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.RemoveSourceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.RemoveSourceNamespaceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdProj.SetAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -417,7 +1087,16 @@ ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.AddAsync(ModularPipelines.Argo
 ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.ExecuteAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.ListAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.ArgoCd.Services.IArgoCdRepocreds.RmAsync(ModularPipelines.ArgoCd.Options.ArgoCdRepocredsRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-static ModularPipelines.ArgoCd.Extensions.ArgoCdExtensions.ArgoCd(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.ArgoCd.Services.IArgoCd!
+override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.<Clone>$() -> ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions!
+override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Equals(object? obj) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.GetHashCode() -> int
+override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.ToString() -> string!
+override sealed ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdOptions? other) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.operator !=(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions? right) -> bool
+static ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.operator ==(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions? left, ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions? right) -> bool
+virtual ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions.Equals(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions? other) -> bool
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAccount.BcryptAsync(ModularPipelines.ArgoCd.Options.ArgoCdAccountBcryptOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAccount.CanIAsync(ModularPipelines.ArgoCd.Options.ArgoCdAccountCanIOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAccount.DeleteTokenAsync(ModularPipelines.ArgoCd.Options.ArgoCdAccountDeleteTokenOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -440,8 +1119,7 @@ virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminApp.GenerateSpecAsync(Modula
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminApp.GetReconcileResultsAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminAppGetReconcileResultsOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.ExecuteAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.GenerateSpecAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterGenerateSpecOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.KubeConfigAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.KubeconfigAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.KubeConfigAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterKubeConfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.ShardsAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterShardsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminCluster.StatsAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterStatsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdAdminClusterNamespaces.DisableNamespacedModeAsync(ModularPipelines.ArgoCd.Options.ArgoCdAdminClusterNamespacesDisableNamespacedModeOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -524,7 +1202,6 @@ virtual ModularPipelines.ArgoCd.Services.ArgoCdGpg.RmAsync(ModularPipelines.Argo
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AddDestinationAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AddDestinationServiceAccountAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddDestinationServiceAccountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AddOrphanedIgnoreAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddOrphanedIgnoreOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AddSignatureKeyAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSignatureKeyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AddSourceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AddSourceNamespaceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAddSourceNamespaceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.AllowClusterResourceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjAllowClusterResourceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -540,7 +1217,6 @@ virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.ListAsync(ModularPipelines.A
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.RemoveDestinationAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.RemoveDestinationServiceAccountAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveDestinationServiceAccountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.RemoveOrphanedIgnoreAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveOrphanedIgnoreOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.RemoveSignatureKeyAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSignatureKeyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.RemoveSourceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.RemoveSourceNamespaceAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjRemoveSourceNamespaceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.ArgoCd.Services.ArgoCdProj.SetAsync(ModularPipelines.ArgoCd.Options.ArgoCdProjSetOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **argocd** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- argocd (argocd: v3.5.2+e258ee2   BuildDate: 2026-08-27T09:34:36Z   GitCommit: e258ee23c3e52266d407572f4bcdfe7d9ed36cb5   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64): 165 commands, tree f12af4288e7a39a4ac683d429edf0cf75b10df027963bc60b408a2f2ea0df4b2
  - Baseline comparison: 165 commands at argocd: v3.5.2+e258ee2   BuildDate: 2026-08-27T09:34:36Z   GitCommit: e258ee23c3e52266d407572f4bcdfe7d9ed36cb5   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64 -> 165 commands at argocd: v3.5.2+e258ee2   BuildDate: 2026-08-27T09:34:36Z   GitCommit: e258ee23c3e52266d407572f4bcdfe7d9ed36cb5   GitTreeState: clean   GoVersion: go1.26.4   Compiler: gc   Platform: linux/amd64

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator