### PR TITLE
[Automated] Update pulumi CLI Options

### DIFF
--- a/src/ModularPipelines.Pulumi/Enums/PulumiInsightsAccountNewProvider.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiInsightsAccountNewProvider.Generated.cs
@@ -19,15 +19,15 @@ public enum PulumiInsightsAccountNewProvider
     [EnumValue("aws")]
     Aws,
 
-    [EnumValue("gcp")]
-    Gcp,
-
     [EnumValue("azure-native")]
     AzureNative,
 
-    [EnumValue("oci")]
-    Oci,
+    [EnumValue("gcp")]
+    Gcp,
 
     [EnumValue("kubernetes")]
-    Kubernetes
+    Kubernetes,
+
+    [EnumValue("oci")]
+    Oci
 }

--- a/src/ModularPipelines.Pulumi/Enums/PulumiInsightsAccountNewScanSchedule.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiInsightsAccountNewScanSchedule.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Pulumi.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PulumiInsightsAccountNewScanSchedule
 {
-    [EnumValue("none")]
-    None,
-
     [EnumValue("12h")]
     Value12H,
 
     [EnumValue("daily")]
-    Daily
+    Daily,
+
+    [EnumValue("none")]
+    None
 }

--- a/src/ModularPipelines.Pulumi/Enums/PulumiOrgAuditLogExportFormat.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiOrgAuditLogExportFormat.Generated.cs
@@ -16,9 +16,9 @@ namespace ModularPipelines.Pulumi.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PulumiOrgAuditLogExportFormat
 {
-    [EnumValue("csv")]
-    Csv,
-
     [EnumValue("cef")]
-    Cef
+    Cef,
+
+    [EnumValue("csv")]
+    Csv
 }

--- a/src/ModularPipelines.Pulumi/Enums/PulumiOrgUsageGetGranularity.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiOrgUsageGetGranularity.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Pulumi.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PulumiOrgUsageGetGranularity
 {
-    [EnumValue("hourly")]
-    Hourly,
-
     [EnumValue("daily")]
     Daily,
+
+    [EnumValue("hourly")]
+    Hourly,
 
     [EnumValue("monthly")]
     Monthly

--- a/src/ModularPipelines.Pulumi/Enums/PulumiStackScheduleEditOperation.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiStackScheduleEditOperation.Generated.cs
@@ -16,8 +16,8 @@ namespace ModularPipelines.Pulumi.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PulumiStackScheduleEditOperation
 {
-    [EnumValue("update")]
-    Update,
+    [EnumValue("destroy")]
+    Destroy,
 
     [EnumValue("preview")]
     Preview,
@@ -25,6 +25,6 @@ public enum PulumiStackScheduleEditOperation
     [EnumValue("refresh")]
     Refresh,
 
-    [EnumValue("destroy")]
-    Destroy
+    [EnumValue("update")]
+    Update
 }

--- a/src/ModularPipelines.Pulumi/Enums/PulumiStackScheduleNewKind.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiStackScheduleNewKind.Generated.cs
@@ -16,11 +16,11 @@ namespace ModularPipelines.Pulumi.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PulumiStackScheduleNewKind
 {
-    [EnumValue("raw")]
-    Raw,
-
     [EnumValue("drift")]
     Drift,
+
+    [EnumValue("raw")]
+    Raw,
 
     [EnumValue("ttl")]
     Ttl

--- a/src/ModularPipelines.Pulumi/Enums/PulumiStackScheduleNewOperation.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Enums/PulumiStackScheduleNewOperation.Generated.cs
@@ -16,8 +16,8 @@ namespace ModularPipelines.Pulumi.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PulumiStackScheduleNewOperation
 {
-    [EnumValue("update")]
-    Update,
+    [EnumValue("destroy")]
+    Destroy,
 
     [EnumValue("preview")]
     Preview,
@@ -25,6 +25,6 @@ public enum PulumiStackScheduleNewOperation
     [EnumValue("refresh")]
     Refresh,
 
-    [EnumValue("destroy")]
-    Destroy
+    [EnumValue("update")]
+    Update
 }

--- a/src/ModularPipelines.Pulumi/Generated/Pulumi.CommandCoverage.json
+++ b/src/ModularPipelines.Pulumi/Generated/Pulumi.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pulumi",
-  "toolVersion": "v3.261.0",
+  "toolVersion": "v3.262.0",
   "commandCount": 233,
   "commandTreeSha256": "26a5eadd276eea43631e4ac3298884c71fca0ef0efa6ed2e1270e406b45179b8",
   "commands": [

--- a/src/ModularPipelines.Pulumi/Generated/Pulumi.Generation.json
+++ b/src/ModularPipelines.Pulumi/Generated/Pulumi.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pulumi",
-  "toolVersion": "v3.261.0",
+  "toolVersion": "v3.262.0",
   "commandTreeSha256": "26a5eadd276eea43631e4ac3298884c71fca0ef0efa6ed2e1270e406b45179b8",
-  "generatorSourceSha256": "3c4a4b7d77c9c486eefb33c6d9f0e900bd1623eade9ce8de1537082c1d5cebeb"
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }

--- a/src/ModularPipelines.Pulumi/Options/PulumiApiListOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiApiListOptions.Generated.cs
@@ -21,6 +21,12 @@ namespace ModularPipelines.Pulumi.Options;
 public record PulumiApiListOptions : PulumiOptions
 {
     /// <summary>
+    /// Show only operations whose ID, path, tag, summary, or description contains this text (case-insensitive)
+    /// </summary>
+    [CliOption("--filter", Format = OptionFormat.EqualsSeparated)]
+    public string? Filter { get; set; }
+
+    /// <summary>
     /// help for list
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]

--- a/src/ModularPipelines.Pulumi/Options/PulumiDeploymentSettingsEditOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiDeploymentSettingsEditOptions.Generated.cs
@@ -82,19 +82,13 @@ public record PulumiDeploymentSettingsEditOptions : PulumiOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// Remove the entire AWS OIDC configuration
-    /// </summary>
-    [CliFlag("--oidc-aws-clear")]
-    public bool? OidcAwsClear { get; set; }
-
-    /// <summary>
     /// AWS OIDC: assume-role session duration (e.g. 30m, 1h)
     /// </summary>
     [CliOption("--oidc-aws-duration", Format = OptionFormat.EqualsSeparated)]
     public string? OidcAwsDuration { get; set; }
 
     /// <summary>
-    /// AWS OIDC: replace the session policy ARN list (repeatable, comma-separated)
+    /// AWS OIDC: replace the session policy ARN list (repeatable or comma-separated)
     /// </summary>
     [CliOption("--oidc-aws-policy-arn", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? OidcAwsPolicyArn { get; set; }
@@ -110,12 +104,6 @@ public record PulumiDeploymentSettingsEditOptions : PulumiOptions
     /// </summary>
     [CliOption("--oidc-aws-session-name", Format = OptionFormat.EqualsSeparated)]
     public string? OidcAwsSessionName { get; set; }
-
-    /// <summary>
-    /// Remove the entire Azure OIDC configuration
-    /// </summary>
-    [CliFlag("--oidc-azure-clear")]
-    public bool? OidcAzureClear { get; set; }
 
     /// <summary>
     /// Azure OIDC: federated workload identity client ID
@@ -134,12 +122,6 @@ public record PulumiDeploymentSettingsEditOptions : PulumiOptions
     /// </summary>
     [CliOption("--oidc-azure-tenant-id", Format = OptionFormat.EqualsSeparated)]
     public string? OidcAzureTenantId { get; set; }
-
-    /// <summary>
-    /// Remove the entire GCP OIDC configuration
-    /// </summary>
-    [CliFlag("--oidc-gcp-clear")]
-    public bool? OidcGcpClear { get; set; }
 
     /// <summary>
     /// GCP OIDC: numerical project number (e.g. 987654321)
@@ -197,7 +179,7 @@ public record PulumiDeploymentSettingsEditOptions : PulumiOptions
     public bool? PrTemplate { get; set; }
 
     /// <summary>
-    /// Replace the pre-run command list (repeatable; pass once per command
+    /// Replace the pre-run command list (repeatable; pass once per command); empty string clears it
     /// </summary>
     [CliOption("--pre-run-command", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? PreRunCommand { get; set; }
@@ -215,10 +197,34 @@ public record PulumiDeploymentSettingsEditOptions : PulumiOptions
     public bool? PushToDeploy { get; set; }
 
     /// <summary>
-    /// Delete an environment variable by key (repeatable, comma-separated)
+    /// Remove every environment variable
+    /// </summary>
+    [CliFlag("--remove-all-env")]
+    public bool? RemoveAllEnv { get; set; }
+
+    /// <summary>
+    /// Delete an environment variable by key (repeatable or comma-separated)
     /// </summary>
     [CliOption("--remove-env", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? RemoveEnv { get; set; }
+
+    /// <summary>
+    /// AWS OIDC: remove the entire configuration
+    /// </summary>
+    [CliFlag("--remove-oidc-aws")]
+    public bool? RemoveOidcAws { get; set; }
+
+    /// <summary>
+    /// Azure OIDC: remove the entire configuration
+    /// </summary>
+    [CliFlag("--remove-oidc-azure")]
+    public bool? RemoveOidcAzure { get; set; }
+
+    /// <summary>
+    /// GCP OIDC: remove the entire configuration
+    /// </summary>
+    [CliFlag("--remove-oidc-gcp")]
+    public bool? RemoveOidcGcp { get; set; }
 
     /// <summary>
     /// Deployment runner pool ID; empty string clears it to the Pulumi-hosted pool

--- a/src/ModularPipelines.Pulumi/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Pulumi/PublicAPI.Shipped.txt
@@ -4,14 +4,7 @@ ModularPipelines.Context.ModularPipelines_Pulumi_b655661490eb4c54ToolsExtensions
 ModularPipelines.Context.ModularPipelines_Pulumi_b655661490eb4c54ToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Pulumi.get -> ModularPipelines.Pulumi.Services.IPulumi!
 ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
 ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Aws = 0 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.AzureNative = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Gcp = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Kubernetes = 4 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Oci = 3 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
 ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Daily = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.None = 0 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
-ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Value12H = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
 ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort
 ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort.Category = 0 -> ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort
 ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort.Created = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort
@@ -32,26 +25,16 @@ ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort.Stack = 15 -> Mod
 ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort.Type = 16 -> ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort
 ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort.Urn = 17 -> ModularPipelines.Pulumi.Enums.PulumiInsightsResourceSearchSort
 ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
-ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat.Cef = 1 -> ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
-ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat.Csv = 0 -> ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
 ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
-ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Daily = 1 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
-ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Hourly = 0 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
 ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Monthly = 2 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
-ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Destroy = 3 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Preview = 1 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Refresh = 2 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
-ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Update = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
-ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Drift = 1 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
-ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Raw = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Ttl = 2 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
-ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Destroy = 3 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Preview = 1 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
 ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Refresh = 2 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
-ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Update = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
 ModularPipelines.Pulumi.Extensions.PulumiExtensions
 ModularPipelines.Pulumi.Options.PulumiApiDescribeOptions
 ModularPipelines.Pulumi.Options.PulumiApiDescribeOptions.Color.get -> string?
@@ -1152,8 +1135,6 @@ ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.Memprofilera
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.Memprofilerate.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.NonInteractive.get -> bool?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.NonInteractive.set -> void
-ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsClear.get -> bool?
-ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsClear.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsDuration.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsDuration.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsPolicyArn.get -> System.Collections.Generic.IEnumerable<string!>?
@@ -1162,16 +1143,12 @@ ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsRoleA
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsRoleArn.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsSessionName.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsSessionName.set -> void
-ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureClear.get -> bool?
-ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureClear.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureClientId.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureClientId.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureSubscriptionId.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureSubscriptionId.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureTenantId.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureTenantId.set -> void
-ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpClear.get -> bool?
-ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpClear.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpProjectNumber.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpProjectNumber.set -> void
 ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpProviderId.get -> string?

--- a/src/ModularPipelines.Pulumi/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Pulumi/PublicAPI.Unshipped.txt
@@ -1,4 +1,27 @@
 #nullable enable
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.AzureNative = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Gcp = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Kubernetes = 4 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Oci = 3 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Daily = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.None = 0 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Value12H = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat.Cef = 1 -> ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat.Csv = 0 -> ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Daily = 1 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Hourly = 0 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Destroy = 3 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Update = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Drift = 1 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Raw = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Destroy = 3 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
+*REMOVED*ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Update = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
+*REMOVED*ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsClear.get -> bool?
+*REMOVED*ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAwsClear.set -> void
+*REMOVED*ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureClear.get -> bool?
+*REMOVED*ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcAzureClear.set -> void
+*REMOVED*ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpClear.get -> bool?
+*REMOVED*ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.OidcGcpClear.set -> void
 *REMOVED*ModularPipelines.Pulumi.Options.PulumiDoOptions.Command.get -> string?
 *REMOVED*ModularPipelines.Pulumi.Options.PulumiDoOptions.Command.set -> void
 *REMOVED*ModularPipelines.Pulumi.Options.PulumiDoOptions.Deconstruct(out string! PkgModTyp) -> void
@@ -392,6 +415,33 @@
 *REMOVED*virtual ModularPipelines.Pulumi.Services.PulumiTemplate.ExecuteAsync(ModularPipelines.Pulumi.Options.PulumiTemplateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Pulumi.Services.PulumiTemplate.ListAsync(ModularPipelines.Pulumi.Options.PulumiTemplateListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Pulumi.Services.PulumiTemplate.PublishAsync(ModularPipelines.Pulumi.Options.PulumiTemplatePublishOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.AzureNative = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Gcp = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Kubernetes = 3 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Oci = 4 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Daily = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.None = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
+ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Value12H = 0 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule
+ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat.Cef = 0 -> ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
+ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat.Csv = 1 -> ModularPipelines.Pulumi.Enums.PulumiOrgAuditLogExportFormat
+ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Daily = 0 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
+ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity.Hourly = 1 -> ModularPipelines.Pulumi.Enums.PulumiOrgUsageGetGranularity
+ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Destroy = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
+ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation.Update = 3 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleEditOperation
+ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Drift = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
+ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind.Raw = 1 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewKind
+ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Destroy = 0 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
+ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation.Update = 3 -> ModularPipelines.Pulumi.Enums.PulumiStackScheduleNewOperation
+ModularPipelines.Pulumi.Options.PulumiApiListOptions.Filter.get -> string?
+ModularPipelines.Pulumi.Options.PulumiApiListOptions.Filter.set -> void
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveAllEnv.get -> bool?
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveAllEnv.set -> void
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveOidcAws.get -> bool?
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveOidcAws.set -> void
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveOidcAzure.get -> bool?
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveOidcAzure.set -> void
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveOidcGcp.get -> bool?
+ModularPipelines.Pulumi.Options.PulumiDeploymentSettingsEditOptions.RemoveOidcGcp.set -> void
 ModularPipelines.Pulumi.Options.PulumiDoOptions.PkgModTyp.get -> string?
 ModularPipelines.Pulumi.Options.PulumiDoOptions.PkgModTyp.set -> void
 ModularPipelines.Pulumi.Options.PulumiDoOptions.PulumiDoOptions() -> void


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pulumi** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Pulumi`.

- Added APIs: 27
- Removed or changed APIs: 23
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.AzureNative = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Gcp = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Kubernetes = 4 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Oci = 3 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Daily = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule`

Representative added members:
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.AzureNative = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Gcp = 2 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Kubernetes = 3 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider.Oci = 4 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewProvider`
- `ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule.Daily = 1 -> ModularPipelines.Pulumi.Enums.PulumiInsightsAccountNewScanSchedule`

## Command coverage
Command coverage report:
- pulumi (v3.262.0): 233 commands, tree 26a5eadd276eea43631e4ac3298884c71fca0ef0efa6ed2e1270e406b45179b8
  - Baseline comparison: 233 commands at v3.261.0 -> 233 commands at v3.262.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added filtering support when listing Pulumi API resources.
  - Added controls to remove all environment settings or specific OIDC provider settings.

- **Breaking Changes**
  - Replaced previous OIDC-clearing options with the new removal controls.
  - Updated numeric values for several Pulumi provider, audit log, usage, and stack scheduling options. Applications relying on serialized enum values may require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->