### PR TITLE
[Automated] Update pip CLI Options

### DIFF
--- a/src/ModularPipelines.Python/Generated/Pip.Generation.json
+++ b/src/ModularPipelines.Python/Generated/Pip.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "pip",
   "toolVersion": "pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)",
   "commandTreeSha256": "a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pip** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- pip (pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)): 14 commands, tree a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac
  - Baseline comparison: 14 commands at pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12) -> 14 commands at pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator