### PR TITLE
[Automated] Update gh CLI Options

### DIFF
--- a/src/ModularPipelines.GitHub/Generated/Gh.Generation.json
+++ b/src/ModularPipelines.GitHub/Generated/Gh.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "gh",
   "toolVersion": "gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0",
   "commandTreeSha256": "3777cffcf304b41a18323a005d1f5bfd5dd24121249da59c9d985e6b8132d552",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
 }

--- a/src/ModularPipelines.GitHub/Options/GhBrowseOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhBrowseOptions.Generated.cs
@@ -14,7 +14,7 @@ using ModularPipelines.Models;
 namespace ModularPipelines.GitHub.Options;
 
 /// <summary>
-/// - Pull requests
+/// - Issues
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.GitHub/Services/IGh.Generated.cs
+++ b/src/ModularPipelines.GitHub/Services/IGh.Generated.cs
@@ -165,7 +165,7 @@ public partial interface IGh
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// - Pull requests
+    /// - Issues
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **gh** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- gh (gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0): 221 commands, tree 3777cffcf304b41a18323a005d1f5bfd5dd24121249da59c9d985e6b8132d552
  - Baseline comparison: 221 commands at gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0 -> 221 commands at gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator