### PR TITLE
[Automated] Update docker CLI Options

### DIFF
--- a/src/ModularPipelines.Docker/Enums/DockerComposeProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerComposeProgress.Generated.cs
@@ -19,15 +19,15 @@ public enum DockerComposeProgress
     [EnumValue("auto")]
     Auto,
 
-    [EnumValue("tty")]
-    Tty,
+    [EnumValue("json")]
+    Json,
 
     [EnumValue("plain")]
     Plain,
 
-    [EnumValue("json")]
-    Json,
-
     [EnumValue("quiet")]
-    Quiet
+    Quiet,
+
+    [EnumValue("tty")]
+    Tty
 }

--- a/src/ModularPipelines.Docker/Generated/Docker.Generation.json
+++ b/src/ModularPipelines.Docker/Generated/Docker.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "docker",
   "toolVersion": "Docker version 28.0.4, build b8034c0",
   "commandTreeSha256": "aa61e74921c1dbff2d43176d940dd6700962c0a41c51db2662fe01e04de0cde2",
-  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }

--- a/src/ModularPipelines.Docker/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Docker/PublicAPI.Shipped.txt
@@ -47,10 +47,7 @@ ModularPipelines.Docker.Enums.DockerBuildxImageToolsCreateProgress.Rawjson = 3 -
 ModularPipelines.Docker.Enums.DockerBuildxImageToolsCreateProgress.Tty = 4 -> ModularPipelines.Docker.Enums.DockerBuildxImageToolsCreateProgress
 ModularPipelines.Docker.Enums.DockerComposeProgress
 ModularPipelines.Docker.Enums.DockerComposeProgress.Auto = 0 -> ModularPipelines.Docker.Enums.DockerComposeProgress
-ModularPipelines.Docker.Enums.DockerComposeProgress.Json = 3 -> ModularPipelines.Docker.Enums.DockerComposeProgress
 ModularPipelines.Docker.Enums.DockerComposeProgress.Plain = 2 -> ModularPipelines.Docker.Enums.DockerComposeProgress
-ModularPipelines.Docker.Enums.DockerComposeProgress.Quiet = 4 -> ModularPipelines.Docker.Enums.DockerComposeProgress
-ModularPipelines.Docker.Enums.DockerComposeProgress.Tty = 1 -> ModularPipelines.Docker.Enums.DockerComposeProgress
 ModularPipelines.Docker.Enums.DockerImageBuildProgress
 ModularPipelines.Docker.Enums.DockerImageBuildProgress.Auto = 0 -> ModularPipelines.Docker.Enums.DockerImageBuildProgress
 ModularPipelines.Docker.Enums.DockerImageBuildProgress.None = 1 -> ModularPipelines.Docker.Enums.DockerImageBuildProgress

--- a/src/ModularPipelines.Docker/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Docker/PublicAPI.Unshipped.txt
@@ -35,6 +35,9 @@
 *REMOVED*ModularPipelines.Docker.Enums.DockerBuilderImageToolsCreateProgress.Plain = 2 -> ModularPipelines.Docker.Enums.DockerBuilderImageToolsCreateProgress
 *REMOVED*ModularPipelines.Docker.Enums.DockerBuilderImageToolsCreateProgress.Rawjson = 3 -> ModularPipelines.Docker.Enums.DockerBuilderImageToolsCreateProgress
 *REMOVED*ModularPipelines.Docker.Enums.DockerBuilderImageToolsCreateProgress.Tty = 4 -> ModularPipelines.Docker.Enums.DockerBuilderImageToolsCreateProgress
+*REMOVED*ModularPipelines.Docker.Enums.DockerComposeProgress.Json = 3 -> ModularPipelines.Docker.Enums.DockerComposeProgress
+*REMOVED*ModularPipelines.Docker.Enums.DockerComposeProgress.Quiet = 4 -> ModularPipelines.Docker.Enums.DockerComposeProgress
+*REMOVED*ModularPipelines.Docker.Enums.DockerComposeProgress.Tty = 1 -> ModularPipelines.Docker.Enums.DockerComposeProgress
 *REMOVED*ModularPipelines.Docker.Options.DockerBuilderBakeOptions
 *REMOVED*ModularPipelines.Docker.Options.DockerBuilderBakeOptions.DockerBuilderBakeOptions() -> void
 *REMOVED*ModularPipelines.Docker.Options.DockerBuilderBakeOptions.DockerBuilderBakeOptions(ModularPipelines.Docker.Options.DockerBuilderBakeOptions! original) -> void
@@ -884,6 +887,9 @@
 *REMOVED*virtual ModularPipelines.Docker.Services.DockerVolume.LsAsync(ModularPipelines.Docker.Options.DockerVolumeLsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Docker.Services.DockerVolume.PruneAsync(ModularPipelines.Docker.Options.DockerVolumePruneOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Docker.Services.DockerVolume.RmAsync(ModularPipelines.Docker.Options.DockerVolumeRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Docker.Enums.DockerComposeProgress.Json = 1 -> ModularPipelines.Docker.Enums.DockerComposeProgress
+ModularPipelines.Docker.Enums.DockerComposeProgress.Quiet = 3 -> ModularPipelines.Docker.Enums.DockerComposeProgress
+ModularPipelines.Docker.Enums.DockerComposeProgress.Tty = 4 -> ModularPipelines.Docker.Enums.DockerComposeProgress
 ModularPipelines.Docker.Services.DockerBuildx.DockerBuildx(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Docker.Services.DockerBuildxDap.DockerBuildxDap(ModularPipelines.Context.ICommandContext! command) -> void
 ModularPipelines.Docker.Services.DockerBuildxHistory.DockerBuildxHistory(ModularPipelines.Context.ICommandContext! command) -> void


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **docker** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Docker`.

- Added APIs: 3
- Removed or changed APIs: 3
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Docker.Enums.DockerComposeProgress.Json = 3 -> ModularPipelines.Docker.Enums.DockerComposeProgress`
- `ModularPipelines.Docker.Enums.DockerComposeProgress.Quiet = 4 -> ModularPipelines.Docker.Enums.DockerComposeProgress`
- `ModularPipelines.Docker.Enums.DockerComposeProgress.Tty = 1 -> ModularPipelines.Docker.Enums.DockerComposeProgress`

Representative added members:
- `ModularPipelines.Docker.Enums.DockerComposeProgress.Json = 1 -> ModularPipelines.Docker.Enums.DockerComposeProgress`
- `ModularPipelines.Docker.Enums.DockerComposeProgress.Quiet = 3 -> ModularPipelines.Docker.Enums.DockerComposeProgress`
- `ModularPipelines.Docker.Enums.DockerComposeProgress.Tty = 4 -> ModularPipelines.Docker.Enums.DockerComposeProgress`

## Command coverage
Command coverage report:
- docker (Docker version 28.0.4, build b8034c0): 205 commands, tree aa61e74921c1dbff2d43176d940dd6700962c0a41c51db2662fe01e04de0cde2
  - Baseline comparison: 205 commands at Docker version 28.0.4, build b8034c0 -> 205 commands at Docker version 28.0.4, build b8034c0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator