### PR TITLE
[Automated] Update docker CLI Options

### DIFF
--- a/src/ModularPipelines.Docker/Generated/Docker.Generation.json
+++ b/src/ModularPipelines.Docker/Generated/Docker.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "docker",
+  "toolVersion": "Docker version 28.0.4, build b8034c0",
+  "commandTreeSha256": "aa61e74921c1dbff2d43176d940dd6700962c0a41c51db2662fe01e04de0cde2",
+  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
+}

--- a/src/ModularPipelines.Docker/Options/DockerBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuildOptions.Generated.cs
@@ -213,7 +213,7 @@ public record DockerBuildOptions(
     public string? Sbom { get; set; }
 
     /// <summary>
-    /// Secret to expose to the build
+    /// Secret to expose to the build (format: "id=mysecret[,src=/local/secret]")
     /// </summary>
     [SecretValue]
     [CliOption("--secret", Format = OptionFormat.EqualsSeparated)]
@@ -226,7 +226,7 @@ public record DockerBuildOptions(
     public string? ShmSize { get; set; }
 
     /// <summary>
-    /// SSH agent socket or keys to expose
+    /// SSH agent socket or keys to expose to the build (format: "default|&lt;id&gt;[=&lt;socket&gt;|&lt;key&gt;[,&lt;key&gt;]]")
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerBuildxBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuildxBuildOptions.Generated.cs
@@ -213,7 +213,7 @@ public record DockerBuildxBuildOptions(
     public string? Sbom { get; set; }
 
     /// <summary>
-    /// Secret to expose to the build
+    /// Secret to expose to the build (format: "id=mysecret[,src=/local/secret]")
     /// </summary>
     [SecretValue]
     [CliOption("--secret", Format = OptionFormat.EqualsSeparated)]
@@ -226,7 +226,7 @@ public record DockerBuildxBuildOptions(
     public string? ShmSize { get; set; }
 
     /// <summary>
-    /// SSH agent socket or keys to expose
+    /// SSH agent socket or keys to expose to the build (format: "default|&lt;id&gt;[=&lt;socket&gt;|&lt;key&gt;[,&lt;key&gt;]]")
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerBuildxDapBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuildxDapBuildOptions.Generated.cs
@@ -213,7 +213,7 @@ public record DockerBuildxDapBuildOptions(
     public string? Sbom { get; set; }
 
     /// <summary>
-    /// Secret to expose to the build
+    /// Secret to expose to the build (format: "id=mysecret[,src=/local/secret]")
     /// </summary>
     [SecretValue]
     [CliOption("--secret", Format = OptionFormat.EqualsSeparated)]
@@ -226,7 +226,7 @@ public record DockerBuildxDapBuildOptions(
     public string? ShmSize { get; set; }
 
     /// <summary>
-    /// SSH agent socket or keys to expose
+    /// SSH agent socket or keys to expose to the build (format: "default|&lt;id&gt;[=&lt;socket&gt;|&lt;key&gt;[,&lt;key&gt;]]")
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerComposeBridgeConvertOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeBridgeConvertOptions.Generated.cs
@@ -39,7 +39,7 @@ public record DockerComposeBridgeConvertOptions : DockerOptions
     public string? Templates { get; set; }
 
     /// <summary>
-    /// Transformation to apply to compose
+    /// Transformation to apply to compose model (default: docker/compose-bridge-kubernetes)
     /// </summary>
     [CliOption("--transformation", ShortForm = "-t", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Transformation { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerComposeCpOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeCpOptions.Generated.cs
@@ -13,7 +13,7 @@ using ModularPipelines.Docker.Options;
 namespace ModularPipelines.Docker.Options;
 
 /// <summary>
-/// docker compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+/// Copy files/folders between a service container and the local filesystem
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.Docker/Options/DockerComposeUpOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeUpOptions.Generated.cs
@@ -69,7 +69,7 @@ public record DockerComposeUpOptions : DockerOptions
     public bool? DryRun { get; set; }
 
     /// <summary>
-    /// Return the exit code of the selected service container. Implies
+    /// Return the exit code of the selected service container. Implies --abort-on-container-exit
     /// </summary>
     [CliOption("--exit-code-from", Format = OptionFormat.EqualsSeparated)]
     public string? ExitCodeFrom { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerContainerCpOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerContainerCpOptions.Generated.cs
@@ -13,7 +13,7 @@ using ModularPipelines.Docker.Options;
 namespace ModularPipelines.Docker.Options;
 
 /// <summary>
-/// docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH
+/// Copy files/folders between a container and the local filesystem
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.Docker/Options/DockerCpOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerCpOptions.Generated.cs
@@ -13,7 +13,7 @@ using ModularPipelines.Docker.Options;
 namespace ModularPipelines.Docker.Options;
 
 /// <summary>
-/// docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH
+/// Copy files/folders between a container and the local filesystem
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.Docker/Options/DockerImageBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerImageBuildOptions.Generated.cs
@@ -213,7 +213,7 @@ public record DockerImageBuildOptions(
     public string? Sbom { get; set; }
 
     /// <summary>
-    /// Secret to expose to the build
+    /// Secret to expose to the build (format: "id=mysecret[,src=/local/secret]")
     /// </summary>
     [SecretValue]
     [CliOption("--secret", Format = OptionFormat.EqualsSeparated)]
@@ -226,7 +226,7 @@ public record DockerImageBuildOptions(
     public string? ShmSize { get; set; }
 
     /// <summary>
-    /// SSH agent socket or keys to expose
+    /// SSH agent socket or keys to expose to the build (format: "default|&lt;id&gt;[=&lt;socket&gt;|&lt;key&gt;[,&lt;key&gt;]]")
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerSwarmInitOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerSwarmInitOptions.Generated.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Docker.Options;
 public record DockerSwarmInitOptions : DockerOptions
 {
     /// <summary>
-    /// Advertised address
+    /// Advertised address (format: "&lt;ip|interface&gt;[:port]")
     /// </summary>
     [CliOption("--advertise-addr", Format = OptionFormat.EqualsSeparated)]
     public string? AdvertiseAddr { get; set; }

--- a/src/ModularPipelines.Docker/Options/DockerTrustSignerRemoveOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerTrustSignerRemoveOptions.Generated.cs
@@ -24,7 +24,7 @@ public record DockerTrustSignerRemoveOptions(
 ) : DockerOptions
 {
     /// <summary>
-    /// Do not prompt for confirmation before removing the most
+    /// Do not prompt for confirmation before removing the most recent signer
     /// </summary>
     [CliFlag("--force", ShortForm = "-f")]
     public bool? Force { get; set; }

--- a/src/ModularPipelines.Docker/Services/DockerCompose.Generated.cs
+++ b/src/ModularPipelines.Docker/Services/DockerCompose.Generated.cs
@@ -118,7 +118,7 @@ public class DockerCompose : IDockerCompose
     }
 
     /// <summary>
-    /// docker compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+    /// Copy files/folders between a service container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Docker/Services/DockerContainer.Generated.cs
+++ b/src/ModularPipelines.Docker/Services/DockerContainer.Generated.cs
@@ -78,7 +78,7 @@ public class DockerContainer : IDockerContainer
     }
 
     /// <summary>
-    /// docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH
+    /// Copy files/folders between a container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Docker/Services/IDocker.Generated.cs
+++ b/src/ModularPipelines.Docker/Services/IDocker.Generated.cs
@@ -115,7 +115,7 @@ public partial interface IDocker
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH
+    /// Copy files/folders between a container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Docker/Services/IDockerCompose.Generated.cs
+++ b/src/ModularPipelines.Docker/Services/IDockerCompose.Generated.cs
@@ -77,7 +77,7 @@ public interface IDockerCompose
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// docker compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+    /// Copy files/folders between a service container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Docker/Services/IDockerContainer.Generated.cs
+++ b/src/ModularPipelines.Docker/Services/IDockerContainer.Generated.cs
@@ -52,7 +52,7 @@ public interface IDockerContainer
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH
+    /// Copy files/folders between a container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **docker** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- docker (Docker version 28.0.4, build b8034c0): 205 commands, tree aa61e74921c1dbff2d43176d940dd6700962c0a41c51db2662fe01e04de0cde2
  - Baseline comparison: 205 commands at Docker version 28.0.4, build b8034c0 -> 205 commands at Docker version 28.0.4, build b8034c0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator