### PR TITLE
[Automated] Update helm CLI Options

### DIFF
--- a/src/ModularPipelines.Helm/Enums/HelmGetMetadataOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmGetMetadataOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmGetMetadataOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmGetValuesOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmGetValuesOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmGetValuesOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmHistoryOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmHistoryOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmHistoryOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmInstallOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmInstallOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmInstallOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmListOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmListOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmListOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmRepoListOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmRepoListOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmRepoListOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmSearchHubOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmSearchHubOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmSearchHubOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmSearchRepoOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmSearchRepoOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmSearchRepoOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmStatusOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmStatusOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmStatusOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Enums/HelmUninstallCascade.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmUninstallCascade.Generated.cs
@@ -19,9 +19,9 @@ public enum HelmUninstallCascade
     [EnumValue("background")]
     Background,
 
-    [EnumValue("orphan")]
-    Orphan,
-
     [EnumValue("foreground")]
-    Foreground
+    Foreground,
+
+    [EnumValue("orphan")]
+    Orphan
 }

--- a/src/ModularPipelines.Helm/Enums/HelmUpgradeOutput.Generated.cs
+++ b/src/ModularPipelines.Helm/Enums/HelmUpgradeOutput.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Helm.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HelmUpgradeOutput
 {
-    [EnumValue("table")]
-    Table,
-
     [EnumValue("json")]
     Json,
+
+    [EnumValue("table")]
+    Table,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Helm/Generated/Helm.Generation.json
+++ b/src/ModularPipelines.Helm/Generated/Helm.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "helm",
   "toolVersion": "version.BuildInfo{Version:\"v3.21.4\", GitCommit:\"813176c51bb5c181dbbd7901298ddcc104cd3417\", GitTreeState:\"clean\", GoVersion:\"go1.26.5\"}",
   "commandTreeSha256": "4899ed49663bc26b485e79579fc4dd8dc6db81e8115ef7343e12699488811782",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }

--- a/src/ModularPipelines.Helm/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Helm/PublicAPI.Shipped.txt
@@ -3,48 +3,26 @@ ModularPipelines.Context.ModularPipelines_Helm_e8de683e0682de7aToolsExtensions
 ModularPipelines.Context.ModularPipelines_Helm_e8de683e0682de7aToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
 ModularPipelines.Context.ModularPipelines_Helm_e8de683e0682de7aToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Helm.get -> ModularPipelines.Helm.Services.IHelm!
 ModularPipelines.Helm.Enums.HelmGetMetadataOutput
-ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
-ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
 ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
 ModularPipelines.Helm.Enums.HelmGetValuesOutput
-ModularPipelines.Helm.Enums.HelmGetValuesOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
-ModularPipelines.Helm.Enums.HelmGetValuesOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
 ModularPipelines.Helm.Enums.HelmGetValuesOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
 ModularPipelines.Helm.Enums.HelmHistoryOutput
-ModularPipelines.Helm.Enums.HelmHistoryOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
-ModularPipelines.Helm.Enums.HelmHistoryOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
 ModularPipelines.Helm.Enums.HelmHistoryOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
 ModularPipelines.Helm.Enums.HelmInstallOutput
-ModularPipelines.Helm.Enums.HelmInstallOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmInstallOutput
-ModularPipelines.Helm.Enums.HelmInstallOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmInstallOutput
 ModularPipelines.Helm.Enums.HelmInstallOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmInstallOutput
 ModularPipelines.Helm.Enums.HelmListOutput
-ModularPipelines.Helm.Enums.HelmListOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmListOutput
-ModularPipelines.Helm.Enums.HelmListOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmListOutput
 ModularPipelines.Helm.Enums.HelmListOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmListOutput
 ModularPipelines.Helm.Enums.HelmRepoListOutput
-ModularPipelines.Helm.Enums.HelmRepoListOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
-ModularPipelines.Helm.Enums.HelmRepoListOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
 ModularPipelines.Helm.Enums.HelmRepoListOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
 ModularPipelines.Helm.Enums.HelmSearchHubOutput
-ModularPipelines.Helm.Enums.HelmSearchHubOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
-ModularPipelines.Helm.Enums.HelmSearchHubOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
 ModularPipelines.Helm.Enums.HelmSearchHubOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
 ModularPipelines.Helm.Enums.HelmSearchRepoOutput
-ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
-ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
 ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
 ModularPipelines.Helm.Enums.HelmStatusOutput
-ModularPipelines.Helm.Enums.HelmStatusOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmStatusOutput
-ModularPipelines.Helm.Enums.HelmStatusOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmStatusOutput
 ModularPipelines.Helm.Enums.HelmStatusOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmStatusOutput
 ModularPipelines.Helm.Enums.HelmUninstallCascade
 ModularPipelines.Helm.Enums.HelmUninstallCascade.Background = 0 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
-ModularPipelines.Helm.Enums.HelmUninstallCascade.Foreground = 2 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
-ModularPipelines.Helm.Enums.HelmUninstallCascade.Orphan = 1 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
 ModularPipelines.Helm.Enums.HelmUpgradeOutput
-ModularPipelines.Helm.Enums.HelmUpgradeOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
-ModularPipelines.Helm.Enums.HelmUpgradeOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
 ModularPipelines.Helm.Enums.HelmUpgradeOutput.Yaml = 2 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
 ModularPipelines.Helm.Extensions.HelmExtensions
 ModularPipelines.Helm.Options.HelmCreateOptions

--- a/src/ModularPipelines.Helm/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Helm/PublicAPI.Unshipped.txt
@@ -1,4 +1,26 @@
 #nullable enable
+*REMOVED*ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmGetValuesOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmGetValuesOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmHistoryOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmHistoryOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmInstallOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmInstallOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmInstallOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmInstallOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmListOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmListOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmListOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmListOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmRepoListOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmRepoListOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmSearchHubOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmSearchHubOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmStatusOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmStatusOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmStatusOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmStatusOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmUninstallCascade.Foreground = 2 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
+*REMOVED*ModularPipelines.Helm.Enums.HelmUninstallCascade.Orphan = 1 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
+*REMOVED*ModularPipelines.Helm.Enums.HelmUpgradeOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
+*REMOVED*ModularPipelines.Helm.Enums.HelmUpgradeOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
 *REMOVED*ModularPipelines.Helm.Services.HelmDependency.HelmDependency(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.Helm.Services.HelmGet.HelmGet(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.Helm.Services.HelmPlugin.HelmPlugin(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
@@ -91,6 +113,28 @@
 *REMOVED*virtual ModularPipelines.Helm.Services.HelmShow.ExecuteAsync(ModularPipelines.Helm.Options.HelmShowOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Helm.Services.HelmShow.ReadmeAsync(ModularPipelines.Helm.Options.HelmShowReadmeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Helm.Services.HelmShow.ValuesAsync(ModularPipelines.Helm.Options.HelmShowValuesOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
+ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput
+ModularPipelines.Helm.Enums.HelmGetValuesOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
+ModularPipelines.Helm.Enums.HelmGetValuesOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput
+ModularPipelines.Helm.Enums.HelmHistoryOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
+ModularPipelines.Helm.Enums.HelmHistoryOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmHistoryOutput
+ModularPipelines.Helm.Enums.HelmInstallOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmInstallOutput
+ModularPipelines.Helm.Enums.HelmInstallOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmInstallOutput
+ModularPipelines.Helm.Enums.HelmListOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmListOutput
+ModularPipelines.Helm.Enums.HelmListOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmListOutput
+ModularPipelines.Helm.Enums.HelmRepoListOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
+ModularPipelines.Helm.Enums.HelmRepoListOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmRepoListOutput
+ModularPipelines.Helm.Enums.HelmSearchHubOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
+ModularPipelines.Helm.Enums.HelmSearchHubOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmSearchHubOutput
+ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
+ModularPipelines.Helm.Enums.HelmSearchRepoOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmSearchRepoOutput
+ModularPipelines.Helm.Enums.HelmStatusOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmStatusOutput
+ModularPipelines.Helm.Enums.HelmStatusOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmStatusOutput
+ModularPipelines.Helm.Enums.HelmUninstallCascade.Foreground = 1 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
+ModularPipelines.Helm.Enums.HelmUninstallCascade.Orphan = 2 -> ModularPipelines.Helm.Enums.HelmUninstallCascade
+ModularPipelines.Helm.Enums.HelmUpgradeOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
+ModularPipelines.Helm.Enums.HelmUpgradeOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmUpgradeOutput
 ModularPipelines.Helm.Services.HelmDependency.HelmDependency(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Helm.Services.HelmGet.HelmGet(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Helm.Services.HelmPlugin.HelmPlugin(ModularPipelines.Context.ICommandContext! command) -> void


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **helm** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Helm`.

- Added APIs: 22
- Removed or changed APIs: 22
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput`
- `ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput`
- `ModularPipelines.Helm.Enums.HelmGetValuesOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput`
- `ModularPipelines.Helm.Enums.HelmGetValuesOutput.Table = 0 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput`
- `ModularPipelines.Helm.Enums.HelmHistoryOutput.Json = 1 -> ModularPipelines.Helm.Enums.HelmHistoryOutput`

Representative added members:
- `ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput`
- `ModularPipelines.Helm.Enums.HelmGetMetadataOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmGetMetadataOutput`
- `ModularPipelines.Helm.Enums.HelmGetValuesOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput`
- `ModularPipelines.Helm.Enums.HelmGetValuesOutput.Table = 1 -> ModularPipelines.Helm.Enums.HelmGetValuesOutput`
- `ModularPipelines.Helm.Enums.HelmHistoryOutput.Json = 0 -> ModularPipelines.Helm.Enums.HelmHistoryOutput`

## Command coverage
Command coverage report:
- helm (version.BuildInfo{Version:"v3.21.4", GitCommit:"813176c51bb5c181dbbd7901298ddcc104cd3417", GitTreeState:"clean", GoVersion:"go1.26.5"}): 50 commands, tree 4899ed49663bc26b485e79579fc4dd8dc6db81e8115ef7343e12699488811782
  - Baseline comparison: 50 commands at version.BuildInfo{Version:"v3.21.4", GitCommit:"813176c51bb5c181dbbd7901298ddcc104cd3417", GitTreeState:"clean", GoVersion:"go1.26.5"} -> 50 commands at version.BuildInfo{Version:"v3.21.4", GitCommit:"813176c51bb5c181dbbd7901298ddcc104cd3417", GitTreeState:"clean", GoVersion:"go1.26.5"}

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator