### PR TITLE
[Automated] Update liquibase CLI Options

### DIFF
--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseChangelogParseMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseChangelogParseMode.Generated.cs
@@ -16,9 +16,9 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseChangelogParseMode
 {
-    [EnumValue("strict")]
-    Strict,
-
     [EnumValue("lax")]
-    Lax
+    Lax,
+
+    [EnumValue("strict")]
+    Strict
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseDuplicateFileMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseDuplicateFileMode.Generated.cs
@@ -16,18 +16,18 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseDuplicateFileMode
 {
-    [EnumValue("silent")]
-    Silent,
-
     [EnumValue("debug")]
     Debug,
+
+    [EnumValue("error")]
+    Error,
 
     [EnumValue("info")]
     Info,
 
-    [EnumValue("warn")]
-    Warn,
+    [EnumValue("silent")]
+    Silent,
 
-    [EnumValue("error")]
-    Error
+    [EnumValue("warn")]
+    Warn
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseLogFormat.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseLogFormat.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseLogFormat
 {
-    [EnumValue("text")]
-    Text,
-
     [EnumValue("json")]
     Json,
 
     [EnumValue("json_pretty")]
-    JsonPretty
+    JsonPretty,
+
+    [EnumValue("text")]
+    Text
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseLogLevel.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseLogLevel.Generated.cs
@@ -16,6 +16,12 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseLogLevel
 {
+    [EnumValue("fine")]
+    Fine,
+
+    [EnumValue("info")]
+    Info,
+
     [EnumValue("off")]
     Off,
 
@@ -23,11 +29,5 @@ public enum LiquibaseLogLevel
     Severe,
 
     [EnumValue("warning")]
-    Warning,
-
-    [EnumValue("info")]
-    Info,
-
-    [EnumValue("fine")]
-    Fine
+    Warning
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseMissingPropertyMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseMissingPropertyMode.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseMissingPropertyMode
 {
-    [EnumValue("preserve")]
-    Preserve,
-
     [EnumValue("empty")]
     Empty,
 
     [EnumValue("error")]
-    Error
+    Error,
+
+    [EnumValue("preserve")]
+    Preserve
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseOnMissingIncludeChangelog.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseOnMissingIncludeChangelog.Generated.cs
@@ -16,9 +16,9 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseOnMissingIncludeChangelog
 {
-    [EnumValue("warn")]
-    Warn,
-
     [EnumValue("fail")]
-    Fail
+    Fail,
+
+    [EnumValue("warn")]
+    Warn
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummaryOutput.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummaryOutput.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseShowSummaryOutput
 {
-    [EnumValue("log")]
-    Log,
+    [EnumValue("all")]
+    All,
 
     [EnumValue("console")]
     Console,
 
-    [EnumValue("all")]
-    All
+    [EnumValue("log")]
+    Log
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseSupportsMethodValidationLevel.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseSupportsMethodValidationLevel.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseSupportsMethodValidationLevel
 {
+    [EnumValue("fail")]
+    Fail,
+
     [EnumValue("off")]
     Off,
 
     [EnumValue("warn")]
-    Warn,
-
-    [EnumValue("fail")]
-    Fail
+    Warn
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseTagVersion.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseTagVersion.Generated.cs
@@ -16,9 +16,9 @@ namespace ModularPipelines.Liquibase.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum LiquibaseTagVersion
 {
-    [EnumValue("oldest")]
-    Oldest,
-
     [EnumValue("newest")]
-    Newest
+    Newest,
+
+    [EnumValue("oldest")]
+    Oldest
 }

--- a/src/ModularPipelines.Liquibase/Generated/Liquibase.Generation.json
+++ b/src/ModularPipelines.Liquibase/Generated/Liquibase.Generation.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": 1,
+  "toolName": "liquibase",
+  "toolVersion": "5.0.3",
+  "commandTreeSha256": "41e289cc33bbedcb50c94a7ac63a85c7d6ddacbd20208a60c02222e6d2d3c647",
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
+}

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseSnapshotReferenceOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseSnapshotReferenceOptions.Generated.cs
@@ -22,34 +22,64 @@ namespace ModularPipelines.Liquibase.Options;
 [CliSubCommand("snapshot-reference")]
 public record LiquibaseSnapshotReferenceOptions : LiquibaseOptions
 {
+    /// <summary>
+    /// The default catalog name to use for the reference database connection
+    /// </summary>
     [CliOption("--reference-default-catalog-name", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceDefaultCatalogName { get; set; }
 
+    /// <summary>
+    /// The default schema name to use for the reference database connection
+    /// </summary>
     [CliOption("--reference-default-schema-name", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceDefaultSchemaName { get; set; }
 
+    /// <summary>
+    /// The JDBC driver class for the reference database
+    /// </summary>
     [CliOption("--reference-driver", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceDriver { get; set; }
 
+    /// <summary>
+    /// The JDBC driver properties file for the reference database
+    /// </summary>
     [CliOption("--reference-driver-properties-file", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceDriverPropertiesFile { get; set; }
 
+    /// <summary>
+    /// Reference catalog to use for Liquibase objects
+    /// </summary>
     [CliOption("--reference-liquibase-catalog-name", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceLiquibaseCatalogName { get; set; }
 
+    /// <summary>
+    /// Reference schema to use for Liquibase objects
+    /// </summary>
     [CliOption("--reference-liquibase-schema-name", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceLiquibaseSchemaName { get; set; }
 
+    /// <summary>
+    /// The reference database password
+    /// </summary>
     [SecretValue]
     [CliOption("--reference-password", Format = OptionFormat.EqualsSeparated)]
     public string? ReferencePassword { get; set; }
 
+    /// <summary>
+    /// The JDBC reference database connection URL
+    /// </summary>
     [CliOption("--reference-url", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceUrl { get; set; }
 
+    /// <summary>
+    /// The reference database username
+    /// </summary>
     [CliOption("--reference-username", Format = OptionFormat.EqualsSeparated)]
     public string? ReferenceUsername { get; set; }
 
+    /// <summary>
+    /// Output format to use (JSON or YAML)
+    /// </summary>
     [CliOption("--snapshot-format", Format = OptionFormat.EqualsSeparated)]
     public string? SnapshotFormat { get; set; }
 

--- a/src/ModularPipelines.Liquibase/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Liquibase/PublicAPI.Shipped.txt
@@ -1,62 +1,39 @@
 #nullable enable
+ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions
+ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
+ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Liquibase.get -> ModularPipelines.Liquibase.Services.ILiquibase!
 ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
-ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Lax = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
-ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Strict = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
 ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
-ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Debug = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
-ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Error = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
 ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Info = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
-ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Silent = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
-ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Warn = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
 ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
-ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.Json = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
-ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.JsonPretty = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
-ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.Text = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
 ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
-ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Fine = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
-ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Info = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
-ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Off = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
-ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Severe = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
-ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Warning = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
 ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
-ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Empty = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
-ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Error = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
-ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Preserve = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
 ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
-ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog.Fail = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
-ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog.Warn = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
 ModularPipelines.Liquibase.Enums.LiquibaseShowSummary
 ModularPipelines.Liquibase.Enums.LiquibaseShowSummary.Off = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummary
 ModularPipelines.Liquibase.Enums.LiquibaseShowSummary.Summary = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummary
 ModularPipelines.Liquibase.Enums.LiquibaseShowSummary.Verbose = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummary
 ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
-ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.All = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
 ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.Console = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
-ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.Log = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
 ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
-ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Fail = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
-ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Off = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
-ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Warn = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
 ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
-ModularPipelines.Liquibase.Enums.LiquibaseTagVersion.Newest = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
-ModularPipelines.Liquibase.Enums.LiquibaseTagVersion.Oldest = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
 ModularPipelines.Liquibase.Enums.LiquibaseUiService
 ModularPipelines.Liquibase.Enums.LiquibaseUiService.Console = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseUiService
 ModularPipelines.Liquibase.Enums.LiquibaseUiService.Logger = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseUiService
 ModularPipelines.Liquibase.Extensions.LiquibaseExtensions
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetAuthor.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetAuthor.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetId.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetId.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetIdentifier.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetIdentifier.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetPath.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetPath.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangelogFile.get -> string?
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangelogFile.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangelogProperty.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetAuthor.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetAuthor.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetId.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetId.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetIdentifier.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetIdentifier.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetPath.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetPath.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.DefaultCatalogName.get -> string?
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.DefaultCatalogName.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.DefaultSchemaName.get -> string?
@@ -578,48 +555,6 @@ ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Url.get -> string?
 ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Url.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Username.get -> string?
 ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Username.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogFile.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogFile.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogProperty.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ContextFilter.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ContextFilter.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultCatalogName.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultCatalogName.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultSchemaName.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultSchemaName.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LabelFilter.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LabelFilter.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LiquibaseMarkNextChangesetRanOptions() -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LiquibaseMarkNextChangesetRanOptions(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions! original) -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Password.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Password.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Url.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Url.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Username.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Username.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogFile.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogFile.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogProperty.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ContextFilter.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ContextFilter.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultCatalogName.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultCatalogName.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultSchemaName.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultSchemaName.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LabelFilter.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LabelFilter.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LiquibaseMarkNextChangesetRanSqlOptions() -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LiquibaseMarkNextChangesetRanSqlOptions(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions! original) -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Password.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Password.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Url.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Url.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Username.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Username.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseOptions
 ModularPipelines.Liquibase.Options.LiquibaseOptions.LiquibaseOptions() -> void
 ModularPipelines.Liquibase.Options.LiquibaseOptions.LiquibaseOptions(ModularPipelines.Liquibase.Options.LiquibaseOptions! original) -> void
@@ -1173,7 +1108,6 @@ ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.Url.set -> void
 ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.Username.get -> string?
 ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.Username.set -> void
 ModularPipelines.Liquibase.Services.ILiquibase
-override abstract ModularPipelines.Liquibase.Options.LiquibaseOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseOptions!
 override ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions!
 override ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.Equals(object? obj) -> bool
@@ -1294,18 +1228,6 @@ override ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Equals(obj
 override ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.GetHashCode() -> int
 override ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.ToString() -> string!
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions!
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Equals(object? obj) -> bool
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.GetHashCode() -> int
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ToString() -> string!
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions!
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.EqualityContract.get -> System.Type!
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Equals(object? obj) -> bool
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.GetHashCode() -> int
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
-override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ToString() -> string!
 override ModularPipelines.Liquibase.Options.LiquibaseOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Liquibase.Options.LiquibaseOptions.Equals(object? obj) -> bool
 override ModularPipelines.Liquibase.Options.LiquibaseOptions.GetHashCode() -> int
@@ -1437,6 +1359,7 @@ override ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.Equals(obje
 override ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.GetHashCode() -> int
 override ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.ToString() -> string!
+override abstract ModularPipelines.Liquibase.Options.LiquibaseOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseOptions!
 override sealed ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseChangelogSyncOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseChangelogSyncSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
@@ -1457,8 +1380,6 @@ override sealed ModularPipelines.Liquibase.Options.LiquibaseInitOptions.Equals(M
 override sealed ModularPipelines.Liquibase.Options.LiquibaseInitProjectOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
-override sealed ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
-override sealed ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseOptions.Equals(ModularPipelines.Options.CommandLineToolOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseReleaseLocksOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseRollbackCountOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
@@ -1481,6 +1402,7 @@ override sealed ModularPipelines.Liquibase.Options.LiquibaseUpdateTestingRollbac
 override sealed ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 override sealed ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
+static ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions.get_Liquibase(ModularPipelines.Context.IToolsContext! tools) -> ModularPipelines.Liquibase.Services.ILiquibase!
 static ModularPipelines.Liquibase.Extensions.LiquibaseExtensions.RegisterLiquibaseContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions? left, ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions? right) -> bool
 static ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions? left, ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions? right) -> bool
@@ -1522,10 +1444,6 @@ static ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options.operator !
 static ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options.operator ==(ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options? left, ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options? right) -> bool
 static ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? left, ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? right) -> bool
 static ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? left, ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? right) -> bool
-static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? right) -> bool
-static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? right) -> bool
-static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? right) -> bool
-static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? right) -> bool
 static ModularPipelines.Liquibase.Options.LiquibaseOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseOptions? left, ModularPipelines.Liquibase.Options.LiquibaseOptions? right) -> bool
 static ModularPipelines.Liquibase.Options.LiquibaseOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseOptions? left, ModularPipelines.Liquibase.Options.LiquibaseOptions? right) -> bool
 static ModularPipelines.Liquibase.Options.LiquibaseReleaseLocksOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseReleaseLocksOptions? left, ModularPipelines.Liquibase.Options.LiquibaseReleaseLocksOptions? right) -> bool
@@ -1590,10 +1508,8 @@ virtual ModularPipelines.Liquibase.Options.LiquibaseInitOptions.Equals(ModularPi
 virtual ModularPipelines.Liquibase.Options.LiquibaseInitProjectOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseInitProjectOptions? other) -> bool
 virtual ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options.Equals(ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options? other) -> bool
 virtual ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? other) -> bool
-virtual ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? other) -> bool
-virtual ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? other) -> bool
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangeSetIdentifiers.get -> bool?
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangesetIdentifiers.set -> void
+virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangeSetIdentifiers.set -> void
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowInheritLogicalFilePath.get -> bool?
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowInheritLogicalFilePath.set -> void
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AlwaysDropInsteadOfReplace.get -> bool?
@@ -1647,8 +1563,8 @@ virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.FileEncoding.get -> 
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.FileEncoding.set -> void
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.FilterLogMessages.get -> string?
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.FilterLogMessages.set -> void
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangesetCreatedValues.get -> bool?
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangesetCreatedValues.set -> void
+virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangeSetCreatedValues.get -> bool?
+virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangeSetCreatedValues.set -> void
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GeneratedChangeSetIdsContainsDescription.get -> bool?
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GeneratedChangeSetIdsContainsDescription.set -> void
 virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.Headless.get -> bool?
@@ -1756,21 +1672,3 @@ virtual ModularPipelines.Liquibase.Options.LiquibaseUpdateTestingRollbackOptions
 virtual ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagOptions? other) -> bool
 virtual ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagSqlOptions? other) -> bool
 virtual ModularPipelines.Liquibase.Options.LiquibaseValidateOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseValidateOptions? other) -> bool
-ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions
-ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions.extension(ModularPipelines.Context.IToolsContext!)
-ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Liquibase.get -> ModularPipelines.Liquibase.Services.ILiquibase!
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetAuthor.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetIdentifier.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetIdentifier.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangeSetPath.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetAuthor.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetId.get -> string?
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetId.set -> void
-ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetPath.set -> void
-static ModularPipelines.Context.ModularPipelines_Liquibase_7a01d7edb4c5f94bToolsExtensions.get_Liquibase(ModularPipelines.Context.IToolsContext! tools) -> ModularPipelines.Liquibase.Services.ILiquibase!
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangeSetIdentifiers.set -> void
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangesetIdentifiers.get -> bool?
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangeSetCreatedValues.get -> bool?
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangeSetCreatedValues.set -> void
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GeneratedChangesetIdsContainsDescription.get -> bool?
-virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GeneratedChangesetIdsContainsDescription.set -> void

--- a/src/ModularPipelines.Liquibase/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Liquibase/PublicAPI.Unshipped.txt
@@ -1,4 +1,80 @@
 #nullable enable
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Lax = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Strict = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Debug = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Error = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Silent = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Warn = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.Json = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.JsonPretty = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.Text = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Fine = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Info = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Off = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Severe = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Warning = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Empty = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Error = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Preserve = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog.Fail = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog.Warn = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.All = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.Log = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Fail = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Off = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Warn = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseTagVersion.Newest = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
+*REMOVED*ModularPipelines.Liquibase.Enums.LiquibaseTagVersion.Oldest = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetAuthor.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetAuthor.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetId.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetId.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetIdentifier.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetIdentifier.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetPath.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions.ChangesetPath.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogFile.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogFile.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ChangelogProperty.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ContextFilter.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ContextFilter.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultCatalogName.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultCatalogName.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultSchemaName.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.DefaultSchemaName.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LabelFilter.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LabelFilter.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LiquibaseMarkNextChangesetRanOptions() -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.LiquibaseMarkNextChangesetRanOptions(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions! original) -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Password.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Password.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Url.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Url.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Username.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Username.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogFile.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogFile.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ChangelogProperty.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ContextFilter.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ContextFilter.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultCatalogName.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultCatalogName.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultSchemaName.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.DefaultSchemaName.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LabelFilter.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LabelFilter.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LiquibaseMarkNextChangesetRanSqlOptions() -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.LiquibaseMarkNextChangesetRanSqlOptions(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions! original) -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Password.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Password.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Url.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Url.set -> void
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Username.get -> string?
+*REMOVED*ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Username.set -> void
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.CalculateChecksumAsync(ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.ChangelogSyncAsync(ModularPipelines.Liquibase.Options.LiquibaseChangelogSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.ChangelogSyncSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseChangelogSyncSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -19,10 +95,10 @@
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.InitProjectAsync(ModularPipelines.Liquibase.Options.LiquibaseInitProjectOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.InitStartH2Async(ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.ListLocksAsync(ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangesetRanAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangeSetRanAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
-*REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangesetRanSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangeSetRanSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangesetRanAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangesetRanSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.ReleaseLocksAsync(ModularPipelines.Liquibase.Options.LiquibaseReleaseLocksOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.RollbackAsync(ModularPipelines.Liquibase.Options.LiquibaseRollbackOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.RollbackCountAsync(ModularPipelines.Liquibase.Options.LiquibaseRollbackCountOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -44,7 +120,101 @@
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.UpdateToTagAsync(ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.UpdateToTagSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*ModularPipelines.Liquibase.Services.ILiquibase.ValidateAsync(ModularPipelines.Liquibase.Options.LiquibaseValidateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions!
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.ToString() -> string!
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions!
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.EqualityContract.get -> System.Type!
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Equals(object? obj) -> bool
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.GetHashCode() -> int
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+*REMOVED*override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.ToString() -> string!
+*REMOVED*override sealed ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
+*REMOVED*override sealed ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
 *REMOVED*static ModularPipelines.Liquibase.Extensions.LiquibaseExtensions.Liquibase(this ModularPipelines.Context.IPipelineContext! context) -> ModularPipelines.Liquibase.Services.ILiquibase!
+*REMOVED*static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? right) -> bool
+*REMOVED*static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? right) -> bool
+*REMOVED*static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? right) -> bool
+*REMOVED*static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? right) -> bool
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? other) -> bool
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangesetIdentifiers.get -> bool?
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.AllowDuplicatedChangesetIdentifiers.set -> void
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangesetCreatedValues.get -> bool?
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GenerateChangesetCreatedValues.set -> void
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GeneratedChangesetIdsContainsDescription.get -> bool?
+*REMOVED*virtual ModularPipelines.Liquibase.Options.LiquibaseOptions.GeneratedChangesetIdsContainsDescription.set -> void
+ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Lax = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
+ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Strict = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode
+ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Debug = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Error = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Silent = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Warn = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode
+ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.Json = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
+ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.JsonPretty = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
+ModularPipelines.Liquibase.Enums.LiquibaseLogFormat.Text = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseLogFormat
+ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Fine = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Info = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Off = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Severe = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+ModularPipelines.Liquibase.Enums.LiquibaseLogLevel.Warning = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseLogLevel
+ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Empty = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
+ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Error = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
+ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode.Preserve = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseMissingPropertyMode
+ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog.Fail = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
+ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog.Warn = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseOnMissingIncludeChangelog
+ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.All = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
+ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput.Log = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseShowSummaryOutput
+ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Fail = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
+ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Off = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
+ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel.Warn = 2 -> ModularPipelines.Liquibase.Enums.LiquibaseSupportsMethodValidationLevel
+ModularPipelines.Liquibase.Enums.LiquibaseTagVersion.Newest = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
+ModularPipelines.Liquibase.Enums.LiquibaseTagVersion.Oldest = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseTagVersion
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ChangelogFile.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ChangelogFile.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ChangelogProperty.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ContextFilter.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ContextFilter.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.DefaultCatalogName.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.DefaultCatalogName.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.DefaultSchemaName.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.DefaultSchemaName.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.LabelFilter.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.LabelFilter.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.LiquibaseMarkNextChangeSetRanOptions() -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.LiquibaseMarkNextChangeSetRanOptions(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions! original) -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Password.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Password.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Url.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Url.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Username.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Username.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ChangelogFile.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ChangelogFile.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ChangelogProperty.get -> System.Collections.Generic.IReadOnlyList<ModularPipelines.Models.KeyValue!>?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ChangelogProperty.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ContextFilter.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ContextFilter.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.DefaultCatalogName.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.DefaultCatalogName.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.DefaultSchemaName.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.DefaultSchemaName.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.LabelFilter.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.LabelFilter.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.LiquibaseMarkNextChangeSetRanSqlOptions() -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.LiquibaseMarkNextChangeSetRanSqlOptions(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions! original) -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Password.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Password.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Url.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Url.set -> void
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Username.get -> string?
+ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Username.set -> void
 ModularPipelines.Liquibase.Services.ILiquibase.CalculateChecksumAsync(ModularPipelines.Liquibase.Options.LiquibaseCalculateChecksumOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.ChangelogSyncAsync(ModularPipelines.Liquibase.Options.LiquibaseChangelogSyncOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.ChangelogSyncSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseChangelogSyncSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -65,10 +235,8 @@ ModularPipelines.Liquibase.Services.ILiquibase.InitAsync(ModularPipelines.Liquib
 ModularPipelines.Liquibase.Services.ILiquibase.InitProjectAsync(ModularPipelines.Liquibase.Options.LiquibaseInitProjectOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.InitStartH2Async(ModularPipelines.Liquibase.Options.LiquibaseInitStartH2Options? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.ListLocksAsync(ModularPipelines.Liquibase.Options.LiquibaseListLocksOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangeSetRanAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangesetRanAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangeSetRanSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangesetRanSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangesetRanSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangeSetRanAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Liquibase.Services.ILiquibase.MarkNextChangeSetRanSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.ReleaseLocksAsync(ModularPipelines.Liquibase.Options.LiquibaseReleaseLocksOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.RollbackAsync(ModularPipelines.Liquibase.Options.LiquibaseRollbackOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.RollbackCountAsync(ModularPipelines.Liquibase.Options.LiquibaseRollbackCountOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -90,4 +258,23 @@ ModularPipelines.Liquibase.Services.ILiquibase.UpdateTestingRollbackAsync(Modula
 ModularPipelines.Liquibase.Services.ILiquibase.UpdateToTagAsync(ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.UpdateToTagSqlAsync(ModularPipelines.Liquibase.Options.LiquibaseUpdateToTagSqlOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Liquibase.Services.ILiquibase.ValidateAsync(ModularPipelines.Liquibase.Options.LiquibaseValidateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
-static ModularPipelines.Liquibase.Extensions.LiquibaseExtensions.Liquibase(this ModularPipelines.IPipelineContext! context) -> ModularPipelines.Liquibase.Services.ILiquibase!
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions!
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Equals(object? obj) -> bool
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.GetHashCode() -> int
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.ToString() -> string!
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.<Clone>$() -> ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions!
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Equals(object? obj) -> bool
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.GetHashCode() -> int
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.ToString() -> string!
+override sealed ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
+override sealed ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseOptions? other) -> bool
+static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions? right) -> bool
+static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions? right) -> bool
+static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.operator !=(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions? right) -> bool
+static ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.operator ==(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions? left, ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions? right) -> bool
+virtual ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanOptions? other) -> bool
+virtual ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions.Equals(ModularPipelines.Liquibase.Options.LiquibaseMarkNextChangeSetRanSqlOptions? other) -> bool


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **liquibase** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Assembly/common`, `Liquibase`.

- Added APIs: 90
- Removed or changed APIs: 107
- Members with matching names but changed signatures: 2

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Lax = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Strict = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Debug = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Error = 4 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Silent = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode`

Representative added members:
- `ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Lax = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode.Strict = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseChangelogParseMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Debug = 0 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Error = 1 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode`
- `ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode.Silent = 3 -> ModularPipelines.Liquibase.Enums.LiquibaseDuplicateFileMode`

## Command coverage
Command coverage report:
- liquibase (5.0.3): 43 commands, tree 41e289cc33bbedcb50c94a7ac63a85c7d6ddacbd20208a60c02222e6d2d3c647
  - Baseline comparison: 43 commands at 5.0.3 -> 43 commands at 5.0.3

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator