### PR TITLE
[Automated] Update terraform CLI Options

### DIFF
--- a/src/ModularPipelines.Terraform/Generated/Terraform.Generation.json
+++ b/src/ModularPipelines.Terraform/Generated/Terraform.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "terraform",
   "toolVersion": "Terraform v1.16.1 on linux_amd64",
   "commandTreeSha256": "68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7",
-  "generatorSourceSha256": "d9158a695acc19054e4501e243f73451e38058e36153726384f7e577db59b384"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepArtifactsOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksDeploymentStepArtifactsOptions.Generated.cs
@@ -27,7 +27,7 @@ public record TerraformStacksDeploymentStepArtifactsOptions : TerraformOptions
     public string? DeploymentStepId { get; set; }
 
     /// <summary>
-    /// The artifact type to retrieve. (required)
+    /// The artifact type to retrieve. (required) One of: plan-description   Plan details apply-description  Apply details (outputs + resource changes) plan-debug-log     Plan execution logs apply-debug-log    Apply execution logs
     /// </summary>
     [CliOption("-artifact-name", Format = OptionFormat.EqualsSeparated)]
     public string? ArtifactName { get; set; }

--- a/src/ModularPipelines.Terraform/Options/TerraformStacksProvidersLockOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformStacksProvidersLockOptions.Generated.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Terraform.Options;
 public record TerraformStacksProvidersLockOptions : TerraformOptions
 {
     /// <summary>
-    /// Output results in JSON format instead of the default
+    /// Output results in JSON format instead of the default human-readable text format.
     /// </summary>
     [CliFlag("-json")]
     public bool? Json { get; set; }

--- a/src/ModularPipelines.Terraform/Options/TerraformTestOptions.Generated.cs
+++ b/src/ModularPipelines.Terraform/Options/TerraformTestOptions.Generated.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Terraform.Options;
 public record TerraformTestOptions : TerraformOptions
 {
     /// <summary>
-    /// If specified, Terraform will execute this test run remotely using HCP Terraform or Terraform Enterprise.
+    /// If specified, Terraform will execute this test run remotely using HCP Terraform or Terraform Enterprise. You must specify the source of a module registered in a private module registry as the argument to this flag. This allows Terraform to associate the cloud run with the correct HCP Terraform or Terraform Enterprise module and organization.
     /// </summary>
     [CliOption("-cloud-run", Format = OptionFormat.EqualsSeparated)]
     public string? CloudRun { get; set; }
@@ -51,7 +51,7 @@ public record TerraformTestOptions : TerraformOptions
     public bool? NoColor { get; set; }
 
     /// <summary>
-    /// Limit the number of concurrent operations within the
+    /// Limit the number of concurrent operations within the plan/apply operation of a test run. Defaults to 10.
     /// </summary>
     [CliOption("-parallelism", Format = OptionFormat.EqualsSeparated)]
     public int? Parallelism { get; set; }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **terraform** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- terraform (Terraform v1.16.1 on linux_amd64): 68 commands, tree 68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7
  - Baseline comparison: 68 commands at Terraform v1.16.1 on linux_amd64 -> 68 commands at Terraform v1.16.1 on linux_amd64

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator