### PR TITLE
[Automated] Update gradle CLI Options

### DIFF
--- a/src/ModularPipelines.Java/Enums/GradleConfigurationCacheProblems.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/GradleConfigurationCacheProblems.Generated.cs
@@ -16,9 +16,9 @@ namespace ModularPipelines.Java.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum GradleConfigurationCacheProblems
 {
-    [EnumValue("warn")]
-    Warn,
-
     [EnumValue("fail")]
-    Fail
+    Fail,
+
+    [EnumValue("warn")]
+    Warn
 }

--- a/src/ModularPipelines.Java/Enums/GradleConsole.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/GradleConsole.Generated.cs
@@ -16,14 +16,14 @@ namespace ModularPipelines.Java.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum GradleConsole
 {
-    [EnumValue("plain")]
-    Plain,
+    [EnumValue("auto")]
+    Auto,
 
     [EnumValue("colored")]
     Colored,
 
-    [EnumValue("auto")]
-    Auto,
+    [EnumValue("plain")]
+    Plain,
 
     [EnumValue("rich")]
     Rich,

--- a/src/ModularPipelines.Java/Enums/GradleDependencyVerification.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/GradleDependencyVerification.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Java.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum GradleDependencyVerification
 {
-    [EnumValue("strict")]
-    Strict,
-
     [EnumValue("lenient")]
     Lenient,
 
     [EnumValue("off")]
-    Off
+    Off,
+
+    [EnumValue("strict")]
+    Strict
 }

--- a/src/ModularPipelines.Java/Enums/GradlePriority.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/GradlePriority.Generated.cs
@@ -16,9 +16,9 @@ namespace ModularPipelines.Java.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum GradlePriority
 {
-    [EnumValue("normal")]
-    Normal,
-
     [EnumValue("low")]
-    Low
+    Low,
+
+    [EnumValue("normal")]
+    Normal
 }

--- a/src/ModularPipelines.Java/Enums/GradleWarningMode.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/GradleWarningMode.Generated.cs
@@ -22,9 +22,9 @@ public enum GradleWarningMode
     [EnumValue("fail")]
     Fail,
 
-    [EnumValue("summary")]
-    Summary,
-
     [EnumValue("none")]
-    None
+    None,
+
+    [EnumValue("summary")]
+    Summary
 }

--- a/src/ModularPipelines.Java/Generated/Gradle.Generation.json
+++ b/src/ModularPipelines.Java/Generated/Gradle.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "gradle",
   "toolVersion": "9.7.1",
   "commandTreeSha256": "0e687aaa28b03552c11dca346c7c8914e62b3e2ada613a7288c28c9e7e9ddeb4",
-  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
+  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
 }

--- a/src/ModularPipelines.Java/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Java/PublicAPI.Shipped.txt
@@ -4,12 +4,8 @@ ModularPipelines.Context.ModularPipelines_Java_04d0dc30f3fd7e8eToolsExtensions.e
 ModularPipelines.Context.ModularPipelines_Java_04d0dc30f3fd7e8eToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Gradle.get -> ModularPipelines.Java.Services.IGradle!
 ModularPipelines.Context.ModularPipelines_Java_04d0dc30f3fd7e8eToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Maven.get -> ModularPipelines.Java.Services.IMaven!
 ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
-ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Fail = 1 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
-ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Warn = 0 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
 ModularPipelines.Java.Enums.GradleConsole
-ModularPipelines.Java.Enums.GradleConsole.Auto = 2 -> ModularPipelines.Java.Enums.GradleConsole
 ModularPipelines.Java.Enums.GradleConsole.Colored = 1 -> ModularPipelines.Java.Enums.GradleConsole
-ModularPipelines.Java.Enums.GradleConsole.Plain = 0 -> ModularPipelines.Java.Enums.GradleConsole
 ModularPipelines.Java.Enums.GradleConsole.Rich = 3 -> ModularPipelines.Java.Enums.GradleConsole
 ModularPipelines.Java.Enums.GradleConsole.Verbose = 4 -> ModularPipelines.Java.Enums.GradleConsole
 ModularPipelines.Java.Enums.GradleConsoleUnicode
@@ -17,17 +13,10 @@ ModularPipelines.Java.Enums.GradleConsoleUnicode.Auto = 0 -> ModularPipelines.Ja
 ModularPipelines.Java.Enums.GradleConsoleUnicode.Disable = 1 -> ModularPipelines.Java.Enums.GradleConsoleUnicode
 ModularPipelines.Java.Enums.GradleConsoleUnicode.Enable = 2 -> ModularPipelines.Java.Enums.GradleConsoleUnicode
 ModularPipelines.Java.Enums.GradleDependencyVerification
-ModularPipelines.Java.Enums.GradleDependencyVerification.Lenient = 1 -> ModularPipelines.Java.Enums.GradleDependencyVerification
-ModularPipelines.Java.Enums.GradleDependencyVerification.Off = 2 -> ModularPipelines.Java.Enums.GradleDependencyVerification
-ModularPipelines.Java.Enums.GradleDependencyVerification.Strict = 0 -> ModularPipelines.Java.Enums.GradleDependencyVerification
 ModularPipelines.Java.Enums.GradlePriority
-ModularPipelines.Java.Enums.GradlePriority.Low = 1 -> ModularPipelines.Java.Enums.GradlePriority
-ModularPipelines.Java.Enums.GradlePriority.Normal = 0 -> ModularPipelines.Java.Enums.GradlePriority
 ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.GradleWarningMode.All = 0 -> ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.GradleWarningMode.Fail = 1 -> ModularPipelines.Java.Enums.GradleWarningMode
-ModularPipelines.Java.Enums.GradleWarningMode.None = 3 -> ModularPipelines.Java.Enums.GradleWarningMode
-ModularPipelines.Java.Enums.GradleWarningMode.Summary = 2 -> ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.MavenColor
 ModularPipelines.Java.Enums.MavenColor.Always = 1 -> ModularPipelines.Java.Enums.MavenColor
 ModularPipelines.Java.Enums.MavenColor.Auto = 0 -> ModularPipelines.Java.Enums.MavenColor

--- a/src/ModularPipelines.Java/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Java/PublicAPI.Unshipped.txt
@@ -1,7 +1,29 @@
 #nullable enable
+*REMOVED*ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Fail = 1 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
+*REMOVED*ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Warn = 0 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
+*REMOVED*ModularPipelines.Java.Enums.GradleConsole.Auto = 2 -> ModularPipelines.Java.Enums.GradleConsole
+*REMOVED*ModularPipelines.Java.Enums.GradleConsole.Plain = 0 -> ModularPipelines.Java.Enums.GradleConsole
+*REMOVED*ModularPipelines.Java.Enums.GradleDependencyVerification.Lenient = 1 -> ModularPipelines.Java.Enums.GradleDependencyVerification
+*REMOVED*ModularPipelines.Java.Enums.GradleDependencyVerification.Off = 2 -> ModularPipelines.Java.Enums.GradleDependencyVerification
+*REMOVED*ModularPipelines.Java.Enums.GradleDependencyVerification.Strict = 0 -> ModularPipelines.Java.Enums.GradleDependencyVerification
+*REMOVED*ModularPipelines.Java.Enums.GradlePriority.Low = 1 -> ModularPipelines.Java.Enums.GradlePriority
+*REMOVED*ModularPipelines.Java.Enums.GradlePriority.Normal = 0 -> ModularPipelines.Java.Enums.GradlePriority
+*REMOVED*ModularPipelines.Java.Enums.GradleWarningMode.None = 3 -> ModularPipelines.Java.Enums.GradleWarningMode
+*REMOVED*ModularPipelines.Java.Enums.GradleWarningMode.Summary = 2 -> ModularPipelines.Java.Enums.GradleWarningMode
 *REMOVED*ModularPipelines.Java.Services.IGradle.ExecuteAsync(ModularPipelines.Java.Options.GradleExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Java.Services.IMaven.ExecuteAsync(ModularPipelines.Java.Options.MavenExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Java.Extensions.GradleExtensions.Gradle(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Java.Services.IGradle!
 *REMOVED*static ModularPipelines.Java.Extensions.MavenExtensions.Maven(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Java.Services.IMaven!
+ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Fail = 0 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
+ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Warn = 1 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems
+ModularPipelines.Java.Enums.GradleConsole.Auto = 0 -> ModularPipelines.Java.Enums.GradleConsole
+ModularPipelines.Java.Enums.GradleConsole.Plain = 2 -> ModularPipelines.Java.Enums.GradleConsole
+ModularPipelines.Java.Enums.GradleDependencyVerification.Lenient = 0 -> ModularPipelines.Java.Enums.GradleDependencyVerification
+ModularPipelines.Java.Enums.GradleDependencyVerification.Off = 1 -> ModularPipelines.Java.Enums.GradleDependencyVerification
+ModularPipelines.Java.Enums.GradleDependencyVerification.Strict = 2 -> ModularPipelines.Java.Enums.GradleDependencyVerification
+ModularPipelines.Java.Enums.GradlePriority.Low = 0 -> ModularPipelines.Java.Enums.GradlePriority
+ModularPipelines.Java.Enums.GradlePriority.Normal = 1 -> ModularPipelines.Java.Enums.GradlePriority
+ModularPipelines.Java.Enums.GradleWarningMode.None = 2 -> ModularPipelines.Java.Enums.GradleWarningMode
+ModularPipelines.Java.Enums.GradleWarningMode.Summary = 3 -> ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Services.IGradle.ExecuteAsync(ModularPipelines.Java.Options.GradleExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Java.Services.IMaven.ExecuteAsync(ModularPipelines.Java.Options.MavenExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **gradle** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Gradle`.

- Added APIs: 11
- Removed or changed APIs: 11
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Fail = 1 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems`
- `ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Warn = 0 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems`
- `ModularPipelines.Java.Enums.GradleConsole.Auto = 2 -> ModularPipelines.Java.Enums.GradleConsole`
- `ModularPipelines.Java.Enums.GradleConsole.Plain = 0 -> ModularPipelines.Java.Enums.GradleConsole`
- `ModularPipelines.Java.Enums.GradleDependencyVerification.Lenient = 1 -> ModularPipelines.Java.Enums.GradleDependencyVerification`

Representative added members:
- `ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Fail = 0 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems`
- `ModularPipelines.Java.Enums.GradleConfigurationCacheProblems.Warn = 1 -> ModularPipelines.Java.Enums.GradleConfigurationCacheProblems`
- `ModularPipelines.Java.Enums.GradleConsole.Auto = 0 -> ModularPipelines.Java.Enums.GradleConsole`
- `ModularPipelines.Java.Enums.GradleConsole.Plain = 2 -> ModularPipelines.Java.Enums.GradleConsole`
- `ModularPipelines.Java.Enums.GradleDependencyVerification.Lenient = 0 -> ModularPipelines.Java.Enums.GradleDependencyVerification`

## Command coverage
Command coverage report:
- gradle (9.7.1): 1 commands, tree 0e687aaa28b03552c11dca346c7c8914e62b3e2ada613a7288c28c9e7e9ddeb4
  - Baseline comparison: 1 commands at 9.7.1 -> 1 commands at 9.7.1

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator