### PR TITLE
[Automated] Update docker CLI Options

### DIFF
--- a/src/ModularPipelines.Docker/Generated/Docker.Generation.json
+++ b/src/ModularPipelines.Docker/Generated/Docker.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "docker",
   "toolVersion": "Docker version 28.0.4, build b8034c0",
   "commandTreeSha256": "aa61e74921c1dbff2d43176d940dd6700962c0a41c51db2662fe01e04de0cde2",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }

--- a/src/ModularPipelines.Docker/Options/DockerBuildxCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuildxCreateOptions.Generated.cs
@@ -51,7 +51,7 @@ public record DockerBuildxCreateOptions : DockerOptions
     public bool? Debug { get; set; }
 
     /// <summary>
-    /// Driver to use (available: "docker-container", "kubernetes", "remote")
+    /// Driver to use (available: "cloud", "docker-container", "kubernetes", "remote")
     /// </summary>
     [CliOption("--driver", Format = OptionFormat.EqualsSeparated)]
     public string? Driver { get; set; }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **docker** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- docker (Docker version 28.0.4, build b8034c0): 205 commands, tree aa61e74921c1dbff2d43176d940dd6700962c0a41c51db2662fe01e04de0cde2
  - Baseline comparison: 205 commands at Docker version 28.0.4, build b8034c0 -> 205 commands at Docker version 28.0.4, build b8034c0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator