### PR TITLE
Widen distributed executor test failsafes

### DIFF
--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -24,6 +24,7 @@ using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
+using ModularPipelines.TestHelpers;
 
 namespace ModularPipelines.Distributed.UnitTests.Master;
 
@@ -1146,7 +1147,7 @@ public class DistributedModuleExecutorTests
             coordinator: coordinator,
             distributedOptions: options);
 
-        await executor.ExecuteAsync([module]).WaitAsync(TimeSpan.FromSeconds(2), testCancellation);
+        await executor.ExecuteAsync([module]).WaitAsync(testCancellation);
 
         var registeredResult = resultRegistry.GetResult(typeof(ShortTimeoutDistributedModule));
         await Assert.That(registeredResult).IsNotNull();
@@ -1411,7 +1412,7 @@ public class DistributedModuleExecutorTests
 
         var executionTask = executor.ExecuteAsync([failedModule, alwaysRunModule]);
         await trackingCoordinator.WaitForResultStartedAsync(typeof(DistributedModule))
-            .WaitAsync(TimeSpan.FromSeconds(2));
+            .WaitAsync(TestHostSettings.DefaultTestTimeout);
         var failedAssignment = await coordinator.DequeueModuleAsync(
             new HashSet<Capability>(),
             CancellationToken.None);
@@ -1419,8 +1420,8 @@ public class DistributedModuleExecutorTests
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
 
         await trackingCoordinator.WaitForResultPublishedAsync(typeof(AlwaysRunDistributedModule))
-            .WaitAsync(TimeSpan.FromSeconds(2));
-        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+            .WaitAsync(TestHostSettings.DefaultTestTimeout);
+        await executionTask.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await Assert.That(resultRegistry.GetResult(typeof(AlwaysRunDistributedModule))?.Status)
             .IsEqualTo(ModuleStatus.Succeeded);
         moduleRunner.VerifyAll();


### PR DESCRIPTION
## Summary

Follow-up to #4587. That PR's review worktree kept an uncommitted test edit after the squash merge; this recovers it onto current `main`.

`DistributedModuleExecutorTests` bounded four coordination waits with a hard-coded `TimeSpan.FromSeconds(2)` failsafe. Those waits normally complete in milliseconds and only exist to stop a hung test from running forever, so on a loaded CI runner the 2 s bound is a source of timing flakes rather than a behavioural check.

- The three waits in `FailFast_LateStarts_AlwaysRun_Through_Distributed_Path` (two `trackingCoordinator` signals plus the final execution wait) now use `TestHostSettings.DefaultTestTimeout` (30 s), the failsafe the rest of the test suite already uses. That test has no `[Timeout]` and no cancellation token, so this failsafe is its only bound.
- The wait in `Module_Timeout_Takes_Precedence_Over_Default_Result_Timeout` already runs under `[Timeout(5_000)]` with `testCancellation`, so it now waits on that token alone instead of carrying a second, unreachable timeout.

The file still has ~30 other 2 s / 3 s failsafes. They were not part of the recovered edit and a few of them deliberately assert a timeout, so converging the whole file on one convention is left for a separate pass.

No production code changes.

## Test plan
- [x] `ModularPipelines.Distributed.UnitTests` filtered to `DistributedModuleExecutorTests`: 57 passed
- [x] `dotnet format --verify-no-changes --severity info` on the changed file
- [ ] CI full pipeline
