### PR TITLE
Make the always-run cancellation classification test deterministic

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -795,7 +795,9 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         throw exception;
     }
 
-    private ModuleStatus ClassifyException(
+    // Internal so tests can pin that classification depends only on the exception and the
+    // module configuration, never on how long the attempt took.
+    internal ModuleStatus ClassifyException(
         ModuleConfiguration config,
         Exception exception)
     {

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -127,8 +127,7 @@ public class ModuleExecutionPipelineTests
     private sealed class AlwaysRunElapsedCancellationModule : Module<int>
     {
         protected override void Configure(ModuleConfigurationBuilder module) => module
-            .WithAlwaysRun()
-            .WithTimeout(TimeSpan.FromMilliseconds(5));
+            .WithAlwaysRun();
 
         protected internal override Task<int> ExecuteAsync(
             IModuleContext context,
@@ -209,11 +208,9 @@ public class ModuleExecutionPipelineTests
     [Test]
     public async Task ExecuteAsync_DoesNotClassifyAlwaysRunElapsedCancellationAsTimeout()
     {
+        // The status comes from the cancellation source, not from how long the attempt took.
         var module = new AlwaysRunElapsedCancellationModule();
         var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
-        executionContext.Stopwatch.Start();
-        await Task.Delay(TimeSpan.FromMilliseconds(25));
-        executionContext.Stopwatch.Stop();
 
         await Assert.That(async () => await ExecuteAfterPipelineCancellation(module, executionContext))
             .Throws<ModuleFailedException>();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -218,6 +218,51 @@ public class ModuleExecutionPipelineTests
         await Assert.That(executionContext.Status).IsEqualTo(ModuleStatus.Failed);
     }
 
+    private sealed class AlwaysRunTinyTimeoutModule : Module<int>
+    {
+        protected override void Configure(ModuleConfigurationBuilder module) => module
+            .WithAlwaysRun()
+            .WithTimeout(TimeSpan.FromMilliseconds(5));
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(42);
+        }
+    }
+
+    [Test]
+    public async Task ClassifyException_UsesTheExceptionNotTheAttemptDuration()
+    {
+        // The module never executes here, so its 5 ms deadline cannot race the classifier.
+        // Any real attempt would outlive that timeout; the status still follows the exception:
+        // a pipeline cancellation stays Failed for an always-run module and only a genuine
+        // ModuleTimeoutException becomes TimedOut.
+        var module = new AlwaysRunTinyTimeoutModule();
+        var configuration = ((IModule) module).Configuration;
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
+        var pipeline = new ModuleExecutionPipeline(
+            Mock.Of<IModuleResultRepository>(),
+            engineCancellationToken,
+            Mock.Of<IDirectHookInvoker>(),
+            Mock.Of<IModuleConditionHandler>(),
+            OptionsFactory.Create(new PipelineOptions()));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(configuration.Timeout).IsEqualTo(TimeSpan.FromMilliseconds(5));
+            await Assert.That(pipeline.ClassifyException(configuration, new OperationCanceledException()))
+                .IsEqualTo(ModuleStatus.Failed);
+            await Assert.That(pipeline.ClassifyException(
+                    configuration,
+                    new ModuleTimeoutException(module.GetType(), configuration.Timeout!.Value)))
+                .IsEqualTo(ModuleStatus.TimedOut);
+        }
+    }
+
     [Test]
     public async Task ExecuteAsync_DisposesOriginalAndLinkedCancellationTokenSources()
     {


### PR DESCRIPTION
## Summary

`ModuleExecutionPipelineTests.ExecuteAsync_DoesNotClassifyAlwaysRunElapsedCancellationAsTimeout` failed on a loaded Ubuntu runner with `TimedOut` instead of `Failed`.

The test dates from #3837, which made status classification depend on the exception type rather than on elapsed time. To reproduce the pre-#3837 bug it configured a 5 ms module timeout and pre-elapsed the context stopwatch by 25 ms. Since #3837 the stopwatch no longer feeds any status decision, so that setup only creates a race: `TimeoutHelper` arms the 5 ms deadline before invoking the module, and under load the deadline fires before the module's already-faulted task is published. Per #4588 a deadline that signals before publication owns the outcome, so the pipeline correctly reports a real `ModuleTimeoutException` and the test's expectation is wrong for that timing, not the product.

Fix (test only): the fixture drops its explicit 5 ms timeout (the pipeline default of 30 minutes still arms the same timeout path and cannot elapse), and the wall-clock delay on the stopwatch is removed. The status now depends solely on the cancellation source, which is what the test names. The historical names are kept so the issue and CI history stay traceable.

The sibling `ExecuteAsync_ClassifiesPipelineCancellationAsCancelled` keeps its 5 ms timeout: for a non-always-run module both an `OperationCanceledException` and a genuine timeout classify as `Cancelled` under pipeline cancellation, so its outcome does not depend on the race.

## Test plan
- [x] `ModuleExecutionPipelineTests` class passes through the agent guard
- [x] The target test passes 5/5 repeated runs locally
- [ ] CI `full pipeline (ubuntu-latest)` core suite green

Closes #4651
