### PR TITLE
Share column-aware wrapped-description detection across CLI scrapers

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CargoCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CargoCliScraperTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class CargoCliScraperTests
+{
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        const string helpText = """
+            Compile a local package and all of its dependencies
+
+            Usage: cargo build [OPTIONS]
+
+            Options:
+                  --ignore-rust-version
+                                      Ignore `rust-version` specification in packages
+                  --keep-going        Do not abort the build as soon as there is an error. Implies
+                                      --jobs
+                  --timings           Output information how long each compilation takes
+              -h, --help              Print help
+            """;
+
+        var command = await new TestCargoCliScraper().Parse(["cargo", "build"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--ignore-rust-version", "--keep-going", "--timings", "--help"]);
+            await Assert.That(GetOption(command, "--ignore-rust-version").Description)
+                .IsEqualTo("Ignore `rust-version` specification in packages");
+            await Assert.That(GetOption(command, "--keep-going").Description)
+                .IsEqualTo("Do not abort the build as soon as there is an error. Implies --jobs");
+            await Assert.That(GetOption(command, "--timings").Description)
+                .IsEqualTo("Output information how long each compilation takes");
+        }
+    }
+
+    private static CliOptionDefinition GetOption(CliCommandDefinition command, string switchName) =>
+        command.Options.Single(option => option.SwitchName == switchName);
+
+    private sealed class TestCargoCliScraper()
+        : CargoCliScraper(
+            new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<CargoCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/ContinuationLineTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/ContinuationLineTests.cs
@@ -1,0 +1,73 @@
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers.Cli;
+
+public class ContinuationLineTests
+{
+    [Test]
+    [Arguments("", 0)]
+    [Arguments("--flag", 0)]
+    [Arguments("    prose", 4)]
+    [Arguments("\tprose", 8)]
+    [Arguments("  \tprose", 8)]
+    [Arguments("\t\tprose", 16)]
+    [Arguments("        \tprose", 16)]
+    public async Task GetIndentation_Counts_Columns_With_Eight_Column_Tab_Stops(string line, int expected)
+    {
+        await Assert.That(CliScraperBase.GetIndentation(line)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("  -f, --file string   Path", 22, 22)]
+    [Arguments("\t--file\tPath", 8, 16)]
+    [Arguments("abc", 10, 3)]
+    public async Task GetColumn_Expands_Tabs_Before_The_Index(string line, int index, int expected)
+    {
+        await Assert.That(CliScraperBase.GetColumn(line, index)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Blank_Lines_Never_Continue_A_Description()
+    {
+        await Assert.That(CliScraperBase.IsContinuationLine("   ", 2, 20, looksLikeOptionRow: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task Prose_Continues_Only_When_Deeper_Than_The_Declaration()
+    {
+        using (Assert.Multiple())
+        {
+            await Assert.That(CliScraperBase.IsContinuationLine("      wrapped prose", 2, null, looksLikeOptionRow: false)).IsTrue();
+            await Assert.That(CliScraperBase.IsContinuationLine("  sibling text", 2, null, looksLikeOptionRow: false)).IsFalse();
+            await Assert.That(CliScraperBase.IsContinuationLine("Section:", 2, null, looksLikeOptionRow: false)).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Option_Rows_Before_The_Description_Column_Start_The_Next_Option()
+    {
+        const string nextOption = "      --tlsverify          Use TLS and verify the remote";
+
+        await Assert.That(CliScraperBase.IsContinuationLine(nextOption, 6, 27, looksLikeOptionRow: true)).IsFalse();
+    }
+
+    [Test]
+    public async Task Option_Looking_Rows_At_The_Description_Column_Are_Wrapped_Prose()
+    {
+        const string wrapped = "                           --tlsverify";
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 6, 27, looksLikeOptionRow: true)).IsTrue();
+            await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 6, 20, looksLikeOptionRow: true)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Option_Looking_Rows_Without_A_Known_Description_Column_Start_The_Next_Option()
+    {
+        const string wrapped = "                           --tlsverify";
+
+        await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 6, null, looksLikeOptionRow: true)).IsFalse();
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DockerCliScraperTests.cs
@@ -103,6 +103,33 @@ public class DockerCliScraperTests
             .And.HasMessageContaining("maps both '--current' and '--CURRENT'");
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Mention_Flags_Stay_Prose()
+    {
+        const string helpText = """
+            Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
+
+            Create and run a new container from an image
+
+            Options:
+                  --tls                Use TLS; implied by
+                                       --tlsverify
+                  --tlsverify          Use TLS and verify the remote
+            """;
+
+        var command = await new TestDockerCliScraper().Parse(["docker", "run"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--tls", "--tlsverify"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--tls").Description)
+                .IsEqualTo("Use TLS; implied by --tlsverify");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--tlsverify").Description)
+                .IsEqualTo("Use TLS and verify the remote");
+        }
+    }
+
     private sealed class TestDockerCliScraper : DockerCliScraper
     {
         public TestDockerCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -337,7 +337,8 @@ public class GitCliScraperTests
             usage: git add [<options>]
 
                 -N, --[no-]intent-to-add
-                                    record only the fact that the path will be added later
+                                    record only the fact that the path will be added
+                                    later
                 -W, --[no-]function-context
                                     generate diffs with <n> lines context
             """;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
@@ -307,6 +307,36 @@ public class KubectlCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Tab_Indented_Descriptions_Are_Joined_Across_Lines()
+    {
+        var helpText = string.Join(
+            "\n",
+            "Usage:",
+            "  kubectl get TYPE [flags] [options]",
+            "",
+            "Options:",
+            "    -A, --all-namespaces=false:",
+            "\tIf present, list the requested object(s) across all namespaces. Namespace in current context is ignored even",
+            "\tif specified with --namespace.",
+            "",
+            "    --allow-missing-template-keys=true:",
+            "\tIf true, ignore any errors in templates when a field or map key is missing in the template.");
+
+        var command = await new TestKubectlCliScraper().Parse(["kubectl", "get"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--all-namespaces", "--allow-missing-template-keys"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--all-namespaces").Description)
+                .IsEqualTo(
+                    "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--allow-missing-template-keys").Description)
+                .IsEqualTo("If true, ignore any errors in templates when a field or map key is missing in the template.");
+        }
+    }
+
     private sealed class TestKubectlCliScraper()
         : KubectlCliScraper(
             new RecordingExecutor(),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -250,13 +250,16 @@ public partial class CargoCliScraper : CliScraperBase
                 csharpType = "IEnumerable<string>?";
             }
 
+            // Consumes wrapped description lines so they are not re-read as declarations.
+            var description = AccumulateWrappedDescription(lines, ref index, match.Groups["desc"], IsOptionRow);
+
             options.Add(new CliOptionDefinition
             {
                 SwitchName = switchName,
                 ShortForm = string.IsNullOrEmpty(shortForm) ? null : shortForm,
                 PropertyName = propertyName,
                 CSharpType = csharpType,
-                Description = GetOptionDescription(lines, index, match.Groups["desc"].Value),
+                Description = description,
                 IsFlag = isFlag,
                 IsRequired = false,
                 AcceptsMultipleValues = csharpType.Contains("IEnumerable"),
@@ -282,34 +285,7 @@ public partial class CargoCliScraper : CliScraperBase
         heading.Contains("option", StringComparison.OrdinalIgnoreCase)
         || heading.EndsWith("selection:", StringComparison.OrdinalIgnoreCase);
 
-    private static string GetOptionDescription(
-        string[] lines,
-        int declarationIndex,
-        string inlineDescription)
-    {
-        var declarationIndentation = lines[declarationIndex].TakeWhile(char.IsWhiteSpace).Count();
-        var description = new List<string>();
-        if (!string.IsNullOrWhiteSpace(inlineDescription))
-        {
-            description.Add(inlineDescription.Trim());
-        }
-
-        for (var index = declarationIndex + 1; index < lines.Length; index++)
-        {
-            var line = lines[index];
-            var trimmed = line.Trim();
-            if (string.IsNullOrEmpty(trimmed)
-                || CargoOptionDeclarationPattern().IsMatch(line)
-                || line.TakeWhile(char.IsWhiteSpace).Count() <= declarationIndentation)
-            {
-                break;
-            }
-
-            description.Add(trimmed);
-        }
-
-        return string.Join(' ', description);
-    }
+    private static bool IsOptionRow(string line) => CargoOptionDeclarationPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliArgumentGroupParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliArgumentGroupParser.cs
@@ -108,7 +108,7 @@ internal static partial class CliArgumentGroupParser
             .Skip(previousDeclaration.LineIndex + 1)
             .Take(candidateIndex - previousDeclaration.LineIndex - 1)
             .Where(line => !string.IsNullOrWhiteSpace(line))
-            .All(line => GetIndentation(line) > declarationIndentation);
+            .All(line => CliScraperBase.GetIndentation(line) > declarationIndentation);
     }
 
     private static void MoveToContainingGroup(
@@ -162,7 +162,7 @@ internal static partial class CliArgumentGroupParser
         for (var index = start; index < end; index++)
         {
             if (!string.IsNullOrWhiteSpace(lines[index])
-                && GetIndentation(lines[index]) <= declarationIndentation)
+                && CliScraperBase.GetIndentation(lines[index]) <= declarationIndentation)
             {
                 return index;
             }
@@ -171,32 +171,11 @@ internal static partial class CliArgumentGroupParser
         return end;
     }
 
-    private static int GetIndentation(string line)
-    {
-        var indentation = 0;
-        foreach (var character in line)
-        {
-            switch (character)
-            {
-                case ' ':
-                    indentation++;
-                    break;
-                case '\t':
-                    indentation += 4;
-                    break;
-                default:
-                    return indentation;
-            }
-        }
-
-        return indentation;
-    }
-
     private static int GetMinimumContentIndentation(IEnumerable<string> lines)
     {
         var indentations = lines
             .Where(line => !string.IsNullOrWhiteSpace(line))
-            .Select(GetIndentation)
+            .Select(CliScraperBase.GetIndentation)
             .ToArray();
 
         return indentations.Length == 0 ? int.MaxValue : indentations.Min();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -16,6 +16,7 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 public abstract partial class CliScraperBase : ICliScraper
 {
     private static readonly string[] DefaultUsageSynopsisHeadings = ["usage"];
+    private const int TabWidth = 8;
     private readonly CliScrapeProvenance _scrapeProvenance = new();
     private readonly HashSet<string> _knownCommandGroups = new(StringComparer.OrdinalIgnoreCase);
 
@@ -1213,6 +1214,113 @@ public abstract partial class CliScraperBase : ICliScraper
         acceptsMultipleValues
             ? $"IEnumerable<{scalarType.TrimEnd('?')}>?"
             : scalarType;
+
+    /// <summary>
+    /// Counts the leading whitespace columns of a help line. A tab advances to the next
+    /// eight-column stop, matching how the terminal rendered the aligned help text.
+    /// </summary>
+    protected internal static int GetIndentation(string line)
+    {
+        var contentIndex = line.AsSpan().IndexOfAnyExcept(' ', '\t');
+        return GetColumn(line, contentIndex < 0 ? line.Length : contentIndex);
+    }
+
+    /// <summary>
+    /// Returns the rendered column at which character <paramref name="index"/> of
+    /// <paramref name="line"/> starts, expanding tabs to eight-column stops.
+    /// </summary>
+    protected internal static int GetColumn(string line, int index)
+    {
+        var column = 0;
+        var end = Math.Min(index, line.Length);
+        for (var position = 0; position < end; position++)
+        {
+            column = line[position] == '\t'
+                ? column + TabWidth - (column % TabWidth)
+                : column + 1;
+        }
+
+        return column;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="line"/> continues the description of the option
+    /// declared at <paramref name="declarationIndentation"/> instead of starting the next
+    /// help row. Formatters wrap prose at or beyond the block's description column, so a
+    /// row that looks like an option declaration but starts at or after that column is
+    /// still wrapped prose (for example a wrapped mention of <c>--flag=value</c>).
+    /// </summary>
+    /// <param name="line">The candidate continuation line.</param>
+    /// <param name="declarationIndentation">Column where the option declaration starts.</param>
+    /// <param name="descriptionColumn">
+    /// Column where the declaration's inline description starts, or <see langword="null"/>
+    /// when the description only begins on a following line.
+    /// </param>
+    /// <param name="looksLikeOptionRow">Whether the scraper's option pattern matches <paramref name="line"/>.</param>
+    protected internal static bool IsContinuationLine(
+        string line,
+        int declarationIndentation,
+        int? descriptionColumn,
+        bool looksLikeOptionRow)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        var indentation = GetIndentation(line);
+        var wrappedAtDescriptionColumn = indentation >= descriptionColumn;
+        return (!looksLikeOptionRow || wrappedAtDescriptionColumn)
+               && indentation > declarationIndentation;
+    }
+
+    /// <summary>
+    /// Joins an option row's inline description with the prose wrapped beneath it, advancing
+    /// <paramref name="declarationIndex"/> past every consumed line so callers never re-read
+    /// wrapped prose as a declaration. Returns an empty string when the row has no description.
+    /// </summary>
+    /// <param name="lines">The help text lines.</param>
+    /// <param name="declarationIndex">Index of the option row; advanced to the last consumed line.</param>
+    /// <param name="inlineDescription">
+    /// Regex group holding the row's inline description, or <see langword="null"/> when the
+    /// scraper did not capture one.
+    /// </param>
+    /// <param name="looksLikeOptionRow">Returns whether a line matches the scraper's option pattern.</param>
+    protected static string AccumulateWrappedDescription(
+        IReadOnlyList<string> lines,
+        ref int declarationIndex,
+        Group? inlineDescription,
+        Func<string, bool> looksLikeOptionRow)
+    {
+        var declaration = lines[declarationIndex];
+        var declarationIndentation = GetIndentation(declaration);
+        var parts = new List<string>();
+        int? descriptionColumn = null;
+        if (inlineDescription is { } group && !string.IsNullOrWhiteSpace(group.Value))
+        {
+            parts.Add(group.Value.Trim());
+            var leadingWhitespace = group.Value.Length - group.Value.TrimStart().Length;
+            descriptionColumn = GetColumn(declaration, group.Index + leadingWhitespace);
+        }
+
+        while (declarationIndex + 1 < lines.Count)
+        {
+            var candidate = lines[declarationIndex + 1];
+            if (!IsContinuationLine(
+                    candidate,
+                    declarationIndentation,
+                    descriptionColumn,
+                    looksLikeOptionRow(candidate)))
+            {
+                break;
+            }
+
+            parts.Add(candidate.Trim());
+            declarationIndex++;
+        }
+
+        return string.Join(' ', parts);
+    }
 
     /// <summary>
     /// Parses indentation-based argument declarations into a reusable nested group model.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -308,17 +308,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
             var lines = section.Split('\n');
             for (var i = 0; i < lines.Length; i++)
             {
-                var line = lines[i];
-
-                // Try standard Cobra pattern first (Docker, Helm)
-                var match = CobraOptionPattern().Match(line);
-
-                // If not matched, try kubectl pattern: "-s, --long=default:"
-                if (!match.Success)
-                {
-                    match = KubectlOptionPattern().Match(line);
-                }
-
+                var match = MatchOptionRow(lines[i]);
                 if (!match.Success)
                 {
                     continue;
@@ -329,12 +319,10 @@ public abstract partial class CobraCliScraper : CliScraperBase
                 var typeHint = match.Groups["type"].Value.Trim();
                 var hasOptionalValue = TryNormalizeOptionalValueTypeHint(ref typeHint);
                 var hasDefaultValue = match.Groups["default"].Success;
-                var description = match.Groups["desc"].Value.Trim();
 
-                // Accumulate multi-line descriptions
-                // Look ahead for continuation lines that are indented but don't start with a dash
-                i = AccumulateMultiLineDescription(lines, i, ref description);
-                description = NormalizeOptionDescription(description);
+                // Consumes the description wrapped beneath the declaration so it is not re-read as a row.
+                var description = NormalizeOptionDescription(
+                    AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow));
 
                 if (string.IsNullOrEmpty(longForm))
                 {
@@ -577,73 +565,15 @@ public abstract partial class CobraCliScraper : CliScraperBase
     }
 
     /// <summary>
-    /// Accumulates multi-line descriptions by looking ahead for continuation lines.
-    /// Continuation lines are identified as:
-    /// - Indented lines that don't start with a dash (not a new option)
-    /// - Not empty lines (stop at blank lines)
-    /// - Not section headers (lines ending with ':')
+    /// Matches a standard Cobra row (Docker, Helm) or a kubectl <c>-s, --long=default:</c> row.
     /// </summary>
-    /// <param name="lines">All lines in the section.</param>
-    /// <param name="currentIndex">Current line index.</param>
-    /// <param name="description">Description to accumulate into (ref).</param>
-    /// <returns>The new line index after consuming continuation lines.</returns>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
+    private static Match MatchOptionRow(string line)
     {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        // Look ahead for continuation lines
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            // Stop conditions:
-            // 1. Empty line (paragraph break)
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // 2. New option line. A single dash can instead be an allowed-value bullet.
-            if (CobraOptionPattern().IsMatch(nextLine) || KubectlOptionPattern().IsMatch(nextLine))
-            {
-                break;
-            }
-
-            // 3. Section header (ends with ':' and is relatively short)
-            if (trimmedNext.EndsWith(':') &&
-                trimmedNext.Length < 50 &&
-                !trimmedNext.Equals("Allowed values:", StringComparison.OrdinalIgnoreCase))
-            {
-                break;
-            }
-
-            // 4. Line is not indented enough (less than ~20 spaces means it's likely a new element)
-            // Continuation lines in Cobra help are typically deeply indented
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20 && !string.IsNullOrEmpty(description))
-            {
-                // If we already have a description and this line is not deeply indented,
-                // it might be a new option without dashes or something else
-                break;
-            }
-
-            // This is a continuation line - add it to the description
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        // Join all parts with space
-        description = string.Join(" ", descriptionParts);
-
-        // Return the last consumed index (loop will increment by 1)
-        return nextIndex - 1;
+        var match = CobraOptionPattern().Match(line);
+        return match.Success ? match : KubectlOptionPattern().Match(line);
     }
+
+    private static bool IsOptionRow(string line) => MatchOptionRow(line).Success;
 
     /// <summary>
     /// Tries to detect enum values from description.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/FlywayCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/FlywayCliScraper.cs
@@ -164,9 +164,6 @@ public partial class FlywayCliScraper : CliScraperBase
         return subcommands;
     }
 
-    private static int GetIndentation(string line) =>
-        line.TakeWhile(character => character is ' ' or '\t').Count();
-
     /// <summary>
     /// Parses a Flyway command from its help text.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -472,17 +472,24 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         for (var index = 0; index < lines.Length; index++)
         {
             var line = lines[index];
-            if (!TryParseOption(line, out var option, out var negatedLongFlag)
+            var match = OptionLineRegex().Match(line);
+            if (!match.Success
+                || !TryParseOption(match, line, out var option, out var negatedLongFlag)
                 || !seenOptions.Add(option.SwitchName))
             {
                 continue;
             }
 
-            if (string.IsNullOrEmpty(option.Description)
-                && TryGetWrappedDescription(lines, index, out var description))
+            // Consumes prose wrapped beneath the declaration so it is not re-read as a row.
+            var declarationIndex = index;
+            var description = AccumulateWrappedDescription(
+                lines,
+                ref index,
+                GetDescriptionGroup(match),
+                IsOptionRow);
+            if (index > declarationIndex)
             {
                 option = AddDescription(option, description);
-                index++;
             }
 
             options.Add(option);
@@ -495,27 +502,12 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         return options;
     }
 
-    private static bool TryGetWrappedDescription(
-        IReadOnlyList<string> lines,
-        int declarationIndex,
-        out string description)
-    {
-        description = "";
-        if (declarationIndex + 1 >= lines.Count)
-        {
-            return false;
-        }
+    private static bool IsOptionRow(string line) => OptionLineRegex().IsMatch(line);
 
-        var declaration = lines[declarationIndex];
-        var candidate = lines[declarationIndex + 1];
-        description = candidate.Trim();
-        return description.Length > 0
-               && !description.StartsWith('-')
-               && GetIndentation(candidate) > GetIndentation(declaration);
-    }
-
-    private static int GetIndentation(string value) =>
-        value.TakeWhile(char.IsWhiteSpace).Count();
+    private static Group GetDescriptionGroup(Match match) =>
+        match.Groups["description"] is { Success: true, Value.Length: > 0 } description
+            ? description
+            : match.Groups["shortDescription"];
 
     private static CliOptionDefinition AddDescription(
         CliOptionDefinition option,
@@ -529,18 +521,13 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     }
 
     private static bool TryParseOption(
+        Match match,
         string line,
         out CliOptionDefinition option,
         out string? negatedLongFlag)
     {
         option = null!;
         negatedLongFlag = null;
-        var match = OptionLineRegex().Match(line);
-        if (!match.Success)
-        {
-            return false;
-        }
-
         var identity = GetOptionIdentity(match);
         if (identity is null)
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/HadolintCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/HadolintCliScraper.cs
@@ -147,7 +147,7 @@ public partial class HadolintCliScraper : CliScraperBase
                 continue;
             }
 
-            var description = AccumulateDescription(lines, ref lineIndex, match);
+            var description = AccumulateWrappedDescription(lines, ref lineIndex, match.Groups["desc"], IsOptionRow);
             var option = CreateOption(match, description, formatEnum, thresholdEnum);
             if (option is not null && seenOptions.Add(option.SwitchName))
             {
@@ -164,33 +164,7 @@ public partial class HadolintCliScraper : CliScraperBase
         return match.Success ? helpText[(match.Index + match.Length)..] : helpText;
     }
 
-    private static string AccumulateDescription(string[] lines, ref int lineIndex, Match match)
-    {
-        var descriptionParts = new List<string>();
-        var inlineDescription = match.Groups["desc"].Value.Trim();
-        if (!string.IsNullOrEmpty(inlineDescription))
-        {
-            descriptionParts.Add(inlineDescription);
-        }
-
-        var optionIndentation = GetIndentation(lines[lineIndex]);
-        while (lineIndex + 1 < lines.Length)
-        {
-            var nextLine = lines[lineIndex + 1];
-            var continuation = nextLine.Trim();
-            if (string.IsNullOrEmpty(continuation)
-                || continuation.StartsWith('-')
-                || GetIndentation(nextLine) <= optionIndentation)
-            {
-                break;
-            }
-
-            descriptionParts.Add(continuation);
-            lineIndex++;
-        }
-
-        return string.Join(' ', descriptionParts);
-    }
+    private static bool IsOptionRow(string line) => HadolintOptionPattern().IsMatch(line);
 
     private CliOptionDefinition? CreateOption(
         Match match,
@@ -251,8 +225,6 @@ public partial class HadolintCliScraper : CliScraperBase
     private static bool IsRepeatableOption(string longForm) => longForm is
         "--error" or "--warning" or "--info" or "--style" or "--ignore" or
         "--trusted-registry" or "--require-label";
-
-    private static int GetIndentation(string line) => line.Length - line.TrimStart().Length;
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -635,11 +635,6 @@ public partial class SnykCliScraper : CliScraperBase
         return line.TrimStart().TrimStart('[').StartsWith("--", StringComparison.Ordinal);
     }
 
-    private static int GetIndentation(string line)
-    {
-        return line.Length - line.TrimStart().Length;
-    }
-
     private static bool HasOptionHeadingIndentation(string[] lines, int index, int standardIndentation)
     {
         var indentation = GetIndentation(lines[index]);


### PR DESCRIPTION
## Summary

Several CLI scrapers each carried a private "is this line a wrapped description continuation?" rule (Cargo indent-based, Git single-line and dash-rejecting, Cobra hard-coded 20-space threshold) and re-derived `GetIndentation` locally. This PR hoists one shared, column-aware mechanism onto `CliScraperBase` and collapses those variants onto it:

- `GetIndentation` / `GetColumn` expand tabs to eight-column stops (the width the terminal used when the help formatter aligned its columns).
- `IsContinuationLine(line, declarationIndentation, descriptionColumn, looksLikeOptionRow)` is the generic rule: blank lines stop; an option-looking row stops unless its content starts at or after the block's description column (wrapped prose such as a wrapped `--flag=value` mention); otherwise prose continues while deeper than the declaration.
- `AccumulateWrappedDescription` joins the inline description with the prose beneath it and advances the caller's index past every consumed line, so wrapped `--flag` tokens are never re-read as declarations. Scrapers only supply their own "is this an option row" predicate.

Collapsed onto the helper: Cargo, Git, Cobra (and therefore all 19 Cobra-based tools), Hadolint. Flyway, Snyk and `CliArgumentGroupParser` now use the shared indentation primitive.

## Behavioural notes

- Cobra: the 20-space continuation threshold and the `IsSectionHeader` stop rule are gone. Sections are already cut at column-0 headers, and same-depth lines fail the depth rule, so the remaining cases were wrapped prose. Descriptions that previously truncated at a tab-indented continuation (kubectl style) or at a wrapped line beginning with `--flag` now join correctly.
- Cargo: a wrapped line consisting of an option-looking token (`--jobs`) no longer becomes a phantom option.
- Git: descriptions wrapped across several lines are now joined (previously only one wrapped line was read).
- Brew is not touched here: its column-aware rule lives in #4635, which is still open. Once #4635 merges, `BrewCliScraper.IsWrappedDescriptionLine` can be replaced by the shared helper.
- Per the issue's scope note this changes generated output for tools whose wrapped descriptions currently mis-parse; those packages should be regenerated via the workflow after merge.

## Follow-up

Fourteen scrapers (Az, DotNet, Go, Gradle, Jq, Liquibase, Maven, Packer, Pip, Pnpm, Terraform, WinGet, Yarn, Ansible) still carry their own `AccumulateMultiLineDescription` with hard-coded indent thresholds. They have the same defect class and can now be ported mechanically onto `AccumulateWrappedDescription`; tracked separately because each port changes generated output and needs a fixture test.

## Test plan

- [x] New `ContinuationLineTests` cover tab-stop indentation, `GetColumn`, and the continuation truth table.
- [x] New `CargoCliScraperTests` (wrapped `--jobs` token stays prose), Docker (wrapped `--tlsverify` mention), Kubectl (tab-indented multi-line description) and the extended Git fixture.
- [x] Full `ModularPipelines.OptionsGenerator.Tests` suite: 1288 passed, 0 failed (guarded local run).
- [x] `dotnet format whitespace --verify-no-changes` clean for the touched files (the only remaining hit, `IHelpTextCache.cs`, pre-exists on `main`).

Closes #4634

https://claude.ai/code/session_01PkLNTUfwGXjqXZrYrHaDGC
