### PR TITLE
[Automated] Update snyk CLI Options

### DIFF
--- a/src/ModularPipelines.Snyk/Enums/SnykCodeTestSeverityThreshold.Generated.cs
+++ b/src/ModularPipelines.Snyk/Enums/SnykCodeTestSeverityThreshold.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Snyk.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum SnykCodeTestSeverityThreshold
 {
+    [EnumValue("high")]
+    High,
+
     [EnumValue("low")]
     Low,
 
     [EnumValue("medium")]
-    Medium,
-
-    [EnumValue("high")]
-    High
+    Medium
 }

--- a/src/ModularPipelines.Snyk/Enums/SnykFailOn.Generated.cs
+++ b/src/ModularPipelines.Snyk/Enums/SnykFailOn.Generated.cs
@@ -19,9 +19,9 @@ public enum SnykFailOn
     [EnumValue("all")]
     All,
 
-    [EnumValue("upgradable")]
-    Upgradable,
-
     [EnumValue("patchable")]
-    Patchable
+    Patchable,
+
+    [EnumValue("upgradable")]
+    Upgradable
 }

--- a/src/ModularPipelines.Snyk/Enums/SnykFilePathGroup.Generated.cs
+++ b/src/ModularPipelines.Snyk/Enums/SnykFilePathGroup.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Snyk.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum SnykFilePathGroup
 {
-    [EnumValue("global")]
-    Global,
-
     [EnumValue("code")]
     Code,
+
+    [EnumValue("global")]
+    Global,
 
     [EnumValue("iac-drift")]
     IacDrift

--- a/src/ModularPipelines.Snyk/Enums/SnykReachabilityFilter.Generated.cs
+++ b/src/ModularPipelines.Snyk/Enums/SnykReachabilityFilter.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Snyk.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum SnykReachabilityFilter
 {
-    [EnumValue("reachable")]
-    Reachable,
-
     [EnumValue("no-info")]
     NoInfo,
 
     [EnumValue("not-applicable")]
-    NotApplicable
+    NotApplicable,
+
+    [EnumValue("reachable")]
+    Reachable
 }

--- a/src/ModularPipelines.Snyk/Enums/SnykSeverityThreshold.Generated.cs
+++ b/src/ModularPipelines.Snyk/Enums/SnykSeverityThreshold.Generated.cs
@@ -16,15 +16,15 @@ namespace ModularPipelines.Snyk.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum SnykSeverityThreshold
 {
-    [EnumValue("low")]
-    Low,
-
-    [EnumValue("medium")]
-    Medium,
+    [EnumValue("critical")]
+    Critical,
 
     [EnumValue("high")]
     High,
 
-    [EnumValue("critical")]
-    Critical
+    [EnumValue("low")]
+    Low,
+
+    [EnumValue("medium")]
+    Medium
 }

--- a/src/ModularPipelines.Snyk/Enums/SnykShowVulnerablePaths.Generated.cs
+++ b/src/ModularPipelines.Snyk/Enums/SnykShowVulnerablePaths.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Snyk.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum SnykShowVulnerablePaths
 {
+    [EnumValue("all")]
+    All,
+
     [EnumValue("none")]
     None,
 
     [EnumValue("some")]
-    Some,
-
-    [EnumValue("all")]
-    All
+    Some
 }

--- a/src/ModularPipelines.Snyk/Generated/Snyk.Generation.json
+++ b/src/ModularPipelines.Snyk/Generated/Snyk.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "snyk",
   "toolVersion": "1.1306.1",
   "commandTreeSha256": "32de8a747296e31736bf613027b19e2b477465ca0d4198f0a4631966ff7f20ac",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }

--- a/src/ModularPipelines.Snyk/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Snyk/PublicAPI.Shipped.txt
@@ -3,19 +3,12 @@ ModularPipelines.Context.ModularPipelines_Snyk_a393d86d3cffbf3fToolsExtensions
 ModularPipelines.Context.ModularPipelines_Snyk_a393d86d3cffbf3fToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
 ModularPipelines.Context.ModularPipelines_Snyk_a393d86d3cffbf3fToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Snyk.get -> ModularPipelines.Snyk.Services.ISnyk!
 ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.High = 2 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Low = 0 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Medium = 1 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
 ModularPipelines.Snyk.Enums.SnykContainerTestFailOn
 ModularPipelines.Snyk.Enums.SnykContainerTestFailOn.All = 0 -> ModularPipelines.Snyk.Enums.SnykContainerTestFailOn
 ModularPipelines.Snyk.Enums.SnykContainerTestFailOn.Upgradable = 1 -> ModularPipelines.Snyk.Enums.SnykContainerTestFailOn
 ModularPipelines.Snyk.Enums.SnykFailOn
 ModularPipelines.Snyk.Enums.SnykFailOn.All = 0 -> ModularPipelines.Snyk.Enums.SnykFailOn
-ModularPipelines.Snyk.Enums.SnykFailOn.Patchable = 2 -> ModularPipelines.Snyk.Enums.SnykFailOn
-ModularPipelines.Snyk.Enums.SnykFailOn.Upgradable = 1 -> ModularPipelines.Snyk.Enums.SnykFailOn
 ModularPipelines.Snyk.Enums.SnykFilePathGroup
-ModularPipelines.Snyk.Enums.SnykFilePathGroup.Code = 1 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
-ModularPipelines.Snyk.Enums.SnykFilePathGroup.Global = 0 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
 ModularPipelines.Snyk.Enums.SnykFilePathGroup.IacDrift = 2 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
 ModularPipelines.Snyk.Enums.SnykFormat
 ModularPipelines.Snyk.Enums.SnykFormat.Cyclonedx14Json = 0 -> ModularPipelines.Snyk.Enums.SnykFormat
@@ -26,18 +19,8 @@ ModularPipelines.Snyk.Enums.SnykFormat.Cyclonedx16Json = 4 -> ModularPipelines.S
 ModularPipelines.Snyk.Enums.SnykFormat.Cyclonedx16Xml = 5 -> ModularPipelines.Snyk.Enums.SnykFormat
 ModularPipelines.Snyk.Enums.SnykFormat.Spdx23Json = 6 -> ModularPipelines.Snyk.Enums.SnykFormat
 ModularPipelines.Snyk.Enums.SnykReachabilityFilter
-ModularPipelines.Snyk.Enums.SnykReachabilityFilter.NoInfo = 1 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
-ModularPipelines.Snyk.Enums.SnykReachabilityFilter.NotApplicable = 2 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
-ModularPipelines.Snyk.Enums.SnykReachabilityFilter.Reachable = 0 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
 ModularPipelines.Snyk.Enums.SnykSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Critical = 3 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykSeverityThreshold.High = 2 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Low = 0 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
-ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Medium = 1 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
 ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
-ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.All = 2 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
-ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.None = 0 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
-ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.Some = 1 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
 ModularPipelines.Snyk.Extensions.SnykExtensions
 ModularPipelines.Snyk.Options.SnykAibomOptions
 ModularPipelines.Snyk.Options.SnykAibomOptions.Debug.get -> bool?

--- a/src/ModularPipelines.Snyk/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Snyk/PublicAPI.Unshipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+*REMOVED*ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.High = 2 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Low = 0 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Medium = 1 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykFailOn.Patchable = 2 -> ModularPipelines.Snyk.Enums.SnykFailOn
+*REMOVED*ModularPipelines.Snyk.Enums.SnykFailOn.Upgradable = 1 -> ModularPipelines.Snyk.Enums.SnykFailOn
+*REMOVED*ModularPipelines.Snyk.Enums.SnykFilePathGroup.Code = 1 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
+*REMOVED*ModularPipelines.Snyk.Enums.SnykFilePathGroup.Global = 0 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
+*REMOVED*ModularPipelines.Snyk.Enums.SnykReachabilityFilter.NoInfo = 1 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
+*REMOVED*ModularPipelines.Snyk.Enums.SnykReachabilityFilter.NotApplicable = 2 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
+*REMOVED*ModularPipelines.Snyk.Enums.SnykReachabilityFilter.Reachable = 0 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
+*REMOVED*ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Critical = 3 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykSeverityThreshold.High = 2 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Low = 0 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Medium = 1 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+*REMOVED*ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.All = 2 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
+*REMOVED*ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.None = 0 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
+*REMOVED*ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.Some = 1 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
 *REMOVED*ModularPipelines.Snyk.Services.ISnyk.AibomAsync(ModularPipelines.Snyk.Options.SnykAibomOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Snyk.Services.ISnyk.AibomTestAsync(ModularPipelines.Snyk.Options.SnykAibomTestOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Snyk.Services.ISnyk.AuthAsync(ModularPipelines.Snyk.Options.SnykAuthOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -18,6 +35,23 @@
 *REMOVED*ModularPipelines.Snyk.Services.ISnyk.SbomTestAsync(ModularPipelines.Snyk.Options.SnykSbomTestOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Snyk.Services.ISnyk.TestAsync(ModularPipelines.Snyk.Options.SnykTestOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*static ModularPipelines.Snyk.Extensions.SnykExtensions.Snyk(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Snyk.Services.ISnyk!
+ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.High = 0 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Low = 1 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Medium = 2 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykFailOn.Patchable = 1 -> ModularPipelines.Snyk.Enums.SnykFailOn
+ModularPipelines.Snyk.Enums.SnykFailOn.Upgradable = 2 -> ModularPipelines.Snyk.Enums.SnykFailOn
+ModularPipelines.Snyk.Enums.SnykFilePathGroup.Code = 0 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
+ModularPipelines.Snyk.Enums.SnykFilePathGroup.Global = 1 -> ModularPipelines.Snyk.Enums.SnykFilePathGroup
+ModularPipelines.Snyk.Enums.SnykReachabilityFilter.NoInfo = 0 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
+ModularPipelines.Snyk.Enums.SnykReachabilityFilter.NotApplicable = 1 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
+ModularPipelines.Snyk.Enums.SnykReachabilityFilter.Reachable = 2 -> ModularPipelines.Snyk.Enums.SnykReachabilityFilter
+ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Critical = 0 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykSeverityThreshold.High = 1 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Low = 2 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykSeverityThreshold.Medium = 3 -> ModularPipelines.Snyk.Enums.SnykSeverityThreshold
+ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.All = 0 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
+ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.None = 1 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
+ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths.Some = 2 -> ModularPipelines.Snyk.Enums.SnykShowVulnerablePaths
 ModularPipelines.Snyk.Services.ISnyk.AibomAsync(ModularPipelines.Snyk.Options.SnykAibomOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Snyk.Services.ISnyk.AibomTestAsync(ModularPipelines.Snyk.Options.SnykAibomTestOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Snyk.Services.ISnyk.AuthAsync(ModularPipelines.Snyk.Options.SnykAuthOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **snyk** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Snyk`.

- Added APIs: 17
- Removed or changed APIs: 17
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.High = 2 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold`
- `ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Low = 0 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold`
- `ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Medium = 1 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold`
- `ModularPipelines.Snyk.Enums.SnykFailOn.Patchable = 2 -> ModularPipelines.Snyk.Enums.SnykFailOn`
- `ModularPipelines.Snyk.Enums.SnykFailOn.Upgradable = 1 -> ModularPipelines.Snyk.Enums.SnykFailOn`

Representative added members:
- `ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.High = 0 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold`
- `ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Low = 1 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold`
- `ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold.Medium = 2 -> ModularPipelines.Snyk.Enums.SnykCodeTestSeverityThreshold`
- `ModularPipelines.Snyk.Enums.SnykFailOn.Patchable = 1 -> ModularPipelines.Snyk.Enums.SnykFailOn`
- `ModularPipelines.Snyk.Enums.SnykFailOn.Upgradable = 2 -> ModularPipelines.Snyk.Enums.SnykFailOn`

## Command coverage
Command coverage report:
- snyk (1.1306.1): 18 commands, tree 32de8a747296e31736bf613027b19e2b477465ca0d4198f0a4631966ff7f20ac
  - Baseline comparison: 18 commands at 1.1306.1 -> 18 commands at 1.1306.1

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator