### PR TITLE
[Automated] Update hadolint CLI Options

### DIFF
--- a/src/ModularPipelines.Hadolint/Enums/HadolintFailureThreshold.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Enums/HadolintFailureThreshold.Generated.cs
@@ -19,18 +19,18 @@ public enum HadolintFailureThreshold
     [EnumValue("error")]
     Error,
 
-    [EnumValue("warning")]
-    Warning,
+    [EnumValue("ignore")]
+    Ignore,
 
     [EnumValue("info")]
     Info,
 
+    [EnumValue("none")]
+    None,
+
     [EnumValue("style")]
     Style,
 
-    [EnumValue("ignore")]
-    Ignore,
-
-    [EnumValue("none")]
-    None
+    [EnumValue("warning")]
+    Warning
 }

--- a/src/ModularPipelines.Hadolint/Enums/HadolintFormat.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Enums/HadolintFormat.Generated.cs
@@ -16,14 +16,11 @@ namespace ModularPipelines.Hadolint.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum HadolintFormat
 {
-    [EnumValue("tty")]
-    Tty,
-
-    [EnumValue("json")]
-    Json,
-
     [EnumValue("checkstyle")]
     Checkstyle,
+
+    [EnumValue("codacy")]
+    Codacy,
 
     [EnumValue("codeclimate")]
     Codeclimate,
@@ -34,15 +31,18 @@ public enum HadolintFormat
     [EnumValue("gnu")]
     Gnu,
 
-    [EnumValue("codacy")]
-    Codacy,
+    [EnumValue("json")]
+    Json,
 
-    [EnumValue("sonarqube")]
-    Sonarqube,
+    [EnumValue("junit")]
+    Junit,
 
     [EnumValue("sarif")]
     Sarif,
 
-    [EnumValue("junit")]
-    Junit
+    [EnumValue("sonarqube")]
+    Sonarqube,
+
+    [EnumValue("tty")]
+    Tty
 }

--- a/src/ModularPipelines.Hadolint/Generated/Hadolint.Generation.json
+++ b/src/ModularPipelines.Hadolint/Generated/Hadolint.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "hadolint",
   "toolVersion": "Haskell Dockerfile Linter 2.15.1",
   "commandTreeSha256": "aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5",
-  "generatorSourceSha256": "c6dd1d3a18193e50ff4e31e4874a68c71996634a1c1ee827c692d0dce1ee5c24"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }

--- a/src/ModularPipelines.Hadolint/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Hadolint/PublicAPI.Shipped.txt
@@ -4,22 +4,8 @@ ModularPipelines.Context.ModularPipelines_Hadolint_a7b9813b1c6440cdToolsExtensio
 ModularPipelines.Context.ModularPipelines_Hadolint_a7b9813b1c6440cdToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Hadolint.get -> ModularPipelines.Hadolint.Services.IHadolint!
 ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
 ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Error = 0 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
-ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Ignore = 4 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
 ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Info = 2 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
-ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.None = 5 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
-ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Style = 3 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
-ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Warning = 1 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
 ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Checkstyle = 2 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Codacy = 6 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Codeclimate = 3 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.GitlabCodeclimate = 4 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Gnu = 5 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Json = 1 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Junit = 9 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Sarif = 8 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Sonarqube = 7 -> ModularPipelines.Hadolint.Enums.HadolintFormat
-ModularPipelines.Hadolint.Enums.HadolintFormat.Tty = 0 -> ModularPipelines.Hadolint.Enums.HadolintFormat
 ModularPipelines.Hadolint.Extensions.HadolintExtensions
 ModularPipelines.Hadolint.Options.HadolintExecuteOptions
 ModularPipelines.Hadolint.Options.HadolintExecuteOptions.Config.get -> string?

--- a/src/ModularPipelines.Hadolint/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Hadolint/PublicAPI.Unshipped.txt
@@ -1,4 +1,32 @@
 #nullable enable
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Ignore = 4 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.None = 5 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Style = 3 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Warning = 1 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Checkstyle = 2 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Codacy = 6 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Codeclimate = 3 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.GitlabCodeclimate = 4 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Gnu = 5 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Json = 1 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Junit = 9 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Sarif = 8 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Sonarqube = 7 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+*REMOVED*ModularPipelines.Hadolint.Enums.HadolintFormat.Tty = 0 -> ModularPipelines.Hadolint.Enums.HadolintFormat
 *REMOVED*ModularPipelines.Hadolint.Services.IHadolint.ExecuteAsync(ModularPipelines.Hadolint.Options.HadolintExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Hadolint.Extensions.HadolintExtensions.Hadolint(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Hadolint.Services.IHadolint!
+ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Ignore = 1 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.None = 3 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Style = 4 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Warning = 5 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold
+ModularPipelines.Hadolint.Enums.HadolintFormat.Checkstyle = 0 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Codacy = 1 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Codeclimate = 2 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.GitlabCodeclimate = 3 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Gnu = 4 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Json = 5 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Junit = 6 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Sarif = 7 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Sonarqube = 8 -> ModularPipelines.Hadolint.Enums.HadolintFormat
+ModularPipelines.Hadolint.Enums.HadolintFormat.Tty = 9 -> ModularPipelines.Hadolint.Enums.HadolintFormat
 ModularPipelines.Hadolint.Services.IHadolint.ExecuteAsync(ModularPipelines.Hadolint.Options.HadolintExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **hadolint** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Hadolint`.

- Added APIs: 14
- Removed or changed APIs: 14
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Ignore = 4 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.None = 5 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Style = 3 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Warning = 1 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFormat.Checkstyle = 2 -> ModularPipelines.Hadolint.Enums.HadolintFormat`

Representative added members:
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Ignore = 1 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.None = 3 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Style = 4 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFailureThreshold.Warning = 5 -> ModularPipelines.Hadolint.Enums.HadolintFailureThreshold`
- `ModularPipelines.Hadolint.Enums.HadolintFormat.Checkstyle = 0 -> ModularPipelines.Hadolint.Enums.HadolintFormat`

## Command coverage
Command coverage report:
- hadolint (Haskell Dockerfile Linter 2.15.1): 1 commands, tree aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5
  - Baseline comparison: 1 commands at Haskell Dockerfile Linter 2.15.1 -> 1 commands at Haskell Dockerfile Linter 2.15.1

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator