### PR TITLE
[Automated] Update eksctl CLI Options

### DIFF
--- a/src/ModularPipelines.Eksctl/Enums/EksctlCreateCapabilityType.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlCreateCapabilityType.Generated.cs
@@ -19,9 +19,9 @@ public enum EksctlCreateCapabilityType
     [EnumValue("ACK")]
     Ack,
 
-    [EnumValue("KRO")]
-    Kro,
-
     [EnumValue("ARGOCD")]
-    Argocd
+    Argocd,
+
+    [EnumValue("KRO")]
+    Kro
 }

--- a/src/ModularPipelines.Eksctl/Enums/EksctlUpdateCapabilityType.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlUpdateCapabilityType.Generated.cs
@@ -19,9 +19,9 @@ public enum EksctlUpdateCapabilityType
     [EnumValue("ACK")]
     Ack,
 
-    [EnumValue("KRO")]
-    Kro,
-
     [EnumValue("ARGOCD")]
-    Argocd
+    Argocd,
+
+    [EnumValue("KRO")]
+    Kro
 }

--- a/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingDisableTypes.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingDisableTypes.Generated.cs
@@ -19,9 +19,6 @@ public enum EksctlUtilsUpdateClusterLoggingDisableTypes
     [EnumValue("all")]
     All,
 
-    [EnumValue("none")]
-    None,
-
     [EnumValue("api")]
     Api,
 
@@ -33,6 +30,9 @@ public enum EksctlUtilsUpdateClusterLoggingDisableTypes
 
     [EnumValue("controllerManager")]
     ControllerManager,
+
+    [EnumValue("none")]
+    None,
 
     [EnumValue("scheduler")]
     Scheduler

--- a/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingEnableTypes.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Enums/EksctlUtilsUpdateClusterLoggingEnableTypes.Generated.cs
@@ -19,9 +19,6 @@ public enum EksctlUtilsUpdateClusterLoggingEnableTypes
     [EnumValue("all")]
     All,
 
-    [EnumValue("none")]
-    None,
-
     [EnumValue("api")]
     Api,
 
@@ -33,6 +30,9 @@ public enum EksctlUtilsUpdateClusterLoggingEnableTypes
 
     [EnumValue("controllerManager")]
     ControllerManager,
+
+    [EnumValue("none")]
+    None,
 
     [EnumValue("scheduler")]
     Scheduler

--- a/src/ModularPipelines.Eksctl/Generated/Eksctl.Generation.json
+++ b/src/ModularPipelines.Eksctl/Generated/Eksctl.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "eksctl",
   "toolVersion": "0.230.0",
   "commandTreeSha256": "84fec058d6a4a16c205233e11b13a4ffb48fce85b9cb074d731bba5dc937d7a5",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }

--- a/src/ModularPipelines.Eksctl/Options/EksctlSetOptions.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Options/EksctlSetOptions.Generated.cs
@@ -12,6 +12,9 @@ using ModularPipelines.Eksctl.Options;
 
 namespace ModularPipelines.Eksctl.Options;
 
+/// <summary>
+/// Set values
+/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("set")]

--- a/src/ModularPipelines.Eksctl/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Eksctl/PublicAPI.Shipped.txt
@@ -4,25 +4,13 @@ ModularPipelines.Context.ModularPipelines_Eksctl_13b7cdfb02b06c74ToolsExtensions
 ModularPipelines.Context.ModularPipelines_Eksctl_13b7cdfb02b06c74ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Eksctl.get -> ModularPipelines.Eksctl.Services.IEksctl!
 ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
 ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Ack = 0 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
-ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Argocd = 2 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
-ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Kro = 1 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
 ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
 ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Ack = 0 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
-ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Argocd = 2 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
-ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Kro = 1 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
 ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
 ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.All = 0 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Api = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Audit = 3 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Authenticator = 4 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.None = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
 ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Scheduler = 6 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
 ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
 ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.All = 0 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Api = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Audit = 3 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Authenticator = 4 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.None = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
 ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Scheduler = 6 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
 ModularPipelines.Eksctl.Extensions.EksctlExtensions
 ModularPipelines.Eksctl.Options.EksctlAssociateIdentityproviderOptions

--- a/src/ModularPipelines.Eksctl/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Eksctl/PublicAPI.Unshipped.txt
@@ -1,6 +1,18 @@
 #nullable enable
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Argocd = 2 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Kro = 1 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Argocd = 2 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Kro = 1 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Api = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Audit = 3 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Authenticator = 4 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
 *REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Controllermanager = 5 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.None = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Api = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Audit = 3 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Authenticator = 4 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
 *REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Controllermanager = 5 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+*REMOVED*ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.None = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
 *REMOVED*ModularPipelines.Eksctl.Services.EksctlAssociate.EksctlAssociate(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.Eksctl.Services.EksctlCreate.EksctlCreate(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
 *REMOVED*ModularPipelines.Eksctl.Services.EksctlDelete.EksctlDelete(ModularPipelines.Context.Domains.Shell.ICommandContext! command) -> void
@@ -189,8 +201,20 @@
 *REMOVED*virtual ModularPipelines.Eksctl.Services.EksctlUtils.UpdateZonalShiftConfigAsync(ModularPipelines.Eksctl.Options.EksctlUtilsUpdateZonalShiftConfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Eksctl.Services.EksctlUtils.WriteKubeConfigAsync(ModularPipelines.Eksctl.Options.EksctlUtilsWriteKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Eksctl.Services.EksctlUtils.WriteKubeconfigAsync(ModularPipelines.Eksctl.Options.EksctlUtilsWriteKubeconfigOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.ControllerManager = 5 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
-ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.ControllerManager = 5 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Argocd = 1 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
+ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Kro = 2 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType
+ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Argocd = 1 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
+ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Kro = 2 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Api = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Audit = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Authenticator = 3 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.ControllerManager = 4 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.None = 5 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Api = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Audit = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.Authenticator = 3 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.ControllerManager = 4 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
+ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes.None = 5 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingEnableTypes
 ModularPipelines.Eksctl.Services.EksctlAssociate.EksctlAssociate(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Eksctl.Services.EksctlCreate.EksctlCreate(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Eksctl.Services.EksctlDelete.EksctlDelete(ModularPipelines.Context.ICommandContext! command) -> void

--- a/src/ModularPipelines.Eksctl/Services/EksctlSet.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/EksctlSet.Generated.cs
@@ -33,7 +33,7 @@ public class EksctlSet : IEksctlSet
     #region Commands
 
     /// <summary>
-    /// Executes the parent command directly.
+    /// Set values
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Eksctl/Services/IEksctlSet.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/IEksctlSet.Generated.cs
@@ -21,6 +21,13 @@ namespace ModularPipelines.Eksctl.Services;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IEksctlSet
 {
+    /// <summary>
+    /// Set values
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
     public Task<CommandResult> ExecuteAsync(EksctlSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **eksctl** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Eksctl`.

- Added APIs: 14
- Removed or changed APIs: 14
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Argocd = 2 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Kro = 1 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Argocd = 2 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Kro = 1 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Api = 2 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes`

Representative added members:
- `ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Argocd = 1 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType.Kro = 2 -> ModularPipelines.Eksctl.Enums.EksctlCreateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Argocd = 1 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType.Kro = 2 -> ModularPipelines.Eksctl.Enums.EksctlUpdateCapabilityType`
- `ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes.Api = 1 -> ModularPipelines.Eksctl.Enums.EksctlUtilsUpdateClusterLoggingDisableTypes`

## Command coverage
Command coverage report:
- eksctl (0.230.0): 85 commands, tree 84fec058d6a4a16c205233e11b13a4ffb48fce85b9cb074d731bba5dc937d7a5
  - Baseline comparison: 85 commands at 0.230.0 -> 85 commands at 0.230.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator