### PR TITLE
[Automated] Update git CLI Options

### DIFF
--- a/src/ModularPipelines.Git/Generated/Git.Generation.json
+++ b/src/ModularPipelines.Git/Generated/Git.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "git",
   "toolVersion": "git version 2.55.0",
   "commandTreeSha256": "465b594e6088738dea79166e0ea6b752ce7d677ae2134a75a474199128856a85",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **git** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- git (git version 2.55.0): 181 commands, tree 465b594e6088738dea79166e0ea6b752ce7d677ae2134a75a474199128856a85
  - Baseline comparison: 181 commands at git version 2.55.0 -> 181 commands at git version 2.55.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator