### PR TITLE
[Automated] Update kind CLI Options

### DIFF
--- a/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
+++ b/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
@@ -16,8 +16,8 @@ namespace ModularPipelines.Kind.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum KindBuildNodeImageType
 {
-    [EnumValue("url")]
-    Url,
+    [EnumValue("ci")]
+    Ci,
 
     [EnumValue("file")]
     File,
@@ -25,9 +25,9 @@ public enum KindBuildNodeImageType
     [EnumValue("release")]
     Release,
 
-    [EnumValue("ci")]
-    Ci,
-
     [EnumValue("source")]
-    Source
+    Source,
+
+    [EnumValue("url")]
+    Url
 }

--- a/src/ModularPipelines.Kind/Generated/Kind.CommandCoverage.json
+++ b/src/ModularPipelines.Kind/Generated/Kind.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "kind",
-  "toolVersion": "kind version 0.34.0-alpha\u002B6a54ab4800dab5",
+  "toolVersion": "kind version 0.34.0-alpha\u002Baa74c7f3e55dba",
   "commandCount": 17,
   "commandTreeSha256": "a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b",
   "commands": [

--- a/src/ModularPipelines.Kind/Generated/Kind.Generation.json
+++ b/src/ModularPipelines.Kind/Generated/Kind.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "kind",
-  "toolVersion": "kind version 0.34.0-alpha+6a54ab4800dab5",
+  "toolVersion": "kind version 0.34.0-alpha+aa74c7f3e55dba",
   "commandTreeSha256": "a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }

--- a/src/ModularPipelines.Kind/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Kind/PublicAPI.Shipped.txt
@@ -3,11 +3,8 @@ ModularPipelines.Context.ModularPipelines_Kind_84aa8736f42f49b8ToolsExtensions
 ModularPipelines.Context.ModularPipelines_Kind_84aa8736f42f49b8ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
 ModularPipelines.Context.ModularPipelines_Kind_84aa8736f42f49b8ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Kind.get -> ModularPipelines.Kind.Services.IKind!
 ModularPipelines.Kind.Enums.KindBuildNodeImageType
-ModularPipelines.Kind.Enums.KindBuildNodeImageType.Ci = 3 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
 ModularPipelines.Kind.Enums.KindBuildNodeImageType.File = 1 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
 ModularPipelines.Kind.Enums.KindBuildNodeImageType.Release = 2 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
-ModularPipelines.Kind.Enums.KindBuildNodeImageType.Source = 4 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
-ModularPipelines.Kind.Enums.KindBuildNodeImageType.Url = 0 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
 ModularPipelines.Kind.Extensions.KindExtensions
 ModularPipelines.Kind.Options.KindBuildNodeImageOptions
 ModularPipelines.Kind.Options.KindBuildNodeImageOptions.Arch.get -> string?

--- a/src/ModularPipelines.Kind/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Kind/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+*REMOVED*ModularPipelines.Kind.Enums.KindBuildNodeImageType.Ci = 3 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
+*REMOVED*ModularPipelines.Kind.Enums.KindBuildNodeImageType.Source = 4 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
+*REMOVED*ModularPipelines.Kind.Enums.KindBuildNodeImageType.Url = 0 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
 *REMOVED*ModularPipelines.Kind.Options.KindCreateClusterOptions.Kubeconfig.get -> string?
 *REMOVED*ModularPipelines.Kind.Options.KindCreateClusterOptions.Kubeconfig.set -> void
 *REMOVED*ModularPipelines.Kind.Options.KindDeleteClusterOptions.Kubeconfig.get -> string?
@@ -100,6 +103,9 @@
 *REMOVED*virtual ModularPipelines.Kind.Services.KindLoad.DockerImageAsync(ModularPipelines.Kind.Options.KindLoadDockerImageOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Kind.Services.KindLoad.ExecuteAsync(ModularPipelines.Kind.Options.KindLoadOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Kind.Services.KindLoad.ImageArchiveAsync(ModularPipelines.Kind.Options.KindLoadImageArchiveOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Kind.Enums.KindBuildNodeImageType.Ci = 0 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
+ModularPipelines.Kind.Enums.KindBuildNodeImageType.Source = 3 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
+ModularPipelines.Kind.Enums.KindBuildNodeImageType.Url = 4 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType
 ModularPipelines.Kind.Options.KindExportKubeConfigOptions
 ModularPipelines.Kind.Options.KindExportKubeConfigOptions.Help.get -> bool?
 ModularPipelines.Kind.Options.KindExportKubeConfigOptions.Help.set -> void


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kind** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Kind`.

- Added APIs: 3
- Removed or changed APIs: 3
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Kind.Enums.KindBuildNodeImageType.Ci = 3 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType`
- `ModularPipelines.Kind.Enums.KindBuildNodeImageType.Source = 4 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType`
- `ModularPipelines.Kind.Enums.KindBuildNodeImageType.Url = 0 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType`

Representative added members:
- `ModularPipelines.Kind.Enums.KindBuildNodeImageType.Ci = 0 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType`
- `ModularPipelines.Kind.Enums.KindBuildNodeImageType.Source = 3 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType`
- `ModularPipelines.Kind.Enums.KindBuildNodeImageType.Url = 4 -> ModularPipelines.Kind.Enums.KindBuildNodeImageType`

## Command coverage
Command coverage report:
- kind (kind version 0.34.0-alpha+aa74c7f3e55dba): 17 commands, tree a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b
  - Baseline comparison: 17 commands at kind version 0.34.0-alpha+6a54ab4800dab5 -> 17 commands at kind version 0.34.0-alpha+aa74c7f3e55dba

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Changes**
  - Updated the `KindBuildNodeImageType` enum values for `Ci`, `Source`, and `Url`.
  - Removed `Ci` and `Source` from the shipped public API while recording their updated values in the upcoming API surface.
  - Consumers relying on the previous enum members or numeric values may need to update their integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->