### PR TITLE
[Automated] Update hadolint CLI Options

### DIFF
--- a/src/ModularPipelines.Hadolint/Generated/Hadolint.Generation.json
+++ b/src/ModularPipelines.Hadolint/Generated/Hadolint.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "hadolint",
   "toolVersion": "Haskell Dockerfile Linter 2.15.1",
   "commandTreeSha256": "aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "c6dd1d3a18193e50ff4e31e4874a68c71996634a1c1ee827c692d0dce1ee5c24"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **hadolint** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- hadolint (Haskell Dockerfile Linter 2.15.1): 1 commands, tree aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5
  - Baseline comparison: 1 commands at Haskell Dockerfile Linter 2.15.1 -> 1 commands at Haskell Dockerfile Linter 2.15.1

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator