### PR TITLE
Keep wrapped brew descriptions that look like option rows

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -291,6 +291,33 @@ public class BrewCliScraperTests
     }
 
     [Test]
+    public async Task Keeps_Option_Like_Wrapped_Line_After_Flags_Only_Option()
+    {
+        const string helpText = """
+            Usage: brew example [options]
+
+            Example command whose first option has no inline description.
+
+                  --foo
+                                               Shortcut for
+                                               --bar=baz.
+                  --bar                        Some real description.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "example"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(static option => option.SwitchName))
+                .IsEquivalentTo(["--foo", "--bar"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--foo").Description)
+                .IsEqualTo("Shortcut for --bar=baz.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--bar").Description)
+                .IsEqualTo("Some real description.");
+        }
+    }
+
+    [Test]
     public async Task Discovers_Colon_Delimited_Bundle_Subcommands()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/BrewCliScraperTests.cs
@@ -252,6 +252,45 @@ public class BrewCliScraperTests
     }
 
     [Test]
+    public async Task Keeps_Wrapped_Description_Lines_That_Look_Like_Option_Rows()
+    {
+        const string helpText = """
+            Usage: brew vulns [options] [formula ...]
+
+            Check formula for known security vulnerabilities using the OSV.dev database.
+            With no arguments, all installed formulae are checked.
+
+              -d, --deps                       Also check the dependencies of named
+                                               formulae.
+                  --fix-available              Only report vulnerabilities that have a
+                                               released version fix available. Shortcut for
+                                               --fix-type=released.
+                  --no-fix-available           Only report vulnerabilities that do not have
+                                               a released version fix available (includes
+                                               unreleased commit SHA patches). Shortcut for
+                                               --fix-type=unreleased.
+                  --fix-type                   Filter findings by fix type: released
+                                               (official version release), patch (unreleased
+                                               commit SHA), any (either), none (neither),
+                                               unreleased (no released version fix).
+                  --list-skipped               List packages skipped due to missing or
+                                               unsupported source URL.
+            """;
+
+        var command = await new TestBrewCliScraper().Parse(["brew", "vulns"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(static option => option.SwitchName))
+                .IsEquivalentTo(["--deps", "--fix-available", "--no-fix-available", "--fix-type", "--list-skipped"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--fix-available").Description)
+                .IsEqualTo("Only report vulnerabilities that have a released version fix available. Shortcut for --fix-type=released.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--fix-type").Description)
+                .IsEqualTo("Filter findings by fix type: released (official version release), patch (unreleased commit SHA), any (either), none (neither), unreleased (no released version fix).");
+        }
+    }
+
+    [Test]
     public async Task Discovers_Colon_Delimited_Bundle_Subcommands()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -621,10 +621,17 @@ public partial class BrewCliScraper : CliScraperBase
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var lines = NormalizeLines(helpText);
+        int? descriptionColumn = null;
 
         for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
         {
             var line = lines[lineIndex];
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                // The description column is only consistent within one option block.
+                descriptionColumn = null;
+                continue;
+            }
 
             // Match option lines
             var match = BrewOptionPattern().Match(line);
@@ -635,15 +642,17 @@ public partial class BrewCliScraper : CliScraperBase
 
             var flagsPart = match.Groups["flags"].Value.Trim();
             var descriptionParts = new List<string>();
-            var inlineDescription = match.Groups["description"].Value.Trim();
+            var descriptionGroup = match.Groups["description"];
+            var inlineDescription = descriptionGroup.Value.Trim();
             if (!string.IsNullOrEmpty(inlineDescription))
             {
                 descriptionParts.Add(inlineDescription);
+                descriptionColumn = descriptionGroup.Index;
             }
 
             while (lineIndex + 1 < lines.Length
                    && !string.IsNullOrWhiteSpace(lines[lineIndex + 1])
-                   && !BrewOptionPattern().IsMatch(lines[lineIndex + 1]))
+                   && IsWrappedDescriptionLine(lines[lineIndex + 1], descriptionColumn))
             {
                 descriptionParts.Add(lines[++lineIndex].Trim());
             }
@@ -722,6 +731,19 @@ public partial class BrewCliScraper : CliScraperBase
         }
 
         return options;
+    }
+
+    /// <summary>
+    /// Homebrew wraps long option descriptions onto lines aligned to the description
+    /// column, and a wrapped fragment can itself look like an option row (for example
+    /// "--fix-type=released." ending the <c>brew vulns --fix-available</c> description).
+    /// Only a line whose flags start before the block's description column begins a new option.
+    /// </summary>
+    private static bool IsWrappedDescriptionLine(string line, int? descriptionColumn)
+    {
+        var match = BrewOptionPattern().Match(line);
+        return !match.Success
+               || (descriptionColumn is { } column && match.Groups["flags"].Index >= column);
     }
 
     private static IReadOnlyDictionary<string, string> ParseOptionTypes(IEnumerable<string> lines) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/BrewCliScraper.cs
@@ -640,7 +640,8 @@ public partial class BrewCliScraper : CliScraperBase
                 continue;
             }
 
-            var flagsPart = match.Groups["flags"].Value.Trim();
+            var flagsGroup = match.Groups["flags"];
+            var flagsPart = flagsGroup.Value.Trim();
             var descriptionParts = new List<string>();
             var descriptionGroup = match.Groups["description"];
             var inlineDescription = descriptionGroup.Value.Trim();
@@ -650,9 +651,14 @@ public partial class BrewCliScraper : CliScraperBase
                 descriptionColumn = descriptionGroup.Index;
             }
 
+            // Without a known description column (a flags-only option opening the block), a
+            // wrapped line still starts well past the end of the current option's own flags,
+            // whereas a genuine option row starts at the flags column.
+            var continuationColumn = descriptionColumn ?? (flagsGroup.Index + flagsGroup.Length);
+
             while (lineIndex + 1 < lines.Length
                    && !string.IsNullOrWhiteSpace(lines[lineIndex + 1])
-                   && IsWrappedDescriptionLine(lines[lineIndex + 1], descriptionColumn))
+                   && IsWrappedDescriptionLine(lines[lineIndex + 1], continuationColumn))
             {
                 descriptionParts.Add(lines[++lineIndex].Trim());
             }
@@ -739,11 +745,10 @@ public partial class BrewCliScraper : CliScraperBase
     /// "--fix-type=released." ending the <c>brew vulns --fix-available</c> description).
     /// Only a line whose flags start before the block's description column begins a new option.
     /// </summary>
-    private static bool IsWrappedDescriptionLine(string line, int? descriptionColumn)
+    private static bool IsWrappedDescriptionLine(string line, int continuationColumn)
     {
         var match = BrewOptionPattern().Match(line);
-        return !match.Success
-               || (descriptionColumn is { } column && match.Groups["flags"].Index >= column);
+        return !match.Success || match.Groups["flags"].Index >= continuationColumn;
     }
 
     private static IReadOnlyDictionary<string, string> ParseOptionTypes(IEnumerable<string> lines) =>


### PR DESCRIPTION
## Summary

`BrewCliScraper.ParseOptions` treated any following line that matched `BrewOptionPattern()` as a new option row. Homebrew wraps long descriptions onto continuation lines aligned to the description column, and a wrapped fragment can itself look like an option row (for example `--fix-type=released.` ending the `brew vulns --fix-available` description). That truncated the parent description at "Shortcut for", registered a bogus `--fix-type` option with no description, and then dropped the real `--fix-type` row as a duplicate. This is the BLOCKING finding on #4621 (`BrewVulnsOptions.Generated.cs`).

- Continuation detection is now column-aware: a line matching the option pattern only starts a new option when its flags begin at an option flag column. Lines whose flags start at (or beyond) the block's description column are wrapped description text. When no description column is known yet, a line is a continuation only if it starts beyond the end of the current option's flag text.
- Added `Keeps_Wrapped_Description_Lines_That_Look_Like_Option_Rows`, a `brew vulns`-shaped regression test. It fails on `main` (descriptions cut at "Shortcut for", `--fix-type` description empty) and passes with the fix.

Sharing this column-aware rule with the other scrapers that carry their own indent-based variants (Cargo, Git, Cobra) is tracked separately in #4634.

No generated files are touched. The generator fingerprint changes, so the Generate CLI Options workflow regenerates every tool from `main` after merge; the brew snapshot in #4621 picks up the corrected `BrewVulnsOptions` documentation from that run.

## Test plan
- [x] `ModularPipelines.OptionsGenerator.Tests` focused `BrewCliScraperTests`: 23 passed (new test confirmed red without the scraper change, green with it)
- [x] Full `ModularPipelines.OptionsGenerator.Tests` project: 1271 passed
- [x] `dotnet format --verify-no-changes --severity info` on the generator solution for the two changed files
- [ ] CI: Generate CLI Options run for `brew` after merge produces complete `--fix-available` / `--no-fix-available` / `--fix-type` docs

Closes #4632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line option parsing for wrapped descriptions that resemble additional option rows.
  * Preserved complete, readable descriptions when help text spans multiple lines.

* **Tests**
  * Added coverage for wrapped Homebrew vulnerability command descriptions and verified all expected options are discovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->