### PR TITLE
[Automated] Update flux CLI Options

### DIFF
--- a/src/ModularPipelines.Flux/Enums/FluxBootstrapGitlabVisibility.Generated.cs
+++ b/src/ModularPipelines.Flux/Enums/FluxBootstrapGitlabVisibility.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Flux.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum FluxBootstrapGitlabVisibility
 {
+    [EnumValue("private")]
+    Private,
+
     [EnumValue("public")]
     Public,
 
     [EnumValue("internal")]
-    Internal,
-
-    [EnumValue("private")]
-    Private
+    Internal
 }

--- a/src/ModularPipelines.Flux/Generated/Flux.Generation.json
+++ b/src/ModularPipelines.Flux/Generated/Flux.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "flux",
   "toolVersion": "flux version 2.9.5",
   "commandTreeSha256": "cce64ef09e13559016b9deee8b350b34916ce2e46c6e248c25ab24ae62a04c00",
-  "generatorSourceSha256": "d9158a695acc19054e4501e243f73451e38058e36153726384f7e577db59b384"
+  "generatorSourceSha256": "724e6e24b67faf1e28bb6a5b10892f1481716a0ca3c7a36e4d874055980a701d"
 }

--- a/src/ModularPipelines.Flux/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Flux/PublicAPI.Shipped.txt
@@ -63,9 +63,6 @@ ModularPipelines.Flux.Enums.FluxBootstrapGitlabSshKeyAlgorithm.Ecdsa = 1 -> Modu
 ModularPipelines.Flux.Enums.FluxBootstrapGitlabSshKeyAlgorithm.Ed25519 = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabSshKeyAlgorithm
 ModularPipelines.Flux.Enums.FluxBootstrapGitlabSshKeyAlgorithm.Rsa = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabSshKeyAlgorithm
 ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
-ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Internal = 1 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
-ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Private = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
-ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Public = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
 ModularPipelines.Flux.Enums.FluxBootstrapLogLevel
 ModularPipelines.Flux.Enums.FluxBootstrapLogLevel.Debug = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapLogLevel
 ModularPipelines.Flux.Enums.FluxBootstrapLogLevel.Error = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapLogLevel

--- a/src/ModularPipelines.Flux/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Flux/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+*REMOVED*ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Internal = 1 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
+*REMOVED*ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Private = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
+*REMOVED*ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Public = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
 *REMOVED*ModularPipelines.Flux.Options.FluxBootstrapOptions.Command.get -> string?
 *REMOVED*ModularPipelines.Flux.Options.FluxBootstrapOptions.Command.set -> void
 *REMOVED*ModularPipelines.Flux.Options.FluxBuildOptions.Command.get -> string?
@@ -356,6 +359,9 @@
 *REMOVED*virtual ModularPipelines.Flux.Services.FluxTreeArtifact.GeneratorAsync(ModularPipelines.Flux.Options.FluxTreeArtifactGeneratorOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Flux.Services.FluxTrigger.ExecuteAsync(ModularPipelines.Flux.Options.FluxTriggerOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Flux.Services.FluxTrigger.ReceiverAsync(ModularPipelines.Flux.Options.FluxTriggerReceiverOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Internal = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
+ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Private = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
+ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Public = 1 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility
 ModularPipelines.Flux.Services.FluxBootstrap.FluxBootstrap(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Flux.Services.FluxBuild.FluxBuild(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Flux.Services.FluxCreate.FluxCreate(ModularPipelines.Context.ICommandContext! command) -> void


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **flux** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Flux`.

- Added APIs: 3
- Removed or changed APIs: 3
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Internal = 1 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility`
- `ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Private = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility`
- `ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Public = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility`

Representative added members:
- `ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Internal = 2 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility`
- `ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Private = 0 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility`
- `ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility.Public = 1 -> ModularPipelines.Flux.Enums.FluxBootstrapGitlabVisibility`

## Command coverage
Command coverage report:
- flux (flux version 2.9.5): 173 commands, tree cce64ef09e13559016b9deee8b350b34916ce2e46c6e248c25ab24ae62a04c00
  - Baseline comparison: 173 commands at flux version 2.9.5 -> 173 commands at flux version 2.9.5

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Updates**
  - Updated GitLab visibility option mappings to reflect the current value assignments.
  - Removed outdated API baseline entries for Flux commands and services.
  - Existing Flux functionality remains available through the current public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->