### PR TITLE
[Automated] Update podman CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/podman.md
+++ b/docs/docs/mp-packages/cli/podman.md
@@ -186,7 +186,9 @@ var podman = context.Tools.Podman;
 | `podman machine list` | `PodmanMachineListOptions` |
 | `podman machine os` | `PodmanMachineOsOptions` |
 | `podman machine os apply` | `PodmanMachineOsApplyOptions` |
+| `podman machine os upgrade` | `PodmanMachineOsUpgradeOptions` |
 | `podman machine reset` | `PodmanMachineResetOptions` |
+| `podman machine restart` | `PodmanMachineRestartOptions` |
 | `podman machine rm` | `PodmanMachineRmOptions` |
 | `podman machine set` | `PodmanMachineSetOptions` |
 | `podman machine ssh` | `PodmanMachineSshOptions` |
@@ -286,6 +288,7 @@ var podman = context.Tools.Podman;
 | `podman volume ls` | `PodmanVolumeLsOptions` |
 | `podman volume mount` | `PodmanVolumeMountOptions` |
 | `podman volume prune` | `PodmanVolumePruneOptions` |
+| `podman volume rename` | `PodmanVolumeRenameOptions` |
 | `podman volume rm` | `PodmanVolumeRmOptions` |
 | `podman volume unmount` | `PodmanVolumeUnmountOptions` |
 | `podman wait` | `PodmanWaitOptions` |

--- a/src/ModularPipelines.Podman/Enums/PodmanComposeProgress.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanComposeProgress.Generated.cs
@@ -19,15 +19,15 @@ public enum PodmanComposeProgress
     [EnumValue("auto")]
     Auto,
 
-    [EnumValue("tty")]
-    Tty,
+    [EnumValue("json")]
+    Json,
 
     [EnumValue("plain")]
     Plain,
 
-    [EnumValue("json")]
-    Json,
-
     [EnumValue("quiet")]
-    Quiet
+    Quiet,
+
+    [EnumValue("tty")]
+    Tty
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanContainerCreateSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanContainerCreateSystemd.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Podman.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PodmanContainerCreateSystemd
 {
-    [EnumValue("true")]
-    True,
+    [EnumValue("always")]
+    Always,
 
     [EnumValue("false")]
     False,
 
-    [EnumValue("always")]
-    Always
+    [EnumValue("true")]
+    True
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanContainerRunSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanContainerRunSystemd.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Podman.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PodmanContainerRunSystemd
 {
-    [EnumValue("true")]
-    True,
+    [EnumValue("always")]
+    Always,
 
     [EnumValue("false")]
     False,
 
-    [EnumValue("always")]
-    Always
+    [EnumValue("true")]
+    True
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanCreateSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanCreateSystemd.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Podman.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PodmanCreateSystemd
 {
-    [EnumValue("true")]
-    True,
+    [EnumValue("always")]
+    Always,
 
     [EnumValue("false")]
     False,
 
-    [EnumValue("always")]
-    Always
+    [EnumValue("true")]
+    True
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanImagePushFormat.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanImagePushFormat.Generated.cs
@@ -19,9 +19,9 @@ public enum PodmanImagePushFormat
     [EnumValue("oci")]
     Oci,
 
-    [EnumValue("v2s2")]
-    V2S2,
-
     [EnumValue("v2s1")]
-    V2S1
+    V2S1,
+
+    [EnumValue("v2s2")]
+    V2S2
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanPushFormat.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanPushFormat.Generated.cs
@@ -19,9 +19,9 @@ public enum PodmanPushFormat
     [EnumValue("oci")]
     Oci,
 
-    [EnumValue("v2s2")]
-    V2S2,
-
     [EnumValue("v2s1")]
-    V2S1
+    V2S1,
+
+    [EnumValue("v2s2")]
+    V2S2
 }

--- a/src/ModularPipelines.Podman/Enums/PodmanRunSystemd.Generated.cs
+++ b/src/ModularPipelines.Podman/Enums/PodmanRunSystemd.Generated.cs
@@ -16,12 +16,12 @@ namespace ModularPipelines.Podman.Enums;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum PodmanRunSystemd
 {
-    [EnumValue("true")]
-    True,
+    [EnumValue("always")]
+    Always,
 
     [EnumValue("false")]
     False,
 
-    [EnumValue("always")]
-    Always
+    [EnumValue("true")]
+    True
 }

--- a/src/ModularPipelines.Podman/Generated/Podman.CommandCoverage.json
+++ b/src/ModularPipelines.Podman/Generated/Podman.CommandCoverage.json
@@ -1,9 +1,9 @@
 {
   "formatVersion": 1,
   "toolName": "podman",
-  "toolVersion": "podman version 5.8.4",
-  "commandCount": 255,
-  "commandTreeSha256": "fa3930718b1ecf476ed61035c75543dfacf4d2df669953615aff3c98925335e8",
+  "toolVersion": "podman version 6.1.1",
+  "commandCount": 258,
+  "commandTreeSha256": "1173613661b2e99570a995b22aeebec1e2ff1858aa1ea713d8f9cf737e06a14c",
   "commands": [
     "podman artifact",
     "podman artifact add",
@@ -157,7 +157,9 @@
     "podman machine list",
     "podman machine os",
     "podman machine os apply",
+    "podman machine os upgrade",
     "podman machine reset",
+    "podman machine restart",
     "podman machine rm",
     "podman machine set",
     "podman machine ssh",
@@ -257,6 +259,7 @@
     "podman volume ls",
     "podman volume mount",
     "podman volume prune",
+    "podman volume rename",
     "podman volume rm",
     "podman volume unmount",
     "podman wait"

--- a/src/ModularPipelines.Podman/Generated/Podman.Generation.json
+++ b/src/ModularPipelines.Podman/Generated/Podman.Generation.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "podman",
-  "toolVersion": "podman version 5.8.4",
-  "commandTreeSha256": "fa3930718b1ecf476ed61035c75543dfacf4d2df669953615aff3c98925335e8",
-  "generatorSourceSha256": "def6f7dcd95c0ad3f3902a39e707f5783b6610d1bd323bf9e9c3a0ea8d9a2d39"
+  "toolVersion": "podman version 6.1.1",
+  "commandTreeSha256": "1173613661b2e99570a995b22aeebec1e2ff1858aa1ea713d8f9cf737e06a14c",
+  "generatorSourceSha256": "9435538e33280f47f84c7e985e3f69f9c75cff48a94eb8a4fe2c1327f00edb6d"
 }

--- a/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
@@ -131,6 +131,18 @@ public record PodmanBuildOptions : PodmanOptions
     public bool? Compress { get; set; }
 
     /// <summary>
+    /// compression format to use for layers and cache
+    /// </summary>
+    [CliOption("--compression-format", Format = OptionFormat.EqualsSeparated)]
+    public string? CompressionFormat { get; set; }
+
+    /// <summary>
+    /// compression level to use for layers and cache
+    /// </summary>
+    [CliOption("--compression-level", Format = OptionFormat.EqualsSeparated)]
+    public int? CompressionLevel { get; set; }
+
+    /// <summary>
     /// set additional flag to pass to C preprocessor (cpp)
     /// </summary>
     [CliOption("--cpp-flag", Format = OptionFormat.EqualsSeparated)]
@@ -234,6 +246,12 @@ public record PodmanBuildOptions : PodmanOptions
     public IEnumerable<string>? Env { get; set; }
 
     /// <summary>
+    /// use the specified compression algorithm even if the destination contains a differently-compressed variant already
+    /// </summary>
+    [CliFlag("--force-compression")]
+    public bool? ForceCompression { get; set; }
+
+    /// <summary>
     /// always remove intermediate containers after a build, even if the build is unsuccessful. (default true)
     /// </summary>
     [CliOption("--force-rm", Format = OptionFormat.EqualsSeparated)]
@@ -286,6 +304,12 @@ public record PodmanBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--iidfile", Format = OptionFormat.EqualsSeparated)]
     public string? Iidfile { get; set; }
+
+    /// <summary>
+    /// file to write the image ID to (without algorithm prefix)
+    /// </summary>
+    [CliOption("--iidfile-raw", Format = OptionFormat.EqualsSeparated)]
+    public string? IidfileRaw { get; set; }
 
     /// <summary>
     /// inherit the annotations from the base image or base stages. (default true)
@@ -364,6 +388,18 @@ public record PodmanBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--memory-swap", Format = OptionFormat.EqualsSeparated)]
     public string? MemorySwap { get; set; }
+
+    /// <summary>
+    /// file to write metadata about the image to
+    /// </summary>
+    [CliOption("--metadata-file", Format = OptionFormat.EqualsSeparated)]
+    public string? MetadataFile { get; set; }
+
+    /// <summary>
+    /// set transient mounts for each RUN instruction, e.g. type=secret,id=mysecret
+    /// </summary>
+    [CliOption("--mount", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? Mount { get; set; }
 
     /// <summary>
     /// 'private', 'none', 'ns:path' of network namespace to join, or 'host'
@@ -474,6 +510,12 @@ public record PodmanBuildOptions : PodmanOptions
     public IEnumerable<string>? RuntimeFlag { get; set; }
 
     /// <summary>
+    /// save intermediate stage images.
+    /// </summary>
+    [CliFlag("--save-stages")]
+    public bool? SaveStages { get; set; }
+
+    /// <summary>
     /// scan working container using preset configuration
     /// </summary>
     [CliOption("--sbom", Format = OptionFormat.EqualsSeparated)]
@@ -559,6 +601,12 @@ public record PodmanBuildOptions : PodmanOptions
     public string? SourceDateEpoch { get; set; }
 
     /// <summary>
+    /// pathname of source policy file for controlling source references during build
+    /// </summary>
+    [CliOption("--source-policy-file", Format = OptionFormat.EqualsSeparated)]
+    public string? SourcePolicyFile { get; set; }
+
+    /// <summary>
     /// squash all image layers into a single layer
     /// </summary>
     [CliFlag("--squash")]
@@ -575,6 +623,12 @@ public record PodmanBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }
+
+    /// <summary>
+    /// add metadata labels to intermediate stage images (requires --save-stages).
+    /// </summary>
+    [CliFlag("--stage-labels")]
+    public bool? StageLabels { get; set; }
 
     /// <summary>
     /// pass stdin into containers

--- a/src/ModularPipelines.Podman/Options/PodmanCommitOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanCommitOptions.Generated.cs
@@ -65,9 +65,9 @@ public record PodmanCommitOptions(
     public string? Message { get; set; }
 
     /// <summary>
-    /// Pause container during commit
+    /// Pause container during commit (default true)
     /// </summary>
-    [CliFlag("--pause", ShortForm = "-p")]
+    [CliOption("--pause", ShortForm = "-p", Format = OptionFormat.EqualsSeparated)]
     public bool? Pause { get; set; }
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Options/PodmanComposeBridgeConvertOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanComposeBridgeConvertOptions.Generated.cs
@@ -39,7 +39,7 @@ public record PodmanComposeBridgeConvertOptions : PodmanOptions
     public string? Templates { get; set; }
 
     /// <summary>
-    /// Transformation to apply to compose
+    /// Transformation to apply to compose model (default: docker/compose-bridge-kubernetes)
     /// </summary>
     [CliOption("--transformation", ShortForm = "-t", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Transformation { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanComposeCpOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanComposeCpOptions.Generated.cs
@@ -13,7 +13,7 @@ using ModularPipelines.Podman.Options;
 namespace ModularPipelines.Podman.Options;
 
 /// <summary>
-/// podman compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+/// Copy files/folders between a service container and the local filesystem
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.Podman/Options/PodmanComposeUpOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanComposeUpOptions.Generated.cs
@@ -69,7 +69,7 @@ public record PodmanComposeUpOptions : PodmanOptions
     public bool? DryRun { get; set; }
 
     /// <summary>
-    /// Return the exit code of the selected service container. Implies
+    /// Return the exit code of the selected service container. Implies --abort-on-container-exit
     /// </summary>
     [CliOption("--exit-code-from", Format = OptionFormat.EqualsSeparated)]
     public string? ExitCodeFrom { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerCommitOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerCommitOptions.Generated.cs
@@ -65,9 +65,9 @@ public record PodmanContainerCommitOptions(
     public string? Message { get; set; }
 
     /// <summary>
-    /// Pause container during commit
+    /// Pause container during commit (default true)
     /// </summary>
-    [CliFlag("--pause", ShortForm = "-p")]
+    [CliOption("--pause", ShortForm = "-p", Format = OptionFormat.EqualsSeparated)]
     public bool? Pause { get; set; }
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Options/PodmanContainerCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerCreateOptions.Generated.cs
@@ -479,7 +479,7 @@ public record PodmanContainerCreateOptions(
     public IEnumerable<string>? LabelFile { get; set; }
 
     /// <summary>
-    /// Logging driver for the container (default "k8s-file")
+    /// Logging driver for the container (default "journald")
     /// </summary>
     [CliOption("--log-driver", Format = OptionFormat.EqualsSeparated)]
     public string? LogDriver { get; set; }
@@ -605,7 +605,7 @@ public record PodmanContainerCreateOptions(
     public string? Pidfile { get; set; }
 
     /// <summary>
-    /// Tune container pids limit (set -1 for unlimited)
+    /// Tune container pids limit (set -1 for unlimited) (default 2048)
     /// </summary>
     [CliOption("--pids-limit", Format = OptionFormat.EqualsSeparated)]
     public int? PidsLimit { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerInitOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerInitOptions.Generated.cs
@@ -29,7 +29,7 @@ public record PodmanContainerInitOptions(
     public bool? All { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerPortOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerPortOptions.Generated.cs
@@ -29,7 +29,7 @@ public record PodmanContainerPortOptions(
     public bool? All { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerRunOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerRunOptions.Generated.cs
@@ -485,7 +485,7 @@ public record PodmanContainerRunOptions(
     public IEnumerable<string>? LabelFile { get; set; }
 
     /// <summary>
-    /// Logging driver for the container (default "k8s-file")
+    /// Logging driver for the container (default "journald")
     /// </summary>
     [CliOption("--log-driver", Format = OptionFormat.EqualsSeparated)]
     public string? LogDriver { get; set; }
@@ -617,7 +617,7 @@ public record PodmanContainerRunOptions(
     public string? Pidfile { get; set; }
 
     /// <summary>
-    /// Tune container pids limit (set -1 for unlimited)
+    /// Tune container pids limit (set -1 for unlimited) (default 2048)
     /// </summary>
     [CliOption("--pids-limit", Format = OptionFormat.EqualsSeparated)]
     public int? PidsLimit { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerTopOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerTopOptions.Generated.cs
@@ -23,7 +23,7 @@ public record PodmanContainerTopOptions(
 ) : PodmanOptions
 {
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerUnmountOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerUnmountOptions.Generated.cs
@@ -35,7 +35,7 @@ public record PodmanContainerUnmountOptions(
     public bool? Force { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanContainerUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerUpdateOptions.Generated.cs
@@ -233,7 +233,7 @@ public record PodmanContainerUpdateOptions(
     public bool? NoHealthcheck { get; set; }
 
     /// <summary>
-    /// Tune container pids limit (set -1 for unlimited)
+    /// Tune container pids limit (set -1 for unlimited) (default 2048)
     /// </summary>
     [CliOption("--pids-limit", Format = OptionFormat.EqualsSeparated)]
     public int? PidsLimit { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanCreateOptions.Generated.cs
@@ -479,7 +479,7 @@ public record PodmanCreateOptions(
     public IEnumerable<string>? LabelFile { get; set; }
 
     /// <summary>
-    /// Logging driver for the container (default "k8s-file")
+    /// Logging driver for the container (default "journald")
     /// </summary>
     [CliOption("--log-driver", Format = OptionFormat.EqualsSeparated)]
     public string? LogDriver { get; set; }
@@ -605,7 +605,7 @@ public record PodmanCreateOptions(
     public string? Pidfile { get; set; }
 
     /// <summary>
-    /// Tune container pids limit (set -1 for unlimited)
+    /// Tune container pids limit (set -1 for unlimited) (default 2048)
     /// </summary>
     [CliOption("--pids-limit", Format = OptionFormat.EqualsSeparated)]
     public int? PidsLimit { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
@@ -119,6 +119,18 @@ public record PodmanFarmBuildOptions : PodmanOptions
     public bool? CompatVolumes { get; set; }
 
     /// <summary>
+    /// compression format to use for layers and cache
+    /// </summary>
+    [CliOption("--compression-format", Format = OptionFormat.EqualsSeparated)]
+    public string? CompressionFormat { get; set; }
+
+    /// <summary>
+    /// compression level to use for layers and cache
+    /// </summary>
+    [CliOption("--compression-level", Format = OptionFormat.EqualsSeparated)]
+    public int? CompressionLevel { get; set; }
+
+    /// <summary>
     /// set additional flag to pass to C preprocessor (cpp)
     /// </summary>
     [CliOption("--cpp-flag", Format = OptionFormat.EqualsSeparated)]
@@ -216,6 +228,12 @@ public record PodmanFarmBuildOptions : PodmanOptions
     public string? Farm { get; set; }
 
     /// <summary>
+    /// use the specified compression algorithm even if the destination contains a differently-compressed variant already
+    /// </summary>
+    [CliFlag("--force-compression")]
+    public bool? ForceCompression { get; set; }
+
+    /// <summary>
     /// always remove intermediate containers after a build, even if the build is unsuccessful. (default true)
     /// </summary>
     [CliOption("--force-rm", Format = OptionFormat.EqualsSeparated)]
@@ -268,6 +286,12 @@ public record PodmanFarmBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--iidfile", Format = OptionFormat.EqualsSeparated)]
     public string? Iidfile { get; set; }
+
+    /// <summary>
+    /// file to write the image ID to (without algorithm prefix)
+    /// </summary>
+    [CliOption("--iidfile-raw", Format = OptionFormat.EqualsSeparated)]
+    public string? IidfileRaw { get; set; }
 
     /// <summary>
     /// inherit the annotations from the base image or base stages. (default true)
@@ -340,6 +364,12 @@ public record PodmanFarmBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--memory-swap", Format = OptionFormat.EqualsSeparated)]
     public string? MemorySwap { get; set; }
+
+    /// <summary>
+    /// set transient mounts for each RUN instruction, e.g. type=secret,id=mysecret
+    /// </summary>
+    [CliOption("--mount", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? Mount { get; set; }
 
     /// <summary>
     /// 'private', 'none', 'ns:path' of network namespace to join, or 'host'
@@ -438,6 +468,12 @@ public record PodmanFarmBuildOptions : PodmanOptions
     public IEnumerable<string>? RuntimeFlag { get; set; }
 
     /// <summary>
+    /// save intermediate stage images.
+    /// </summary>
+    [CliFlag("--save-stages")]
+    public bool? SaveStages { get; set; }
+
+    /// <summary>
     /// scan working container using preset configuration
     /// </summary>
     [CliOption("--sbom", Format = OptionFormat.EqualsSeparated)]
@@ -517,6 +553,12 @@ public record PodmanFarmBuildOptions : PodmanOptions
     public string? SourceDateEpoch { get; set; }
 
     /// <summary>
+    /// pathname of source policy file for controlling source references during build
+    /// </summary>
+    [CliOption("--source-policy-file", Format = OptionFormat.EqualsSeparated)]
+    public string? SourcePolicyFile { get; set; }
+
+    /// <summary>
     /// squash all image layers into a single layer
     /// </summary>
     [CliFlag("--squash")]
@@ -533,6 +575,12 @@ public record PodmanFarmBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }
+
+    /// <summary>
+    /// add metadata labels to intermediate stage images (requires --save-stages).
+    /// </summary>
+    [CliFlag("--stage-labels")]
+    public bool? StageLabels { get; set; }
 
     /// <summary>
     /// tagged name to apply to the built image

--- a/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
@@ -131,6 +131,18 @@ public record PodmanImageBuildOptions : PodmanOptions
     public bool? Compress { get; set; }
 
     /// <summary>
+    /// compression format to use for layers and cache
+    /// </summary>
+    [CliOption("--compression-format", Format = OptionFormat.EqualsSeparated)]
+    public string? CompressionFormat { get; set; }
+
+    /// <summary>
+    /// compression level to use for layers and cache
+    /// </summary>
+    [CliOption("--compression-level", Format = OptionFormat.EqualsSeparated)]
+    public int? CompressionLevel { get; set; }
+
+    /// <summary>
     /// set additional flag to pass to C preprocessor (cpp)
     /// </summary>
     [CliOption("--cpp-flag", Format = OptionFormat.EqualsSeparated)]
@@ -234,6 +246,12 @@ public record PodmanImageBuildOptions : PodmanOptions
     public IEnumerable<string>? Env { get; set; }
 
     /// <summary>
+    /// use the specified compression algorithm even if the destination contains a differently-compressed variant already
+    /// </summary>
+    [CliFlag("--force-compression")]
+    public bool? ForceCompression { get; set; }
+
+    /// <summary>
     /// always remove intermediate containers after a build, even if the build is unsuccessful. (default true)
     /// </summary>
     [CliOption("--force-rm", Format = OptionFormat.EqualsSeparated)]
@@ -286,6 +304,12 @@ public record PodmanImageBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--iidfile", Format = OptionFormat.EqualsSeparated)]
     public string? Iidfile { get; set; }
+
+    /// <summary>
+    /// file to write the image ID to (without algorithm prefix)
+    /// </summary>
+    [CliOption("--iidfile-raw", Format = OptionFormat.EqualsSeparated)]
+    public string? IidfileRaw { get; set; }
 
     /// <summary>
     /// inherit the annotations from the base image or base stages. (default true)
@@ -364,6 +388,18 @@ public record PodmanImageBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--memory-swap", Format = OptionFormat.EqualsSeparated)]
     public string? MemorySwap { get; set; }
+
+    /// <summary>
+    /// file to write metadata about the image to
+    /// </summary>
+    [CliOption("--metadata-file", Format = OptionFormat.EqualsSeparated)]
+    public string? MetadataFile { get; set; }
+
+    /// <summary>
+    /// set transient mounts for each RUN instruction, e.g. type=secret,id=mysecret
+    /// </summary>
+    [CliOption("--mount", Format = OptionFormat.EqualsSeparated)]
+    public IEnumerable<string>? Mount { get; set; }
 
     /// <summary>
     /// 'private', 'none', 'ns:path' of network namespace to join, or 'host'
@@ -474,6 +510,12 @@ public record PodmanImageBuildOptions : PodmanOptions
     public IEnumerable<string>? RuntimeFlag { get; set; }
 
     /// <summary>
+    /// save intermediate stage images.
+    /// </summary>
+    [CliFlag("--save-stages")]
+    public bool? SaveStages { get; set; }
+
+    /// <summary>
     /// scan working container using preset configuration
     /// </summary>
     [CliOption("--sbom", Format = OptionFormat.EqualsSeparated)]
@@ -559,6 +601,12 @@ public record PodmanImageBuildOptions : PodmanOptions
     public string? SourceDateEpoch { get; set; }
 
     /// <summary>
+    /// pathname of source policy file for controlling source references during build
+    /// </summary>
+    [CliOption("--source-policy-file", Format = OptionFormat.EqualsSeparated)]
+    public string? SourcePolicyFile { get; set; }
+
+    /// <summary>
     /// squash all image layers into a single layer
     /// </summary>
     [CliFlag("--squash")]
@@ -575,6 +623,12 @@ public record PodmanImageBuildOptions : PodmanOptions
     /// </summary>
     [CliOption("--ssh", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Ssh { get; set; }
+
+    /// <summary>
+    /// add metadata labels to intermediate stage images (requires --save-stages).
+    /// </summary>
+    [CliFlag("--stage-labels")]
+    public bool? StageLabels { get; set; }
 
     /// <summary>
     /// pass stdin into containers

--- a/src/ModularPipelines.Podman/Options/PodmanImageTrustSetOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageTrustSetOptions.Generated.cs
@@ -29,6 +29,12 @@ public record PodmanImageTrustSetOptions(
     public IEnumerable<string>? Pubkeysfile { get; set; }
 
     /// <summary>
+    /// Path to a signature-policy file
+    /// </summary>
+    [CliOption("--signature-policy", Format = OptionFormat.EqualsSeparated)]
+    public string? SignaturePolicy { get; set; }
+
+    /// <summary>
     /// Trust type, accept values: signedBy(default), accept, reject (default "signedBy")
     /// </summary>
     [CliOption("--type", ShortForm = "-t", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Podman/Options/PodmanImageTrustShowOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageTrustShowOptions.Generated.cs
@@ -39,6 +39,12 @@ public record PodmanImageTrustShowOptions : PodmanOptions
     public bool? Raw { get; set; }
 
     /// <summary>
+    /// Path to a signature-policy file
+    /// </summary>
+    [CliOption("--signature-policy", Format = OptionFormat.EqualsSeparated)]
+    public string? SignaturePolicy { get; set; }
+
+    /// <summary>
     /// The REGISTRY operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]

--- a/src/ModularPipelines.Podman/Options/PodmanKubePlayOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanKubePlayOptions.Generated.cs
@@ -79,7 +79,7 @@ public record PodmanKubePlayOptions(
     public string? Ip { get; set; }
 
     /// <summary>
-    /// Logging driver for the container (default "k8s-file")
+    /// Logging driver for the container (default "journald")
     /// </summary>
     [CliOption("--log-driver", Format = OptionFormat.EqualsSeparated)]
     public string? LogDriver { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineInitOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineInitOptions.Generated.cs
@@ -39,10 +39,16 @@ public record PodmanMachineInitOptions : PodmanOptions
     public string? IgnitionPath { get; set; }
 
     /// <summary>
-    /// Bootable image for machine
+    /// Bootable image for machine (default "docker://quay.io/podman/machine-os")
     /// </summary>
     [CliOption("--image", Format = OptionFormat.EqualsSeparated)]
     public string? Image { get; set; }
+
+    /// <summary>
+    /// Import the host trusted CA certificates into the machine
+    /// </summary>
+    [CliFlag("--import-native-ca")]
+    public bool? ImportNativeCa { get; set; }
 
     /// <summary>
     /// Memory in MiB (default 2048)
@@ -61,6 +67,12 @@ public record PodmanMachineInitOptions : PodmanOptions
     /// </summary>
     [CliOption("--playbook", Format = OptionFormat.EqualsSeparated)]
     public string? Playbook { get; set; }
+
+    /// <summary>
+    /// Override the default machine provider
+    /// </summary>
+    [CliOption("--provider", Format = OptionFormat.EqualsSeparated)]
+    public string? Provider { get; set; }
 
     /// <summary>
     /// Whether this machine should prefer rootful container execution
@@ -87,6 +99,12 @@ public record PodmanMachineInitOptions : PodmanOptions
     public bool? TlsVerify { get; set; }
 
     /// <summary>
+    /// Set default system connection for this machine
+    /// </summary>
+    [CliFlag("--update-connection", ShortForm = "-u")]
+    public bool? UpdateConnection { get; set; }
+
+    /// <summary>
     /// USB Host passthrough: bus=$1,devnum=$2 or vendor=$1,product=$2
     /// </summary>
     [CliOption("--usb", Format = OptionFormat.EqualsSeparated)]
@@ -105,7 +123,7 @@ public record PodmanMachineInitOptions : PodmanOptions
     public string? Username { get; set; }
 
     /// <summary>
-    /// Volumes to mount, source:target (default [$HOME:$HOME])
+    /// Volumes to mount, source:target (default [$HOME:$HOME,~/.config/containers:/etc/containers])
     /// </summary>
     [CliOption("--volume", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Volume { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineListOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineListOptions.Generated.cs
@@ -21,12 +21,6 @@ namespace ModularPipelines.Podman.Options;
 public record PodmanMachineListOptions : PodmanOptions
 {
     /// <summary>
-    /// Show machines from all providers
-    /// </summary>
-    [CliFlag("--all-providers")]
-    public bool? AllProviders { get; set; }
-
-    /// <summary>
     /// Format volume output using JSON or a Go template (default "{{range .}}{{.Name}}\t{{.VMType}}\t{{.Created}}\t{{.LastUp}}\t{{.CPUs}}\t{{.Memory}}\t{{.DiskSize}}\n{{end -}}")
     /// </summary>
     [CliOption("--format", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Podman/Options/PodmanMachineOsApplyOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineOsApplyOptions.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Podman.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("machine", "os", "apply")]
 public record PodmanMachineOsApplyOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Image
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Uri
 ) : PodmanOptions
 {
     /// <summary>
@@ -29,9 +29,9 @@ public record PodmanMachineOsApplyOptions(
     public bool? Restart { get; set; }
 
     /// <summary>
-    /// The NAME operand.
+    /// The MACHINE operand.
     /// </summary>
     [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
-    public string? Name { get; set; }
+    public string? Machine { get; set; }
 
 }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineOsUpgradeOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineOsUpgradeOptions.Generated.cs
@@ -13,29 +13,35 @@ using ModularPipelines.Podman.Options;
 namespace ModularPipelines.Podman.Options;
 
 /// <summary>
-/// Reload firewall rules for one or more containers
+/// Upgrade machine os
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("network", "reload")]
-public record PodmanNetworkReloadOptions : PodmanOptions
+[CliSubCommand("machine", "os", "upgrade")]
+public record PodmanMachineOsUpgradeOptions : PodmanOptions
 {
     /// <summary>
-    /// Reload network configuration of all containers
+    /// Only check if an upgrade is available
     /// </summary>
-    [CliFlag("--all", ShortForm = "-a")]
-    public bool? All { get; set; }
+    [CliFlag("--dry-run", ShortForm = "-n")]
+    public bool? DryRun { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
+    /// suppress output except for specified format. Implies -n
     /// </summary>
-    [CliFlag("--latest", ShortForm = "-l")]
-    public bool? Latest { get; set; }
+    [CliOption("--format", ShortForm = "-f", Format = OptionFormat.EqualsSeparated)]
+    public string? Format { get; set; }
 
     /// <summary>
-    /// The CONTAINER operand.
+    /// Restart VM to upgrade
+    /// </summary>
+    [CliFlag("--restart")]
+    public bool? Restart { get; set; }
+
+    /// <summary>
+    /// The NAME operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Container { get; set; }
+    public string? Name { get; set; }
 
 }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineRestartOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineRestartOptions.Generated.cs
@@ -13,25 +13,29 @@ using ModularPipelines.Podman.Options;
 namespace ModularPipelines.Podman.Options;
 
 /// <summary>
-/// Initialize one or more containers
+/// Restart an existing machine
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("init")]
-public record PodmanInitOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Container
-) : PodmanOptions
+[CliSubCommand("machine", "restart")]
+public record PodmanMachineRestartOptions : PodmanOptions
 {
     /// <summary>
-    /// Initialize all containers
+    /// Suppress informational tips
     /// </summary>
-    [CliFlag("--all", ShortForm = "-a")]
-    public bool? All { get; set; }
+    [CliFlag("--no-info")]
+    public bool? NoInfo { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
+    /// Suppress machine restarting status output
     /// </summary>
-    [CliFlag("--latest", ShortForm = "-l")]
-    public bool? Latest { get; set; }
+    [CliFlag("--quiet", ShortForm = "-q")]
+    public bool? Quiet { get; set; }
+
+    /// <summary>
+    /// The MACHINE operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? Machine { get; set; }
 
 }

--- a/src/ModularPipelines.Podman/Options/PodmanMachineSetOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineSetOptions.Generated.cs
@@ -33,6 +33,12 @@ public record PodmanMachineSetOptions : PodmanOptions
     public int? DiskSize { get; set; }
 
     /// <summary>
+    /// Import the host trusted CA certificates into the machine
+    /// </summary>
+    [CliFlag("--import-native-ca")]
+    public bool? ImportNativeCa { get; set; }
+
+    /// <summary>
     /// Memory in MiB
     /// </summary>
     [CliOption("--memory", ShortForm = "-m", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Podman/Options/PodmanMachineStartOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanMachineStartOptions.Generated.cs
@@ -33,6 +33,12 @@ public record PodmanMachineStartOptions : PodmanOptions
     public bool? Quiet { get; set; }
 
     /// <summary>
+    /// Set default system connection for this machine
+    /// </summary>
+    [CliFlag("--update-connection", ShortForm = "-u")]
+    public bool? UpdateConnection { get; set; }
+
+    /// <summary>
     /// The MACHINE operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]

--- a/src/ModularPipelines.Podman/Options/PodmanManifestPushOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanManifestPushOptions.Generated.cs
@@ -98,6 +98,18 @@ public record PodmanManifestPushOptions(
     public bool? RemoveSignatures { get; set; }
 
     /// <summary>
+    /// number of times to retry in case of failure when performing push (default 3)
+    /// </summary>
+    [CliOption("--retry", Format = OptionFormat.EqualsSeparated)]
+    public int? Retry { get; set; }
+
+    /// <summary>
+    /// delay between retries in case of push failures
+    /// </summary>
+    [CliOption("--retry-delay", Format = OptionFormat.EqualsSeparated)]
+    public string? RetryDelay { get; set; }
+
+    /// <summary>
     /// remove the manifest list if push succeeds
     /// </summary>
     [CliFlag("--rm")]

--- a/src/ModularPipelines.Podman/Options/PodmanNetworkCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanNetworkCreateOptions.Generated.cs
@@ -93,7 +93,7 @@ public record PodmanNetworkCreateOptions : PodmanOptions
     public IEnumerable<string>? Opt { get; set; }
 
     /// <summary>
-    /// static routes
+    /// Static routes for this network. Format: &lt;destination&gt;,&lt;gateway&gt;[,&lt;metric&gt;] or &lt;destination&gt;,&lt;type&gt;[,&lt;metric&gt;] where type is blackhole, unreachable, or prohibit
     /// </summary>
     [CliOption("--route", Format = OptionFormat.EqualsSeparated)]
     public IEnumerable<string>? Route { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanNetworkRmOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanNetworkRmOptions.Generated.cs
@@ -29,6 +29,12 @@ public record PodmanNetworkRmOptions(
     public bool? Force { get; set; }
 
     /// <summary>
+    /// ignore if a specified network does not exist
+    /// </summary>
+    [CliFlag("--ignore", ShortForm = "-i")]
+    public bool? Ignore { get; set; }
+
+    /// <summary>
     /// Seconds to wait for running containers to stop before killing the container (default 10)
     /// </summary>
     [CliOption("--time", ShortForm = "-t", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Podman/Options/PodmanPodPauseOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPodPauseOptions.Generated.cs
@@ -29,7 +29,7 @@ public record PodmanPodPauseOptions(
     public bool? All { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanPodPsOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPodPsOptions.Generated.cs
@@ -13,7 +13,7 @@ using ModularPipelines.Podman.Options;
 namespace ModularPipelines.Podman.Options;
 
 /// <summary>
-/// List all pods on system including their names, ids and current state.
+/// List pods
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]

--- a/src/ModularPipelines.Podman/Options/PodmanPodRestartOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPodRestartOptions.Generated.cs
@@ -29,7 +29,7 @@ public record PodmanPodRestartOptions(
     public bool? All { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanPodTopOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPodTopOptions.Generated.cs
@@ -23,7 +23,7 @@ public record PodmanPodTopOptions(
 ) : PodmanOptions
 {
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanPodUnpauseOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPodUnpauseOptions.Generated.cs
@@ -29,7 +29,7 @@ public record PodmanPodUnpauseOptions(
     public bool? All { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanPortOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPortOptions.Generated.cs
@@ -29,7 +29,7 @@ public record PodmanPortOptions(
     public bool? All { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanQuadletInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanQuadletInstallOptions.Generated.cs
@@ -23,6 +23,12 @@ public record PodmanQuadletInstallOptions(
 ) : PodmanOptions
 {
     /// <summary>
+    /// Group quadlets and associated file in a directory named after the application
+    /// </summary>
+    [CliOption("--application", Format = OptionFormat.EqualsSeparated)]
+    public string? Application { get; set; }
+
+    /// <summary>
     /// Reload systemd after installing Quadlets (default true)
     /// </summary>
     [CliOption("--reload-systemd", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Podman/Options/PodmanQuadletListOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanQuadletListOptions.Generated.cs
@@ -27,9 +27,15 @@ public record PodmanQuadletListOptions : PodmanOptions
     public IEnumerable<string>? Filter { get; set; }
 
     /// <summary>
-    /// Pretty-print output to JSON or using a Go template (default "{{range .}}{{.Name}}\t{{.UnitName}}\t{{.Path}}\t{{.Status}}\t{{.App}}\n{{end -}}")
+    /// Pretty-print output to JSON or using a Go template (default "{{range .}}{{.Name}}\t{{.UnitName}}\t{{.Path}}\t{{.Status}}\t{{.App}}\t{{.Pod}}\n{{end -}}")
     /// </summary>
     [CliOption("--format", Format = OptionFormat.EqualsSeparated)]
     public string? Format { get; set; }
+
+    /// <summary>
+    /// Do not print headers
+    /// </summary>
+    [CliFlag("--noheading", ShortForm = "-n")]
+    public bool? Noheading { get; set; }
 
 }

--- a/src/ModularPipelines.Podman/Options/PodmanQuadletRmOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanQuadletRmOptions.Generated.cs
@@ -39,6 +39,12 @@ public record PodmanQuadletRmOptions : PodmanOptions
     public bool? Ignore { get; set; }
 
     /// <summary>
+    /// Remove all Quadlets belonging to the specified application and its directory
+    /// </summary>
+    [CliFlag("--recursive")]
+    public bool? Recursive { get; set; }
+
+    /// <summary>
     /// Reload systemd after removal (default true)
     /// </summary>
     [CliOption("--reload-systemd", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Podman/Options/PodmanRunOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanRunOptions.Generated.cs
@@ -485,7 +485,7 @@ public record PodmanRunOptions(
     public IEnumerable<string>? LabelFile { get; set; }
 
     /// <summary>
-    /// Logging driver for the container (default "k8s-file")
+    /// Logging driver for the container (default "journald")
     /// </summary>
     [CliOption("--log-driver", Format = OptionFormat.EqualsSeparated)]
     public string? LogDriver { get; set; }
@@ -617,7 +617,7 @@ public record PodmanRunOptions(
     public string? Pidfile { get; set; }
 
     /// <summary>
-    /// Tune container pids limit (set -1 for unlimited)
+    /// Tune container pids limit (set -1 for unlimited) (default 2048)
     /// </summary>
     [CliOption("--pids-limit", Format = OptionFormat.EqualsSeparated)]
     public int? PidsLimit { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanTopOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanTopOptions.Generated.cs
@@ -23,7 +23,7 @@ public record PodmanTopOptions(
 ) : PodmanOptions
 {
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanUnmountOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanUnmountOptions.Generated.cs
@@ -35,7 +35,7 @@ public record PodmanUnmountOptions(
     public bool? Force { get; set; }
 
     /// <summary>
-    /// Act on the latest container podman is aware of
+    /// Act on the latest container podman is aware of Not supported with the "--remote" flag
     /// </summary>
     [CliFlag("--latest", ShortForm = "-l")]
     public bool? Latest { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanUnshareOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanUnshareOptions.Generated.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Podman.Options;
 public record PodmanUnshareOptions : PodmanOptions
 {
     /// <summary>
-    /// Join the rootless network namespace used for CNI and netavark networking
+    /// Join the rootless network namespace used for netavark networking
     /// </summary>
     [CliFlag("--rootless-netns")]
     public bool? RootlessNetns { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanUpdateOptions.Generated.cs
@@ -233,7 +233,7 @@ public record PodmanUpdateOptions(
     public bool? NoHealthcheck { get; set; }
 
     /// <summary>
-    /// Tune container pids limit (set -1 for unlimited)
+    /// Tune container pids limit (set -1 for unlimited) (default 2048)
     /// </summary>
     [CliOption("--pids-limit", Format = OptionFormat.EqualsSeparated)]
     public int? PidsLimit { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanVolumePruneOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanVolumePruneOptions.Generated.cs
@@ -13,13 +13,25 @@ using ModularPipelines.Podman.Options;
 namespace ModularPipelines.Podman.Options;
 
 /// <summary>
-/// Remove all unused volumes
+/// Remove unused volumes
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("volume", "prune")]
 public record PodmanVolumePruneOptions : PodmanOptions
 {
+    /// <summary>
+    /// Remove all unused volumes, both anonymous and named
+    /// </summary>
+    [CliFlag("--all", ShortForm = "-a")]
+    public bool? All { get; set; }
+
+    /// <summary>
+    /// Show what would be pruned without actually pruning
+    /// </summary>
+    [CliFlag("--dry-run")]
+    public bool? DryRun { get; set; }
+
     /// <summary>
     /// Provide filter values (e.g. 'label=&lt;key&gt;=&lt;value&gt;')
     /// </summary>

--- a/src/ModularPipelines.Podman/Options/PodmanVolumeRenameOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanVolumeRenameOptions.Generated.cs
@@ -13,19 +13,14 @@ using ModularPipelines.Podman.Options;
 namespace ModularPipelines.Podman.Options;
 
 /// <summary>
-/// Run the health check of a container
+/// Rename a volume
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("healthcheck", "run")]
-public record PodmanHealthcheckRunOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Container
+[CliSubCommand("volume", "rename")]
+public record PodmanVolumeRenameOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Volume,
+    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Newname
 ) : PodmanOptions
 {
-    /// <summary>
-    /// Exit with code 0 regardless of healthcheck result or if the container is still in startup period
-    /// </summary>
-    [CliFlag("--ignore-result")]
-    public bool? IgnoreResult { get; set; }
-
 }

--- a/src/ModularPipelines.Podman/PublicAPI.Shipped.txt
+++ b/src/ModularPipelines.Podman/PublicAPI.Shipped.txt
@@ -4,34 +4,19 @@ ModularPipelines.Context.ModularPipelines_Podman_d124988c81134c6bToolsExtensions
 ModularPipelines.Context.ModularPipelines_Podman_d124988c81134c6bToolsExtensions.extension(ModularPipelines.Context.IToolsContext!).Podman.get -> ModularPipelines.Podman.Services.IPodman!
 ModularPipelines.Podman.Enums.PodmanComposeProgress
 ModularPipelines.Podman.Enums.PodmanComposeProgress.Auto = 0 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
-ModularPipelines.Podman.Enums.PodmanComposeProgress.Json = 3 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
 ModularPipelines.Podman.Enums.PodmanComposeProgress.Plain = 2 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
-ModularPipelines.Podman.Enums.PodmanComposeProgress.Quiet = 4 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
-ModularPipelines.Podman.Enums.PodmanComposeProgress.Tty = 1 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
 ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
-ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
 ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.False = 1 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
-ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
 ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
-ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
 ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.False = 1 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
-ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
 ModularPipelines.Podman.Enums.PodmanCreateSystemd
-ModularPipelines.Podman.Enums.PodmanCreateSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
 ModularPipelines.Podman.Enums.PodmanCreateSystemd.False = 1 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
-ModularPipelines.Podman.Enums.PodmanCreateSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
 ModularPipelines.Podman.Enums.PodmanImagePushFormat
 ModularPipelines.Podman.Enums.PodmanImagePushFormat.Oci = 0 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
-ModularPipelines.Podman.Enums.PodmanImagePushFormat.V2S1 = 2 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
-ModularPipelines.Podman.Enums.PodmanImagePushFormat.V2S2 = 1 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
 ModularPipelines.Podman.Enums.PodmanPushFormat
 ModularPipelines.Podman.Enums.PodmanPushFormat.Oci = 0 -> ModularPipelines.Podman.Enums.PodmanPushFormat
-ModularPipelines.Podman.Enums.PodmanPushFormat.V2S1 = 2 -> ModularPipelines.Podman.Enums.PodmanPushFormat
-ModularPipelines.Podman.Enums.PodmanPushFormat.V2S2 = 1 -> ModularPipelines.Podman.Enums.PodmanPushFormat
 ModularPipelines.Podman.Enums.PodmanRunSystemd
-ModularPipelines.Podman.Enums.PodmanRunSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
 ModularPipelines.Podman.Enums.PodmanRunSystemd.False = 1 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
-ModularPipelines.Podman.Enums.PodmanRunSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
 ModularPipelines.Podman.Extensions.PodmanExtensions
 ModularPipelines.Podman.Options.PodmanArtifactAddOptions
 ModularPipelines.Podman.Options.PodmanArtifactAddOptions.Annotation.get -> string?
@@ -3951,8 +3936,6 @@ ModularPipelines.Podman.Options.PodmanMachineInspectOptions.Machine.set -> void
 ModularPipelines.Podman.Options.PodmanMachineInspectOptions.PodmanMachineInspectOptions() -> void
 ModularPipelines.Podman.Options.PodmanMachineInspectOptions.PodmanMachineInspectOptions(ModularPipelines.Podman.Options.PodmanMachineInspectOptions! original) -> void
 ModularPipelines.Podman.Options.PodmanMachineListOptions
-ModularPipelines.Podman.Options.PodmanMachineListOptions.AllProviders.get -> bool?
-ModularPipelines.Podman.Options.PodmanMachineListOptions.AllProviders.set -> void
 ModularPipelines.Podman.Options.PodmanMachineListOptions.Format.get -> string?
 ModularPipelines.Podman.Options.PodmanMachineListOptions.Format.set -> void
 ModularPipelines.Podman.Options.PodmanMachineListOptions.Noheading.get -> bool?
@@ -3962,13 +3945,7 @@ ModularPipelines.Podman.Options.PodmanMachineListOptions.PodmanMachineListOption
 ModularPipelines.Podman.Options.PodmanMachineListOptions.Quiet.get -> bool?
 ModularPipelines.Podman.Options.PodmanMachineListOptions.Quiet.set -> void
 ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions
-ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Deconstruct(out string! Image) -> void
-ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Image.get -> string!
-ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Image.init -> void
-ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Name.get -> string?
-ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Name.set -> void
 ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.PodmanMachineOsApplyOptions(ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions! original) -> void
-ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.PodmanMachineOsApplyOptions(string! Image) -> void
 ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Restart.get -> bool?
 ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Restart.set -> void
 ModularPipelines.Podman.Options.PodmanMachineResetOptions

--- a/src/ModularPipelines.Podman/PublicAPI.Unshipped.txt
+++ b/src/ModularPipelines.Podman/PublicAPI.Unshipped.txt
@@ -1,4 +1,19 @@
 #nullable enable
+*REMOVED*ModularPipelines.Podman.Enums.PodmanComposeProgress.Json = 3 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
+*REMOVED*ModularPipelines.Podman.Enums.PodmanComposeProgress.Quiet = 4 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
+*REMOVED*ModularPipelines.Podman.Enums.PodmanComposeProgress.Tty = 1 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
+*REMOVED*ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanCreateSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanCreateSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanImagePushFormat.V2S1 = 2 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
+*REMOVED*ModularPipelines.Podman.Enums.PodmanImagePushFormat.V2S2 = 1 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
+*REMOVED*ModularPipelines.Podman.Enums.PodmanPushFormat.V2S1 = 2 -> ModularPipelines.Podman.Enums.PodmanPushFormat
+*REMOVED*ModularPipelines.Podman.Enums.PodmanPushFormat.V2S2 = 1 -> ModularPipelines.Podman.Enums.PodmanPushFormat
+*REMOVED*ModularPipelines.Podman.Enums.PodmanRunSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
+*REMOVED*ModularPipelines.Podman.Enums.PodmanRunSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
 *REMOVED*ModularPipelines.Podman.Options.PodmanBuildOptions.Output.get -> string?
 *REMOVED*ModularPipelines.Podman.Options.PodmanBuildOptions.Output.set -> void
 *REMOVED*ModularPipelines.Podman.Options.PodmanBuildOptions.Timestamp.get -> int?
@@ -19,6 +34,14 @@
 *REMOVED*ModularPipelines.Podman.Options.PodmanMachineInitOptions.ImagePath.set -> void
 *REMOVED*ModularPipelines.Podman.Options.PodmanMachineInitOptions.VolumeDriver.get -> string?
 *REMOVED*ModularPipelines.Podman.Options.PodmanMachineInitOptions.VolumeDriver.set -> void
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineListOptions.AllProviders.get -> bool?
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineListOptions.AllProviders.set -> void
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Deconstruct(out string! Image) -> void
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Image.get -> string!
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Image.init -> void
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Name.get -> string?
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Name.set -> void
+*REMOVED*ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.PodmanMachineOsApplyOptions(string! Image) -> void
 *REMOVED*ModularPipelines.Podman.Options.PodmanMachineRmOptions.SaveKeys.get -> bool?
 *REMOVED*ModularPipelines.Podman.Options.PodmanMachineRmOptions.SaveKeys.set -> void
 *REMOVED*ModularPipelines.Podman.Services.IPodman.AttachAsync(ModularPipelines.Podman.Options.PodmanAttachOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
@@ -462,12 +485,61 @@
 *REMOVED*virtual ModularPipelines.Podman.Services.PodmanVolume.PruneAsync(ModularPipelines.Podman.Options.PodmanVolumePruneOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Podman.Services.PodmanVolume.RmAsync(ModularPipelines.Podman.Options.PodmanVolumeRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
 *REMOVED*virtual ModularPipelines.Podman.Services.PodmanVolume.UnmountAsync(ModularPipelines.Podman.Options.PodmanVolumeUnmountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.Models.CommandResult!>!
+ModularPipelines.Podman.Enums.PodmanComposeProgress.Json = 1 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
+ModularPipelines.Podman.Enums.PodmanComposeProgress.Quiet = 3 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
+ModularPipelines.Podman.Enums.PodmanComposeProgress.Tty = 4 -> ModularPipelines.Podman.Enums.PodmanComposeProgress
+ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.Always = 0 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
+ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.True = 2 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd
+ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.Always = 0 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
+ModularPipelines.Podman.Enums.PodmanContainerRunSystemd.True = 2 -> ModularPipelines.Podman.Enums.PodmanContainerRunSystemd
+ModularPipelines.Podman.Enums.PodmanCreateSystemd.Always = 0 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
+ModularPipelines.Podman.Enums.PodmanCreateSystemd.True = 2 -> ModularPipelines.Podman.Enums.PodmanCreateSystemd
+ModularPipelines.Podman.Enums.PodmanImagePushFormat.V2S1 = 1 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
+ModularPipelines.Podman.Enums.PodmanImagePushFormat.V2S2 = 2 -> ModularPipelines.Podman.Enums.PodmanImagePushFormat
+ModularPipelines.Podman.Enums.PodmanPushFormat.V2S1 = 1 -> ModularPipelines.Podman.Enums.PodmanPushFormat
+ModularPipelines.Podman.Enums.PodmanPushFormat.V2S2 = 2 -> ModularPipelines.Podman.Enums.PodmanPushFormat
+ModularPipelines.Podman.Enums.PodmanRunSystemd.Always = 0 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
+ModularPipelines.Podman.Enums.PodmanRunSystemd.True = 2 -> ModularPipelines.Podman.Enums.PodmanRunSystemd
 ModularPipelines.Podman.Options.PodmanArtifactOptions
 ModularPipelines.Podman.Options.PodmanArtifactOptions.PodmanArtifactOptions() -> void
 ModularPipelines.Podman.Options.PodmanArtifactOptions.PodmanArtifactOptions(ModularPipelines.Podman.Options.PodmanArtifactOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.CompressionFormat.get -> string?
+ModularPipelines.Podman.Options.PodmanBuildOptions.CompressionFormat.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.CompressionLevel.get -> int?
+ModularPipelines.Podman.Options.PodmanBuildOptions.CompressionLevel.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.ForceCompression.get -> bool?
+ModularPipelines.Podman.Options.PodmanBuildOptions.ForceCompression.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.IidfileRaw.get -> string?
+ModularPipelines.Podman.Options.PodmanBuildOptions.IidfileRaw.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.MetadataFile.get -> string?
+ModularPipelines.Podman.Options.PodmanBuildOptions.MetadataFile.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.Mount.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Podman.Options.PodmanBuildOptions.Mount.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.SaveStages.get -> bool?
+ModularPipelines.Podman.Options.PodmanBuildOptions.SaveStages.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.SourcePolicyFile.get -> string?
+ModularPipelines.Podman.Options.PodmanBuildOptions.SourcePolicyFile.set -> void
+ModularPipelines.Podman.Options.PodmanBuildOptions.StageLabels.get -> bool?
+ModularPipelines.Podman.Options.PodmanBuildOptions.StageLabels.set -> void
 ModularPipelines.Podman.Options.PodmanContainerOptions
 ModularPipelines.Podman.Options.PodmanContainerOptions.PodmanContainerOptions() -> void
 ModularPipelines.Podman.Options.PodmanContainerOptions.PodmanContainerOptions(ModularPipelines.Podman.Options.PodmanContainerOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.CompressionFormat.get -> string?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.CompressionFormat.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.CompressionLevel.get -> int?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.CompressionLevel.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.ForceCompression.get -> bool?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.ForceCompression.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.IidfileRaw.get -> string?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.IidfileRaw.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.Mount.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.Mount.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.SaveStages.get -> bool?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.SaveStages.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.SourcePolicyFile.get -> string?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.SourcePolicyFile.set -> void
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.StageLabels.get -> bool?
+ModularPipelines.Podman.Options.PodmanFarmBuildOptions.StageLabels.set -> void
 ModularPipelines.Podman.Options.PodmanFarmOptions
 ModularPipelines.Podman.Options.PodmanFarmOptions.PodmanFarmOptions() -> void
 ModularPipelines.Podman.Options.PodmanFarmOptions.PodmanFarmOptions(ModularPipelines.Podman.Options.PodmanFarmOptions! original) -> void
@@ -477,30 +549,102 @@ ModularPipelines.Podman.Options.PodmanGenerateOptions.PodmanGenerateOptions(Modu
 ModularPipelines.Podman.Options.PodmanHealthcheckOptions
 ModularPipelines.Podman.Options.PodmanHealthcheckOptions.PodmanHealthcheckOptions() -> void
 ModularPipelines.Podman.Options.PodmanHealthcheckOptions.PodmanHealthcheckOptions(ModularPipelines.Podman.Options.PodmanHealthcheckOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanHealthcheckRunOptions.IgnoreResult.get -> bool?
+ModularPipelines.Podman.Options.PodmanHealthcheckRunOptions.IgnoreResult.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.CompressionFormat.get -> string?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.CompressionFormat.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.CompressionLevel.get -> int?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.CompressionLevel.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.ForceCompression.get -> bool?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.ForceCompression.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.IidfileRaw.get -> string?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.IidfileRaw.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.MetadataFile.get -> string?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.MetadataFile.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.Mount.get -> System.Collections.Generic.IEnumerable<string!>?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.Mount.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.SaveStages.get -> bool?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.SaveStages.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.SourcePolicyFile.get -> string?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.SourcePolicyFile.set -> void
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.StageLabels.get -> bool?
+ModularPipelines.Podman.Options.PodmanImageBuildOptions.StageLabels.set -> void
 ModularPipelines.Podman.Options.PodmanImageOptions
 ModularPipelines.Podman.Options.PodmanImageOptions.PodmanImageOptions() -> void
 ModularPipelines.Podman.Options.PodmanImageOptions.PodmanImageOptions(ModularPipelines.Podman.Options.PodmanImageOptions! original) -> void
 ModularPipelines.Podman.Options.PodmanImageTrustOptions
 ModularPipelines.Podman.Options.PodmanImageTrustOptions.PodmanImageTrustOptions() -> void
 ModularPipelines.Podman.Options.PodmanImageTrustOptions.PodmanImageTrustOptions(ModularPipelines.Podman.Options.PodmanImageTrustOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanImageTrustSetOptions.SignaturePolicy.get -> string?
+ModularPipelines.Podman.Options.PodmanImageTrustSetOptions.SignaturePolicy.set -> void
+ModularPipelines.Podman.Options.PodmanImageTrustShowOptions.SignaturePolicy.get -> string?
+ModularPipelines.Podman.Options.PodmanImageTrustShowOptions.SignaturePolicy.set -> void
 ModularPipelines.Podman.Options.PodmanKubeOptions
 ModularPipelines.Podman.Options.PodmanKubeOptions.PodmanKubeOptions() -> void
 ModularPipelines.Podman.Options.PodmanKubeOptions.PodmanKubeOptions(ModularPipelines.Podman.Options.PodmanKubeOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanMachineInitOptions.ImportNativeCa.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineInitOptions.ImportNativeCa.set -> void
+ModularPipelines.Podman.Options.PodmanMachineInitOptions.Provider.get -> string?
+ModularPipelines.Podman.Options.PodmanMachineInitOptions.Provider.set -> void
+ModularPipelines.Podman.Options.PodmanMachineInitOptions.UpdateConnection.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineInitOptions.UpdateConnection.set -> void
 ModularPipelines.Podman.Options.PodmanMachineOptions
 ModularPipelines.Podman.Options.PodmanMachineOptions.PodmanMachineOptions() -> void
 ModularPipelines.Podman.Options.PodmanMachineOptions.PodmanMachineOptions(ModularPipelines.Podman.Options.PodmanMachineOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Deconstruct(out string! Uri) -> void
+ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Machine.get -> string?
+ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Machine.set -> void
+ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.PodmanMachineOsApplyOptions(string! Uri) -> void
+ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Uri.get -> string!
+ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions.Uri.init -> void
 ModularPipelines.Podman.Options.PodmanMachineOsOptions
 ModularPipelines.Podman.Options.PodmanMachineOsOptions.PodmanMachineOsOptions() -> void
 ModularPipelines.Podman.Options.PodmanMachineOsOptions.PodmanMachineOsOptions(ModularPipelines.Podman.Options.PodmanMachineOsOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.DryRun.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.DryRun.set -> void
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Format.get -> string?
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Format.set -> void
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Name.get -> string?
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Name.set -> void
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.PodmanMachineOsUpgradeOptions() -> void
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.PodmanMachineOsUpgradeOptions(ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Restart.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Restart.set -> void
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Machine.get -> string?
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Machine.set -> void
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.NoInfo.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.NoInfo.set -> void
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.PodmanMachineRestartOptions() -> void
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.PodmanMachineRestartOptions(ModularPipelines.Podman.Options.PodmanMachineRestartOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Quiet.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Quiet.set -> void
+ModularPipelines.Podman.Options.PodmanMachineSetOptions.ImportNativeCa.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineSetOptions.ImportNativeCa.set -> void
+ModularPipelines.Podman.Options.PodmanMachineStartOptions.UpdateConnection.get -> bool?
+ModularPipelines.Podman.Options.PodmanMachineStartOptions.UpdateConnection.set -> void
+ModularPipelines.Podman.Options.PodmanManifestPushOptions.Retry.get -> int?
+ModularPipelines.Podman.Options.PodmanManifestPushOptions.Retry.set -> void
+ModularPipelines.Podman.Options.PodmanManifestPushOptions.RetryDelay.get -> string?
+ModularPipelines.Podman.Options.PodmanManifestPushOptions.RetryDelay.set -> void
 ModularPipelines.Podman.Options.PodmanNetworkOptions
 ModularPipelines.Podman.Options.PodmanNetworkOptions.PodmanNetworkOptions() -> void
 ModularPipelines.Podman.Options.PodmanNetworkOptions.PodmanNetworkOptions(ModularPipelines.Podman.Options.PodmanNetworkOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanNetworkRmOptions.Ignore.get -> bool?
+ModularPipelines.Podman.Options.PodmanNetworkRmOptions.Ignore.set -> void
 ModularPipelines.Podman.Options.PodmanPodOptions
 ModularPipelines.Podman.Options.PodmanPodOptions.PodmanPodOptions() -> void
 ModularPipelines.Podman.Options.PodmanPodOptions.PodmanPodOptions(ModularPipelines.Podman.Options.PodmanPodOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanQuadletInstallOptions.Application.get -> string?
+ModularPipelines.Podman.Options.PodmanQuadletInstallOptions.Application.set -> void
+ModularPipelines.Podman.Options.PodmanQuadletListOptions.Noheading.get -> bool?
+ModularPipelines.Podman.Options.PodmanQuadletListOptions.Noheading.set -> void
 ModularPipelines.Podman.Options.PodmanQuadletOptions
 ModularPipelines.Podman.Options.PodmanQuadletOptions.PodmanQuadletOptions() -> void
 ModularPipelines.Podman.Options.PodmanQuadletOptions.PodmanQuadletOptions(ModularPipelines.Podman.Options.PodmanQuadletOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanQuadletRmOptions.Recursive.get -> bool?
+ModularPipelines.Podman.Options.PodmanQuadletRmOptions.Recursive.set -> void
 ModularPipelines.Podman.Options.PodmanSecretOptions
 ModularPipelines.Podman.Options.PodmanSecretOptions.PodmanSecretOptions() -> void
 ModularPipelines.Podman.Options.PodmanSecretOptions.PodmanSecretOptions(ModularPipelines.Podman.Options.PodmanSecretOptions! original) -> void
@@ -513,6 +657,18 @@ ModularPipelines.Podman.Options.PodmanSystemOptions.PodmanSystemOptions(ModularP
 ModularPipelines.Podman.Options.PodmanVolumeOptions
 ModularPipelines.Podman.Options.PodmanVolumeOptions.PodmanVolumeOptions() -> void
 ModularPipelines.Podman.Options.PodmanVolumeOptions.PodmanVolumeOptions(ModularPipelines.Podman.Options.PodmanVolumeOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanVolumePruneOptions.All.get -> bool?
+ModularPipelines.Podman.Options.PodmanVolumePruneOptions.All.set -> void
+ModularPipelines.Podman.Options.PodmanVolumePruneOptions.DryRun.get -> bool?
+ModularPipelines.Podman.Options.PodmanVolumePruneOptions.DryRun.set -> void
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Deconstruct(out string! Volume, out string! Newname) -> void
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Newname.get -> string!
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Newname.init -> void
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.PodmanVolumeRenameOptions(ModularPipelines.Podman.Options.PodmanVolumeRenameOptions! original) -> void
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.PodmanVolumeRenameOptions(string! Volume, string! Newname) -> void
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Volume.get -> string!
+ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Volume.init -> void
 ModularPipelines.Podman.Services.IPodman.AttachAsync(ModularPipelines.Podman.Options.PodmanAttachOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodman.AutoUpdateAsync(ModularPipelines.Podman.Options.PodmanAutoUpdateOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodman.BuildAsync(ModularPipelines.Podman.Options.PodmanBuildOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -680,6 +836,7 @@ ModularPipelines.Podman.Services.IPodmanMachine.InitAsync(ModularPipelines.Podma
 ModularPipelines.Podman.Services.IPodmanMachine.InspectAsync(ModularPipelines.Podman.Options.PodmanMachineInspectOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanMachine.ListAsync(ModularPipelines.Podman.Options.PodmanMachineListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanMachine.ResetAsync(ModularPipelines.Podman.Options.PodmanMachineResetOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Podman.Services.IPodmanMachine.RestartAsync(ModularPipelines.Podman.Options.PodmanMachineRestartOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanMachine.RmAsync(ModularPipelines.Podman.Options.PodmanMachineRmOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanMachine.SetAsync(ModularPipelines.Podman.Options.PodmanMachineSetOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanMachine.SshAsync(ModularPipelines.Podman.Options.PodmanMachineSshOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -750,6 +907,7 @@ ModularPipelines.Podman.Services.IPodmanVolume.InspectAsync(ModularPipelines.Pod
 ModularPipelines.Podman.Services.IPodmanVolume.LsAsync(ModularPipelines.Podman.Options.PodmanVolumeLsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanVolume.MountAsync(ModularPipelines.Podman.Options.PodmanVolumeMountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanVolume.PruneAsync(ModularPipelines.Podman.Options.PodmanVolumePruneOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+ModularPipelines.Podman.Services.IPodmanVolume.RenameAsync(ModularPipelines.Podman.Options.PodmanVolumeRenameOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanVolume.RmAsync(ModularPipelines.Podman.Options.PodmanVolumeRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.IPodmanVolume.UnmountAsync(ModularPipelines.Podman.Options.PodmanVolumeUnmountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 ModularPipelines.Podman.Services.PodmanArtifact.PodmanArtifact(ModularPipelines.Context.ICommandContext! command) -> void
@@ -833,6 +991,18 @@ override ModularPipelines.Podman.Options.PodmanMachineOsOptions.Equals(object? o
 override ModularPipelines.Podman.Options.PodmanMachineOsOptions.GetHashCode() -> int
 override ModularPipelines.Podman.Options.PodmanMachineOsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Podman.Options.PodmanMachineOsOptions.ToString() -> string!
+override ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.<Clone>$() -> ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions!
+override ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Equals(object? obj) -> bool
+override ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.GetHashCode() -> int
+override ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.ToString() -> string!
+override ModularPipelines.Podman.Options.PodmanMachineRestartOptions.<Clone>$() -> ModularPipelines.Podman.Options.PodmanMachineRestartOptions!
+override ModularPipelines.Podman.Options.PodmanMachineRestartOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Equals(object? obj) -> bool
+override ModularPipelines.Podman.Options.PodmanMachineRestartOptions.GetHashCode() -> int
+override ModularPipelines.Podman.Options.PodmanMachineRestartOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Podman.Options.PodmanMachineRestartOptions.ToString() -> string!
 override ModularPipelines.Podman.Options.PodmanNetworkOptions.<Clone>$() -> ModularPipelines.Podman.Options.PodmanNetworkOptions!
 override ModularPipelines.Podman.Options.PodmanNetworkOptions.EqualityContract.get -> System.Type!
 override ModularPipelines.Podman.Options.PodmanNetworkOptions.Equals(object? obj) -> bool
@@ -875,6 +1045,12 @@ override ModularPipelines.Podman.Options.PodmanVolumeOptions.Equals(object? obj)
 override ModularPipelines.Podman.Options.PodmanVolumeOptions.GetHashCode() -> int
 override ModularPipelines.Podman.Options.PodmanVolumeOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
 override ModularPipelines.Podman.Options.PodmanVolumeOptions.ToString() -> string!
+override ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.<Clone>$() -> ModularPipelines.Podman.Options.PodmanVolumeRenameOptions!
+override ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.EqualityContract.get -> System.Type!
+override ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Equals(object? obj) -> bool
+override ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.GetHashCode() -> int
+override ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.ToString() -> string!
 override sealed ModularPipelines.Podman.Options.PodmanArtifactOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanContainerOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanFarmOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
@@ -885,6 +1061,8 @@ override sealed ModularPipelines.Podman.Options.PodmanImageTrustOptions.Equals(M
 override sealed ModularPipelines.Podman.Options.PodmanKubeOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanMachineOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanMachineOsOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
+override sealed ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
+override sealed ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanNetworkOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanPodOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanQuadletOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
@@ -892,6 +1070,7 @@ override sealed ModularPipelines.Podman.Options.PodmanSecretOptions.Equals(Modul
 override sealed ModularPipelines.Podman.Options.PodmanSystemConnectionOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanSystemOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 override sealed ModularPipelines.Podman.Options.PodmanVolumeOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
+override sealed ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Equals(ModularPipelines.Podman.Options.PodmanOptions? other) -> bool
 static ModularPipelines.Podman.Options.PodmanArtifactOptions.operator !=(ModularPipelines.Podman.Options.PodmanArtifactOptions? left, ModularPipelines.Podman.Options.PodmanArtifactOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanArtifactOptions.operator ==(ModularPipelines.Podman.Options.PodmanArtifactOptions? left, ModularPipelines.Podman.Options.PodmanArtifactOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanContainerOptions.operator !=(ModularPipelines.Podman.Options.PodmanContainerOptions? left, ModularPipelines.Podman.Options.PodmanContainerOptions? right) -> bool
@@ -912,6 +1091,10 @@ static ModularPipelines.Podman.Options.PodmanMachineOptions.operator !=(ModularP
 static ModularPipelines.Podman.Options.PodmanMachineOptions.operator ==(ModularPipelines.Podman.Options.PodmanMachineOptions? left, ModularPipelines.Podman.Options.PodmanMachineOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanMachineOsOptions.operator !=(ModularPipelines.Podman.Options.PodmanMachineOsOptions? left, ModularPipelines.Podman.Options.PodmanMachineOsOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanMachineOsOptions.operator ==(ModularPipelines.Podman.Options.PodmanMachineOsOptions? left, ModularPipelines.Podman.Options.PodmanMachineOsOptions? right) -> bool
+static ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.operator !=(ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions? left, ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions? right) -> bool
+static ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.operator ==(ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions? left, ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions? right) -> bool
+static ModularPipelines.Podman.Options.PodmanMachineRestartOptions.operator !=(ModularPipelines.Podman.Options.PodmanMachineRestartOptions? left, ModularPipelines.Podman.Options.PodmanMachineRestartOptions? right) -> bool
+static ModularPipelines.Podman.Options.PodmanMachineRestartOptions.operator ==(ModularPipelines.Podman.Options.PodmanMachineRestartOptions? left, ModularPipelines.Podman.Options.PodmanMachineRestartOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanNetworkOptions.operator !=(ModularPipelines.Podman.Options.PodmanNetworkOptions? left, ModularPipelines.Podman.Options.PodmanNetworkOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanNetworkOptions.operator ==(ModularPipelines.Podman.Options.PodmanNetworkOptions? left, ModularPipelines.Podman.Options.PodmanNetworkOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanPodOptions.operator !=(ModularPipelines.Podman.Options.PodmanPodOptions? left, ModularPipelines.Podman.Options.PodmanPodOptions? right) -> bool
@@ -926,6 +1109,8 @@ static ModularPipelines.Podman.Options.PodmanSystemOptions.operator !=(ModularPi
 static ModularPipelines.Podman.Options.PodmanSystemOptions.operator ==(ModularPipelines.Podman.Options.PodmanSystemOptions? left, ModularPipelines.Podman.Options.PodmanSystemOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanVolumeOptions.operator !=(ModularPipelines.Podman.Options.PodmanVolumeOptions? left, ModularPipelines.Podman.Options.PodmanVolumeOptions? right) -> bool
 static ModularPipelines.Podman.Options.PodmanVolumeOptions.operator ==(ModularPipelines.Podman.Options.PodmanVolumeOptions? left, ModularPipelines.Podman.Options.PodmanVolumeOptions? right) -> bool
+static ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.operator !=(ModularPipelines.Podman.Options.PodmanVolumeRenameOptions? left, ModularPipelines.Podman.Options.PodmanVolumeRenameOptions? right) -> bool
+static ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.operator ==(ModularPipelines.Podman.Options.PodmanVolumeRenameOptions? left, ModularPipelines.Podman.Options.PodmanVolumeRenameOptions? right) -> bool
 virtual ModularPipelines.Podman.Options.PodmanArtifactOptions.Equals(ModularPipelines.Podman.Options.PodmanArtifactOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanContainerOptions.Equals(ModularPipelines.Podman.Options.PodmanContainerOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanFarmOptions.Equals(ModularPipelines.Podman.Options.PodmanFarmOptions? other) -> bool
@@ -936,6 +1121,8 @@ virtual ModularPipelines.Podman.Options.PodmanImageTrustOptions.Equals(ModularPi
 virtual ModularPipelines.Podman.Options.PodmanKubeOptions.Equals(ModularPipelines.Podman.Options.PodmanKubeOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanMachineOptions.Equals(ModularPipelines.Podman.Options.PodmanMachineOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanMachineOsOptions.Equals(ModularPipelines.Podman.Options.PodmanMachineOsOptions? other) -> bool
+virtual ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions.Equals(ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions? other) -> bool
+virtual ModularPipelines.Podman.Options.PodmanMachineRestartOptions.Equals(ModularPipelines.Podman.Options.PodmanMachineRestartOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanNetworkOptions.Equals(ModularPipelines.Podman.Options.PodmanNetworkOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanPodOptions.Equals(ModularPipelines.Podman.Options.PodmanPodOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanQuadletOptions.Equals(ModularPipelines.Podman.Options.PodmanQuadletOptions? other) -> bool
@@ -943,6 +1130,7 @@ virtual ModularPipelines.Podman.Options.PodmanSecretOptions.Equals(ModularPipeli
 virtual ModularPipelines.Podman.Options.PodmanSystemConnectionOptions.Equals(ModularPipelines.Podman.Options.PodmanSystemConnectionOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanSystemOptions.Equals(ModularPipelines.Podman.Options.PodmanSystemOptions? other) -> bool
 virtual ModularPipelines.Podman.Options.PodmanVolumeOptions.Equals(ModularPipelines.Podman.Options.PodmanVolumeOptions? other) -> bool
+virtual ModularPipelines.Podman.Options.PodmanVolumeRenameOptions.Equals(ModularPipelines.Podman.Options.PodmanVolumeRenameOptions? other) -> bool
 virtual ModularPipelines.Podman.Services.PodmanArtifact.AddAsync(ModularPipelines.Podman.Options.PodmanArtifactAddOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanArtifact.ExecuteAsync(ModularPipelines.Podman.Options.PodmanArtifactOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanArtifact.ExtractAsync(ModularPipelines.Podman.Options.PodmanArtifactExtractOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -1074,6 +1262,7 @@ virtual ModularPipelines.Podman.Services.PodmanMachine.InitAsync(ModularPipeline
 virtual ModularPipelines.Podman.Services.PodmanMachine.InspectAsync(ModularPipelines.Podman.Options.PodmanMachineInspectOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachine.ListAsync(ModularPipelines.Podman.Options.PodmanMachineListOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachine.ResetAsync(ModularPipelines.Podman.Options.PodmanMachineResetOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+virtual ModularPipelines.Podman.Services.PodmanMachine.RestartAsync(ModularPipelines.Podman.Options.PodmanMachineRestartOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachine.RmAsync(ModularPipelines.Podman.Options.PodmanMachineRmOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachine.SetAsync(ModularPipelines.Podman.Options.PodmanMachineSetOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachine.SshAsync(ModularPipelines.Podman.Options.PodmanMachineSshOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -1081,6 +1270,7 @@ virtual ModularPipelines.Podman.Services.PodmanMachine.StartAsync(ModularPipelin
 virtual ModularPipelines.Podman.Services.PodmanMachine.StopAsync(ModularPipelines.Podman.Options.PodmanMachineStopOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachineOs.ApplyAsync(ModularPipelines.Podman.Options.PodmanMachineOsApplyOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanMachineOs.ExecuteAsync(ModularPipelines.Podman.Options.PodmanMachineOsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+virtual ModularPipelines.Podman.Services.PodmanMachineOs.UpgradeAsync(ModularPipelines.Podman.Options.PodmanMachineOsUpgradeOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanManifest.AddAsync(ModularPipelines.Podman.Options.PodmanManifestAddOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanManifest.AnnotateAsync(ModularPipelines.Podman.Options.PodmanManifestAnnotateOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanManifest.CreateAsync(ModularPipelines.Podman.Options.PodmanManifestCreateOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
@@ -1152,5 +1342,6 @@ virtual ModularPipelines.Podman.Services.PodmanVolume.InspectAsync(ModularPipeli
 virtual ModularPipelines.Podman.Services.PodmanVolume.LsAsync(ModularPipelines.Podman.Options.PodmanVolumeLsOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanVolume.MountAsync(ModularPipelines.Podman.Options.PodmanVolumeMountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanVolume.PruneAsync(ModularPipelines.Podman.Options.PodmanVolumePruneOptions? options = null, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
+virtual ModularPipelines.Podman.Services.PodmanVolume.RenameAsync(ModularPipelines.Podman.Options.PodmanVolumeRenameOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanVolume.RmAsync(ModularPipelines.Podman.Options.PodmanVolumeRmOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!
 virtual ModularPipelines.Podman.Services.PodmanVolume.UnmountAsync(ModularPipelines.Podman.Options.PodmanVolumeUnmountOptions! options, ModularPipelines.Options.CommandExecutionOptions? executionOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ModularPipelines.CommandResult!>!

--- a/src/ModularPipelines.Podman/Services/IPodmanCompose.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/IPodmanCompose.Generated.cs
@@ -77,7 +77,7 @@ public interface IPodmanCompose
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// podman compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+    /// Copy files/folders between a service container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Podman/Services/IPodmanMachine.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/IPodmanMachine.Generated.cs
@@ -87,6 +87,16 @@ public interface IPodmanMachine
         => throw new System.NotSupportedException();
 
     /// <summary>
+    /// Restart an existing machine
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> RestartAsync(PodmanMachineRestartOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
     /// Remove an existing machine
     /// </summary>
     /// <param name="options">The command options.</param>

--- a/src/ModularPipelines.Podman/Services/IPodmanPod.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/IPodmanPod.Generated.cs
@@ -112,7 +112,7 @@ public interface IPodmanPod
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// List all pods on system including their names, ids and current state.
+    /// List pods
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Podman/Services/IPodmanVolume.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/IPodmanVolume.Generated.cs
@@ -102,13 +102,23 @@ public interface IPodmanVolume
         => throw new System.NotSupportedException();
 
     /// <summary>
-    /// Remove all unused volumes
+    /// Remove unused volumes
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public Task<CommandResult> PruneAsync(PodmanVolumePruneOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Rename a volume
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> RenameAsync(PodmanVolumeRenameOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Services/PodmanCompose.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanCompose.Generated.cs
@@ -118,7 +118,7 @@ public class PodmanCompose : IPodmanCompose
     }
 
     /// <summary>
-    /// podman compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH
+    /// Copy files/folders between a service container and the local filesystem
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Podman/Services/PodmanMachine.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanMachine.Generated.cs
@@ -133,6 +133,21 @@ public class PodmanMachine : IPodmanMachine
     }
 
     /// <summary>
+    /// Restart an existing machine
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> RestartAsync(
+        PodmanMachineRestartOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new PodmanMachineRestartOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <summary>
     /// Remove an existing machine
     /// </summary>
     /// <param name="options">The command options.</param>

--- a/src/ModularPipelines.Podman/Services/PodmanMachineOs.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanMachineOs.Generated.cs
@@ -62,5 +62,20 @@ public class PodmanMachineOs
         return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
+    /// <summary>
+    /// Upgrade machine os
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> UpgradeAsync(
+        PodmanMachineOsUpgradeOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new PodmanMachineOsUpgradeOptions(), executionOptions, cancellationToken);
+    }
+
     #endregion
 }

--- a/src/ModularPipelines.Podman/Services/PodmanPod.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanPod.Generated.cs
@@ -168,7 +168,7 @@ public class PodmanPod : IPodmanPod
     }
 
     /// <summary>
-    /// List all pods on system including their names, ids and current state.
+    /// List pods
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>

--- a/src/ModularPipelines.Podman/Services/PodmanVolume.Generated.cs
+++ b/src/ModularPipelines.Podman/Services/PodmanVolume.Generated.cs
@@ -153,7 +153,7 @@ public class PodmanVolume : IPodmanVolume
     }
 
     /// <summary>
-    /// Remove all unused volumes
+    /// Remove unused volumes
     /// </summary>
     /// <param name="options">The command options.</param>
     /// <param name="executionOptions">The execution configuration options.</param>
@@ -165,6 +165,21 @@ public class PodmanVolume : IPodmanVolume
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new PodmanVolumePruneOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Rename a volume
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> RenameAsync(
+        PodmanVolumeRenameOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **podman** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Assembly-wide public API impact

Affected API families: `Assembly/common`, `Podman`.

- Added APIs: 168
- Removed or changed APIs: 23
- Members with matching names but changed signatures: 2

Breaking changes are present. Consumers may need to update method arguments, option property types or nullability, enum members, and references to removed APIs.

Representative removed or changed members:
- `ModularPipelines.Podman.Enums.PodmanComposeProgress.Json = 3 -> ModularPipelines.Podman.Enums.PodmanComposeProgress`
- `ModularPipelines.Podman.Enums.PodmanComposeProgress.Quiet = 4 -> ModularPipelines.Podman.Enums.PodmanComposeProgress`
- `ModularPipelines.Podman.Enums.PodmanComposeProgress.Tty = 1 -> ModularPipelines.Podman.Enums.PodmanComposeProgress`
- `ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.Always = 2 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd`
- `ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.True = 0 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd`

Representative added members:
- `ModularPipelines.Podman.Enums.PodmanComposeProgress.Json = 1 -> ModularPipelines.Podman.Enums.PodmanComposeProgress`
- `ModularPipelines.Podman.Enums.PodmanComposeProgress.Quiet = 3 -> ModularPipelines.Podman.Enums.PodmanComposeProgress`
- `ModularPipelines.Podman.Enums.PodmanComposeProgress.Tty = 4 -> ModularPipelines.Podman.Enums.PodmanComposeProgress`
- `ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.Always = 0 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd`
- `ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd.True = 2 -> ModularPipelines.Podman.Enums.PodmanContainerCreateSystemd`

## Command coverage
Command coverage report:
- podman (podman version 6.1.1): 258 commands, tree 1173613661b2e99570a995b22aeebec1e2ff1858aa1ea713d8f9cf737e06a14c
  - Baseline comparison: 255 commands at podman version 5.8.4 -> 258 commands at podman version 6.1.1
  - Added: podman machine os upgrade, podman machine restart, podman volume rename

## Verification
- [x] Solution builds successfully

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for upgrading Podman machine operating systems, restarting machines, and renaming volumes.
  * Added configuration options for builds, machine initialization and startup, image trust, manifest pushes, networks, Quadlet, volumes, and health checks.
  * Added corresponding Podman CLI command documentation for machine OS upgrades, machine restarts, and volume renaming.
  * Expanded Podman service APIs to expose the new machine, OS, and volume operations.

* **Breaking Changes**
  * Removed several previously available Podman options and enum values from the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->