### PR TITLE
ci: install podman from Homebrew for CLI option generation

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -419,8 +419,13 @@ jobs:
           fi
           cp "$compose_plugin" "$CLI_TOOLS_ROOT/bin/docker-compose"
           chmod +x "$CLI_TOOLS_ROOT/bin/docker-compose"
-          sudo apt-get update
-          sudo apt-get install -y podman
+          # Ubuntu's apt package is podman 4.9, which predates `podman artifact` (5.4) and
+          # `podman quadlet` (5.6), so regenerating from it shrinks the command set. The
+          # runner image no longer ships a newer podman either, so install the current
+          # Homebrew bottle and put it ahead of /usr/bin for the remaining steps.
+          brew="/home/linuxbrew/.linuxbrew/bin/brew"
+          HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 "$brew" install podman
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
           echo "PODMAN_COMPOSE_PROVIDER=$CLI_TOOLS_ROOT/bin/docker-compose" >> "$GITHUB_ENV"
 
       - name: Install Buildah
@@ -579,7 +584,7 @@ jobs:
         run: echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
 
       - name: Verify affected tool installation
-        if: steps.should-run.outputs.run == 'true' && contains(fromJSON('["aws","gh","git","brew","snyk","yarn","cosign","eksctl","trivy","liquibase"]'), matrix.tool)
+        if: steps.should-run.outputs.run == 'true' && contains(fromJSON('["aws","gh","git","brew","podman","snyk","yarn","cosign","eksctl","trivy","liquibase"]'), matrix.tool)
         run: |
           command -v "${{ matrix.tool }}"
           case "${{ matrix.tool }}" in


### PR DESCRIPTION
## Summary

The scheduled podman regeneration (#4680, run 34006412119) resolved Ubuntu's apt `podman` 4.9.3 and the coverage guard rejected eleven removed commands (`podman artifact *`, `podman machine cp/reset`, `podman quadlet`). Those commands are real 5.4+/5.6+ additions, so the guard was right: the runner was scraping an older tool than the 5.8.4 snapshot on `main`.

Root cause: the job log for the run that produced the 5.8.4 snapshot (33748284437, image `ubuntu-24.04` 20260823.283.1) shows apt installing 4.9.3 but the scraper pinning `/usr/local/bin/podman`, a newer podman the runner image happened to ship. Image 20260831.293.1 no longer ships it, so `command -v podman` now resolves `/usr/bin/podman` 4.9.3.

## Change

- Install podman from the Homebrew bottle (the Linux formula is the full podman with conmon/crun, not the remote-only client) instead of apt, and prepend `/home/linuxbrew/.linuxbrew/bin` to `GITHUB_PATH` so the "Pin resolved executable" step picks it up.
- Add `podman` to the "Verify affected tool installation" list so the resolved version is printed in the job log.

The next podman regeneration will move the snapshot from 5.8.4 to the current Homebrew release (6.1.1 today); that is additive relative to the baseline and is what the coverage guard expects.

## Validation

A podman-only `workflow_dispatch` of this branch with `create-pr=false` is linked in the comments; it exercises the install step and the coverage comparison end to end.

## Not in this PR

- A generic "resolved tool is older than the snapshot" guard in the generator would catch this class of drift for every tool, but tool version strings are not uniformly parseable; the coverage guard already fails closed on removals, which is what caught this run.
- Buildah and Skopeo still install from apt; their snapshots were produced from apt, so they are consistent today.

Closes #4690

https://claude.ai/code/session_01PkLNTUfwGXjqXZrYrHaDGC
