### PR TITLE
Port Packer, Gradle, jq, Liquibase and Ansible scrapers onto the shared wrapped-description helper

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AnsibleCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AnsibleCliScraperTests.cs
@@ -98,6 +98,31 @@ public class AnsibleCliScraperTests
         await Assert.That(GetOption(ansible, "--extra-vars").AcceptsMultipleValues).IsTrue();
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Mention_Flags_Stay_Prose()
+    {
+        const string helpText = """
+            usage: ansible [-h] [-C] pattern
+
+            options:
+              -C, --check           don't make any changes; instead, try to predict
+                                    --diff output for the changes that would be made
+              -D, --diff            when changing files, show the differences
+            """;
+
+        var command = await new TestAnsibleCliScraper().Parse(helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--check", "--diff"]);
+            await Assert.That(GetOption(command, "--check").Description)
+                .IsEqualTo("don't make any changes; instead, try to predict --diff output for the changes that would be made");
+            await Assert.That(GetOption(command, "--diff").Description)
+                .IsEqualTo("when changing files, show the differences");
+        }
+    }
+
     private static CliOptionDefinition GetOption(CliCommandDefinition command, string switchName) =>
         command.Options.Single(option => option.SwitchName == switchName);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
@@ -354,6 +354,47 @@ public class LiquibaseCliScraperTests
         await Assert.That(version).IsEqualTo("5.0.3");
     }
 
+    [Test]
+    public async Task ParseOptions_Keeps_Wrapped_Option_Looking_Prose()
+    {
+        const string helpText = """
+                  --show-summary=PARAM     Values can be 'off', 'summary', or 'verbose'. Pair with
+                                           --show-summary-output=PARAM to choose the target
+                  --log-level=PARAM        Log level
+            """;
+
+        var options = _scraper.ParseLiquibaseOptions(helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--show-summary", "--log-level"]);
+            await Assert.That(options.Single(option => option.SwitchName == "--show-summary").Description)
+                .IsEqualTo("Values can be 'off', 'summary', or 'verbose'. Pair with --show-summary-output=PARAM to choose the target");
+        }
+    }
+
+    [Test]
+    public async Task ParseOptions_Infers_The_Description_Column_From_The_First_Wrapped_Line()
+    {
+        const string helpText = """
+                  --show-summary=PARAM
+                                           Values can be 'off', 'summary', or 'verbose'. Pair with
+                                           --show-summary-output=PARAM to choose the target
+                  --log-level=PARAM        Log level
+            """;
+
+        var options = _scraper.ParseLiquibaseOptions(helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--show-summary", "--log-level"]);
+            await Assert.That(options.Single(option => option.SwitchName == "--show-summary").Description)
+                .IsEqualTo("Values can be 'off', 'summary', or 'verbose'. Pair with --show-summary-output=PARAM to choose the target");
+        }
+    }
+
     private sealed class TestLiquibaseCliScraper(ICliCommandExecutor? executor = null)
         : LiquibaseCliScraper(executor ?? new StubExecutor(), new StubHelpTextCache(), NullLogger<LiquibaseCliScraper>.Instance)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GradleCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GradleCliScraperTests.cs
@@ -88,6 +88,31 @@ public class GradleCliScraperTests
         await Assert.That(version).IsEqualTo("9.7.1");
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--continue  to ..." line deliberately keeps two spaces so it satisfies
+        // the option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            USAGE: gradle [option...] [task...]
+
+            Execution:
+            --console                          Specifies which type of console output to generate. Combine with
+                                               --continue  to keep going after a failure.
+            --offline                          Execute the build without accessing network resources.
+            """;
+
+        var command = await new TestGradleCliScraper().Parse(helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--console", "--offline"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--console").Description)
+                .IsEqualTo("Specifies which type of console output to generate. Combine with --continue  to keep going after a failure.");
+        }
+    }
+
     private sealed class TestGradleCliScraper : GradleCliScraper
     {
         public TestGradleCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/JqCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/JqCliScraperTests.cs
@@ -99,6 +99,30 @@ public class JqCliScraperTests
         await Assert.That(binary.PreferShortForm).IsTrue();
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        const string helpText = """
+            Usage: jq [options] <jq filter> [file...]
+
+            Command options:
+              -s, --slurp               read all inputs into an array; combine with
+                                        --null-input to run the filter once;
+              -f, --from-file           load the filter from a file;
+            """;
+
+        var command = await new TestJqCliScraper().Parse(helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.Options.Select(option => option.SwitchName))
+                .Contains("--from-file")
+                .And.DoesNotContain("--null-input");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--slurp").Description)
+                .IsEqualTo("read all inputs into an array; combine with --null-input to run the filter once");
+        }
+    }
+
     private sealed class TestJqCliScraper : JqCliScraper
     {
         public TestJqCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PackerCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PackerCliScraperTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class PackerCliScraperTests
+{
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "-only=foo,bar  to ..." line deliberately keeps two spaces so it satisfies
+        // the option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            Usage: packer build [options] TEMPLATE
+
+            Options:
+              -color=false                 Disable color output. (Default: color)
+              -except=foo,bar,baz          Run all builds and post-processors other than these. Combine with
+                                           -only=foo,bar  to narrow the selection further.
+              -force                       Force a build to continue if artifacts exist, deletes existing artifacts.
+            """;
+
+        var command = await new TestPackerCliScraper().Parse(["packer", "build"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--color", "--except", "--force"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--except").Description)
+                .IsEqualTo("Run all builds and post-processors other than these. Combine with -only=foo,bar  to narrow the selection further.");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--force").Description)
+                .IsEqualTo("Force a build to continue if artifacts exist, deletes existing artifacts.");
+        }
+    }
+
+    private sealed class TestPackerCliScraper()
+        : PackerCliScraper(
+            new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<PackerCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AnsibleCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AnsibleCliScraper.cs
@@ -110,18 +110,17 @@ public partial class AnsibleCliScraper : CliScraperBase
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var lines = GetOptionsSection(helpText).Split('\n');
+        var lines = GetOptionsSection(helpText).ReplaceLineEndings("\n").Split('\n');
 
         for (var i = 0; i < lines.Length; i++)
         {
-            var match = AnsibleOptionPattern().Match(lines[i].TrimEnd('\r'));
+            var match = AnsibleOptionPattern().Match(lines[i]);
             if (!match.Success)
             {
                 continue;
             }
 
-            var description = match.Groups["desc"].Value.Trim();
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
             var option = ParseOption(match.Groups["spec"].Value, description);
             if (option is not null && seenOptions.Add(option.SwitchName))
             {
@@ -247,36 +246,7 @@ public partial class AnsibleCliScraper : CliScraperBase
         return isNumeric ? "int?" : "string?";
     }
 
-    private static int AccumulateMultiLineDescription(
-        string[] lines,
-        int currentIndex,
-        ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex].TrimEnd('\r');
-            var trimmedLine = nextLine.Trim();
-            if (trimmedLine.Length == 0 ||
-                AnsibleOptionPattern().IsMatch(nextLine) ||
-                nextLine.Length == nextLine.TrimStart().Length)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedLine);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => AnsibleOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1317,6 +1317,10 @@ public abstract partial class CliScraperBase : ICliScraper
 
             parts.Add(candidate.Trim());
             declarationIndex++;
+
+            // A row whose prose only starts on the next line (picocli, argparse, git) reveals its
+            // description column there, so later wrapped lines get the same column-aware rule.
+            descriptionColumn ??= GetIndentation(candidate);
         }
 
         return string.Join(' ', parts);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GradleCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GradleCliScraper.cs
@@ -159,7 +159,6 @@ public partial class GradleCliScraper : CliScraperBase
 
             var shortForms = match.Groups["shorts"].Value.Trim();
             var longForm = match.Groups["long"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(longForm))
             {
@@ -174,7 +173,7 @@ public partial class GradleCliScraper : CliScraperBase
 
             seenOptions.Add(longForm);
 
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             // Skip deprecated options
             if (description.Contains("[deprecated]", StringComparison.OrdinalIgnoreCase))
@@ -254,32 +253,7 @@ public partial class GradleCliScraper : CliScraperBase
         return isNumeric ? "int?" : "string?";
     }
 
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string> { description };
-        var nextIndex = currentIndex + 1;
-
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            if (string.IsNullOrWhiteSpace(nextLine) || GradleOptionPattern().IsMatch(nextLine))
-            {
-                break;
-            }
-
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 4)
-            {
-                break;
-            }
-
-            descriptionParts.Add(nextLine.Trim());
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts.Where(x => !string.IsNullOrWhiteSpace(x)));
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => GradleOptionPattern().IsMatch(line);
 
     private static CliEnumDefinition? TryCreateEnumDefinition(string longForm, string propertyName, string description)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
@@ -186,8 +186,11 @@ public partial class JqCliScraper : CliScraperBase
 
             var shortForm = match.Groups["short"].Value.Trim();
             var operandCount = OptionOperandCounts.GetValueOrDefault(longForm);
-            var description = RemoveDisplayedOperands(longForm, match.Groups["tail"].Value);
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            // The tail shows the displayed operands ahead of the prose; strip them after the
+            // wrapped lines are joined so the operand prefix is removed exactly once.
+            var description = RemoveDisplayedOperands(
+                longForm,
+                AccumulateWrappedDescription(lines, ref i, match.Groups["tail"], IsOptionRow));
 
             var propertyName = NormalizeJqPropertyName(longForm);
             if (propertyName is null)
@@ -311,32 +314,7 @@ public partial class JqCliScraper : CliScraperBase
         return acceptsMultipleValues ? "IEnumerable<string>?" : "string?";
     }
 
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string> { description };
-        var nextIndex = currentIndex + 1;
-
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            if (string.IsNullOrWhiteSpace(nextLine) || JqOptionPattern().IsMatch(nextLine))
-            {
-                break;
-            }
-
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20)
-            {
-                break;
-            }
-
-            descriptionParts.Add(nextLine.Trim());
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts.Where(x => !string.IsNullOrWhiteSpace(x)));
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => JqOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
@@ -335,8 +335,7 @@ public partial class LiquibaseCliScraper : CliScraperBase
             return true;
         }
 
-        var description = match.Groups["desc"].Value.Trim();
-        index = AccumulateMultiLineDescription(lines, index, ref description);
+        var description = AccumulateWrappedDescription(lines, ref index, match.Groups["desc"], IsOptionRow);
         option = CreateDefineOption(CleanDescription(description));
         return true;
     }
@@ -355,8 +354,7 @@ public partial class LiquibaseCliScraper : CliScraperBase
         var shortForm = match.Groups["short"].Value.Trim();
         var longForm = match.Groups["long"].Value.Trim();
         var valueHint = match.Groups["value"].Value.Trim();
-        var description = match.Groups["desc"].Value.Trim();
-        index = AccumulateMultiLineDescription(lines, index, ref description);
+        var description = AccumulateWrappedDescription(lines, ref index, match.Groups["desc"], IsOptionRow);
 
         if (!seenOptions.Add(longForm))
         {
@@ -501,34 +499,8 @@ public partial class LiquibaseCliScraper : CliScraperBase
         };
     }
 
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string> { description };
-        var nextIndex = currentIndex + 1;
-
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            if (string.IsNullOrWhiteSpace(nextLine) ||
-                LiquibaseOptionPattern().IsMatch(nextLine) ||
-                LiquibaseDefinePattern().IsMatch(nextLine))
-            {
-                break;
-            }
-
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20)
-            {
-                break;
-            }
-
-            descriptionParts.Add(nextLine.Trim());
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts.Where(x => !string.IsNullOrWhiteSpace(x)));
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) =>
+        LiquibaseOptionPattern().IsMatch(line) || LiquibaseDefinePattern().IsMatch(line);
 
     private static string? CleanDescription(string description)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
@@ -234,7 +234,6 @@ public partial class PackerCliScraper : CliScraperBase
 
             var flagName = match.Groups["flag"].Value.Trim();
             var valueHint = match.Groups["value"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(flagName))
             {
@@ -250,7 +249,7 @@ public partial class PackerCliScraper : CliScraperBase
 
             seenOptions.Add(longForm);
 
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             var propertyName = NormalizePropertyName(longForm);
             if (propertyName is null)
@@ -286,37 +285,7 @@ public partial class PackerCliScraper : CliScraperBase
         return options;
     }
 
-    private static int AccumulateMultiLineDescription(
-        string[] lines,
-        int currentIndex,
-        ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var optionIndent = lines[currentIndex].Length - lines[currentIndex].TrimStart().Length;
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-            if (string.IsNullOrWhiteSpace(trimmedNext)
-                || trimmedNext.StartsWith('-')
-                || nextLine.Length - nextLine.TrimStart().Length <= optionIndent)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => PackerOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.


### PR DESCRIPTION
## Summary

First child of #4646. Ports the five scrapers whose wrapped-description logic was closest to the shared shape onto `CliScraperBase.AccumulateWrappedDescription` (from #4645):

- **Packer** — dropped the dash-led stop and the hand-rolled indent maths; a wrapped `-only=foo,bar  ...` fragment now stays in the description instead of becoming a phantom option.
- **Gradle** — dropped the absolute `< 4` indent threshold; a wrapped `--continue  ...` fragment stays prose.
- **jq** — dropped the `< 20` threshold; the displayed operands are stripped after the wrapped lines are joined, so the operand prefix is removed once.
- **Liquibase** — dropped the `< 20` threshold; the row predicate covers both the option and `-D=PARAM` shapes.
- **Ansible** — line endings are normalised once at the split (no more per-line `TrimEnd('\r')`); sibling rows at the declaration's indentation now stop the description as they should.

Each scraper only supplies its own option-row predicate; none defines its own accumulation loop or indentation counter any more.

One base improvement fell out of the Liquibase port: a row whose prose only begins on the next line (picocli, argparse, git) had no description column, so the column-aware rule could not protect its later wrapped lines. `AccumulateWrappedDescription` now infers the column from the first wrapped line, which benefits every scraper.

## Behavioural notes

Per the parent issue's scope note this changes generated output for these tools wherever wrapped descriptions previously mis-parsed; regenerate the five packages via the workflow after merge. Remaining scrapers are tracked in #4654 and #4655.

## Test plan

- [x] New fixtures: Packer (new `PackerCliScraperTests`), Gradle, jq, Liquibase (inline and two-line rows), Ansible — each pins a wrapped `--flag`-led line as prose.
- [x] `ModularPipelines.OptionsGenerator.Tests`: 1304 passed, 0 failed (guarded local run).
- [x] `dotnet format whitespace --verify-no-changes` clean for the touched files (the only remaining hit, `IHelpTextCache.cs`, pre-exists on `main`).

Closes #4653

https://claude.ai/code/session_01PkLNTUfwGXjqXZrYrHaDGC
