### PR TITLE
Fix generated-options CI routing for shipped API baselines

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,6 +79,7 @@ jobs:
             -RepositoryRoot $env:GITHUB_WORKSPACE `
             -GitHubOutput $env:GITHUB_OUTPUT
       - name: Reject stale generated snapshots
+        # Generated routing includes both shipped and unshipped API baseline updates.
         if: steps.generated_integration.outputs.is_generated_integration == 'true'
         shell: pwsh
         env:
@@ -705,6 +706,7 @@ jobs:
             --no-restore
 
   required-pipeline:
+    # Stable branch-protection check for either validation route; runs after that route finishes.
     name: pipeline (ubuntu-latest)
     needs: [fast-fail, pipeline, generated-integration]
     if: always()

--- a/scripts/Resolve-GeneratedIntegrationValidation.ps1
+++ b/scripts/Resolve-GeneratedIntegrationValidation.ps1
@@ -51,7 +51,9 @@ function Test-GeneratedIntegrationPath {
     }
 
     $packagePath = $Path.Substring($PackagePrefix.Length)
-    if ($packagePath.Equals('PublicAPI.Unshipped.txt', [StringComparison]::OrdinalIgnoreCase) -or
+    # Generation stages both assembly-wide API baselines, including for shared tool packages.
+    if ($packagePath.Equals('PublicAPI.Shipped.txt', [StringComparison]::OrdinalIgnoreCase) -or
+        $packagePath.Equals('PublicAPI.Unshipped.txt', [StringComparison]::OrdinalIgnoreCase) -or
         $packagePath.Equals(
             "Generated/$NamespacePrefix.CommandCoverage.json",
             [StringComparison]::OrdinalIgnoreCase) -or

--- a/scripts/Test-GeneratedOptionsProvenance.ps1
+++ b/scripts/Test-GeneratedOptionsProvenance.ps1
@@ -1,4 +1,7 @@
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Resolve-GeneratedIntegrationValidation.ps1') `
+    -HeadRef ignored `
+    -ChangedPath @()
 
 function Invoke-Git {
     param(
@@ -10,6 +13,28 @@ function Invoke-Git {
     if ($LASTEXITCODE -ne 0) {
         throw "git $($ArgumentList -join ' ') failed."
     }
+}
+
+function Assert-GeneratedBaselineFreshness {
+    param([Parameter(Mandatory)][string]$RepositoryRoot)
+
+    $route = Resolve-GeneratedIntegrationValidation `
+        -HeadRef 'automated/update-cli-options-fake' `
+        -HeadRepository 'owner/repo' `
+        -PullRequestAuthor 'owner' `
+        -Repository 'owner/repo' `
+        -ChangedPath @('src/ModularPipelines.Fake/PublicAPI.Shipped.txt') `
+        -RepositoryRoot $RepositoryRoot
+    if (-not $route.IsGeneratedIntegration) {
+        throw "Shipped baseline changes bypassed the freshness gate: $($route.Reason)"
+    }
+
+    & (Join-Path $PSScriptRoot 'Assert-GeneratedOptionsFreshness.ps1') `
+        -RepositoryRoot $RepositoryRoot `
+        -Tool $route.Tool `
+        -Package $route.Package `
+        -NamespacePrefix $route.NamespacePrefix `
+        -CurrentBase HEAD
 }
 
 $repositoryRoot = Split-Path $PSScriptRoot -Parent
@@ -113,6 +138,12 @@ try {
     New-Item -ItemType Directory -Path (Join-Path $tempRoot '.github/workflows') | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $tempRoot 'tools/ModularPipelines.OptionsGenerator') | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $tempRoot 'src/ModularPipelines.Fake/Generated') | Out-Null
+    Set-Content `
+        -LiteralPath (Join-Path $tempRoot 'src/ModularPipelines.Fake/ModularPipelines.Fake.slnx') `
+        -Value '<Solution />'
+    Set-Content `
+        -LiteralPath (Join-Path $tempRoot 'src/ModularPipelines.Fake/PublicAPI.Shipped.txt') `
+        -Value '#nullable enable'
 
     foreach ($sourcePath in Get-GeneratedOptionsSourcePath) {
         if ($sourcePath -eq 'tools/ModularPipelines.OptionsGenerator') {
@@ -180,12 +211,7 @@ try {
     Invoke-Git $tempRoot add .
     Invoke-Git $tempRoot commit -m generated
 
-    & $assertScript `
-        -RepositoryRoot $tempRoot `
-        -Tool fake `
-        -Package ModularPipelines.Fake `
-        -NamespacePrefix Fake `
-        -CurrentBase HEAD
+    Assert-GeneratedBaselineFreshness -RepositoryRoot $tempRoot
 
     Set-Content -LiteralPath (Join-Path $tempRoot 'README.md') -Value 'unrelated change'
     Invoke-Git $tempRoot add README.md
@@ -205,12 +231,7 @@ try {
 
     $centralPackageError = $null
     try {
-        & $assertScript `
-            -RepositoryRoot $tempRoot `
-            -Tool fake `
-            -Package ModularPipelines.Fake `
-            -NamespacePrefix Fake `
-            -CurrentBase HEAD
+        Assert-GeneratedBaselineFreshness -RepositoryRoot $tempRoot
     }
     catch {
         $centralPackageError = $_.Exception.Message

--- a/scripts/Test-ResolveGeneratedIntegrationValidation.ps1
+++ b/scripts/Test-ResolveGeneratedIntegrationValidation.ps1
@@ -49,6 +49,49 @@ if ($aws.Solution -match 'Azure|Google') {
     throw "AWS validation selected an unrelated integration: $($aws.Solution)."
 }
 
+foreach ($case in @(
+        @{ Tool = 'dotnet'; Package = 'ModularPipelines.DotNet'; Prefix = 'DotNet' },
+        @{ Tool = 'mvn'; Package = 'ModularPipelines.Java'; Prefix = 'Maven' },
+        @{ Tool = 'gradle'; Package = 'ModularPipelines.Java'; Prefix = 'Gradle' },
+        @{ Tool = 'kubectl'; Package = 'ModularPipelines.Kubernetes'; Prefix = 'Kubernetes' },
+        @{ Tool = 'kustomize'; Package = 'ModularPipelines.Kubernetes'; Prefix = 'Kustomize' }
+    )) {
+    $parameters = @{
+        HeadRef = "automated/update-cli-options-$($case.Tool)"
+        HeadRepository = $repository
+        PullRequestAuthor = $automationAuthor
+        Repository = $repository
+        RepositoryRoot = $repositoryRoot
+    }
+    $shippedPath = "src/$($case.Package)/PublicAPI.Shipped.txt"
+    foreach ($paths in @(
+            @{ Values = @($shippedPath) },
+            @{ Values = @(
+                    $shippedPath,
+                    "src/$($case.Package)/PublicAPI.Unshipped.txt",
+                    "src/$($case.Package)/Generated/$($case.Prefix).Generation.json"
+                ) }
+        )) {
+        $result = Resolve-GeneratedIntegrationValidation @parameters -ChangedPath $paths.Values
+        Assert-Equal $result.IsGeneratedIntegration $true "$($case.Tool) baseline updates should use generated validation."
+        Assert-Equal $result.NamespacePrefix $case.Prefix 'Shared packages must select the branch tool manifest.'
+        Assert-Equal $result.Solution "src/$($case.Package)/$($case.Package).slnx" 'Baseline updates selected the wrong solution.'
+    }
+
+    foreach ($unexpectedPath in @(
+            '.github/workflows/dotnet.yml',
+            'scripts/Resolve-GeneratedIntegrationValidation.ps1',
+            'src/ModularPipelines/Engine/ModuleScheduler.cs',
+            'src/ModularPipelines.Pulumi/PublicAPI.Shipped.txt',
+            "src/$($case.Package)/Handwritten.cs",
+            "src/$($case.Package)/Generated/Other.Generation.json"
+        )) {
+        $result = Resolve-GeneratedIntegrationValidation @parameters `
+            -ChangedPath @($shippedPath, $unexpectedPath)
+        Assert-Equal $result.IsGeneratedIntegration $false "A shipped baseline must not hide unrelated changes: $unexpectedPath."
+    }
+}
+
 $unrelatedManifest = Resolve-GeneratedIntegrationValidation `
     -HeadRef 'automated/update-cli-options-aws' `
     -HeadRepository $repository `


### PR DESCRIPTION
Generated options PRs that modify `PublicAPI.Shipped.txt` were classified as ordinary changes, running the full repository pipeline and skipping the generated-options freshness gate. Accept both API baseline files within the existing package-scoped allowlist so these PRs use their tool validation job and provenance check.

The required `pipeline (ubuntu-latest)` check remains the final gate for either route; no branch-protection changes are needed. Workflow comments clarify this relationship. Existing ownership, branch, manifest, and unrelated-path restrictions remain enforced.

Validation:
- Routing regression fails before the fix and passes afterward; covers .NET, Maven/Gradle, kubectl/kustomize, baseline-only updates, and mixed handwritten/workflow/package paths.
- Provenance tests exercise baseline routing with current and stale generator inputs.
- `Test-ResolveGeneratedIntegrationValidation.ps1`, `Test-GeneratedOptionsProvenance.ps1`, `Test-RequiredPipelineContext.ps1`, and `git diff --check` pass.
- Actual file lists from Pulumi #4736, kubectl #4694, and Maven #4717 select their expected tool solutions.

Closes #4740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for generated integration validation, including shipped public API baseline updates.
  * Prevented unrelated file changes from incorrectly triggering generated validation.

* **Tests**
  * Expanded coverage across supported package types and combinations of shipped, unshipped, and generated files.
  * Added freshness validation scenarios for generated integration outputs and central package changes.

* **Documentation**
  * Added workflow comments clarifying API baseline coverage and validation status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->