### PR TITLE
[Automated] Update cosign CLI Options

### DIFF
--- a/src/ModularPipelines.Cosign/Generated/Cosign.Generation.json
+++ b/src/ModularPipelines.Cosign/Generated/Cosign.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "cosign",
+  "toolVersion": "v3.1.3",
+  "commandTreeSha256": "1973081916b34287502c8fc7331d2ed8753564b45fb33dfcbf974028d53beb6b",
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+}

--- a/src/ModularPipelines.Cosign/Options/CosignBundleUpgradeOptions.Generated.cs
+++ b/src/ModularPipelines.Cosign/Options/CosignBundleUpgradeOptions.Generated.cs
@@ -35,7 +35,7 @@ public record CosignBundleUpgradeOptions(
     public string? Out { get; set; }
 
     /// <summary>
-    /// //rekor.sigstore.dev':
+    /// //rekor.sigstore.dev': URL of the transparency log
     /// </summary>
     [CliOption("--rekor-url", Format = OptionFormat.EqualsSeparated)]
     public string? RekorUrl { get; set; }

--- a/src/ModularPipelines.Cosign/Options/CosignInitializeOptions.Generated.cs
+++ b/src/ModularPipelines.Cosign/Options/CosignInitializeOptions.Generated.cs
@@ -27,7 +27,7 @@ public record CosignInitializeOptions : CosignOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// //tuf-repo-cdn.sigstore.dev':
+    /// //tuf-repo-cdn.sigstore.dev': GCS bucket to a SigStore TUF repository, or HTTP(S) base URL, or file:/// for local filestore remote (air-gap)
     /// </summary>
     [CliOption("--mirror", Format = OptionFormat.EqualsSeparated)]
     public string? Mirror { get; set; }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **cosign** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- cosign (v3.1.3): 29 commands, tree 1973081916b34287502c8fc7331d2ed8753564b45fb33dfcbf974028d53beb6b
  - Baseline comparison: 29 commands at v3.1.3 -> 29 commands at v3.1.3

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator