### PR TITLE
Remove five-second shutdown delay when progress is disabled

### DIFF
--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -484,6 +484,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     {
         await using var session = await BeginProgressAsync(organizedModules, cancellationToken).ConfigureAwait(false);
 
+        if (session is NoOpProgressSession)
+        {
+            // There is no display to keep alive when progress is disabled.
+            return;
+        }
+
         // Wait for cancellation - the session runs until disposed
         try
         {

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -8,6 +8,7 @@ using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
+using ModularPipelines.Models;
 using ModularPipelines.Options;
 using Moq;
 using Spectre.Console;
@@ -17,6 +18,34 @@ namespace ModularPipelines.UnitTests.Console;
 [TUnit.Core.NotInParallel]
 public class ConsoleCoordinatorTests
 {
+    [Test]
+    public async Task DisabledProgress_CompletesWithoutWaitingForCancellation()
+    {
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        await using var coordinator = CreateCoordinator(
+            outputCoordinator.Object,
+            new PipelineOptions
+            {
+                Console = new PipelineConsoleOptions { ShowProgress = false },
+            });
+        using var cancellation = new CancellationTokenSource();
+        var progress = ((IProgressDisplay) coordinator).RunAsync(
+            new OrganizedModules([], []),
+            cancellation.Token);
+
+        try
+        {
+            // A no-op display must not make pipeline shutdown wait for the five-second grace period.
+            await Assert.That(progress.IsCompletedSuccessfully).IsTrue();
+            outputCoordinator.Verify(output => output.SetProgressActive(false), Times.Once);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            await progress;
+        }
+    }
+
     [Test]
     public async Task PeriodicFlush_SchedulesCompletedBufferPopulatedByRetainedWrite()
     {


### PR DESCRIPTION
When console progress is disabled, `ConsoleCoordinator` creates a no-op session but still waits indefinitely for cancellation. `PrintProgressExecutor` cancels that wait only after its five-second shutdown grace period, adding five seconds to every pipeline run. Tests that repeatedly run pipelines compound this delay, contributing to the roughly 20-minute core test run.

Return immediately after creating a no-op progress session. Real progress sessions retain their existing lifecycle. Add a regression test that verifies disabled progress completes without cancellation while still disabling output deferral.

Validation:
- Confirmed the regression test fails before the fix and passes afterward.
- Representative three-run cache test with coverage: 16.73 seconds before, 1.66 seconds after.
- Full core test project on Windows with coverage and eight concurrent tests: 2,672 passed, 2 skipped in 4m 13s.
- Targeted project build and `git diff --check` passed.

The local timing is not a like-for-like CI comparison; a fresh CI run will establish the new Linux duration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress operations now complete promptly when progress output is disabled, instead of waiting unnecessarily for cancellation.
  * Active progress sessions continue to follow their existing cancellation behavior.

* **Tests**
  * Added coverage confirming disabled progress completes successfully without delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->