### PR TITLE
[Automated] Update brew CLI Options

### DIFF
--- a/src/ModularPipelines.Homebrew/Generated/Brew.Generation.json
+++ b/src/ModularPipelines.Homebrew/Generated/Brew.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "brew",
   "toolVersion": "Homebrew 6.0.20",
   "commandTreeSha256": "0c701de73d7e728cba2bd96e3b9aa36c0025ba16c8f47f26b230e86d9ffc2e54",
-  "generatorSourceSha256": "552d4395a33f42492ed8341747df5e743a54c1cb6a388656d4e31f1bbff3b900"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **brew** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- brew (Homebrew 6.0.20): 122 commands, tree 0c701de73d7e728cba2bd96e3b9aa36c0025ba16c8f47f26b230e86d9ffc2e54
  - Baseline comparison: 122 commands at Homebrew 6.0.20 -> 122 commands at Homebrew 6.0.20

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator