### PR TITLE
test: move short literal hang guards onto TestHostSettings.DefaultTestTimeout

### DIFF
--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -777,7 +777,7 @@ public class DistributedModuleExecutorTests
             workerIndex: 1);
         // Act
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serialized, CancellationToken.None);
         await executionTask;
 
@@ -817,7 +817,7 @@ public class DistributedModuleExecutorTests
             workerIndex: 1);
         // Act
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serialized, CancellationToken.None);
         await executionTask;
 
@@ -1229,7 +1229,7 @@ public class DistributedModuleExecutorTests
             workerIndex: 1);
         // Act
         var executionTask = executor.ExecuteAsync([moduleA, moduleB]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
         // Don't publish moduleB result — it should be cancelled
         await executionTask;
@@ -1295,23 +1295,23 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         var executionTask = executor.ExecuteAsync([failedModule, alwaysRunModule]);
-        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
-        await noDequeue.WaitForResultStartedAsync(typeof(AlwaysRunDistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TestHostSettings.DefaultTestTimeout);
+        await noDequeue.WaitForResultStartedAsync(typeof(AlwaysRunDistributedModule)).WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
-        await pipelineCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await pipelineCancelled.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
 
         var alwaysRunWaitToken = noDequeue.ResultWaitTokens[typeof(AlwaysRunDistributedModule).FullName!];
         await Assert.That(alwaysRunWaitToken.IsCancellationRequested).IsFalse();
         await Assert.That(executionTask.IsCompleted).IsFalse();
 
         await coordinator.PublishResultAsync(serializedAlwaysRunResult, CancellationToken.None);
-        await alwaysRunStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await alwaysRunStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await Assert.That(executionTask.IsCompleted).IsFalse();
         await Assert.That(noDequeue.CompletionSignaled.Task.IsCompleted).IsFalse();
 
         releaseAlwaysRun.TrySetResult();
-        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
-        await noDequeue.CompletionSignaled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await executionTask.WaitAsync(TestHostSettings.DefaultTestTimeout);
+        await noDequeue.CompletionSignaled.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await Assert.That(resultRegistry.GetResult(typeof(AlwaysRunDistributedModule))?.ExceptionOrDefault).IsNull();
         alwaysRunHandler.VerifyAll();
     }
@@ -1346,11 +1346,11 @@ public class DistributedModuleExecutorTests
             resultCollector: new DistributedResultCollector(noDequeue, serializer));
 
         var executionTask = executor.ExecuteAsync([failedModule, alwaysRunModule]);
-        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TestHostSettings.DefaultTestTimeout);
         await noDequeue.WaitForResultStartedAsync(typeof(ShortTimeoutAlwaysRunDistributedModule))
-            .WaitAsync(TimeSpan.FromSeconds(2));
+            .WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
-        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await executionTask.WaitAsync(TestHostSettings.DefaultTestTimeout);
 
         var result = resultRegistry.GetResult(typeof(ShortTimeoutAlwaysRunDistributedModule));
         await Assert.That(result).IsNotNull();
@@ -1458,14 +1458,13 @@ public class DistributedModuleExecutorTests
             alwaysRunHandler: alwaysRunHandler.Object);
 
         var executionTask = executor.ExecuteAsync([module]);
-        await trackingCoordinator.WaitForResultStartedAsync(typeof(DistributedModule))
-            .WaitAsync(TimeSpan.FromSeconds(2));
+        await trackingCoordinator.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
         var exception = await Assert.That(async () => await executionTask)
             .Throws<InvalidOperationException>();
 
         await Assert.That(exception).IsSameReferenceAs(failure);
-        await trackingCoordinator.CompletionSignaled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await trackingCoordinator.CompletionSignaled.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         alwaysRunHandler.VerifyAll();
     }
 
@@ -1515,17 +1514,17 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         var executionTask = executor.ExecuteAsync([failedModule, queuedModule]);
-        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
-        await noDequeue.WaitForResultStartedAsync(typeof(AnotherDistributedModule)).WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WaitForResultStartedAsync(typeof(DistributedModule)).WaitAsync(TestHostSettings.DefaultTestTimeout);
+        await noDequeue.WaitForResultStartedAsync(typeof(AnotherDistributedModule)).WaitAsync(TestHostSettings.DefaultTestTimeout);
         var externalWorkerAssignment = await coordinator.DequeueModuleAsync(
             new HashSet<Capability>(),
             CancellationToken.None);
         await Assert.That(externalWorkerAssignment?.ModuleTypeName)
             .IsEqualTo(typeof(DistributedModule).FullName);
         await coordinator.PublishResultAsync(serializedFailure, CancellationToken.None);
-        await pipelineCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await pipelineCancelled.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
 
-        await executionTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await executionTask.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await Assert.That(noDequeue.DequeueCount).IsEqualTo(1);
         moduleRunner.Verify(runner => runner.ExecuteWithoutDependencyWaitAsync(
             It.IsAny<ModuleState>(),
@@ -2164,7 +2163,7 @@ public class DistributedModuleExecutorTests
         var serialized = serializer.Serialize(successResult, typeof(DistributedModule).FullName!, typeof(SimpleResult).FullName!, 1);
         // Act
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serialized, CancellationToken.None);
         await executionTask;
 
@@ -2280,7 +2279,7 @@ public class DistributedModuleExecutorTests
             typeof(SimpleResult).FullName!,
             1);
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serialized, CancellationToken.None);
         await executionTask;
 
@@ -2472,7 +2471,7 @@ public class DistributedModuleExecutorTests
         var serialized = serializer.Serialize(failureResult, typeof(DistributedModule).FullName!, typeof(SimpleResult).FullName!, 1);
         // Act
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await coordinator.PublishResultAsync(serialized, CancellationToken.None);
         await executionTask;
 
@@ -2554,7 +2553,9 @@ public class DistributedModuleExecutorTests
         var resultCollector = new DistributedResultCollector(noDequeue, serializer);
         var resultRegistry = new ModuleResultRegistry();
 
-        var distributedOptions = new DistributedOptions { TotalInstances = 2, CapabilityTimeout = TimeSpan.FromSeconds(10) };
+        // Above DefaultTestTimeout so a regressed worker gate fails on the guard instead of
+        // falling through to dispatch first.
+        var distributedOptions = new DistributedOptions { TotalInstances = 2, CapabilityTimeout = TimeSpan.FromMinutes(1) };
 
         var lifetime = new Mock<IHostApplicationLifetime>();
         lifetime.Setup(l => l.ApplicationStopping).Returns(CancellationToken.None);
@@ -2576,7 +2577,7 @@ public class DistributedModuleExecutorTests
 
         // Act
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         var workers = await coordinator.GetRegisteredWorkersAsync(CancellationToken.None);
         var successResult = CreateSuccessResult(new SimpleResult { Message = "ok" }, "DistributedModule");
         var serialized = serializer.Serialize(
@@ -2614,7 +2615,10 @@ public class DistributedModuleExecutorTests
         {
             TotalInstances = 2,
             MinimumWorkerCount = 1,
-            CapabilityTimeout = TimeSpan.FromSeconds(10),
+
+            // Above DefaultTestTimeout so a regressed worker gate fails on the guard instead of
+            // falling through to dispatch first.
+            CapabilityTimeout = TimeSpan.FromMinutes(1),
         };
 
         var executor = CreateExecutor(
@@ -2625,14 +2629,14 @@ public class DistributedModuleExecutorTests
             distributedOptions: options);
 
         var executionTask = executor.ExecuteAsync([module]);
-        await noDequeue.WorkerQueryStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.WorkerQueryStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         await Assert.That(noDequeue.ResultWaitStarted.Task.IsCompleted).IsFalse();
 
         await coordinator.RegisterWorkerAsync(
             new WorkerRegistration(1, new HashSet<Capability>(), DateTimeOffset.UtcNow),
             CancellationToken.None);
         noDequeue.ReleaseWorkerQuery();
-        await noDequeue.ResultWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await noDequeue.ResultWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         var successResult = CreateSuccessResult(new SimpleResult { Message = "ok" }, "DistributedModule");
         var serialized = serializer.Serialize(
             successResult,

--- a/test/ModularPipelines.TestHelpers/TestHostSettings.cs
+++ b/test/ModularPipelines.TestHelpers/TestHostSettings.cs
@@ -25,6 +25,9 @@ public record TestHostSettings
 {
     /// <summary>
     /// Default timeout for test pipeline execution to prevent tests from hanging indefinitely.
+    /// Also the budget for awaiting signals a test releases itself; shorter literal budgets
+    /// lost to CI scheduling jitter (#4666). Tests under a shorter <c>[Timeout]</c> keep
+    /// literal budgets below that attribute instead.
     /// </summary>
     public static readonly TimeSpan DefaultTestTimeout = TimeSpan.FromSeconds(30);
 

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -1441,7 +1441,7 @@ public class ModuleOutputBufferTests
             loggerControl,
             loggerControl,
             OutputFlushKind.Incremental));
-        await renderingStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await renderingStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
 
         try
         {
@@ -1761,7 +1761,7 @@ public class ModuleOutputBufferTests
             }
         });
 
-        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await lockAcquired.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         try
         {
             var flush = Task.Run(() => buffer.FlushToAsync(
@@ -1773,7 +1773,7 @@ public class ModuleOutputBufferTests
                 [fallbackLogger],
                 CancellationToken.None));
 
-            await flush.WaitAsync(TimeSpan.FromSeconds(2));
+            await flush.WaitAsync(TestHostSettings.DefaultTestTimeout);
         }
         finally
         {
@@ -1965,7 +1965,7 @@ public class ModuleOutputBufferTests
             }
         });
 
-        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await lockAcquired.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         try
         {
             await buffer.FlushToAsync(
@@ -2015,7 +2015,7 @@ public class ModuleOutputBufferTests
             }
         });
 
-        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await lockAcquired.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         try
         {
             await buffer.FlushToAsync(

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -66,7 +66,7 @@ public class AlwaysRunHandlerTests
         var ranConcurrently = true;
         try
         {
-            await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            await bothStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         }
         catch (TimeoutException)
         {
@@ -159,7 +159,7 @@ public class AlwaysRunHandlerTests
         var handler = CreateHandler(moduleRunner.Object);
 
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
-        await blockerWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await blockerWaitObserved.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         var attemptsBeforeProgress = attempts;
 
         blockerState.State = ModuleExecutionState.Completed;
@@ -215,7 +215,7 @@ public class AlwaysRunHandlerTests
         var handler = CreateHandler(moduleRunner.Object);
 
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
-        await blockerWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await blockerWaitObserved.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         var attemptsBeforeProgress = attempts;
 
         blockerState.State = ModuleExecutionState.Completed;
@@ -375,7 +375,7 @@ public class AlwaysRunHandlerTests
         var handler = CreateHandler(moduleRunner.Object, pipelineOptions, timeProvider);
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
 
-        await progressWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await progressWaitObserved.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         timeProvider.Advance(TimeSpan.FromSeconds(30));
         var exception = await Assert.ThrowsAsync<AggregateException>(() => handlerTask);
 
@@ -438,11 +438,11 @@ public class AlwaysRunHandlerTests
             scheduler.Object,
             [module, firstBlocker, secondBlocker]);
 
-        await firstWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await firstWaitObserved.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         timeProvider.Advance(TimeSpan.FromMilliseconds(150));
         firstBlockerState.State = ModuleExecutionState.Completed;
         firstBlockerState.CompletionSource.TrySetResult(firstBlocker);
-        await secondWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await secondWaitObserved.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
 
         timeProvider.Advance(TimeSpan.FromMilliseconds(50));
         var exception = await Assert.ThrowsAsync<AggregateException>(() => handlerTask);

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -104,7 +104,7 @@ public class ParallelLimitHandlerTests
             moduleState,
             scheduler.Object,
             CancellationToken.None);
-        await limitWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await limitWaitObserved.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
 
         handler.Verify(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()), Times.Once);
         await Assert.That(TrackingReadyAttribute.InvocationCount).IsEqualTo(1);
@@ -266,7 +266,7 @@ public class ParallelLimitHandlerTests
             moduleState,
             scheduler.Object,
             workerCancellationTokenSource.Token);
-        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await limiterWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         engineCancellationToken.Cancel();
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
@@ -319,7 +319,7 @@ public class ParallelLimitHandlerTests
             moduleState,
             scheduler.Object,
             workerCancellationTokenSource.Token);
-        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await limiterWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         engineCancellationToken.CancelWithReason("User cancellation");
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
@@ -361,7 +361,7 @@ public class ParallelLimitHandlerTests
             moduleState,
             scheduler.Object,
             workerCancellationTokenSource.Token);
-        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await limiterWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         engineCancellationToken.CancelWithException(originalException);
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
@@ -555,7 +555,7 @@ public class ParallelLimitHandlerTests
             moduleState,
             scheduler.Object,
             workerCancellationTokenSource.Token);
-        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await limiterWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
         workerCancellationTokenSource.Cancel();
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);


### PR DESCRIPTION
## Summary

#4666 showed that a 2 s `.WaitAsync(TimeSpan.FromSeconds(2))` around work a test drives to completion itself can lose to thread-pool scheduling on a loaded Ubuntu runner: both a millisecond timer and the continuation after it queue behind thread-pool injection. #4678 fixed `RunReportTests`; this PR covers the remaining short literal guards.

The issue proposed a new sub-30 s shared constant. Review of the touched files showed that the repo already has a shared hang guard, `TestHostSettings.DefaultTestTimeout` (30 s), used at about forty `WaitAsync` sites in eight files, including calls adjacent to and character-identical with the converted ones (`DistributedModuleExecutorTests` lines 1415/1423 next to 1462, `ModuleOutputBufferTests` lines 1654 to 1719 next to 1776). A second near-synonymous constant would have split that vocabulary with no rule for choosing between them, and nothing at these sites races a 30 s service default: every converted await resolves on a `TaskCompletionSource`, tracking-coordinator signal or execution task the test releases, and the tests that inject short timeouts either drive a `FakeTimeProvider` (`AlwaysRunHandlerTests`) or wait on a `SemaphoreSlim` (`ParallelLimitHandlerTests`). The only place the sub-30 s argument holds is `RunReportTests`, whose private 10 s constant #4678 documents for exactly that reason. TUnit's default per-test timeout is 30 minutes, so these guards localise a hang to the stalled await rather than prevent one; 30 s does that fine.

- The 36 two-second sites in `DistributedModuleExecutorTests` (24), `AlwaysRunHandlerTests` (6), `ParallelLimitHandlerTests` (5) and `ModuleOutputBufferTests` (1) use `TestHostSettings.DefaultTestTimeout`, as do the four 1 s guards in `ModuleOutputBufferTests` that wait for a `Task.Run` to reach a lock, the most jitter-prone shape in the file.
- The doc comment on `DefaultTestTimeout` now states the rule and its exception: tests under a shorter `[Timeout]` keep literal budgets below that attribute. The nine token-carrying 1 s to 3 s guards inside `[Timeout(5_000)]` tests in `DistributedModuleExecutorTests` are therefore unchanged; a 30 s guard there would be dead code behind the attribute.
- Two tests set `CapabilityTimeout` to 10 s, which is now shorter than the guard. If the minimum-worker gate regressed, the executor would fall through to dispatch at 10 s and complete the awaited signal before the guard fired, turning a loud failure into a 10 s stall. Both now use one minute, with a comment, so the guard stays the stricter clock. The happy path registers the worker immediately, so their duration is unchanged.
- `AlwaysRunHandlerTests` line 69 is the one site where the guard is the assertion (a `TimeoutException` becomes `ranConcurrently = false`); on a genuine regression it now reports after 30 s instead of 2 s, and on a pass nothing changes.
- 5 s budgets elsewhere in the tree (`SecretMaskingPatternTests`, `ModuleSchedulerDynamicCycleTests`, `DistributedCoordinatorContract` in TestHelpers, and others) and a handful of 1 s ones in unrelated files are left alone; they were not part of the flake report and are worth a separate pass if they ever fail the same way.

No production code changes, and no new public API.

## Test plan
- [x] `AlwaysRunHandlerTests`, `ParallelLimitHandlerTests`, `ModuleOutputBufferTests` (core unit-test project): 89/89 passed
- [x] `DistributedModuleExecutorTests` (distributed unit-test project): 57/57 passed
- [x] `dotnet format --verify-no-changes --severity info` on the changed files in all three projects

Closes #4679

https://claude.ai/code/session_01EHe9J8SumuZb2NBZxpGBzc
