### PR TITLE
[Automated] Update gh CLI Options

### DIFF
--- a/src/ModularPipelines.GitHub/Generated/Gh.CommandCoverage.json
+++ b/src/ModularPipelines.GitHub/Generated/Gh.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "gh",
-  "toolVersion": "gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0",
+  "toolVersion": "gh version 2.100.0 (2026-09-03) https://github.com/cli/cli/releases/tag/v2.100.0",
   "commandCount": 221,
   "commandTreeSha256": "3777cffcf304b41a18323a005d1f5bfd5dd24121249da59c9d985e6b8132d552",
   "commands": [

--- a/src/ModularPipelines.GitHub/Generated/Gh.Generation.json
+++ b/src/ModularPipelines.GitHub/Generated/Gh.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "gh",
-  "toolVersion": "gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0",
+  "toolVersion": "gh version 2.100.0 (2026-09-03) https://github.com/cli/cli/releases/tag/v2.100.0",
   "commandTreeSha256": "3777cffcf304b41a18323a005d1f5bfd5dd24121249da59c9d985e6b8132d552",
-  "generatorSourceSha256": "773b4f943140dab43ee649323893d06346286caa0635dcf177d0bfb536a63497"
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }

--- a/src/ModularPipelines.GitHub/Options/GhIssueCommentOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhIssueCommentOptions.Generated.cs
@@ -23,6 +23,12 @@ public record GhIssueCommentOptions(
 ) : GhOptions
 {
     /// <summary>
+    /// Attach an image or video file, in '&lt;file&gt;#&lt;image alt text&gt;' format
+    /// </summary>
+    [CliOption("--attach", Format = OptionFormat.EqualsSeparated)]
+    public string? Attach { get; set; }
+
+    /// <summary>
     /// The comment body text
     /// </summary>
     [CliOption("--body", ShortForm = "-b", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.GitHub/Options/GhIssueCreateOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhIssueCreateOptions.Generated.cs
@@ -27,6 +27,12 @@ public record GhIssueCreateOptions : GhOptions
     public string? Assignee { get; set; }
 
     /// <summary>
+    /// Attach an image or video file, in '&lt;file&gt;#&lt;image alt text&gt;' format
+    /// </summary>
+    [CliOption("--attach", Format = OptionFormat.EqualsSeparated)]
+    public string? Attach { get; set; }
+
+    /// <summary>
     /// Mark the new issue as blocked by these issue numbers or URLs
     /// </summary>
     [CliOption("--blocked-by", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.GitHub/Options/GhIssueDevelopOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhIssueDevelopOptions.Generated.cs
@@ -53,6 +53,12 @@ public record GhIssueDevelopOptions(
     public string? Name { get; set; }
 
     /// <summary>
+    /// Check out the branch into a worktree at the given path
+    /// </summary>
+    [CliOption("--worktree", Format = OptionFormat.EqualsSeparated)]
+    public string? Worktree { get; set; }
+
+    /// <summary>
     /// Show help for command
     /// </summary>
     [CliFlag("--help")]

--- a/src/ModularPipelines.GitHub/Options/GhIssueEditOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhIssueEditOptions.Generated.cs
@@ -59,6 +59,12 @@ public record GhIssueEditOptions(
     public int? AddSubIssue { get; set; }
 
     /// <summary>
+    /// Attach an image or video file, in '&lt;file&gt;#&lt;image alt text&gt;' format
+    /// </summary>
+    [CliOption("--attach", Format = OptionFormat.EqualsSeparated)]
+    public string? Attach { get; set; }
+
+    /// <summary>
     /// Set the new body.
     /// </summary>
     [CliOption("--body", ShortForm = "-b", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.GitHub/Options/GhPrCommentOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhPrCommentOptions.Generated.cs
@@ -21,6 +21,12 @@ namespace ModularPipelines.GitHub.Options;
 public record GhPrCommentOptions : GhOptions
 {
     /// <summary>
+    /// Attach an image or video file, in '&lt;file&gt;#&lt;image alt text&gt;' format
+    /// </summary>
+    [CliOption("--attach", Format = OptionFormat.EqualsSeparated)]
+    public string? Attach { get; set; }
+
+    /// <summary>
     /// The comment body text
     /// </summary>
     [CliOption("--body", ShortForm = "-b", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.GitHub/Options/GhPrCreateOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhPrCreateOptions.Generated.cs
@@ -27,6 +27,12 @@ public record GhPrCreateOptions : GhOptions
     public string? Assignee { get; set; }
 
     /// <summary>
+    /// Attach an image or video file, in '&lt;file&gt;#&lt;image alt text&gt;' format
+    /// </summary>
+    [CliOption("--attach", Format = OptionFormat.EqualsSeparated)]
+    public string? Attach { get; set; }
+
+    /// <summary>
     /// The branch into which you want your code merged
     /// </summary>
     [CliOption("--base", ShortForm = "-B", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.GitHub/Options/GhPrEditOptions.Generated.cs
+++ b/src/ModularPipelines.GitHub/Options/GhPrEditOptions.Generated.cs
@@ -45,6 +45,12 @@ public record GhPrEditOptions : GhOptions
     public string? AddReviewer { get; set; }
 
     /// <summary>
+    /// Attach an image or video file, in '&lt;file&gt;#&lt;image alt text&gt;' format
+    /// </summary>
+    [CliOption("--attach", Format = OptionFormat.EqualsSeparated)]
+    public string? Attach { get; set; }
+
+    /// <summary>
     /// Change the base branch for this pull request
     /// </summary>
     [CliOption("--base", ShortForm = "-B", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.GitHub/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.GitHub/PublicAPI.Unshipped.txt
@@ -635,6 +635,8 @@ ModularPipelines.GitHub.Options.GhIssueCloseOptions.Reason.set -> void
 ModularPipelines.GitHub.Options.GhIssueCloseOptions.Repo.get -> string?
 ModularPipelines.GitHub.Options.GhIssueCloseOptions.Repo.set -> void
 ModularPipelines.GitHub.Options.GhIssueCommentOptions
+ModularPipelines.GitHub.Options.GhIssueCommentOptions.Attach.get -> string?
+ModularPipelines.GitHub.Options.GhIssueCommentOptions.Attach.set -> void
 ModularPipelines.GitHub.Options.GhIssueCommentOptions.Body.get -> string?
 ModularPipelines.GitHub.Options.GhIssueCommentOptions.Body.set -> void
 ModularPipelines.GitHub.Options.GhIssueCommentOptions.BodyFile.get -> string?
@@ -663,6 +665,8 @@ ModularPipelines.GitHub.Options.GhIssueCommentOptions.Yes.set -> void
 ModularPipelines.GitHub.Options.GhIssueCreateOptions
 ModularPipelines.GitHub.Options.GhIssueCreateOptions.Assignee.get -> string?
 ModularPipelines.GitHub.Options.GhIssueCreateOptions.Assignee.set -> void
+ModularPipelines.GitHub.Options.GhIssueCreateOptions.Attach.get -> string?
+ModularPipelines.GitHub.Options.GhIssueCreateOptions.Attach.set -> void
 ModularPipelines.GitHub.Options.GhIssueCreateOptions.BlockedBy.get -> string?
 ModularPipelines.GitHub.Options.GhIssueCreateOptions.BlockedBy.set -> void
 ModularPipelines.GitHub.Options.GhIssueCreateOptions.Blocking.get -> string?
@@ -729,6 +733,8 @@ ModularPipelines.GitHub.Options.GhIssueDevelopOptions.NumberOrUrl.get -> string!
 ModularPipelines.GitHub.Options.GhIssueDevelopOptions.NumberOrUrl.init -> void
 ModularPipelines.GitHub.Options.GhIssueDevelopOptions.Repo.get -> string?
 ModularPipelines.GitHub.Options.GhIssueDevelopOptions.Repo.set -> void
+ModularPipelines.GitHub.Options.GhIssueDevelopOptions.Worktree.get -> string?
+ModularPipelines.GitHub.Options.GhIssueDevelopOptions.Worktree.set -> void
 ModularPipelines.GitHub.Options.GhIssueEditOptions
 ModularPipelines.GitHub.Options.GhIssueEditOptions.AddAssignee.get -> string?
 ModularPipelines.GitHub.Options.GhIssueEditOptions.AddAssignee.set -> void
@@ -742,6 +748,8 @@ ModularPipelines.GitHub.Options.GhIssueEditOptions.AddProject.get -> string?
 ModularPipelines.GitHub.Options.GhIssueEditOptions.AddProject.set -> void
 ModularPipelines.GitHub.Options.GhIssueEditOptions.AddSubIssue.get -> int?
 ModularPipelines.GitHub.Options.GhIssueEditOptions.AddSubIssue.set -> void
+ModularPipelines.GitHub.Options.GhIssueEditOptions.Attach.get -> string?
+ModularPipelines.GitHub.Options.GhIssueEditOptions.Attach.set -> void
 ModularPipelines.GitHub.Options.GhIssueEditOptions.Body.get -> string?
 ModularPipelines.GitHub.Options.GhIssueEditOptions.Body.set -> void
 ModularPipelines.GitHub.Options.GhIssueEditOptions.BodyFile.get -> string?
@@ -1001,6 +1009,8 @@ ModularPipelines.GitHub.Options.GhPrCloseOptions.NumberOrUrlOrBranch.init -> voi
 ModularPipelines.GitHub.Options.GhPrCloseOptions.Repo.get -> string?
 ModularPipelines.GitHub.Options.GhPrCloseOptions.Repo.set -> void
 ModularPipelines.GitHub.Options.GhPrCommentOptions
+ModularPipelines.GitHub.Options.GhPrCommentOptions.Attach.get -> string?
+ModularPipelines.GitHub.Options.GhPrCommentOptions.Attach.set -> void
 ModularPipelines.GitHub.Options.GhPrCommentOptions.Body.get -> string?
 ModularPipelines.GitHub.Options.GhPrCommentOptions.Body.set -> void
 ModularPipelines.GitHub.Options.GhPrCommentOptions.BodyFile.get -> string?
@@ -1028,6 +1038,8 @@ ModularPipelines.GitHub.Options.GhPrCommentOptions.Yes.set -> void
 ModularPipelines.GitHub.Options.GhPrCreateOptions
 ModularPipelines.GitHub.Options.GhPrCreateOptions.Assignee.get -> string?
 ModularPipelines.GitHub.Options.GhPrCreateOptions.Assignee.set -> void
+ModularPipelines.GitHub.Options.GhPrCreateOptions.Attach.get -> string?
+ModularPipelines.GitHub.Options.GhPrCreateOptions.Attach.set -> void
 ModularPipelines.GitHub.Options.GhPrCreateOptions.Base.get -> string?
 ModularPipelines.GitHub.Options.GhPrCreateOptions.Base.set -> void
 ModularPipelines.GitHub.Options.GhPrCreateOptions.Body.get -> string?
@@ -1102,6 +1114,8 @@ ModularPipelines.GitHub.Options.GhPrEditOptions.AddProject.get -> string?
 ModularPipelines.GitHub.Options.GhPrEditOptions.AddProject.set -> void
 ModularPipelines.GitHub.Options.GhPrEditOptions.AddReviewer.get -> string?
 ModularPipelines.GitHub.Options.GhPrEditOptions.AddReviewer.set -> void
+ModularPipelines.GitHub.Options.GhPrEditOptions.Attach.get -> string?
+ModularPipelines.GitHub.Options.GhPrEditOptions.Attach.set -> void
 ModularPipelines.GitHub.Options.GhPrEditOptions.Base.get -> string?
 ModularPipelines.GitHub.Options.GhPrEditOptions.Base.set -> void
 ModularPipelines.GitHub.Options.GhPrEditOptions.Body.get -> string?


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **gh** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Gh`.

- Added APIs: 14
- Removed or changed APIs: 0
- Members with matching names but changed signatures: 0

Representative added members:
- `ModularPipelines.GitHub.Options.GhIssueCommentOptions.Attach.get -> string?`
- `ModularPipelines.GitHub.Options.GhIssueCommentOptions.Attach.set -> void`
- `ModularPipelines.GitHub.Options.GhIssueCreateOptions.Attach.get -> string?`
- `ModularPipelines.GitHub.Options.GhIssueCreateOptions.Attach.set -> void`
- `ModularPipelines.GitHub.Options.GhIssueDevelopOptions.Worktree.get -> string?`

## Command coverage
Command coverage report:
- gh (gh version 2.100.0 (2026-09-03) https://github.com/cli/cli/releases/tag/v2.100.0): 221 commands, tree 3777cffcf304b41a18323a005d1f5bfd5dd24121249da59c9d985e6b8132d552
  - Baseline comparison: 221 commands at gh version 2.98.0 (2026-08-20) https://github.com/cli/cli/releases/tag/v2.98.0 -> 221 commands at gh version 2.100.0 (2026-09-03) https://github.com/cli/cli/releases/tag/v2.100.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator