### PR TITLE
Keep colons inside quoted kubectl-style defaults out of option descriptions

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CobraCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CobraCliScraperTests.cs
@@ -32,6 +32,47 @@ public class CobraCliScraperTests
     }
 
     [Test]
+    public async Task Quoted_Kubectl_Style_Defaults_Containing_Colons_Stay_Out_Of_Descriptions()
+    {
+        // minikube (kubectl-style rows) prints the default inside quotes; the value itself may
+        // contain colons, which must not be mistaken for the description separator.
+        const string helpText = """
+            Starts a local Kubernetes cluster
+
+            Usage: fake start [OPTIONS]
+
+            Options:
+                  --base-image='gcr.io/k8s-minikube/kicbase:v0.0.51@sha256:4a1c825b61479e6c898851ea66f13c620aaeab6002746e95067fc2c4b38a0b24': The base image to use for docker/podman drivers. Intended for local development.
+                  --iso-url='[https://storage.googleapis.com/minikube/iso/minikube-v1.39.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.39.0/minikube-v1.39.0-amd64.iso]': Locations to fetch the minikube ISO from.
+                  --kvm-qemu-uri='qemu:///system': The KVM QEMU connection URI. (kvm2 driver only)
+                  --memory='': Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).
+                  --nodes=1: The total number of nodes to spin up.
+            """;
+        var command = await new TestCobraCliScraper().Parse(["fake", "start"], helpText);
+
+        string Description(string switchName) =>
+            command!.Options.Single(option => option.SwitchName == switchName).Description!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--base-image", "--iso-url", "--kvm-qemu-uri", "--memory", "--nodes"]);
+            await Assert.That(Description("--base-image"))
+                .IsEqualTo("The base image to use for docker/podman drivers. Intended for local development.");
+            await Assert.That(Description("--iso-url"))
+                .IsEqualTo("Locations to fetch the minikube ISO from.");
+            await Assert.That(Description("--kvm-qemu-uri"))
+                .IsEqualTo("The KVM QEMU connection URI. (kvm2 driver only)");
+            await Assert.That(Description("--memory"))
+                .IsEqualTo("Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--kvm-qemu-uri").CSharpType)
+                .IsEqualTo("string?");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--nodes").CSharpType)
+                .IsEqualTo("int?");
+        }
+    }
+
+    [Test]
     public async Task Short_Command_Descriptions_Are_Preserved()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -986,7 +986,9 @@ public abstract partial class CobraCliScraper : CliScraperBase
     ///     -A, --all-namespaces=false:
     ///     --chunk-size=500:
     /// </summary>
-    [GeneratedRegex(@"^\s*(?:(?<short>-\w),\s*)?(?<long>--[\w-]+)(?:(?<default>=)(?<type>[^:\s]*))?:\s*(?<desc>.*)?$", RegexOptions.Multiline)]
+    // A quoted default ('gcr.io/kicbase:v1', "a:b") is captured whole so the colons inside it are
+    // never mistaken for the separator that precedes the description.
+    [GeneratedRegex(@"^\s*(?:(?<short>-\w),\s*)?(?<long>--[\w-]+)(?:(?<default>=)(?<type>'[^']*'|""[^""]*""|[^:\s]*))?:\s*(?<desc>.*)?$", RegexOptions.Multiline)]
     private static partial Regex KubectlOptionPattern();
 
     [GeneratedRegex(@"allowed values:\s*(?<values>[\w-]+(?:\s*,\s*[\w-]+)+|(?:-\s*[\w-]+\s*){2,})", RegexOptions.IgnoreCase)]


### PR DESCRIPTION
## Summary

The automated minikube regeneration (#4676) shipped XML docs that open with fragments of the default value (`v0.0.51@sha256:…': The base image…`, `//storage.googleapis.com/…]: Locations…`, `///system': The KVM QEMU…`). The review attributed this to wrapped `(default "…")` continuations, but the rows are single lines: `KubectlOptionPattern` captures the default with `[^:\s]*`, so a quoted default containing a colon is cut at that colon and the remainder of the value becomes the description.

- `KubectlOptionPattern` now captures a single- or double-quoted default whole (`'[^']*'|"[^"]*"`) before the unquoted `[^:\s]*` form, so the `:` that precedes the description is found after the closing quote.
- Type inference is unchanged: quoted defaults already normalised to `string`; `--nodes=1:` still yields `int?`.
- Regression `Quoted_Kubectl_Style_Defaults_Containing_Colons_Stay_Out_Of_Descriptions` uses the three real minikube rows plus `--memory=''` and `--nodes=1` controls; it reproduces the exact garbled descriptions on the previous regex and passes now.

minikube derives from `CobraCliScraper`, so no minikube-specific code is involved; kubectl-style rows in any Cobra-derived scraper get the same fix. #4676 will be refreshed by the push-triggered regeneration once this merges.

## Test plan
- [x] New regression fails on the previous regex (all three descriptions garbled) and passes with the fix.
- [x] Full OptionsGenerator test suite: 1344/1344.
- [x] `dotnet format --verify-no-changes --severity warn` on the two changed files.
- [ ] CI generator suite and the next minikube regeneration.

Closes #4696

https://claude.ai/code/session_01MGEyXW2HYJpJ47tqnpjWMa
