### PR TITLE
[Automated] Update helm CLI Options

### DIFF
--- a/src/ModularPipelines.Helm/Generated/Helm.CommandCoverage.json
+++ b/src/ModularPipelines.Helm/Generated/Helm.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "helm",
-  "toolVersion": "version.BuildInfo{Version:\u0022v3.21.4\u0022, GitCommit:\u0022813176c51bb5c181dbbd7901298ddcc104cd3417\u0022, GitTreeState:\u0022clean\u0022, GoVersion:\u0022go1.26.5\u0022}",
+  "toolVersion": "version.BuildInfo{Version:\u0022v3.22.0\u0022, GitCommit:\u0022144ca65f8501953fa8b41cd1d37c7223051c85b7\u0022, GitTreeState:\u0022clean\u0022, GoVersion:\u0022go1.26.8\u0022}",
   "commandCount": 50,
   "commandTreeSha256": "4899ed49663bc26b485e79579fc4dd8dc6db81e8115ef7343e12699488811782",
   "commands": [

--- a/src/ModularPipelines.Helm/Generated/Helm.Generation.json
+++ b/src/ModularPipelines.Helm/Generated/Helm.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "helm",
-  "toolVersion": "version.BuildInfo{Version:\"v3.21.4\", GitCommit:\"813176c51bb5c181dbbd7901298ddcc104cd3417\", GitTreeState:\"clean\", GoVersion:\"go1.26.5\"}",
+  "toolVersion": "version.BuildInfo{Version:\"v3.22.0\", GitCommit:\"144ca65f8501953fa8b41cd1d37c7223051c85b7\", GitTreeState:\"clean\", GoVersion:\"go1.26.8\"}",
   "commandTreeSha256": "4899ed49663bc26b485e79579fc4dd8dc6db81e8115ef7343e12699488811782",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **helm** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- helm (version.BuildInfo{Version:"v3.22.0", GitCommit:"144ca65f8501953fa8b41cd1d37c7223051c85b7", GitTreeState:"clean", GoVersion:"go1.26.8"}): 50 commands, tree 4899ed49663bc26b485e79579fc4dd8dc6db81e8115ef7343e12699488811782
  - Baseline comparison: 50 commands at version.BuildInfo{Version:"v3.21.4", GitCommit:"813176c51bb5c181dbbd7901298ddcc104cd3417", GitTreeState:"clean", GoVersion:"go1.26.5"} -> 50 commands at version.BuildInfo{Version:"v3.22.0", GitCommit:"144ca65f8501953fa8b41cd1d37c7223051c85b7", GitTreeState:"clean", GoVersion:"go1.26.8"}

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator