### PR TITLE
[Automated] Update git CLI Options

### DIFF
--- a/src/ModularPipelines.Git/Generated/Git.Generation.json
+++ b/src/ModularPipelines.Git/Generated/Git.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "git",
   "toolVersion": "git version 2.55.0",
   "commandTreeSha256": "465b594e6088738dea79166e0ea6b752ce7d677ae2134a75a474199128856a85",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **git** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- git (git version 2.55.0): 181 commands, tree 465b594e6088738dea79166e0ea6b752ce7d677ae2134a75a474199128856a85
  - Baseline comparison: 181 commands at git version 2.55.0 -> 181 commands at git version 2.55.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator