### PR TITLE
Measure gcloud declaration indentation in tab-aware columns

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -199,6 +199,50 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_Measures_Declaration_Indentation_With_Tab_Stops()
+    {
+        // Declarations must use the same tab-aware column units as the parser's line
+        // comparisons; a raw character count makes a tab-indented sibling look nested.
+        var helpText = """
+            NAME
+                gcloud example deploy - deploy an example
+
+            SYNOPSIS
+                gcloud example deploy
+
+            FLAGS
+                 --mode=MODE
+                    Select the operating mode.
+
+                 At most one of these can be specified:
+
+            {TAB}--token=TOKEN
+            {TAB}   Authenticate with a token.
+
+            {TAB}--profile=PROFILE
+            {TAB}   Select a saved profile.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """.Replace("{TAB}", "\t", StringComparison.Ordinal);
+
+        var command = await CreateGcloudScraper().Parse(["gcloud", "example", "deploy"], helpText);
+
+        var root = command!.ArgumentGroups.Single();
+        var nested = root.Groups.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--mode", "--token", "--profile"]);
+            await Assert.That(root.Arguments.Select(argument => argument.SwitchName))
+                .IsEquivalentTo(["--mode"]);
+            await Assert.That(nested.Kind).IsEqualTo(CliArgumentGroupKind.AtMostOne);
+            await Assert.That(nested.Arguments.Select(argument => argument.SwitchName))
+                .IsEquivalentTo(["--token", "--profile"]);
+        }
+    }
+
+    [Test]
     public async Task Gcloud_Does_Not_Leak_Named_Flag_Sections()
     {
         const string helpText = """
@@ -1106,7 +1150,7 @@ public partial class NestedArgumentGroupParsingTests
                     : match.Groups["long"].Value,
                 ValueHint = match.Groups["value"].Value,
                 IsNegatable = negatable,
-                Indentation = match.Groups["indent"].Value.Length,
+                Indentation = GetIndentation(match.Groups["indent"].Value),
             };
         }
     }
@@ -1169,7 +1213,7 @@ public partial class NestedArgumentGroupParsingTests
                 {
                     SwitchName = match.Groups["long"].Value,
                     ValueHint = match.Groups["value"].Value,
-                    Indentation = match.Groups["indent"].Value.Length,
+                    Indentation = GetIndentation(match.Groups["indent"].Value),
                 };
         }
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -420,7 +420,8 @@ public partial class GcloudCliScraper : CliScraperBase
             SwitchName = name,
             ValueHint = match.Groups["value"].Value,
             IsNegatable = negatable,
-            Indentation = match.Groups["indent"].Value.Length,
+            // Same tab-aware units as the CliArgumentGroupParser comparisons.
+            Indentation = GetIndentation(match.Groups["indent"].Value),
         };
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #4645, which merged with the automated review's remaining finding still open: `CliArgumentGroupParser` now measures line indentation with the shared tab-aware `CliScraperBase.GetIndentation` (8-column tab stops), but `GcloudCliScraper.ParseGcloudArgument` still recorded `Indentation = match.Groups["indent"].Value.Length`, a raw character count. The two units were compared directly in `IsInsideDocumentationBlock`, `FindDescriptionEnd` and the group-nesting checks, so a tab-indented nested group in gcloud help popped out of its parent group instead of nesting.

- `GcloudCliScraper` computes `Indentation` with `GetIndentation(...)`, the same units every consumer uses.
- The two fake scrapers in `NestedArgumentGroupParsingTests` do the same, so the shared parser tests exercise consistent units.
- New regression `Gcloud_Measures_Declaration_Indentation_With_Tab_Stops`: a tab-indented "At most one of these can be specified" group under a space-indented flag must nest as one `AtMostOne` group holding both options. On the previous head the root group ends up with more than one child group; with the fix the suite passes 29/29.

Not addressed: the non-blocking Cobra `IsOptionRow` double-match nit from the same review (generator-time only).

## Test plan
- [x] `NestedArgumentGroupParsingTests` 29/29 with the fix; the new test fails on `738bdf82` (pre-fix).
- [x] `ContinuationLineTests` 15/15.
- [x] `dotnet format --verify-no-changes --severity info` on the two changed files.
- [ ] CI generator suite.

Refs #4634

https://claude.ai/code/session_01MGEyXW2HYJpJ47tqnpjWMa
