### PR TITLE
[Automated] Update dotnet CLI Options

### DIFF
--- a/src/ModularPipelines.DotNet/Generated/DotNet.CommandCoverage.json
+++ b/src/ModularPipelines.DotNet/Generated/DotNet.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "dotnet",
-  "toolVersion": "10.0.400",
+  "toolVersion": "10.0.401",
   "commandCount": 97,
   "commandTreeSha256": "5a6ae5c35827884fff645cc37ecfe24e941dde2425778fae8feb055e1a0e1155",
   "commands": [

--- a/src/ModularPipelines.DotNet/Generated/DotNet.Generation.json
+++ b/src/ModularPipelines.DotNet/Generated/DotNet.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "dotnet",
-  "toolVersion": "10.0.400",
+  "toolVersion": "10.0.401",
   "commandTreeSha256": "5a6ae5c35827884fff645cc37ecfe24e941dde2425778fae8feb055e1a0e1155",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **dotnet** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- dotnet (10.0.401): 97 commands, tree 5a6ae5c35827884fff645cc37ecfe24e941dde2425778fae8feb055e1a0e1155
  - Baseline comparison: 97 commands at 10.0.400 -> 97 commands at 10.0.401

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator