### PR TITLE
test(core): arm an unreachable deadline in the synchronous-outcome timeout tests

### DIFF
--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -10,6 +10,11 @@ namespace ModularPipelines.UnitTests.Execution;
 
 public class ModuleTimeoutTests : TestBase
 {
+    // A deadline the helper arms but that can never elapse, for tests that decide the outcome
+    // themselves. A 10 ms deadline fired before the already-faulted task was published on a
+    // starved runner and claimed the outcome (#4714).
+    private static readonly TimeSpan UnreachableDeadline = Timeout.InfiniteTimeSpan;
+
     private class Module_UsingCancellationToken : Module<string>
     {
         private static readonly TaskCompletionSource<bool> _taskCompletionSource = new();
@@ -233,7 +238,7 @@ public class ModuleTimeoutTests : TestBase
                 externalCancellation.Cancel();
                 return Task.FromResult(true);
             },
-            TimeSpan.FromSeconds(10),
+            UnreachableDeadline,
             externalCancellation.Token);
 
         await Assert.That(result.Value).IsTrue();
@@ -249,7 +254,7 @@ public class ModuleTimeoutTests : TestBase
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
                 _ => Task.FromCanceled<bool>(unrelatedCancellation.Token),
-                TimeSpan.FromSeconds(1),
+                UnreachableDeadline,
                 CancellationToken.None));
 
         await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
@@ -285,7 +290,7 @@ public class ModuleTimeoutTests : TestBase
         var exception = await Assert.ThrowsAsync<TimeoutException>(async () =>
             await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
                 _ => Task.FromException<bool>(new TimeoutException("Inner operation timed out.")),
-                TimeSpan.FromMilliseconds(10),
+                UnreachableDeadline,
                 CancellationToken.None));
 
         await Assert.That(exception!.Message).IsEqualTo("Inner operation timed out.");
@@ -304,7 +309,7 @@ public class ModuleTimeoutTests : TestBase
         var exception = await Assert.ThrowsAsync<FactoryCancellationException>(() =>
             TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync<bool>(
                 _ => throw expectedException,
-                TimeSpan.FromSeconds(1),
+                UnreachableDeadline,
                 CancellationToken.None));
 
         using (Assert.Multiple())
@@ -323,7 +328,7 @@ public class ModuleTimeoutTests : TestBase
 
         var execution = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
             _ => completion.Task,
-            TimeSpan.FromSeconds(1),
+            UnreachableDeadline,
             CancellationToken.None);
 
         completion.SetResult(true);
@@ -402,6 +407,24 @@ public class ModuleTimeoutTests : TestBase
         cancellationSignals.PublishExecutionTask(Task.FromCanceled<bool>(attemptCancellation.Token));
 
         await Assert.That(await signalState.Signal.Task).IsFalse();
+    }
+
+    [Test]
+    public async Task Faulted_Execution_Published_After_Deadline_Signal_Belongs_To_Deadline()
+    {
+        // The state #4714 reproduced on a starved runner: the deadline fired before the
+        // already-faulted task was published, and a fault carries no token that could
+        // prove it happened independently of the cancelled attempt.
+        using var attemptCancellation = new CancellationTokenSource();
+        var cancellationSignals = new TimeoutHelper.CancellationSignals<bool>(attemptCancellation);
+        var signalState = cancellationSignals.Deadline;
+        var executionTask = Task.FromException<bool>(new TimeoutException("Inner operation timed out."));
+
+        signalState.SignalCancellation();
+        cancellationSignals.PublishExecutionTask(executionTask);
+
+        await Assert.That(await signalState.Signal.Task).IsFalse();
+        await Assert.ThrowsAsync<TimeoutException>(() => executionTask);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

`ModuleTimeoutTests.Fault_Completed_Before_Deadline_Is_Not_Claimed_By_Timeout` failed on #4678's `full pipeline (ubuntu-latest)` run 34016747680 with `Expected to throw TimeoutException but no exception was thrown`, on a PR that only touches `RunReportTests`.

The test armed a **10 ms** deadline around a factory that returns `Task.FromException`. On a starved runner the timer fired before `TimeoutHelper` published the factory's task, so `CancellationSignalState.TaskOwnsOutcome` ran with the signal already recorded and the deadline claimed the outcome: a timeout result came back and nothing threw. That attribution is the design pinned by `Execution_Published_After_Deadline_Signal_Belongs_To_Deadline`, `Cancelled_Execution_Published_After_Deadline_Signal_Belongs_To_Deadline` and `Faulted_Execution_Published_After_External_Cancellation_Belongs_To_Cancellation` (#4588): a task published after a signal fired belongs to the signal, because the helper cannot tell a fault caused by the cancelled attempt token from an independent one. It can only misfire when an entire timeout elapses between arming and publication, which thread starvation cannot do to production-scale timeouts of seconds; it did it to 10 ms.

## Change

Five tests in `ModuleTimeoutTests` decide the outcome themselves (a synchronously completed, faulted or cancelled task, a factory that throws, or a `TaskCompletionSource` the test resolves) and only need the helper to arm a deadline. They now share one `UnreachableDeadline = Timeout.InfiniteTimeSpan`, with the rationale on the field. `TimeoutHelper` only special-cases `TimeSpan.Zero`, so the helper still takes its armed-deadline path (`CancellationSignals`, `Task.WhenAny`) exactly as before, while `CancelAfter(Timeout.InfiniteTimeSpan)` never schedules the timer. The deadline therefore cannot claim an outcome on any runner, which is a guarantee rather than a larger budget. Two of the five used 1 s, one 10 s, one 10 ms; the three deadlines that must fire (`Timeout_Fault_During_Grace_Period_Counts_As_Response`, `Timeout_Claims_Cancellation_Through_Linked_Attempt_Token`, `Timeout_Claims_Tokenless_Cooperative_Cancellation`) keep their 10 ms.

`Timeout.InfiniteTimeSpan` is already this file's and `TestHostSettings`' spelling for "never", and `TestHostSettings.DefaultTestTimeout` stays in its hang-guard role (line 92 in the same file). No production code changes.

The signal-level ownership matrix had one unpinned cell, deadline × faulted, which is exactly the state the flake produced. `Faulted_Execution_Published_After_Deadline_Signal_Belongs_To_Deadline` now pins it deterministically (signal first, then publish `Task.FromException`, assert the deadline owns the outcome and observe the fault), so reintroducing the pre-#4588 fault-wins rule fails loudly without any timer.

## Test plan
- [x] `ModuleTimeoutTests`: 27/27 passed, including the new pin test
- [x] `dotnet format --verify-no-changes --severity info` on the changed file

Closes #4714

https://claude.ai/code/session_01EHe9J8SumuZb2NBZxpGBzc
