### PR TITLE
[Automated] Update terraform CLI Options

### DIFF
--- a/src/ModularPipelines.Terraform/Generated/Terraform.CommandCoverage.json
+++ b/src/ModularPipelines.Terraform/Generated/Terraform.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "terraform",
-  "toolVersion": "Terraform v1.16.1 on linux_amd64",
+  "toolVersion": "Terraform v1.16.2 on linux_amd64",
   "commandCount": 68,
   "commandTreeSha256": "68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7",
   "commands": [

--- a/src/ModularPipelines.Terraform/Generated/Terraform.Generation.json
+++ b/src/ModularPipelines.Terraform/Generated/Terraform.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "terraform",
-  "toolVersion": "Terraform v1.16.1 on linux_amd64",
+  "toolVersion": "Terraform v1.16.2 on linux_amd64",
   "commandTreeSha256": "68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **terraform** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- terraform (Terraform v1.16.2 on linux_amd64): 68 commands, tree 68f2991aabc4276d9134b5e632ec9fd9e0613705bb3edfc0c0b5b39c4f665dc7
  - Baseline comparison: 68 commands at Terraform v1.16.1 on linux_amd64 -> 68 commands at Terraform v1.16.2 on linux_amd64

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator