### PR TITLE
[Automated] Update minikube CLI Options

### DIFF
--- a/src/ModularPipelines.Minikube/Enums/MinikubeDockerEnvOutput.Generated.cs
+++ b/src/ModularPipelines.Minikube/Enums/MinikubeDockerEnvOutput.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Minikube.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum MinikubeDockerEnvOutput
 {
+    [EnumValue("json")]
+    Json,
+
     [EnumValue("text")]
     Text,
 
     [EnumValue("yaml")]
-    Yaml,
-
-    [EnumValue("json")]
-    Json
+    Yaml
 }

--- a/src/ModularPipelines.Minikube/Enums/MinikubeImageLsFormat.Generated.cs
+++ b/src/ModularPipelines.Minikube/Enums/MinikubeImageLsFormat.Generated.cs
@@ -16,14 +16,14 @@ namespace ModularPipelines.Minikube.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum MinikubeImageLsFormat
 {
+    [EnumValue("json")]
+    Json,
+
     [EnumValue("short")]
     Short,
 
     [EnumValue("table")]
     Table,
-
-    [EnumValue("json")]
-    Json,
 
     [EnumValue("yaml")]
     Yaml

--- a/src/ModularPipelines.Minikube/Enums/MinikubeStartDriver.Generated.cs
+++ b/src/ModularPipelines.Minikube/Enums/MinikubeStartDriver.Generated.cs
@@ -16,30 +16,30 @@ namespace ModularPipelines.Minikube.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum MinikubeStartDriver
 {
-    [EnumValue("virtualbox")]
-    Virtualbox,
+    [EnumValue("docker")]
+    Docker,
 
     [EnumValue("kvm2")]
     Kvm2,
 
-    [EnumValue("qemu2")]
-    Qemu2,
-
-    [EnumValue("qemu")]
-    Qemu,
-
-    [EnumValue("vmware")]
-    Vmware,
-
     [EnumValue("none")]
     None,
-
-    [EnumValue("docker")]
-    Docker,
 
     [EnumValue("podman")]
     Podman,
 
+    [EnumValue("qemu")]
+    Qemu,
+
+    [EnumValue("qemu2")]
+    Qemu2,
+
     [EnumValue("ssh")]
-    Ssh
+    Ssh,
+
+    [EnumValue("virtualbox")]
+    Virtualbox,
+
+    [EnumValue("vmware")]
+    Vmware
 }

--- a/src/ModularPipelines.Minikube/Generated/Minikube.Generation.json
+++ b/src/ModularPipelines.Minikube/Generated/Minikube.Generation.json
@@ -3,5 +3,5 @@
   "toolName": "minikube",
   "toolVersion": "v1.39.0",
   "commandTreeSha256": "bf42616787394cb9655a39166d359fda44cf62395db38aa427f98dc1b9f67bd6",
-  "generatorSourceSha256": "d9158a695acc19054e4501e243f73451e38058e36153726384f7e577db59b384"
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }

--- a/src/ModularPipelines.Minikube/Options/MinikubeStartOptions.Generated.cs
+++ b/src/ModularPipelines.Minikube/Options/MinikubeStartOptions.Generated.cs
@@ -64,7 +64,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public bool? AutoUpdateDrivers { get; set; }
 
     /// <summary>
-    /// v0.0.51@sha256:4a1c825b61479e6c898851ea66f13c620aaeab6002746e95067fc2c4b38a0b24':
+    /// The base image to use for docker/podman drivers. Intended for local development.
     /// </summary>
     [CliOption("--base-image", Format = OptionFormat.EqualsSeparated)]
     public string? BaseImage { get; set; }
@@ -322,7 +322,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public bool? Interactive { get; set; }
 
     /// <summary>
-    /// //storage.googleapis.com/minikube/iso/minikube-v1.39.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.39.0/minikube-v1.39.0-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.39.0-amd64.iso]:
+    /// //storage.googleapis.com/minikube/iso/minikube-v1.39.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.39.0/minikube-v1.39.0-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.39.0-amd64.iso]: Locations to fetch the minikube ISO from.
     /// </summary>
     [CliOption("--iso-url", Format = OptionFormat.EqualsSeparated)]
     public string? IsoUrl { get; set; }
@@ -364,7 +364,7 @@ public record MinikubeStartOptions : MinikubeOptions
     public int? KvmNumaCount { get; set; }
 
     /// <summary>
-    /// ///system':
+    /// The KVM QEMU connection URI. (kvm2 driver only)
     /// </summary>
     [CliOption("--kvm-qemu-uri", Format = OptionFormat.EqualsSeparated)]
     public string? KvmQemuUri { get; set; }

--- a/src/ModularPipelines.Minikube/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Minikube/PublicAPI.Shipped.txt
@@ -6,13 +6,7 @@ ModularPipelines.Minikube.Enums.MinikubeConfigDefaultsOutput
 ModularPipelines.Minikube.Enums.MinikubeConfigDefaultsOutput.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeConfigDefaultsOutput
 ModularPipelines.Minikube.Enums.MinikubeConfigDefaultsOutput.Yaml = 1 -> ModularPipelines.Minikube.Enums.MinikubeConfigDefaultsOutput
 ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
-ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Json = 2 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
-ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Text = 0 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
-ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Yaml = 1 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
 ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
-ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Json = 2 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
-ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Short = 0 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
-ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Table = 1 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
 ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Yaml = 3 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
 ModularPipelines.Minikube.Enums.MinikubeProfileListOutput
 ModularPipelines.Minikube.Enums.MinikubeProfileListOutput.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeProfileListOutput
@@ -21,15 +15,7 @@ ModularPipelines.Minikube.Enums.MinikubeServiceListOutput
 ModularPipelines.Minikube.Enums.MinikubeServiceListOutput.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeServiceListOutput
 ModularPipelines.Minikube.Enums.MinikubeServiceListOutput.Table = 1 -> ModularPipelines.Minikube.Enums.MinikubeServiceListOutput
 ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Docker = 6 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
 ModularPipelines.Minikube.Enums.MinikubeStartDriver.Kvm2 = 1 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.None = 5 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Podman = 7 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Qemu = 3 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Qemu2 = 2 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Ssh = 8 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Virtualbox = 0 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
-ModularPipelines.Minikube.Enums.MinikubeStartDriver.Vmware = 4 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
 ModularPipelines.Minikube.Extensions.MinikubeExtensions
 ModularPipelines.Minikube.Options.MinikubeAddonsConfigureOptions
 ModularPipelines.Minikube.Options.MinikubeAddonsConfigureOptions.AddonName.get -> string!

--- a/src/ModularPipelines.Minikube/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Minikube/PublicAPI.Unshipped.txt
@@ -1,4 +1,18 @@
 #nullable enable
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Json = 2 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Text = 0 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Yaml = 1 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Json = 2 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Short = 0 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Table = 1 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Docker = 6 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.None = 5 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Podman = 7 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Qemu = 3 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Qemu2 = 2 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Ssh = 8 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Virtualbox = 0 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+*REMOVED*ModularPipelines.Minikube.Enums.MinikubeStartDriver.Vmware = 4 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
 *REMOVED*ModularPipelines.Minikube.Options.MinikubeNodeStartOptions.MinikubeNodeStartOptions() -> void
 *REMOVED*ModularPipelines.Minikube.Services.IMinikube.CpAsync(ModularPipelines.Minikube.Options.MinikubeCpOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Minikube.Services.IMinikube.DashboardAsync(ModularPipelines.Minikube.Options.MinikubeDashboardOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -81,6 +95,20 @@
 *REMOVED*virtual ModularPipelines.Minikube.Services.MinikubeProfile.ListAsync(ModularPipelines.Minikube.Options.MinikubeProfileListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Minikube.Services.MinikubeService.ExecuteAsync(ModularPipelines.Minikube.Options.MinikubeServiceOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Minikube.Services.MinikubeService.ListAsync(ModularPipelines.Minikube.Options.MinikubeServiceListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
+ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Text = 1 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
+ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Yaml = 2 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput
+ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
+ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Short = 1 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
+ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Table = 2 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Docker = 0 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.None = 2 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Podman = 3 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Qemu = 4 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Qemu2 = 5 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Ssh = 6 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Virtualbox = 7 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
+ModularPipelines.Minikube.Enums.MinikubeStartDriver.Vmware = 8 -> ModularPipelines.Minikube.Enums.MinikubeStartDriver
 ModularPipelines.Minikube.Options.MinikubeNodeDeleteOptions
 ModularPipelines.Minikube.Options.MinikubeNodeDeleteOptions.Deconstruct(out string! NodeName) -> void
 ModularPipelines.Minikube.Options.MinikubeNodeDeleteOptions.MinikubeNodeDeleteOptions(ModularPipelines.Minikube.Options.MinikubeNodeDeleteOptions! original) -> void


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **minikube** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Minikube`.

- Added APIs: 14
- Removed or changed APIs: 14
- Members with matching names but changed signatures: 0

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Json = 2 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput`
- `ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Text = 0 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput`
- `ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Yaml = 1 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput`
- `ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Json = 2 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat`
- `ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Short = 0 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat`

Representative added members:
- `ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput`
- `ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Text = 1 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput`
- `ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput.Yaml = 2 -> ModularPipelines.Minikube.Enums.MinikubeDockerEnvOutput`
- `ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Json = 0 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat`
- `ModularPipelines.Minikube.Enums.MinikubeImageLsFormat.Short = 1 -> ModularPipelines.Minikube.Enums.MinikubeImageLsFormat`

## Command coverage
Command coverage report:
- minikube (v1.39.0): 48 commands, tree bf42616787394cb9655a39166d359fda44cf62395db38aa427f98dc1b9f67bd6
  - Baseline comparison: 48 commands at v1.39.0 -> 48 commands at v1.39.0

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator