### PR TITLE
[Automated] Update mvn CLI Options

### DIFF
--- a/src/ModularPipelines.Java/Enums/MavenColor.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/MavenColor.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Java.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum MavenColor
 {
-    [EnumValue("auto")]
-    Auto,
-
     [EnumValue("always")]
     Always,
+
+    [EnumValue("auto")]
+    Auto,
 
     [EnumValue("never")]
     Never

--- a/src/ModularPipelines.Java/Generated/Maven.Generation.json
+++ b/src/ModularPipelines.Java/Generated/Maven.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "mvn",
   "toolVersion": "3.9.16",
   "commandTreeSha256": "77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f",
-  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }

--- a/src/ModularPipelines.Java/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Java/PublicAPI.Shipped.txt
@@ -18,8 +18,6 @@ ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.GradleWarningMode.All = 0 -> ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.GradleWarningMode.Fail = 1 -> ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.MavenColor
-ModularPipelines.Java.Enums.MavenColor.Always = 1 -> ModularPipelines.Java.Enums.MavenColor
-ModularPipelines.Java.Enums.MavenColor.Auto = 0 -> ModularPipelines.Java.Enums.MavenColor
 ModularPipelines.Java.Enums.MavenColor.Never = 2 -> ModularPipelines.Java.Enums.MavenColor
 ModularPipelines.Java.Extensions.GradleExtensions
 ModularPipelines.Java.Extensions.MavenExtensions

--- a/src/ModularPipelines.Java/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Java/PublicAPI.Unshipped.txt
@@ -10,6 +10,8 @@
 *REMOVED*ModularPipelines.Java.Enums.GradlePriority.Normal = 0 -> ModularPipelines.Java.Enums.GradlePriority
 *REMOVED*ModularPipelines.Java.Enums.GradleWarningMode.None = 3 -> ModularPipelines.Java.Enums.GradleWarningMode
 *REMOVED*ModularPipelines.Java.Enums.GradleWarningMode.Summary = 2 -> ModularPipelines.Java.Enums.GradleWarningMode
+*REMOVED*ModularPipelines.Java.Enums.MavenColor.Always = 1 -> ModularPipelines.Java.Enums.MavenColor
+*REMOVED*ModularPipelines.Java.Enums.MavenColor.Auto = 0 -> ModularPipelines.Java.Enums.MavenColor
 *REMOVED*ModularPipelines.Java.Services.IGradle.ExecuteAsync(ModularPipelines.Java.Options.GradleExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Java.Services.IMaven.ExecuteAsync(ModularPipelines.Java.Options.MavenExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Java.Extensions.GradleExtensions.Gradle(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Java.Services.IGradle!
@@ -25,5 +27,7 @@ ModularPipelines.Java.Enums.GradlePriority.Low = 0 -> ModularPipelines.Java.Enum
 ModularPipelines.Java.Enums.GradlePriority.Normal = 1 -> ModularPipelines.Java.Enums.GradlePriority
 ModularPipelines.Java.Enums.GradleWarningMode.None = 2 -> ModularPipelines.Java.Enums.GradleWarningMode
 ModularPipelines.Java.Enums.GradleWarningMode.Summary = 3 -> ModularPipelines.Java.Enums.GradleWarningMode
+ModularPipelines.Java.Enums.MavenColor.Always = 0 -> ModularPipelines.Java.Enums.MavenColor
+ModularPipelines.Java.Enums.MavenColor.Auto = 1 -> ModularPipelines.Java.Enums.MavenColor
 ModularPipelines.Java.Services.IGradle.ExecuteAsync(ModularPipelines.Java.Options.GradleExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Java.Services.IMaven.ExecuteAsync(ModularPipelines.Java.Options.MavenExecuteOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **mvn** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Maven (mvn)`.

- Added APIs: 2
- Removed or changed APIs: 2
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Java.Enums.MavenColor.Always = 1 -> ModularPipelines.Java.Enums.MavenColor`
- `ModularPipelines.Java.Enums.MavenColor.Auto = 0 -> ModularPipelines.Java.Enums.MavenColor`

Representative added members:
- `ModularPipelines.Java.Enums.MavenColor.Always = 0 -> ModularPipelines.Java.Enums.MavenColor`
- `ModularPipelines.Java.Enums.MavenColor.Auto = 1 -> ModularPipelines.Java.Enums.MavenColor`

## Command coverage
Command coverage report:
- mvn (3.9.16): 1 commands, tree 77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f
  - Baseline comparison: 1 commands at 3.9.16 -> 1 commands at 3.9.16

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator