### PR TITLE
fix(generator): keep "is a list of one or more" descriptions scalar

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -959,6 +959,7 @@ public class CliScraperTraversalTests
     [Test]
     [Arguments("Accepts multiple values")]
     [Arguments("One or more label selectors")]
+    [Arguments("Specifications of one or more certificate signing endpoints")]
     public async Task SharedShapeInference_Preserves_Common_Repeatability_Phrases(string description)
     {
         var helpText = $"""
@@ -978,6 +979,32 @@ public class CliScraperTraversalTests
 
         await Assert.That(tag.AcceptsMultipleValues).IsTrue();
         await Assert.That(tag.CSharpType).IsEqualTo("IEnumerable<string>?");
+    }
+
+    [Test]
+    [Arguments("Expression is a list of one or more restrictions combined via logical operators 'AND' and 'OR'.")]
+    [Arguments("The expression is a list of one or more restrictions. Restrictions have the form '<field> <operator> <value>'.")]
+    public async Task SharedShapeInference_Keeps_A_Value_Described_As_A_List_Of_Restrictions_Scalar(string description)
+    {
+        // gcloud's --filter is one expression string; the prose describes its grammar, not how
+        // many times the flag may be passed.
+        var helpText = $"""
+            Execute a command.
+
+            Usage:
+              fake execute [flags]
+
+            Flags:
+              --filter string   {description}
+            """;
+        var scraper = new TestCobraScraper(new StubExecutor(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+
+        var command = await scraper.Parse(["fake", "execute"], helpText);
+        var filter = command!.Options.Single();
+
+        await Assert.That(filter.AcceptsMultipleValues).IsFalse();
+        await Assert.That(filter.CSharpType).IsEqualTo("string?");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1423,7 +1423,10 @@ public abstract partial class CliScraperBase : ICliScraper
         + @"|(?:is|are)\s+repeated"
         + @"|multiples?\s+(?:are\s+)?supported\s+by\s+passing\s+--?[\w-]+\s+multiple\s+times"
         + @"|\A" + RepeatableItemCountPattern
-        + @"|(?:specifications?|lists?)\s+of\s+" + RepeatableItemCountPattern
+        // "Specifications of one or more endpoints" describes the option's values; "Expression is
+        // a list of one or more restrictions" describes the grammar of one value, so an
+        // article-led predicate keeps this alternative from matching.
+        + @"|(?<!\b(?:is|are|as|be|being)\s+(?:an?|the)\s+)(?:specifications?|lists?)\s+of\s+" + RepeatableItemCountPattern
         + @"|(?:can|may|must|should)\s+be\s+"
         + @"(?:specified|supplied|provided|used|passed|set|given)\s+"
         + @"(?:(?:one|zero)\s+or\s+more\s+times|multiple\s+times|more\s+than\s+once)"


### PR DESCRIPTION
## Summary

`CliScraperBase.RepeatableValueRegex` treats `(specifications?|lists?) of (one|zero) or more <noun>` as a repeatable-option signal. #4543 added it for Docker's `--external-ca external-ca   Specifications of one or more certificate signing endpoints`. It also matches gcloud's `--filter=FILTER` prose, "Expression is a list of one or more restrictions combined via logical operators 'AND' and 'OR'", which describes the grammar of one expression string. The latest gcloud regeneration (#4665) therefore flipped `GcloudSccAssetsGroupOptions.Filter` and `GcloudSccFindingsGroupOptions.Filter` to `IEnumerable<string>?`, and the review blocked it.

## Change

- The `list of / specification of` alternative no longer matches when it is the predicate of an article-led sentence about one value (`is|are|as|be|being` + `a|an|the`). Docker's phrasing has no article and keeps matching.
- Tests: the Docker phrase joins the positive repeatability cases; both gcloud phrasings are covered by a new scalar case.

`CliScraperTraversalTests` (61) and the full Scrapers namespace (665) pass locally.

## Follow-up

#4665 is regenerated from `main` via the generation workflow once this merges (automated PRs are never rebased).

Closes #4718

https://claude.ai/code/session_01PkLNTUfwGXjqXZrYrHaDGC
