### PR TITLE
Isolate pipeline-directory environment tests from the whole suite

### DIFF
--- a/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineWorkingDirectoryTests.cs
@@ -211,7 +211,10 @@ public class PipelineWorkingDirectoryTests
         }
     }
 
+    // Pointing MODULAR_PIPELINES_DIRECTORY at a missing path makes every inferring
+    // Pipeline.CreateBuilder() in the process throw, so run alone, not just in the group.
     [Test]
+    [TUnit.Core.NotInParallel]
     public async Task ExplicitWorkingDirectorySkipsProjectInference()
     {
         var variableName = "MODULAR_PIPELINES_DIRECTORY";
@@ -238,6 +241,7 @@ public class PipelineWorkingDirectoryTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel]
     public async Task NonInferringBuilderIgnoresPipelineDirectoryEnvironmentVariable()
     {
         var variableName = "MODULAR_PIPELINES_DIRECTORY";


### PR DESCRIPTION
## Summary

`RunHistoryPersistsAndCalculatesDeltasWithoutReportWriting` failed on `main` with `MODULAR_PIPELINES_DIRECTORY must point to a directory containing appsettings.json and a project file` even though it never touches that variable.

Root cause: `Pipeline.CreateBuilder()` infers the pipeline project eagerly (`PipelineBuilder.CreateHostEnvironment` tries `PipelineDirectory.TryFindPipelineProject` before falling back to the current directory), and that lookup validates `MODULAR_PIPELINES_DIRECTORY` whenever it is set. Two tests in `PipelineWorkingDirectoryTests` deliberately point the variable at a missing path to prove it is ignored by explicit and non-inferring builders. The class was only serialized under the `ProcessEnvironment` key, so while those tests ran, every inferring `CreateBuilder()` in any other class (about 300 call sites across the core suite, `RunReportTests` included) could throw.

Fix: the two mutating tests (`ExplicitWorkingDirectorySkipsProjectInference`, `NonInferringBuilderIgnoresPipelineDirectoryEnvironmentVariable`) now carry a keyless `[NotInParallel]`, which TUnit treats as "not in parallel with any other test" and which takes precedence over the class-level keyed constraint, so the process-wide variable is never set while another test creates a builder. The other seven tests in the class stay in the `ProcessEnvironment` group. No production code changes; the eager validation stays because an invalid override must surface to real callers.

Injecting the directory into the run-history tests alone would have fixed one symptom and left the other builder-based tests exposed to the same race, so the isolation is placed on the writer side instead.

## Test plan
- [x] `PipelineWorkingDirectoryTests` and `RunReportTests.RunHistoryPersistsAndCalculatesDeltasWithoutReportWriting` pass locally through the agent guard
- [ ] CI `full pipeline (ubuntu-latest)` core suite green with parallel execution

Closes #4652
