### PR TITLE
[Automated] Update ansible CLI Options

### DIFF
--- a/src/ModularPipelines.Ansible/Generated/Ansible.Generation.json
+++ b/src/ModularPipelines.Ansible/Generated/Ansible.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "ansible",
   "toolVersion": "ansible [core 2.21.3]   config file = None   configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jul 15 2026, 23:46:41) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/",
   "commandTreeSha256": "0cb87f727f31e5f5a59cca8a10c8f9b55622be05305d4e7e92c334f5911e1034",
-  "generatorSourceSha256": "d9158a695acc19054e4501e243f73451e38058e36153726384f7e577db59b384"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **ansible** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- ansible (ansible [core 2.21.3]   config file = None   configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jul 15 2026, 23:46:41) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/): 1 commands, tree 0cb87f727f31e5f5a59cca8a10c8f9b55622be05305d4e7e92c334f5911e1034
  - Baseline comparison: 1 commands at ansible [core 2.21.3]   config file = None   configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jul 15 2026, 23:46:41) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/ -> 1 commands at ansible [core 2.21.3]   config file = None   configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jul 15 2026, 23:46:41) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator