### PR TITLE
Order generated enum members by CLI value instead of scrape order

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/External/ExternalToolDefinitionTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/External/ExternalToolDefinitionTests.cs
@@ -866,6 +866,61 @@ public class ExternalToolDefinitionTests
     }
 
     [Test]
+    public async Task External_Metadata_Accepts_Same_Name_Enums_Whose_Values_Differ_Only_In_Order()
+    {
+        var workspace = CreateTemporaryDirectory();
+        var metadataPath = Path.Combine(workspace, "private-widget.json");
+        var outputDirectory = Path.Combine(workspace, "integration");
+
+        try
+        {
+            await File.WriteAllTextAsync(metadataPath, ValidMetadata("generated"));
+            var tool = await ExternalToolDefinitionLoader.LoadAsync(
+                metadataPath,
+                outputDirectory);
+            var deploy = tool.Commands.Single();
+            var production = new CliEnumValue { MemberName = "Production", CliValue = "production" };
+            var staging = new CliEnumValue { MemberName = "Staging", CliValue = "staging" };
+            var environment = new CliEnumDefinition
+            {
+                EnumName = "PrivateWidgetEnvironment",
+                Values = [production, staging],
+            };
+            tool = tool with
+            {
+                Commands =
+                [
+                    deploy with
+                    {
+                        Enums = [environment],
+                    },
+                    deploy with
+                    {
+                        FullCommand = "private-widget destroy",
+                        CommandParts = ["destroy"],
+                        ClassName = "PrivateWidgetDestroyOptions",
+                        Enums = [environment with { Values = [staging, production] }],
+                    },
+                ],
+            };
+
+            await CreateOrchestrator().GenerateFromDefinitionAsync(tool, outputDirectory);
+
+            var generatedEnum = await File.ReadAllTextAsync(Path.Combine(
+                outputDirectory,
+                "generated",
+                "Enums",
+                "PrivateWidgetEnvironment.Generated.cs"));
+            await Assert.That(generatedEnum).Contains("Production,");
+            await Assert.That(generatedEnum).Contains("    Staging");
+        }
+        finally
+        {
+            Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task External_Generation_Includes_Option_Local_Enum()
     {
         var workspace = CreateTemporaryDirectory();
@@ -1516,7 +1571,7 @@ public class ExternalToolDefinitionTests
     }
 
     [Test]
-    public async Task External_Metadata_Uses_Current_Enum_Order_When_Output_Moves()
+    public async Task External_Metadata_Sorts_Enum_Members_From_Current_Values_When_Output_Moves()
     {
         var workspace = CreateTemporaryDirectory();
         var metadataPath = Path.Combine(workspace, "private-widget.json");
@@ -1592,13 +1647,15 @@ public class ExternalToolDefinitionTests
                 "generated-b",
                 "Enums",
                 "PrivateWidgetEnvironment.Generated.cs"));
-            await Assert.That(generatedEnum).Contains("Staging,");
+            // Neither the previous output's order nor the current scrape order matters: members
+            // follow their CLI values so ordinals stay stable across regenerations.
             await Assert.That(generatedEnum).Contains("Development,");
-            await Assert.That(generatedEnum).Contains("    Production");
-            await Assert.That(generatedEnum.IndexOf("Staging,", StringComparison.Ordinal))
-                .IsLessThan(generatedEnum.IndexOf("Development,", StringComparison.Ordinal));
+            await Assert.That(generatedEnum).Contains("Production,");
+            await Assert.That(generatedEnum).Contains("    Staging");
             await Assert.That(generatedEnum.IndexOf("Development,", StringComparison.Ordinal))
-                .IsLessThan(generatedEnum.IndexOf("    Production", StringComparison.Ordinal));
+                .IsLessThan(generatedEnum.IndexOf("Production,", StringComparison.Ordinal));
+            await Assert.That(generatedEnum.IndexOf("Production,", StringComparison.Ordinal))
+                .IsLessThan(generatedEnum.IndexOf("    Staging", StringComparison.Ordinal));
             await Assert.That(generatedEnum).DoesNotContain(" = ");
         }
         finally

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1398,16 +1398,44 @@ public class GeneratorHardeningTests
             // Alphabetical by CLI value; the lowercase alias keeps the plain member name even
             // though the uppercase one was scraped first.
             await Assert.That(EnumBodyLines(generated)).IsEquivalentTo(
-            [
-                "[EnumValue(\"internal\")]",
-                "Internal,",
-                "[EnumValue(\"private\")]",
-                "Private,",
-                "[EnumValue(\"public\")]",
-                "Public,",
-                "[EnumValue(\"PUBLIC\")]",
-                "PublicUppercase",
-            ]);
+                [
+                    "[EnumValue(\"internal\")]",
+                    "Internal,",
+                    "[EnumValue(\"private\")]",
+                    "Private,",
+                    "[EnumValue(\"public\")]",
+                    "Public,",
+                    "[EnumValue(\"PUBLIC\")]",
+                    "PublicUppercase",
+                ],
+                TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        }
+    }
+
+    [Test]
+    public async Task EnumGenerator_Keeps_The_Same_Duplicate_Regardless_Of_Scrape_Order()
+    {
+        CliEnumValue[] values =
+        [
+            new() { MemberName = "JsonOutput", CliValue = "json", Description = "Alias." },
+            new() { MemberName = "Json", CliValue = "json", Description = "JSON output." },
+        ];
+
+        var generated = await GenerateVisibilityEnum(values);
+        var generatedFromReorderedScrape = await GenerateVisibilityEnum([values[1], values[0]]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generatedFromReorderedScrape).IsEqualTo(generated);
+            await Assert.That(EnumBodyLines(generated)).IsEquivalentTo(
+                [
+                    "/// <summary>",
+                    "/// JSON output.",
+                    "/// </summary>",
+                    "[EnumValue(\"json\")]",
+                    "Json",
+                ],
+                TUnit.Assertions.Enums.CollectionOrdering.Matching);
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1368,14 +1368,66 @@ public class GeneratorHardeningTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(generated).Contains("    Friday,");
             await Assert.That(generated).Contains("    Fri,");
-            await Assert.That(generated).Contains("    FridayUppercase,");
-            await Assert.That(generated).Contains("    FriUppercase");
+            await Assert.That(generated).Contains("    FriUppercase,");
+            await Assert.That(generated).Contains("    Friday,");
+            await Assert.That(generated).Contains("    FridayUppercase");
             await Assert.That(generated.Split("[EnumValue(\"fri\")]", StringSplitOptions.None).Length)
                 .IsEqualTo(2);
         }
     }
+
+    [Test]
+    public async Task EnumGenerator_Emits_The_Same_Members_Regardless_Of_Scrape_Order()
+    {
+        CliEnumValue[] values =
+        [
+            new() { MemberName = "Public", CliValue = "PUBLIC" },
+            new() { MemberName = "Public", CliValue = "public" },
+            new() { MemberName = "Internal", CliValue = "internal" },
+            new() { MemberName = "Private", CliValue = "private" },
+        ];
+
+        var generated = await GenerateVisibilityEnum(values);
+        var generatedFromReorderedScrape = await GenerateVisibilityEnum([values[2], values[1], values[3], values[0]]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generatedFromReorderedScrape).IsEqualTo(generated);
+
+            // Alphabetical by CLI value; the lowercase alias keeps the plain member name even
+            // though the uppercase one was scraped first.
+            await Assert.That(EnumBodyLines(generated)).IsEquivalentTo(
+            [
+                "[EnumValue(\"internal\")]",
+                "Internal,",
+                "[EnumValue(\"private\")]",
+                "Private,",
+                "[EnumValue(\"public\")]",
+                "Public,",
+                "[EnumValue(\"PUBLIC\")]",
+                "PublicUppercase",
+            ]);
+        }
+    }
+
+    private static async Task<string> GenerateVisibilityEnum(IReadOnlyList<CliEnumValue> values)
+    {
+        var tool = Tool(Command(
+            "ToolGetOptions",
+            "ToolOptions",
+            ["get"],
+            enums: [new CliEnumDefinition { EnumName = "ToolVisibility", Values = values }]));
+
+        return (await new EnumGenerator().GenerateAsync(tool)).Single().Content;
+    }
+
+    private static string[] EnumBodyLines(string generated) =>
+        generated
+            .Split(Environment.NewLine)
+            .Where(line => line.StartsWith("    ", StringComparison.Ordinal))
+            .Select(line => line.Trim())
+            .ToArray();
 
     [Test]
     public async Task Case_Variant_Enum_Names_Fail_The_Duplicate_Path_Check()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliGlobalOptionMergerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Models/CliGlobalOptionMergerTests.cs
@@ -60,6 +60,26 @@ public class CliGlobalOptionMergerTests
     }
 
     [Test]
+    public async Task Merge_Deduplicates_Enum_Definitions_Whose_Values_Were_Scraped_In_A_Different_Order()
+    {
+        var json = new CliEnumValue { MemberName = "Json", CliValue = "json" };
+        var yaml = new CliEnumValue { MemberName = "Yaml", CliValue = "yaml" };
+        var scraped = Option("--format", "Format") with
+        {
+            CSharpType = "OutputFormat?",
+            EnumDefinition = EnumDefinition() with { Values = [yaml, json] },
+        };
+        var supplemental = scraped with
+        {
+            EnumDefinition = EnumDefinition() with { Values = [json, yaml] },
+        };
+
+        var merged = CliGlobalOptionMerger.Merge([scraped], [supplemental]);
+
+        await Assert.That(merged).Count().IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Merge_Rejects_Conflicting_Definitions_For_The_Same_Switch()
     {
         await Assert.That(() => CliGlobalOptionMerger.Merge(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
@@ -51,6 +51,48 @@ public class OptionTypeEnhancerTests
     }
 
     [Test]
+    public async Task EnhanceAsync_Builds_The_Same_Enum_Regardless_Of_Detected_Value_Order()
+    {
+        // "PUBLIC" and "public" collide on the member name; the lowercase spelling must win
+        // whichever the detector listed first.
+        var first = await EnhanceWithDetectedEnum(["PUBLIC", "public", "internal"]);
+        var second = await EnhanceWithDetectedEnum(["internal", "public", "PUBLIC"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(first.Values.Select(value => value.CliValue))
+                .IsEquivalentTo(["internal", "public"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+            await Assert.That(second.Values)
+                .IsEquivalentTo(first.Values, TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        }
+    }
+
+    private static async Task<CliEnumDefinition> EnhanceWithDetectedEnum(string[] enumValues)
+    {
+        var result = new OptionTypeDetectionResult
+        {
+            Type = CliOptionType.Enum,
+            Confidence = 100,
+            Source = "ManualOverride",
+            EnumValues = enumValues,
+        };
+        var pipeline = new OptionTypeDetectorPipeline(
+            [new FixedDetector(result)],
+            NullLogger<OptionTypeDetectorPipeline>.Instance);
+        var enhancer = new OptionTypeEnhancer(pipeline, NullLogger<OptionTypeEnhancer>.Instance);
+        var tool = CreateTool(new CliOptionDefinition
+        {
+            SwitchName = "--visibility",
+            PropertyName = "Visibility",
+            CSharpType = "string?",
+        });
+
+        var enhanced = await enhancer.EnhanceAsync(tool);
+
+        return enhanced.Commands.Single().Options.Single().EnumDefinition!;
+    }
+
+    [Test]
     public async Task EnhanceAsync_Applies_Key_Filtered_Secret_Metadata()
     {
         var result = new OptionTypeDetectionResult

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
@@ -441,11 +441,7 @@ public static class ExternalToolDefinitionLoader
         CliEnumDefinition first,
         CliEnumDefinition second) =>
         string.Equals(first.Description, second.Description, StringComparison.Ordinal)
-        && first.Values.Count == second.Values.Count
-        && CliEnumDefinition.OrderValues(first.Values).Zip(CliEnumDefinition.OrderValues(second.Values)).All(pair =>
-            string.Equals(pair.First.MemberName, pair.Second.MemberName, StringComparison.Ordinal)
-            && string.Equals(pair.First.CliValue, pair.Second.CliValue, StringComparison.Ordinal)
-            && string.Equals(pair.First.Description, pair.Second.Description, StringComparison.Ordinal));
+        && CliEnumDefinition.OrderValues(first.Values).SequenceEqual(CliEnumDefinition.OrderValues(second.Values));
 
     private static void ValidateUniqueEffectiveSwitches(
         CliCommandDefinition command,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/External/ExternalToolDefinitionLoader.cs
@@ -442,7 +442,7 @@ public static class ExternalToolDefinitionLoader
         CliEnumDefinition second) =>
         string.Equals(first.Description, second.Description, StringComparison.Ordinal)
         && first.Values.Count == second.Values.Count
-        && first.Values.Zip(second.Values).All(pair =>
+        && CliEnumDefinition.OrderValues(first.Values).Zip(CliEnumDefinition.OrderValues(second.Values)).All(pair =>
             string.Equals(pair.First.MemberName, pair.Second.MemberName, StringComparison.Ordinal)
             && string.Equals(pair.First.CliValue, pair.Second.CliValue, StringComparison.Ordinal)
             && string.Equals(pair.First.Description, pair.Second.Description, StringComparison.Ordinal));

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumGenerator.cs
@@ -4,7 +4,10 @@ using ModularPipelines.OptionsGenerator.Models;
 namespace ModularPipelines.OptionsGenerator.Generators;
 
 /// <summary>
-/// Generates enum types for CLI options with constrained values.
+/// Generates enum types for CLI options with constrained values. Members are emitted in a
+/// deterministic order derived from their CLI values, so regenerating from the same allowed
+/// value set never reorders members (or their ordinals) when a tool prints its values in an
+/// unstable order.
 /// </summary>
 public class EnumGenerator : ICodeGenerator
 {
@@ -103,7 +106,7 @@ public class EnumGenerator : ICodeGenerator
         var usedMemberNames = new HashSet<string>(StringComparer.Ordinal);
         var uniqueValues = new List<CliEnumValue>();
 
-        foreach (var value in values)
+        foreach (var value in CliEnumDefinition.OrderValues(values))
         {
             if (!usedCliValues.Add(value.CliValue))
             {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliEnumDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliEnumDefinition.cs
@@ -19,6 +19,18 @@ public record CliEnumDefinition
     /// Description for XML documentation.
     /// </summary>
     public string? Description { get; init; }
+
+    /// <summary>
+    /// Orders values by their CLI string rather than by scrape order, so anything that emits or
+    /// compares enum values sees the same sequence no matter how a tool happened to print its
+    /// allowed values. Case-insensitive alphabetical order keeps case variants adjacent; among
+    /// case variants the lowercase spelling sorts first so it claims the plain member name and
+    /// the uppercase alias receives the casing suffix.
+    /// </summary>
+    public static IEnumerable<CliEnumValue> OrderValues(IEnumerable<CliEnumValue> values) =>
+        values
+            .OrderBy(value => value.CliValue, StringComparer.OrdinalIgnoreCase)
+            .ThenByDescending(value => value.CliValue, StringComparer.Ordinal);
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliEnumDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliEnumDefinition.cs
@@ -25,12 +25,16 @@ public record CliEnumDefinition
     /// compares enum values sees the same sequence no matter how a tool happened to print its
     /// allowed values. Case-insensitive alphabetical order keeps case variants adjacent; among
     /// case variants the lowercase spelling sorts first so it claims the plain member name and
-    /// the uppercase alias receives the casing suffix.
+    /// the uppercase alias receives the casing suffix. Entries that repeat the same CLI string
+    /// are ordered by member name, then description, so the one that survives deduplication
+    /// does not depend on scrape order either.
     /// </summary>
     public static IEnumerable<CliEnumValue> OrderValues(IEnumerable<CliEnumValue> values) =>
         values
             .OrderBy(value => value.CliValue, StringComparer.OrdinalIgnoreCase)
-            .ThenByDescending(value => value.CliValue, StringComparer.Ordinal);
+            .ThenByDescending(value => value.CliValue, StringComparer.Ordinal)
+            .ThenBy(value => value.MemberName, StringComparer.Ordinal)
+            .ThenBy(value => value.Description, StringComparer.Ordinal);
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliGlobalOptionMerger.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliGlobalOptionMerger.cs
@@ -138,7 +138,7 @@ public static class CliGlobalOptionMerger
                && right is not null
                && left.EnumName.Equals(right.EnumName, StringComparison.Ordinal)
                && string.Equals(left.Description, right.Description, StringComparison.Ordinal)
-               && left.Values.SequenceEqual(right.Values);
+               && CliEnumDefinition.OrderValues(left.Values).SequenceEqual(CliEnumDefinition.OrderValues(right.Values));
     }
 
     private static bool StringEquals(string? left, string? right)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeEnhancer.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeEnhancer.cs
@@ -260,15 +260,16 @@ public class OptionTypeEnhancer
         var commandPrefix = command.ClassName.Replace("Options", "");
         var enumName = GeneratorUtils.ToEnumName(option.SwitchName, commandPrefix);
 
-        // Create enum values
-        var values = enumValues
-            .Where(v => !string.IsNullOrWhiteSpace(v))
-            .Select(cliValue => new CliEnumValue
-            {
-                MemberName = GeneratorUtils.ToEnumMemberName(cliValue),
-                CliValue = cliValue,
-                Description = null
-            })
+        // Create enum values in the shared order first, so which of two colliding member
+        // names survives does not depend on the order the tool printed its values.
+        var values = CliEnumDefinition.OrderValues(enumValues
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(cliValue => new CliEnumValue
+                {
+                    MemberName = GeneratorUtils.ToEnumMemberName(cliValue),
+                    CliValue = cliValue,
+                    Description = null
+                }))
             .DistinctBy(v => v.MemberName) // Avoid duplicate member names
             .ToList();
 


### PR DESCRIPTION
## Summary

`EnumGenerator` emitted enum members in raw scrape order. When a CLI prints its allowed values in an unstable order (Go map iteration leaking into help text), every scheduled regeneration flipped the member order, silently reassigning ordinals and making the automated PR's API-impact scan report phantom removed/added members. Observed on #4650 (`FluxBootstrapGitlabVisibility` flipped between two scrapes of the same `flux` 2.9.5).

Runtime resolution (`CommandArgumentBuilder.ParseEnum`) goes through `[EnumValue]` by member name and never depends on ordinals, so member order can be a pure function of the current value set.

## Change

- New `CliEnumDefinition.OrderValues`: orders values by CLI string, case-insensitive alphabetical, with the lowercase spelling first on case ties so it claims the plain member name and the uppercase alias keeps the `Uppercase` suffix.
- `EnumGenerator.GetUniqueValues` iterates that order. Deduplication and member-name collision handling are unchanged, they just run over the sorted sequence, so suffix assignment is deterministic too.
- The two places that compared enum values positionally now compare the ordered sequences, so an unstable scrape cannot raise a false "conflicting definition" error either:
  - `CliGlobalOptionMerger.EnumDefinitionsEqual` (scraped vs supplemental global option shape check)
  - `ExternalToolDefinitionLoader.AreEquivalent` (same-name enums across commands in external metadata)
- No prior-output preservation is reintroduced (removed on purpose in #4404); output depends only on the current scrape.

## Tests

- `EnumGenerator_Emits_The_Same_Members_Regardless_Of_Scrape_Order`: shuffled input (including a `PUBLIC`/`public` case pair) produces byte-identical output with the exact expected attribute/member sequence.
- `Merge_Deduplicates_Enum_Definitions_Whose_Values_Were_Scraped_In_A_Different_Order` and `External_Metadata_Accepts_Same_Name_Enums_Whose_Values_Differ_Only_In_Order` cover the two equality checks.
- `EnumGenerator_Preserves_Aliases_With_Unique_Member_Names` expectations reordered for the sorted output; `External_Metadata_Uses_Current_Enum_Order_When_Output_Moves` renamed to `..._Sorts_Enum_Members_From_Current_Values_...` and asserts the sorted order with no influence from the previous output.
- Full `ModularPipelines.OptionsGenerator.Tests` run: 1324/1324. `dotnet format --verify-no-changes` reports nothing in the touched files (the remaining diagnostics are pre-existing elsewhere in the tool solution).

## ⚠️ One-time reorder

Existing generated enums whose scrape order is not already sorted will reorder once on their next regeneration and show up as removed/added members in that regeneration PR. That is expected and consistent with the #4404 policy (v4 not yet tagged, #3997). Labelled `breaking` so it lands in the release notes.

Closes #4661

https://claude.ai/code/session_01PkLNTUfwGXjqXZrYrHaDGC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enum definitions with the same values in different orders are now recognized as equivalent and deduplicated.
  - Generated enum members now use consistent, deterministic ordering based on CLI values.
  - Enum aliases retain stable naming and ordering, including case-sensitive variants.

- **Tests**
  - Added coverage for order-independent enum matching, merging, generation, and alias handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->