### PR TITLE
Port the remaining nine CLI scrapers onto the shared wrapped-description helper

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -661,6 +661,35 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Mention_Flags_Stay_Prose()
+    {
+        const string helpText = """
+            Command
+                az vm create : Create an Azure Virtual Machine.
+
+            Arguments
+                --name -n [Required] : Name of the virtual machine. The operation returns immediately when
+                                       --no-wait is also set.
+                --size               : The VM size to be created.
+                    Argument '--size' is in preview and under development.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(["az", "vm", "create"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--name", "--size"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--name").Description)
+                .IsEqualTo("Name of the virtual machine. The operation returns immediately when --no-wait is also set.");
+
+            // knack prints preview notices four columns under the row; they now join the description.
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--size").Description)
+                .IsEqualTo("The VM size to be created. Argument '--size' is in preview and under development.");
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/ContinuationLineTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/ContinuationLineTests.cs
@@ -70,4 +70,55 @@ public class ContinuationLineTests
 
         await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 6, null, looksLikeOptionRow: true)).IsFalse();
     }
+
+    [Test]
+    public async Task Rows_Without_Inline_Prose_Infer_The_Description_Column_From_The_First_Wrapped_Line()
+    {
+        string[] lines =
+        [
+            "    --all-namespaces",
+            "        If present, list the requested objects across all namespaces. Pair with",
+            "        --namespace to scope the listing instead.",
+            "    --allow-missing-template-keys",
+            "        If true, ignore any errors in templates.",
+        ];
+        var index = 0;
+
+        var description = CliScraperBase.AccumulateWrappedDescription(
+            lines,
+            ref index,
+            inlineDescription: null,
+            static line => line.TrimStart().StartsWith("--", StringComparison.Ordinal));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(description)
+                .IsEqualTo("If present, list the requested objects across all namespaces. Pair with --namespace to scope the listing instead.");
+            await Assert.That(index).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task Option_Rows_Shallower_Than_The_Inferred_Column_Still_Start_The_Next_Option()
+    {
+        string[] lines =
+        [
+            "    --all-namespaces",
+            "        If present, list the requested objects across all namespaces.",
+            "      --namespace  Scope the listing to one namespace.",
+        ];
+        var index = 0;
+
+        var description = CliScraperBase.AccumulateWrappedDescription(
+            lines,
+            ref index,
+            inlineDescription: null,
+            static line => line.TrimStart().StartsWith("--", StringComparison.Ordinal));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(description).IsEqualTo("If present, list the requested objects across all namespaces.");
+            await Assert.That(index).IsEqualTo(1);
+        }
+    }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/ContinuationLineTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/ContinuationLineTests.cs
@@ -64,11 +64,41 @@ public class ContinuationLineTests
     }
 
     [Test]
-    public async Task Option_Looking_Rows_Without_A_Known_Description_Column_Start_The_Next_Option()
+    public async Task Option_Looking_Rows_Deeper_Than_The_Declaration_Continue_Until_A_Column_Is_Known()
     {
-        const string wrapped = "                           --tlsverify";
+        const string wrapped = "        --tlsverify is implied by this flag.";
 
-        await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 6, null, looksLikeOptionRow: true)).IsFalse();
+        using (Assert.Multiple())
+        {
+            await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 6, null, looksLikeOptionRow: true)).IsTrue();
+            await Assert.That(CliScraperBase.IsContinuationLine(wrapped, 8, null, looksLikeOptionRow: true)).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task First_Wrapped_Line_That_Looks_Like_An_Option_Row_Still_Establishes_The_Column()
+    {
+        string[] lines =
+        [
+            "    --all-namespaces",
+            "        --namespace is ignored when this flag is set. Lists the requested",
+            "        objects across every namespace instead.",
+            "      --namespace  Scope the listing to one namespace.",
+        ];
+        var index = 0;
+
+        var description = CliScraperBase.AccumulateWrappedDescription(
+            lines,
+            ref index,
+            inlineDescription: null,
+            static line => line.TrimStart().StartsWith("--", StringComparison.Ordinal));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(description)
+                .IsEqualTo("--namespace is ignored when this flag is set. Lists the requested objects across every namespace instead.");
+            await Assert.That(index).IsEqualTo(2);
+        }
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/TerraformCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/TerraformCliScraperTests.cs
@@ -140,6 +140,31 @@ public class TerraformCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "-lock=false  to ..." line deliberately keeps two spaces so it satisfies
+        // the option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            Usage: terraform plan [options]
+
+            Options:
+              -input=false        Ask for input for variables if not directly set. Combine with
+                                  -lock=false  to skip state locking as well.
+              -lock=false         Don't hold a state lock during the operation.
+            """;
+
+        var definition = await _scraper.Parse(["terraform", "plan"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(definition!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["-input", "-lock"]);
+            await Assert.That(definition.Options.Single(option => option.SwitchName == "-input").Description)
+                .IsEqualTo("Ask for input for variables if not directly set. Combine with -lock=false  to skip state locking as well.");
+        }
+    }
+
     private sealed class TestTerraformCliScraper()
         : TerraformCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
@@ -157,6 +157,33 @@ public class DotNetCliScraperTests
         IsFlag = true,
     };
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--no-restore  to ..." line deliberately keeps two spaces so it satisfies
+        // the option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            Usage:
+              dotnet build [options] <PROJECT | SOLUTION>
+
+            Options:
+              -c, --configuration <CONFIGURATION>  The configuration to use for building the project. Pair with
+                                                   --no-restore  to skip restoring first.
+              -o, --output <OUTPUT_DIR>            The output directory to place built artifacts in.
+            """;
+
+        var command = await new TestDotNetCliScraper().Parse(["dotnet", "build"], helpText);
+
+        using (Assert.Multiple())
+        {
+            // "-p" is the synthesized MSBuild property switch every build command receives.
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--configuration", "--output", "-p"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--configuration").Description)
+                .IsEqualTo("The configuration to use for building the project. Pair with --no-restore  to skip restoring first.");
+        }
+    }
+
     private sealed class TestDotNetCliScraper : DotNetCliScraper
     {
         public TestDotNetCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MavenCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/MavenCliScraperTests.cs
@@ -66,6 +66,31 @@ public class MavenCliScraperTests
         await Assert.That(version).IsEqualTo("3.9.16");
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--quiet  to ..." line deliberately keeps two spaces so it satisfies the
+        // option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            usage: mvn [options] [<goal(s)>] [<phase(s)>]
+
+            Options:
+             -B,--batch-mode                         Run in non-interactive mode. Combine with
+                                                     --quiet  to reduce output further.
+             -q,--quiet                              Quiet output - only show errors
+            """;
+
+        var command = await new TestMavenCliScraper().Parse(helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--batch-mode", "--quiet"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--batch-mode").Description)
+                .IsEqualTo("Run in non-interactive mode. Combine with --quiet  to reduce output further.");
+        }
+    }
+
     private sealed class TestMavenCliScraper : MavenCliScraper
     {
         public TestMavenCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PipCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PipCliScraperTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class PipCliScraperTests
+{
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--no-deps  to ..." line deliberately keeps two spaces so it satisfies the
+        // option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            Usage:
+              pip install [options] <requirement specifier> ...
+
+            Install Options:
+              -r, --requirement <file>    Install from the given requirements file. Combine with
+                                          --no-deps  to skip dependency installation.
+              -e, --editable <path/url>   Install a project in editable mode.
+            """;
+
+        var command = await new TestPipCliScraper().Parse(["pip", "install"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--requirement", "--editable"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--requirement").Description)
+                .IsEqualTo("Install from the given requirements file. Combine with --no-deps  to skip dependency installation.");
+        }
+    }
+
+    private sealed class TestPipCliScraper()
+        : PipCliScraper(
+            new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<PipCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PnpmCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PnpmCliScraperTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class PnpmCliScraperTests
+{
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--save-exact  to ..." line deliberately keeps two spaces so it satisfies
+        // the option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            Usage: pnpm add <name>
+
+            Options:
+              -D, --save-dev                 Save package to your `devDependencies`. Combine with
+                                             --save-exact  to pin the installed version.
+              -E, --save-exact               Install exact version
+            """;
+
+        var command = await new TestPnpmCliScraper().Parse(["pnpm", "add"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--save-dev", "--save-exact"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--save-dev").Description)
+                .IsEqualTo("Save package to your `devDependencies`. Combine with --save-exact  to pin the installed version.");
+        }
+    }
+
+    private sealed class TestPnpmCliScraper()
+        : PnpmCliScraper(
+            new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<PnpmCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
@@ -322,6 +322,31 @@ public class WinGetCliScraperTests
         await Assert.That(new TestWinGetCliScraper().Parallelism).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--exact  to ..." line deliberately keeps two spaces so it satisfies the
+        // option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            usage: winget install [[-q] <query>] [<options>]
+
+            The following options are available:
+              -q,--query                    The query used to search for a package. Combine with
+                                            --exact  to match the query exactly.
+              -e,--exact                    Find package using exact match
+            """;
+
+        var command = await new TestWinGetCliScraper().Parse(["winget", "install"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--query", "--exact"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--query").Description)
+                .IsEqualTo("The query used to search for a package. Combine with --exact  to match the query exactly.");
+        }
+    }
+
     private sealed class TestWinGetCliScraper : WinGetCliScraper
     {
         public TestWinGetCliScraper(ICliCommandExecutor? executor = null)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -226,6 +226,34 @@ public class YarnCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Wrapped_Descriptions_That_Look_Like_Option_Rows_Stay_Prose()
+    {
+        // The wrapped "--exact  to ..." line deliberately keeps two spaces so it satisfies the
+        // option-row pattern; only its column keeps it inside the description.
+        const string helpText = """
+            ━━━ Usage ━━━
+
+            $ yarn add [--json] [-E,--exact] ...
+
+            ━━━ Options ━━━
+
+              --json                     Format the output as an NDJSON stream. Combine with
+                                         --exact  to pin the resolved versions.
+              -E,--exact                 Don't use any semver modifier on the resolved range
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(["yarn", "add"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--json", "--exact"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--json").Description)
+                .IsEqualTo("Format the output as an NDJSON stream. Combine with --exact  to pin the resolved versions.");
+        }
+    }
+
     private sealed class TestYarnCliScraper : YarnCliScraper
     {
         public TestYarnCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -311,8 +311,7 @@ public partial class AzCliScraper : CliScraperBase
 
         var alias = match.Groups["alias"].Value.Trim();
         var valueHint = match.Groups["value"].Value.Trim();
-        var description = match.Groups["desc"].Value.Trim();
-        lineIndex = AccumulateMultiLineDescription(lines, lineIndex, ref description);
+        var description = AccumulateWrappedDescription(lines, ref lineIndex, match.Groups["desc"], IsOptionRow);
 
         var propertyName = NormalizePropertyName(longFlag);
         if (propertyName is null)
@@ -504,59 +503,7 @@ public partial class AzCliScraper : CliScraperBase
         return globalOptions.Contains(optionName);
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            // Stop conditions
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // New option line (starts with dash)
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            // Section header (ends with colon and is short)
-            if (trimmedNext.Length < 50 && (trimmedNext.EndsWith(':') || char.IsUpper(trimmedNext[0])))
-            {
-                var words = trimmedNext.Split(' ');
-                if (words.Length <= 3)
-                {
-                    break;
-                }
-            }
-
-            // Line must be indented to be a continuation
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20) // Azure CLI uses heavy indentation for descriptions
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => AzOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1254,7 +1254,9 @@ public abstract partial class CliScraperBase : ICliScraper
     /// <param name="declarationIndentation">Column where the option declaration starts.</param>
     /// <param name="descriptionColumn">
     /// Column where the declaration's inline description starts, or <see langword="null"/>
-    /// when the description only begins on a following line.
+    /// when the description only begins on a following line. Until that column is known any
+    /// line deeper than the declaration is accepted, because the first wrapped line is what
+    /// establishes the column.
     /// </param>
     /// <param name="looksLikeOptionRow">Whether the scraper's option pattern matches <paramref name="line"/>.</param>
     protected internal static bool IsContinuationLine(
@@ -1269,7 +1271,7 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         var indentation = GetIndentation(line);
-        var wrappedAtDescriptionColumn = indentation >= descriptionColumn;
+        var wrappedAtDescriptionColumn = descriptionColumn is null || indentation >= descriptionColumn;
         return (!looksLikeOptionRow || wrappedAtDescriptionColumn)
                && indentation > declarationIndentation;
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1286,7 +1286,7 @@ public abstract partial class CliScraperBase : ICliScraper
     /// scraper did not capture one.
     /// </param>
     /// <param name="looksLikeOptionRow">Returns whether a line matches the scraper's option pattern.</param>
-    protected static string AccumulateWrappedDescription(
+    protected internal static string AccumulateWrappedDescription(
         IReadOnlyList<string> lines,
         ref int declarationIndex,
         Group? inlineDescription,
@@ -1317,6 +1317,10 @@ public abstract partial class CliScraperBase : ICliScraper
 
             parts.Add(candidate.Trim());
             declarationIndex++;
+
+            // A row whose prose only starts on the next line (picocli, argparse, git) reveals its
+            // description column there, so later wrapped lines get the same column-aware rule.
+            descriptionColumn ??= GetIndentation(candidate);
         }
 
         return string.Join(' ', parts);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -276,7 +276,6 @@ public partial class DotNetCliScraper : CliScraperBase
             var valueHint = (hasOptionalValue
                 ? match.Groups["optionalValue"]
                 : match.Groups["value"]).Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             // Need at least one flag
             if (string.IsNullOrEmpty(longFlag) && string.IsNullOrEmpty(shortFlag))
@@ -301,8 +300,7 @@ public partial class DotNetCliScraper : CliScraperBase
                 continue;
             }
 
-            // Accumulate multi-line descriptions
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             var propertyName = NormalizePropertyName(primaryFlag);
             if (propertyName is null)
@@ -652,55 +650,7 @@ public partial class DotNetCliScraper : CliScraperBase
                lowerDesc.Contains("comma-separated list");
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            // Stop conditions
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // New option line (starts with dash)
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            // Section header
-            if (trimmedNext.EndsWith(':') && trimmedNext.Length < 50)
-            {
-                break;
-            }
-
-            // Line must be indented to be a continuation
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 10)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => DotNetOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -774,8 +774,9 @@ public partial class GoCliScraper : CliScraperBase
 
             var optionKey = flagName.TrimStart('-');
 
-            // Accumulate multi-line descriptions
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            // go help puts the prose beneath the flag line, so the description column is
+            // inferred from the first wrapped line rather than taken from the declaration.
+            description = $"{description} {AccumulateWrappedDescription(lines, ref i, inlineDescription: null, IsOptionRow)}".Trim();
 
             var propertyName = NormalizePropertyName(optionKey);
             if (propertyName is null)
@@ -979,69 +980,7 @@ public partial class GoCliScraper : CliScraperBase
             : existing.Description;
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        var declarationIndentation = GetIndentationWidth(lines[currentIndex]);
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            if (trimmedNext.EndsWith(':') && trimmedNext.Length < 30)
-            {
-                break;
-            }
-
-            var continuationIndentation = GetIndentationWidth(nextLine);
-            if (continuationIndentation <= declarationIndentation)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
-
-    private static int GetIndentationWidth(string line)
-    {
-        var width = 0;
-        foreach (var character in line)
-        {
-            if (character == ' ')
-            {
-                width++;
-            }
-            else if (character == '\t')
-            {
-                width += 8 - (width % 8);
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        return width;
-    }
+    private static bool IsOptionRow(string line) => GoOptionLinePattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MavenCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/MavenCliScraper.cs
@@ -174,7 +174,6 @@ public partial class MavenCliScraper : CliScraperBase
             var shortForm = match.Groups["short"].Value.Trim();
             var longForm = match.Groups["long"].Value.Trim();
             var valueHint = match.Groups["value"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(longForm))
             {
@@ -194,8 +193,7 @@ public partial class MavenCliScraper : CliScraperBase
 
             seenOptions.Add(longForm);
 
-            // Accumulate multi-line descriptions
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             var propertyName = NormalizePropertyName(longForm);
             if (propertyName is null)
@@ -263,48 +261,7 @@ public partial class MavenCliScraper : CliScraperBase
         };
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // If line starts with -, it's a new option
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            // Check indentation - continuation lines are heavily indented
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 30)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => MavenOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -289,7 +289,6 @@ public partial class PipCliScraper : CliScraperBase
                 var shortForm = match.Groups["short"].Value.Trim();
                 var longForm = match.Groups["long"].Value.Trim();
                 var valueHint = match.Groups["value"].Value.Trim();
-                var description = match.Groups["desc"].Value.Trim();
 
                 if (string.IsNullOrEmpty(longForm))
                 {
@@ -311,8 +310,7 @@ public partial class PipCliScraper : CliScraperBase
 
                 seenOptions.Add(longForm);
 
-                // Accumulate multi-line descriptions
-                i = AccumulateMultiLineDescription(lines, i, ref description);
+                var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
                 var propertyName = NormalizePropertyName(longForm);
                 if (propertyName is null)
@@ -379,51 +377,7 @@ public partial class PipCliScraper : CliScraperBase
         return false;
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            if (trimmedNext.EndsWith(':') && trimmedNext.Length < 30)
-            {
-                break;
-            }
-
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => PipOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -359,7 +359,6 @@ public partial class PnpmCliScraper : CliScraperBase
             var shortForm = match.Groups["short"].Value.Trim();
             var longForm = match.Groups["long"].Value.Trim();
             var valueHint = match.Groups["value"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(longForm))
             {
@@ -382,8 +381,7 @@ public partial class PnpmCliScraper : CliScraperBase
 
             seenOptions.Add(longForm);
 
-            // Accumulate multi-line descriptions
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             var propertyName = NormalizePropertyName(longForm);
             if (propertyName is null)
@@ -443,51 +441,7 @@ public partial class PnpmCliScraper : CliScraperBase
                    description.Contains(part, StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            if (trimmedNext.EndsWith(':') && trimmedNext.Length < 30)
-            {
-                break;
-            }
-
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => PnpmOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -315,7 +315,6 @@ public partial class TerraformCliScraper : CliScraperBase
 
             var flagName = match.Groups["flag"].Value.Trim();
             var valueHint = match.Groups["value"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(flagName))
             {
@@ -330,8 +329,7 @@ public partial class TerraformCliScraper : CliScraperBase
 
             seenOptions.Add(flagName);
 
-            // Accumulate multi-line descriptions
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             var propertyName = NormalizePropertyName(flagName);
             if (propertyName is null)
@@ -408,55 +406,7 @@ public partial class TerraformCliScraper : CliScraperBase
         return numericHints.Contains(hint, StringComparer.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            // Stop conditions
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // New option line (starts with dash)
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            // Section header
-            if (trimmedNext.EndsWith(':') && trimmedNext.Length < 50)
-            {
-                break;
-            }
-
-            // Line must be indented to be a continuation
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 10)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => TerraformOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -426,7 +426,6 @@ public partial class WinGetCliScraper : CliScraperBase
 
         var shortForm = match.Groups["short"].Value.Trim();
         var longForm = match.Groups["long"].Value.Trim();
-        var description = match.Groups["desc"].Value.Trim();
 
         if (string.IsNullOrEmpty(longForm))
         {
@@ -441,8 +440,7 @@ public partial class WinGetCliScraper : CliScraperBase
 
         seenOptions.Add(longForm);
 
-        // Accumulate multi-line descriptions
-        lineIndex = AccumulateMultiLineDescription(allLines, lineIndex, ref description);
+        var description = AccumulateWrappedDescription(allLines, ref lineIndex, match.Groups["desc"], IsOptionRow);
 
         var propertyName = NormalizePropertyName(longForm);
         if (propertyName is null)
@@ -511,55 +509,7 @@ public partial class WinGetCliScraper : CliScraperBase
         || (className.Equals("WingetSourceAddOptions", StringComparison.Ordinal)
             && longForm.Equals("--explicit", StringComparison.OrdinalIgnoreCase));
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            // Stop conditions
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // New option line (starts with dash)
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            // Section header
-            if (trimmedNext.StartsWith("The following"))
-            {
-                break;
-            }
-
-            // Line must be indented to be a continuation
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => WinGetOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -537,7 +537,6 @@ public partial class YarnCliScraper : CliScraperBase
 
             var shortForm = match.Groups["short"].Value.Trim();
             var longForm = match.Groups["long"].Value.Trim();
-            var description = match.Groups["desc"].Value.Trim();
 
             if (string.IsNullOrEmpty(longForm))
             {
@@ -561,8 +560,7 @@ public partial class YarnCliScraper : CliScraperBase
 
             seenOptions.Add(longForm);
 
-            // Accumulate multi-line descriptions
-            i = AccumulateMultiLineDescription(lines, i, ref description);
+            var description = AccumulateWrappedDescription(lines, ref i, match.Groups["desc"], IsOptionRow);
 
             var propertyName = NormalizePropertyName(longForm);
             if (propertyName is null)
@@ -630,55 +628,7 @@ public partial class YarnCliScraper : CliScraperBase
         };
     }
 
-    /// <summary>
-    /// Accumulates multi-line descriptions.
-    /// </summary>
-    private static int AccumulateMultiLineDescription(string[] lines, int currentIndex, ref string description)
-    {
-        var descriptionParts = new List<string>();
-        if (!string.IsNullOrEmpty(description))
-        {
-            descriptionParts.Add(description);
-        }
-
-        var nextIndex = currentIndex + 1;
-        while (nextIndex < lines.Length)
-        {
-            var nextLine = lines[nextIndex];
-            var trimmedNext = nextLine.Trim();
-
-            // Stop conditions
-            if (string.IsNullOrWhiteSpace(trimmedNext))
-            {
-                break;
-            }
-
-            // New option line (starts with dash)
-            if (trimmedNext.StartsWith('-'))
-            {
-                break;
-            }
-
-            // Section header
-            if (trimmedNext.EndsWith(':') && trimmedNext.Length < 30)
-            {
-                break;
-            }
-
-            // Line must be indented to be a continuation
-            var leadingSpaces = nextLine.Length - nextLine.TrimStart().Length;
-            if (leadingSpaces < 20)
-            {
-                break;
-            }
-
-            descriptionParts.Add(trimmedNext);
-            nextIndex++;
-        }
-
-        description = string.Join(" ", descriptionParts);
-        return nextIndex - 1;
-    }
+    private static bool IsOptionRow(string line) => YarnOptionPattern().IsMatch(line);
 
     /// <summary>
     /// Checks if help text indicates the command has options.


### PR DESCRIPTION
## Summary

Second child of #4646. Ports the remaining nine scrapers onto `CliScraperBase.AccumulateWrappedDescription` (from #4645): **Az, DotNet, Go, Maven, pip, pnpm, Terraform, WinGet, Yarn**. Their private accumulators (dash-led stops, absolute indent thresholds of 8–30 spaces, and per-tool section-header heuristics) and Go's private `GetIndentationWidth` are deleted; each scraper now supplies only its own option-row predicate. Every ported scraper has a fixture that pins a wrapped `--flag`-led line as prose (Go's existing `Preserves_Hyphen_Led_Description_Continuations` already covers it).

Base: a row whose prose only begins on the next line (go, picocli, argparse) had no description column, so the column-aware rule could not protect its later wrapped lines. `AccumulateWrappedDescription` now infers the column from the first wrapped line. The same four-line hunk is in #4657 (deliberately identical so either PR can land first; git merges it as a no-op), and it is pinned here by two direct `ContinuationLineTests` cases.

## Behavioural notes

- The dropped section-header stops were redundant: every option loop is already section-scoped before accumulation, and no real sub-header sits deeper than its option rows in these nine formats.
- **Az:** knack prints an argument's long summary and preview notice four columns under the row (`Argument '--x' is in preview…`); the old `< 20` threshold dropped those lines, the depth rule now joins them into the description. Pinned in `AzCliScraperTests`.
- Per the parent issue's scope note this changes generated output for these tools wherever wrapped descriptions previously mis-parsed; regenerate the nine packages via the workflow after merge. The base lookahead in `HelpDeclaresRepeatableOption` is tracked in #4655.

## Test plan

- [x] New fixtures for Az, DotNet, Maven, pip (new `PipCliScraperTests`), pnpm (new `PnpmCliScraperTests`), Terraform, WinGet, Yarn; two direct base tests for the inferred column.
- [x] `ModularPipelines.OptionsGenerator.Tests`: 1328 passed, 0 failed (guarded local run).
- [x] `dotnet format whitespace --verify-no-changes` clean for the touched files (the only remaining hit, `IHelpTextCache.cs`, pre-exists on `main`).

Closes #4654

https://claude.ai/code/session_01PkLNTUfwGXjqXZrYrHaDGC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line help parsing across supported tools.
  * Wrapped descriptions that resemble option rows are now preserved as prose instead of being incorrectly parsed as separate options.
  * Multi-line descriptions are more reliably combined, including continuation text with varying indentation.

* **Tests**
  * Added coverage for wrapped descriptions and continuation-line parsing across multiple CLI formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->