### PR TITLE
[Automated] Update buildah CLI Options

### DIFF
--- a/src/ModularPipelines.Buildah/Generated/Buildah.Generation.json
+++ b/src/ModularPipelines.Buildah/Generated/Buildah.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "buildah",
   "toolVersion": "buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)",
   "commandTreeSha256": "40421c40371cc91f2731cecc414602c829d251cb603067ac9cbef046a69eeb90",
-  "generatorSourceSha256": "4055c4fa8efec2dc68f469f3c22b66a7d91896bb51fd4c06fc3a1d5b1cf50f47"
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **buildah** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

No active public API changes were detected in this assembly.

## Command coverage
Command coverage report:
- buildah (buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)): 37 commands, tree 40421c40371cc91f2731cecc414602c829d251cb603067ac9cbef046a69eeb90
  - Baseline comparison: 37 commands at buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0) -> 37 commands at buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator