### PR TITLE
[Automated] Update buildah CLI Options

### DIFF
--- a/src/ModularPipelines.Buildah/Generated/Buildah.Generation.json
+++ b/src/ModularPipelines.Buildah/Generated/Buildah.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "buildah",
   "toolVersion": "buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)",
   "commandTreeSha256": "40421c40371cc91f2731cecc414602c829d251cb603067ac9cbef046a69eeb90",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **buildah** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- buildah (buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)): 37 commands, tree 40421c40371cc91f2731cecc414602c829d251cb603067ac9cbef046a69eeb90
  - Baseline comparison: 37 commands at buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0) -> 37 commands at buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator