### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/src/ModularPipelines.Go/Generated/Go.Generation.json
+++ b/src/ModularPipelines.Go/Generated/Go.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "go",
   "toolVersion": "go version go1.27.1 linux/amd64",
   "commandTreeSha256": "548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- go (go version go1.27.1 linux/amd64): 32 commands, tree 548eeaf55d8f76eaffb8b5deb06e1abb41e16c60a69466a4358433d5ecd3df4f
  - Baseline comparison: 32 commands at go version go1.27.1 linux/amd64 -> 32 commands at go version go1.27.1 linux/amd64

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator