### PR TITLE
[Automated] Update shellcheck CLI Options

### DIFF
--- a/src/ModularPipelines.Shellcheck/Enums/ShellcheckColor.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Enums/ShellcheckColor.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Shellcheck.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum ShellcheckColor
 {
-    [EnumValue("auto")]
-    Auto,
-
     [EnumValue("always")]
     Always,
+
+    [EnumValue("auto")]
+    Auto,
 
     [EnumValue("never")]
     Never

--- a/src/ModularPipelines.Shellcheck/Enums/ShellcheckSeverity.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Enums/ShellcheckSeverity.Generated.cs
@@ -19,12 +19,12 @@ public enum ShellcheckSeverity
     [EnumValue("error")]
     Error,
 
-    [EnumValue("warning")]
-    Warning,
-
     [EnumValue("info")]
     Info,
 
     [EnumValue("style")]
-    Style
+    Style,
+
+    [EnumValue("warning")]
+    Warning
 }

--- a/src/ModularPipelines.Shellcheck/Enums/ShellcheckShell.Generated.cs
+++ b/src/ModularPipelines.Shellcheck/Enums/ShellcheckShell.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Shellcheck.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum ShellcheckShell
 {
-    [EnumValue("sh")]
-    Sh,
-
     [EnumValue("bash")]
     Bash,
+
+    [EnumValue("busybox")]
+    Busybox,
 
     [EnumValue("dash")]
     Dash,
@@ -28,6 +28,6 @@ public enum ShellcheckShell
     [EnumValue("ksh")]
     Ksh,
 
-    [EnumValue("busybox")]
-    Busybox
+    [EnumValue("sh")]
+    Sh
 }

--- a/src/ModularPipelines.Shellcheck/Generated/Shellcheck.Generation.json
+++ b/src/ModularPipelines.Shellcheck/Generated/Shellcheck.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "shellcheck",
   "toolVersion": "ShellCheck - shell script analysis tool version: 0.11.0 license: GNU General Public License, version 3 website: https://www.shellcheck.net",
   "commandTreeSha256": "e0feeff705f2c41109aa86a93c5d59e3b3bcad2e39dc7621ab911897e22c7bc4",
-  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }

--- a/src/ModularPipelines.Shellcheck/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Shellcheck/PublicAPI.Shipped.txt
@@ -3,8 +3,6 @@ ModularPipelines.Context.ModularPipelines_Shellcheck_74437ba6b640cfd0ToolsExtens
 ModularPipelines.Context.ModularPipelines_Shellcheck_74437ba6b640cfd0ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
 ModularPipelines.Context.ModularPipelines_Shellcheck_74437ba6b640cfd0ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Shellcheck.get -> ModularPipelines.Shellcheck.Services.IShellcheck!
 ModularPipelines.Shellcheck.Enums.ShellcheckColor
-ModularPipelines.Shellcheck.Enums.ShellcheckColor.Always = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
-ModularPipelines.Shellcheck.Enums.ShellcheckColor.Auto = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
 ModularPipelines.Shellcheck.Enums.ShellcheckColor.Never = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
 ModularPipelines.Shellcheck.Enums.ShellcheckFormat
 ModularPipelines.Shellcheck.Enums.ShellcheckFormat.Checkstyle = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckFormat
@@ -16,15 +14,9 @@ ModularPipelines.Shellcheck.Enums.ShellcheckFormat.Quiet = 5 -> ModularPipelines
 ModularPipelines.Shellcheck.Enums.ShellcheckFormat.Tty = 6 -> ModularPipelines.Shellcheck.Enums.ShellcheckFormat
 ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
 ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Error = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
-ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Info = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
-ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Style = 3 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
-ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Warning = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
 ModularPipelines.Shellcheck.Enums.ShellcheckShell
-ModularPipelines.Shellcheck.Enums.ShellcheckShell.Bash = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
-ModularPipelines.Shellcheck.Enums.ShellcheckShell.Busybox = 4 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
 ModularPipelines.Shellcheck.Enums.ShellcheckShell.Dash = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
 ModularPipelines.Shellcheck.Enums.ShellcheckShell.Ksh = 3 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
-ModularPipelines.Shellcheck.Enums.ShellcheckShell.Sh = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
 ModularPipelines.Shellcheck.Extensions.ShellcheckExtensions
 ModularPipelines.Shellcheck.Options.ShellcheckExecuteOptions
 ModularPipelines.Shellcheck.Options.ShellcheckExecuteOptions.CheckSourced.get -> bool?

--- a/src/ModularPipelines.Shellcheck/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Shellcheck/PublicAPI.Unshipped.txt
@@ -1,4 +1,20 @@
 #nullable enable
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckColor.Always = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckColor.Auto = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Info = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Style = 3 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Warning = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckShell.Bash = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckShell.Busybox = 4 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
+*REMOVED*ModularPipelines.Shellcheck.Enums.ShellcheckShell.Sh = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
 *REMOVED*ModularPipelines.Shellcheck.Services.IShellcheck.ExecuteAsync(ModularPipelines.Shellcheck.Options.ShellcheckExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Shellcheck.Extensions.ShellcheckExtensions.Shellcheck(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Shellcheck.Services.IShellcheck!
+ModularPipelines.Shellcheck.Enums.ShellcheckColor.Always = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
+ModularPipelines.Shellcheck.Enums.ShellcheckColor.Auto = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor
+ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Info = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
+ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Style = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
+ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Warning = 3 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity
+ModularPipelines.Shellcheck.Enums.ShellcheckShell.Bash = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
+ModularPipelines.Shellcheck.Enums.ShellcheckShell.Busybox = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
+ModularPipelines.Shellcheck.Enums.ShellcheckShell.Sh = 4 -> ModularPipelines.Shellcheck.Enums.ShellcheckShell
 ModularPipelines.Shellcheck.Services.IShellcheck.ExecuteAsync(ModularPipelines.Shellcheck.Options.ShellcheckExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **shellcheck** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Shellcheck`.

- Added APIs: 8
- Removed or changed APIs: 8
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Shellcheck.Enums.ShellcheckColor.Always = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor`
- `ModularPipelines.Shellcheck.Enums.ShellcheckColor.Auto = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor`
- `ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Info = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity`
- `ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Style = 3 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity`
- `ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Warning = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity`

Representative added members:
- `ModularPipelines.Shellcheck.Enums.ShellcheckColor.Always = 0 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor`
- `ModularPipelines.Shellcheck.Enums.ShellcheckColor.Auto = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckColor`
- `ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Info = 1 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity`
- `ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Style = 2 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity`
- `ModularPipelines.Shellcheck.Enums.ShellcheckSeverity.Warning = 3 -> ModularPipelines.Shellcheck.Enums.ShellcheckSeverity`

## Command coverage
Command coverage report:
- shellcheck (ShellCheck - shell script analysis tool version: 0.11.0 license: GNU General Public License, version 3 website: https://www.shellcheck.net): 1 commands, tree e0feeff705f2c41109aa86a93c5d59e3b3bcad2e39dc7621ab911897e22c7bc4
  - Baseline comparison: 1 commands at ShellCheck - shell script analysis tool version: 0.11.0 license: GNU General Public License, version 3 website: https://www.shellcheck.net -> 1 commands at ShellCheck - shell script analysis tool version: 0.11.0 license: GNU General Public License, version 3 website: https://www.shellcheck.net

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator